### PR TITLE
Allow dynamically override hive dependency version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val kamuCli = (project in file("."))
       "sqlline" % "sqlline" % "1.8.0",
       // NOTE: Using kamu-specific Hive version with some bugfixes
       // remove `kamu.X` part if you want a simpler build
-      ("org.spark-project.hive" % "hive-jdbc" % "1.2.1.spark2.kamu.1")
+      ("org.spark-project.hive" % "hive-jdbc" % Versions.hiveJDBC)
         .excludeAll(ExclusionRule(organization = "log4j"))
         .excludeAll(ExclusionRule(organization = "org.apache.geronimo.specs"))
         .exclude("org.apache.hadoop", "hadoop-yarn-api")

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -29,7 +29,7 @@ We use `hive-jdbc` to connect the SQL shell to Spark Thrift Server exposed by Li
 
 This has to be done only once. After you build it and publish the package in your local maven repository you pretty much won't have to touch `hive` ever again.
 
-> Note: You can skip this step entirely if you're in a hurry by changing `hive-jdbc` dependency version from `1.2.1.spark2.kamu.X` to `1.2.1.spark2`.
+> Note: You can skip this step entirely if you're in a hurry by running `sbt` with `-Dhive.jdbc.version=upstream`. You can use this option if your work is not related to SQL shell and JDBC connector.
 
 Instructions:
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,4 +1,11 @@
 object Versions {
   val spark = "2.4.0"
   val geoSpark = "1.2.0"
+  val hiveJDBC = sys.props
+    .get("hive.jdbc.version")
+    .map {
+      case "upstream" => "1.2.1.spark2"
+      case other      => other
+    }
+    .getOrElse("1.2.1.spark2.kamu.1")
 }


### PR DESCRIPTION
@LinuxUser404 

Usage:
```
$ sbt -Dhive.jdbc.version=1.2.1.spark2 dependencyList | grep hive-jdbc
[info] org.spark-project.hive:hive-jdbc:1.2.1.spark2

$ sbt -Dhive.jdbc.version=upstream dependencyList | grep hive-jdbc
[info] org.spark-project.hive:hive-jdbc:1.2.1.spark2

$ sbt dependencyList | grep hive-jdbc
[info] org.spark-project.hive:hive-jdbc:1.2.1.spark2.kamu.1
```

So in travis build we can set `-Dhive.jdbc.version=upstream`.