### PR TITLE
Fix panic on pulling non-existing dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Panic when pulling a non-existing dataset
+
 ## [0.96.0] - 2022-07-23
 ### Added
 - Support for ingesting Parquet format, a new kind of ReadStep in ODF protocol

--- a/kamu-core/tests/tests/test_pull_service_impl.rs
+++ b/kamu-core/tests/tests/test_pull_service_impl.rs
@@ -309,6 +309,24 @@ async fn test_pull_batching_complex() {
         vec![PullBatch::Transform(refs!["e"])]
     );
 
+    assert_matches!(
+        harness
+            .pull_svc
+            .pull_multi(
+                &mut vec![ar!("z")].into_iter(),
+                PullOptions::default(),
+                None,
+                None,
+                None
+            )
+            .await
+            .unwrap()[0],
+        PullResponse {
+            result: Err(PullError::NotFound(_)),
+            ..
+        },
+    );
+
     assert_eq!(
         harness
             .pull(


### PR DESCRIPTION
```bash
$ kamu list
┌─────────────────────────────────┬──────┬────────┬─────────┬──────┐
│              Name               │ Kind │ Pulled │ Records │ Size │
├─────────────────────────────────┼──────┼────────┼─────────┼──────┤
│ com.cryptocompare.ohlcv.eth-usd │ Root │   -    │       - │    - │
└─────────────────────────────────┴──────┴────────┴─────────┴──────┘

$ kamu pull zzz
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', kamu-core/src/infra/pull_service_impl.rs:165:45
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```