### PR TITLE
Improve paginator performance on large block counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Added `kamu reset` command that reverts the dataset back to the specified state
+### Added
+- New `kamu reset` command that reverts the dataset back to the specified state
+### Fixed
+- Improved the `kamu log` command's performance on datasets with high block counts and introruced a `--limit` parameter
 
 ## [0.94.0] - 2022-06-22
 ### Added

--- a/kamu-cli/src/cli_commands.rs
+++ b/kamu-cli/src/cli_commands.rs
@@ -119,6 +119,7 @@ pub fn get_command(
             submatches.value_of_t_or_exit("dataset"),
             submatches.value_of("output-format"),
             submatches.value_of("filter"),
+            submatches.value_of_t_or_exit("limit"),
             catalog.get_one()?,
         )),
         Some(("new", submatches)) => Box::new(NewDatasetCommand::new(

--- a/kamu-cli/src/cli_parser.rs
+++ b/kamu-cli/src/cli_parser.rs
@@ -484,6 +484,11 @@ pub fn cli() -> Command<'static> {
                         .takes_value(true)
                         .value_name("FLT")
                         .validator(validate_log_filter),
+                    Arg::new("limit")
+                        .long("limit")
+                        .takes_value(true)
+                        .default_value("500")
+                        .help("Maximum number of blocks to display"),
                 ])
                 .after_help(indoc::indoc!(
                     "


### PR DESCRIPTION
This PR adds two workarounds for poor pagination performance on datasets with high block counts.

1) Individual writes into `minus::Pager` seem to have high overhead, so we format the entire block using a temporary buffer and only write to `Pager` once per block.

This already improves performance significanlty (e.g. `kamu log` on a 1000-block dataset takes about 3 seconds to render).

2) On top of that to limit performance degradation we introduce `--limit` parameter to the `log` command that defaults to 500 blocks.

Note:
* `kamu log x > file` is blazing fast even with 1K blocks, so its all overhead is in the `minus` pager library
* `minus` library has support for "dynamic paging" where a separate thread can push more data progressively but it doesn't work as I expected - it doesn't backpressure the producing thread and seems to make the problem only worse

@zaychenko-sergei please review