### PR TITLE
Unified table output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.104.0] - 2022-12-28
 ### Added
 - Installer script that can be used via `curl -s "https://get.kamu.dev" | sh`
+- Unified table output allowsing commands like `kamu list` to output in `json` and other formats
 
 ## [0.103.0] - 2022-12-23
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,17 +446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,16 +764,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
 dependencies = [
  "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -823,7 +811,7 @@ checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "container-runtime"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "dill",
  "regex",
@@ -1793,15 +1781,6 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -2142,7 +2121,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.42.0",
@@ -2215,7 +2194,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "kamu"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -2279,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -2298,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2930,7 +2909,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2983,7 +2962,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendatafabric"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "bs58",
  "byteorder",
@@ -3254,9 +3233,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bdd679d533107e090c2704a35982fc06302e30898e63ffa26a81155c012e92"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -3266,13 +3245,13 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettytable-rs"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f375cb74c23b51d23937ffdeb48b1fbf5b6409d4b9979c1418c1de58bc8f801"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
 dependencies = [
- "atty",
  "csv",
  "encode_unicode 1.0.0",
+ "is-terminal",
  "lazy_static",
  "term",
  "unicode-width",
@@ -3786,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
@@ -3944,18 +3923,18 @@ checksum = "1685deded9b272198423bdbdb907d8519def2f26cf3699040e54e8c4fbd5c5ce"
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4337,16 +4316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "test-log"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4596,9 +4565,9 @@ checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
 
 [[package]]
 name = "toml_edit"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd65b83c7473af53e3fd994eb2888dfddfeb28cac9a82825ec5803c233c882c"
+checksum = "5c040d7eb2b695a2a39048f9d8e7ee865ef1c57cd9c44ba9b4a4d389095f7e6a"
 dependencies = [
  "indexmap",
  "itertools",

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.103.0
+Licensed Work:             Kamu CLI Version 0.104.0
                            The Licensed Work is © 2021 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2026-12-24
+Change Date:               2026-12-28
 
 Change License:            Apache License, Version 2.0
 

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,7 +1,7 @@
 IMAGE_REPO = docker.io/kamudata
 IMAGE_JUPYTER_TAG = 0.5.0
 
-KAMU_VERSION = 0.103.0
+KAMU_VERSION = 0.104.0
 
 
 .PHONY: jupyter

--- a/images/demo/Makefile
+++ b/images/demo/Makefile
@@ -1,5 +1,5 @@
 IMAGE_REPO = docker.io/kamudata
-KAMU_VERSION = 0.103.0
+KAMU_VERSION = 0.104.0
 DEMO_VERSION = 0.6.1
 
 #########################################################################################

--- a/kamu-adapter-graphql/Cargo.toml
+++ b/kamu-adapter-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-adapter-graphql"
-version = "0.103.0"
+version = "0.104.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 

--- a/kamu-cli/Cargo.toml
+++ b/kamu-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-cli"
-version = "0.103.0"
+version = "0.104.0"
 description = "Decentralized data management tool"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"

--- a/kamu-cli/src/commands/list_command.rs
+++ b/kamu-cli/src/commands/list_command.rs
@@ -8,13 +8,12 @@
 // by the Apache License, Version 2.0.
 
 use super::{CLIError, Command};
-use crate::{output::*, records_writers::TableWriter};
-use kamu::domain::*;
-use opendatafabric::*;
-
-use chrono::{DateTime, SecondsFormat, Utc};
+use crate::output::*;
+use chrono::{DateTime, Utc};
 use chrono_humanize::HumanTime;
 use futures::TryStreamExt;
+use kamu::domain::*;
+use opendatafabric::*;
 use std::sync::Arc;
 
 pub struct ListCommand {
@@ -39,167 +38,11 @@ impl ListCommand {
         }
     }
 
-    // TODO: support multiple format specifiers
-    async fn print_machine_readable(&self) -> Result<(), CLIError> {
-        use std::io::Write;
-
-        let mut datasets: Vec<_> = self.local_repo.get_all_datasets().try_collect().await?;
-        datasets.sort_by(|a, b| a.name.cmp(&b.name));
-
-        let mut out = std::io::stdout();
-        write!(
-            out,
-            "ID,Name,Kind,Head,Pulled,Records,Blocks,Size,Watermark\n"
-        )?;
-
-        for hdl in &datasets {
-            let dataset = self.local_repo.get_dataset(&hdl.as_local_ref()).await?;
-            let head = dataset.as_metadata_chain().get_ref(&BlockRef::Head).await?;
-            let summary = dataset.get_summary(SummaryOptions::default()).await?;
-
-            // TODO: Should be precomputed
-            let mut num_blocks = 0;
-            let mut watermark = None;
-            let mut blocks_stream = dataset.as_metadata_chain().iter_blocks();
-            while let Some((_, b)) = blocks_stream.try_next().await? {
-                num_blocks += 1;
-                if watermark.is_none() {
-                    if let Some(b) = b.as_data_stream_block() {
-                        watermark = b.event.output_watermark.cloned();
-                    }
-                }
-            }
-
-            write!(
-                out,
-                "{},{},{},{},{},{},{},{},{}\n",
-                hdl.id,
-                hdl.name,
-                self.get_kind(hdl, &summary).await?,
-                head,
-                match summary.last_pulled {
-                    None => "".to_owned(),
-                    Some(t) => t.to_rfc3339_opts(SecondsFormat::Millis, true),
-                },
-                summary.num_records,
-                num_blocks,
-                summary.data_size,
-                match watermark {
-                    None => "".to_owned(),
-                    Some(t) => t.to_rfc3339_opts(SecondsFormat::Millis, true),
-                },
-            )?;
-        }
-        Ok(())
+    fn humanize_relative_date(last_pulled: DateTime<Utc>) -> String {
+        format!("{}", HumanTime::from(last_pulled - Utc::now()))
     }
 
-    async fn print_pretty(&self) -> Result<(), CLIError> {
-        use prettytable::*;
-
-        let mut datasets: Vec<_> = self.local_repo.get_all_datasets().try_collect().await?;
-        datasets.sort_by(|a, b| a.name.cmp(&b.name));
-
-        let mut table = Table::new();
-        table.set_format(TableWriter::get_table_format());
-
-        if self.detail_level == 0 {
-            table.set_titles(row![
-                bc->"Name",
-                bc->"Kind",
-                bc->"Pulled",
-                bc->"Records",
-                bc->"Size",
-            ]);
-        } else {
-            table.set_titles(row![
-                bc->"ID",
-                bc->"Name",
-                bc->"Kind",
-                bc->"Head",
-                bc->"Pulled",
-                bc->"Records",
-                bc->"Blocks",
-                bc->"Size",
-                bc->"Watermark"
-            ]);
-        }
-
-        for hdl in datasets.iter() {
-            let dataset = self.local_repo.get_dataset(&hdl.as_local_ref()).await?;
-            let head = dataset.as_metadata_chain().get_ref(&BlockRef::Head).await?;
-            let summary = dataset.get_summary(SummaryOptions::default()).await?;
-
-            if self.detail_level == 0 {
-                table.add_row(Row::new(vec![
-                    Cell::new(&hdl.name),
-                    Cell::new(&self.get_kind(hdl, &summary).await?).style_spec("c"),
-                    Cell::new(&self.humanize_relative_date(summary.last_pulled)).style_spec("c"),
-                    Cell::new(&self.humanize_quantity(summary.num_records)).style_spec("r"),
-                    Cell::new(&self.humanize_data_size(summary.data_size)).style_spec("r"),
-                ]));
-            } else {
-                // TODO: Should be precomputed
-                let mut num_blocks = 0;
-                let mut watermark = None;
-                let mut blocks_stream = dataset.as_metadata_chain().iter_blocks();
-                while let Some((_, b)) = blocks_stream.try_next().await? {
-                    num_blocks += 1;
-                    if watermark.is_none() {
-                        if let Some(b) = b.as_data_stream_block() {
-                            watermark = b.event.output_watermark.cloned();
-                        }
-                    }
-                }
-
-                table.add_row(Row::new(vec![
-                    Cell::new(&hdl.id.to_did_string()),
-                    Cell::new(&hdl.name),
-                    Cell::new(&self.get_kind(hdl, &summary).await?).style_spec("c"),
-                    Cell::new(&head.short().to_string()),
-                    Cell::new(&self.humanize_relative_date(summary.last_pulled)).style_spec("c"),
-                    Cell::new(&self.humanize_quantity(summary.num_records)).style_spec("r"),
-                    Cell::new(&self.humanize_quantity(num_blocks)).style_spec("r"),
-                    Cell::new(&self.humanize_data_size(summary.data_size)).style_spec("r"),
-                    Cell::new(&self.humanize_relative_date(watermark)).style_spec("r"),
-                ]));
-            }
-        }
-
-        // Header doesn't render when there are no data rows in the table
-        if datasets.is_empty() {
-            if self.detail_level == 0 {
-                table.add_row(Row::new(vec![
-                    Cell::new(""),
-                    Cell::new(""),
-                    Cell::new(""),
-                    Cell::new(""),
-                    Cell::new(""),
-                ]));
-            } else {
-                table.add_row(Row::new(vec![
-                    Cell::new(""),
-                    Cell::new(""),
-                    Cell::new(""),
-                    Cell::new(""),
-                    Cell::new(""),
-                    Cell::new(""),
-                    Cell::new(""),
-                ]));
-            }
-        }
-
-        table.printstd();
-        Ok(())
-    }
-
-    fn humanize_relative_date(&self, last_pulled: Option<DateTime<Utc>>) -> String {
-        match last_pulled {
-            None => "-".to_owned(),
-            Some(t) => format!("{}", HumanTime::from(t - Utc::now())),
-        }
-    }
-
-    fn humanize_data_size(&self, size: u64) -> String {
+    fn humanize_data_size(size: u64) -> String {
         if size == 0 {
             return "-".to_owned();
         }
@@ -207,7 +50,7 @@ impl ListCommand {
         format_size(size, BINARY)
     }
 
-    fn humanize_quantity(&self, num: u64) -> String {
+    fn humanize_quantity(num: u64) -> String {
         use num_format::{Locale, ToFormattedString};
         if num == 0 {
             return "-".to_owned();
@@ -238,12 +81,162 @@ impl ListCommand {
 #[async_trait::async_trait(?Send)]
 impl Command for ListCommand {
     async fn run(&mut self) -> Result<(), CLIError> {
-        // TODO: replace with formatters
-        match self.output_config.format {
-            OutputFormat::Table => self.print_pretty().await?,
-            OutputFormat::Csv => self.print_machine_readable().await?,
-            _ => unimplemented!("Unsupported format: {:?}", self.output_config.format),
+        use datafusion::arrow::{
+            array::{StringArray, TimestampMicrosecondArray, UInt64Array},
+            datatypes::{DataType, Field, Schema, TimeUnit},
+            record_batch::RecordBatch,
+        };
+
+        let records_format = RecordsFormat::new()
+            .with_default_column_format(ColumnFormat::default().with_null_value("-"))
+            .with_column_formats(if self.detail_level == 0 {
+                vec![
+                    ColumnFormat::new().with_style_spec("l"),
+                    ColumnFormat::new().with_style_spec("c"),
+                    ColumnFormat::new()
+                        .with_style_spec("c")
+                        .with_value_fmt(Self::humanize_relative_date),
+                    ColumnFormat::new()
+                        .with_style_spec("r")
+                        .with_value_fmt(Self::humanize_quantity),
+                    ColumnFormat::new()
+                        .with_style_spec("r")
+                        .with_value_fmt(Self::humanize_data_size),
+                ]
+            } else {
+                vec![
+                    ColumnFormat::new().with_style_spec("l"),
+                    ColumnFormat::new().with_style_spec("l"),
+                    ColumnFormat::new().with_style_spec("c"),
+                    ColumnFormat::new().with_style_spec("l"),
+                    ColumnFormat::new()
+                        .with_style_spec("c")
+                        .with_value_fmt(Self::humanize_relative_date),
+                    ColumnFormat::new()
+                        .with_style_spec("r")
+                        .with_value_fmt(Self::humanize_quantity),
+                    ColumnFormat::new()
+                        .with_style_spec("r")
+                        .with_value_fmt(Self::humanize_quantity),
+                    ColumnFormat::new()
+                        .with_style_spec("r")
+                        .with_value_fmt(Self::humanize_data_size),
+                    ColumnFormat::new()
+                        .with_style_spec("c")
+                        .with_value_fmt(Self::humanize_relative_date),
+                ]
+            });
+
+        let mut writer = self.output_config.get_records_writer(records_format);
+
+        let schema = Arc::new(Schema::new(if self.detail_level == 0 {
+            vec![
+                Field::new("Name", DataType::Utf8, false),
+                Field::new("Kind", DataType::Utf8, false),
+                Field::new(
+                    "Pulled",
+                    DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".to_string())),
+                    true,
+                ),
+                Field::new("Records", DataType::UInt64, false),
+                Field::new("Size", DataType::UInt64, false),
+            ]
+        } else {
+            vec![
+                Field::new("ID", DataType::Utf8, false),
+                Field::new("Name", DataType::Utf8, false),
+                Field::new("Kind", DataType::Utf8, false),
+                Field::new("Head", DataType::Utf8, false),
+                Field::new(
+                    "Pulled",
+                    DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".to_string())),
+                    true,
+                ),
+                Field::new("Records", DataType::UInt64, false),
+                Field::new("Blocks", DataType::UInt64, false),
+                Field::new("Size", DataType::UInt64, false),
+                Field::new(
+                    "Watermark",
+                    DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".to_string())),
+                    true,
+                ),
+            ]
+        }));
+
+        let mut id: Vec<String> = Vec::new();
+        let mut name: Vec<String> = Vec::new();
+        let mut kind: Vec<String> = Vec::new();
+        let mut head: Vec<String> = Vec::new();
+        let mut pulled: Vec<Option<i64>> = Vec::new();
+        let mut records: Vec<u64> = Vec::new();
+        let mut blocks: Vec<u64> = Vec::new();
+        let mut size: Vec<u64> = Vec::new();
+        let mut watermark: Vec<Option<i64>> = Vec::new();
+
+        let mut datasets: Vec<_> = self.local_repo.get_all_datasets().try_collect().await?;
+        datasets.sort_by(|a, b| a.name.cmp(&b.name));
+
+        for hdl in datasets.iter() {
+            let dataset = self.local_repo.get_dataset(&hdl.as_local_ref()).await?;
+            let current_head = dataset.as_metadata_chain().get_ref(&BlockRef::Head).await?;
+            let summary = dataset.get_summary(SummaryOptions::default()).await?;
+
+            name.push(hdl.name.to_string());
+            kind.push(self.get_kind(hdl, &summary).await?);
+            pulled.push(summary.last_pulled.map(|t| t.timestamp_micros()));
+            records.push(summary.num_records);
+            size.push(summary.data_size);
+
+            if self.detail_level > 0 {
+                // TODO: Should be precomputed
+                let mut num_blocks = 0;
+                let mut last_watermark: Option<DateTime<Utc>> = None;
+                let mut blocks_stream = dataset.as_metadata_chain().iter_blocks();
+                while let Some((_, b)) = blocks_stream.try_next().await? {
+                    if num_blocks == 0 {
+                        num_blocks = b.sequence_number as u64 + 1;
+                    }
+                    if let Some(b) = b.as_data_stream_block() {
+                        last_watermark = b.event.output_watermark.cloned();
+                        break;
+                    }
+                }
+
+                id.push(hdl.id.to_did_string());
+                head.push(current_head.to_multibase_string());
+                blocks.push(num_blocks);
+                watermark.push(last_watermark.map(|t| t.timestamp_micros()));
+            }
         }
+
+        let records = RecordBatch::try_new(
+            schema,
+            if self.detail_level == 0 {
+                vec![
+                    Arc::new(StringArray::from(name)),
+                    Arc::new(StringArray::from(kind)),
+                    Arc::new(TimestampMicrosecondArray::from(pulled).with_timezone_utc()),
+                    Arc::new(UInt64Array::from(records)),
+                    Arc::new(UInt64Array::from(size)),
+                ]
+            } else {
+                vec![
+                    Arc::new(StringArray::from(id)),
+                    Arc::new(StringArray::from(name)),
+                    Arc::new(StringArray::from(kind)),
+                    Arc::new(StringArray::from(head)),
+                    Arc::new(TimestampMicrosecondArray::from(pulled).with_timezone_utc()),
+                    Arc::new(UInt64Array::from(records)),
+                    Arc::new(UInt64Array::from(blocks)),
+                    Arc::new(UInt64Array::from(size)),
+                    Arc::new(TimestampMicrosecondArray::from(watermark).with_timezone_utc()),
+                ]
+            },
+        )
+        .unwrap();
+
+        writer.write_batches(&[records])?;
+        writer.finish()?;
 
         Ok(())
     }

--- a/kamu-cli/src/commands/sql_shell_command.rs
+++ b/kamu-cli/src/commands/sql_shell_command.rs
@@ -108,7 +108,9 @@ impl SqlShellCommand {
 
         let records = df.collect().await.map_err(|e| CLIError::failure(e))?;
 
-        let mut writer = self.output_config.get_records_writer();
+        let mut writer = self
+            .output_config
+            .get_records_writer(RecordsFormat::default());
         writer.write_batches(&records)?;
         writer.finish()?;
 

--- a/kamu-cli/src/commands/tail_command.rs
+++ b/kamu-cli/src/commands/tail_command.rs
@@ -49,7 +49,7 @@ impl Command for TailCommand {
 
         let record_batches = df.collect().await.map_err(|e| CLIError::failure(e))?;
 
-        let mut writer = self.output_cfg.get_records_writer();
+        let mut writer = self.output_cfg.get_records_writer(RecordsFormat::default());
         writer.write_batches(&record_batches)?;
         writer.finish()?;
         Ok(())

--- a/kamu-cli/src/output/output_config.rs
+++ b/kamu-cli/src/output/output_config.rs
@@ -10,6 +10,9 @@
 use kamu::infra::utils::records_writers::RecordsWriter;
 
 use super::records_writers::*;
+pub use super::records_writers::{ColumnFormat, RecordsFormat};
+
+/////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Clone)]
 pub struct OutputConfig {
@@ -20,7 +23,7 @@ pub struct OutputConfig {
 }
 
 impl OutputConfig {
-    pub fn get_records_writer(&self) -> Box<dyn RecordsWriter> {
+    pub fn get_records_writer(&self, fmt: RecordsFormat) -> Box<dyn RecordsWriter> {
         match self.format {
             OutputFormat::Csv => Box::new(
                 CsvWriterBuilder::new()
@@ -30,14 +33,12 @@ impl OutputConfig {
             OutputFormat::Json => Box::new(JsonArrayWriter::new(std::io::stdout())),
             OutputFormat::JsonLD => Box::new(JsonLineDelimitedWriter::new(std::io::stdout())),
             OutputFormat::JsonSoA => unimplemented!("SoA Json format is not yet implemented"),
-            OutputFormat::Table => Box::new(
-                TableWriter::new()
-                    .with_max_cell_len(Some(90))
-                    .with_binary_placeholder(Some("<binary>".to_owned())),
-            ),
+            OutputFormat::Table => Box::new(TableWriter::new(fmt)),
         }
     }
 }
+
+/////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Clone, Copy)]
 pub enum OutputFormat {

--- a/kamu-cli/src/output/records_writers.rs
+++ b/kamu-cli/src/output/records_writers.rs
@@ -7,48 +7,258 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use chrono::{DateTime, Utc};
+use datafusion::arrow::array::ArrayRef;
 use datafusion::arrow::util::display::array_value_to_string;
 use datafusion::arrow::{datatypes::DataType, record_batch::RecordBatch};
 pub use kamu::infra::utils::records_writers::{
     CsvWriter, CsvWriterBuilder, JsonArrayWriter, JsonLineDelimitedWriter, RecordsWriter,
 };
 use prettytable::{Cell, Row, Table};
+use std::any::Any;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+macro_rules! format_typed {
+    ($array_type:ty, $item_type: ty, $array: ident, $value_fmt: ident, $row: ident) => {{
+        let t_array = $array.as_any().downcast_ref::<$array_type>().unwrap();
+        let t_value_fmt = $value_fmt
+            .downcast_ref::<fn($item_type) -> String>()
+            .unwrap();
+        t_value_fmt(t_array.value($row))
+    }};
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct RecordsFormat {
+    column_formats: Vec<ColumnFormat>,
+    default_column_format: ColumnFormat,
+}
+
+impl RecordsFormat {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_column_formats(self, column_formats: Vec<ColumnFormat>) -> Self {
+        Self {
+            column_formats,
+            ..self
+        }
+    }
+
+    pub fn with_default_column_format(self, default_column_format: ColumnFormat) -> Self {
+        Self {
+            default_column_format,
+            ..self
+        }
+    }
+
+    pub fn get_style_spec(&self, _row: usize, column: usize, _array: &ArrayRef) -> &str {
+        self.column_formats
+            .get(column)
+            .and_then(|cf| cf.style_spec.as_ref())
+            .or_else(|| self.default_column_format.style_spec.as_ref())
+            .map(|s| s.as_str())
+            .unwrap()
+    }
+
+    pub fn format(&self, row: usize, col: usize, array: &ArrayRef) -> String {
+        use datafusion::arrow::array::*;
+        use datafusion::arrow::datatypes::TimeUnit;
+
+        // Check for null
+        let null_value = self
+            .column_formats
+            .get(col)
+            .and_then(|cf| cf.null_value.as_ref())
+            .or_else(|| self.default_column_format.null_value.as_ref())
+            .unwrap();
+
+        if array.is_null(row) {
+            return null_value.clone();
+        }
+
+        // Check for binary data
+        match array.data_type() {
+            DataType::Binary
+            | DataType::LargeBinary
+            | DataType::List(_)
+            | DataType::LargeList(_) => {
+                let binary_placeholder = self
+                    .column_formats
+                    .get(col)
+                    .and_then(|cf| cf.binary_placeholder.as_ref())
+                    .or_else(|| self.default_column_format.binary_placeholder.as_ref());
+
+                if let Some(binary_placeholder) = binary_placeholder {
+                    return binary_placeholder.clone();
+                }
+            }
+            _ => (),
+        }
+
+        // Format value
+        let mut value = if let Some(value_fmt) = self
+            .column_formats
+            .get(col)
+            .and_then(|cf| cf.value_fmt.as_ref())
+            .or_else(|| self.default_column_format.value_fmt.as_ref())
+        {
+            match array.data_type() {
+                DataType::Int8 => format_typed!(Int8Array, i8, array, value_fmt, row),
+                DataType::Int16 => format_typed!(Int16Array, i16, array, value_fmt, row),
+                DataType::Int32 => format_typed!(Int32Array, i32, array, value_fmt, row),
+                DataType::Int64 => format_typed!(Int64Array, i64, array, value_fmt, row),
+                DataType::UInt8 => format_typed!(UInt8Array, u8, array, value_fmt, row),
+                DataType::UInt16 => format_typed!(UInt16Array, u16, array, value_fmt, row),
+                DataType::UInt32 => format_typed!(UInt32Array, u32, array, value_fmt, row),
+                DataType::UInt64 => format_typed!(UInt64Array, u64, array, value_fmt, row),
+                DataType::Float32 => format_typed!(Float32Array, f32, array, value_fmt, row),
+                DataType::Float64 => format_typed!(Float64Array, f64, array, value_fmt, row),
+                DataType::Timestamp(time_unit, _) => match time_unit {
+                    TimeUnit::Microsecond => {
+                        let t_array = array
+                            .as_any()
+                            .downcast_ref::<TimestampMicrosecondArray>()
+                            .unwrap();
+                        let t_value_fmt = value_fmt
+                            .downcast_ref::<fn(DateTime<Utc>) -> String>()
+                            .unwrap();
+                        let value = t_array.value_as_datetime(row).unwrap();
+                        let value = DateTime::from_utc(value, Utc);
+                        t_value_fmt(value)
+                    }
+                    _ => unimplemented!(),
+                },
+                _ => unimplemented!(),
+            }
+        } else {
+            array_value_to_string(array, row).unwrap()
+        };
+
+        // Truncate to limit
+        // TODO: Avoid formatting very long values in the first place
+        if let Some(max_len) = self
+            .column_formats
+            .get(col)
+            .and_then(|cf| cf.max_len)
+            .or_else(|| self.default_column_format.max_len)
+        {
+            if value.len() > max_len {
+                value.truncate(max_len);
+                value.push_str("...");
+            }
+        }
+
+        value
+    }
+}
+
+impl Default for RecordsFormat {
+    fn default() -> Self {
+        Self {
+            column_formats: Vec::new(),
+            default_column_format: ColumnFormat::new()
+                .with_style_spec("r")
+                .with_null_value("")
+                .with_binary_placeholder("<binary>")
+                .with_max_len(90),
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct ColumnFormat {
+    style_spec: Option<String>,
+    null_value: Option<String>,
+    binary_placeholder: Option<String>,
+    max_len: Option<usize>,
+    value_fmt: Option<Box<dyn Any>>,
+}
+
+impl ColumnFormat {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_style_spec(self, style_spec: impl Into<String>) -> Self {
+        Self {
+            style_spec: Some(style_spec.into()),
+            ..self
+        }
+    }
+
+    pub fn with_null_value(self, null_value: impl Into<String>) -> Self {
+        Self {
+            null_value: Some(null_value.into()),
+            ..self
+        }
+    }
+
+    pub fn with_binary_placeholder(self, binary_placeholder: impl Into<String>) -> Self {
+        Self {
+            binary_placeholder: Some(binary_placeholder.into()),
+            ..self
+        }
+    }
+
+    pub fn with_max_len(self, max_len: usize) -> Self {
+        Self {
+            max_len: Some(max_len),
+            ..self
+        }
+    }
+
+    pub fn with_value_fmt<T: 'static>(self, value_fmt: fn(T) -> String) -> Self {
+        Self {
+            value_fmt: Some(Box::new(value_fmt)),
+            ..self
+        }
+    }
+
+    pub fn get_style_spec(&self) -> Option<&str> {
+        self.style_spec.as_ref().map(|s| s.as_str())
+    }
+}
+
+impl Default for ColumnFormat {
+    fn default() -> Self {
+        Self {
+            style_spec: None,
+            null_value: None,
+            binary_placeholder: None,
+            max_len: None,
+            value_fmt: None,
+        }
+    }
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 pub struct TableWriter {
-    first_row_written: bool,
+    format: RecordsFormat,
+    header_written: bool,
+    rows_written: usize,
+    num_columns: usize,
     table: Table,
-    max_cell_len: Option<usize>,
-    binary_placeholder: Option<String>,
 }
 
 impl TableWriter {
     // TODO: prettytable is hard to print out into a generic Writer
     // as it wants tty output to implement term::Terminal trait
-    pub fn new() -> Self {
+    pub fn new(format: RecordsFormat) -> Self {
         let mut table = Table::new();
         table.set_format(Self::get_table_format());
 
         Self {
-            first_row_written: false,
+            format,
+            header_written: false,
+            rows_written: 0,
+            num_columns: 0,
             table,
-            max_cell_len: None,
-            binary_placeholder: None,
-        }
-    }
-
-    pub fn with_max_cell_len(self, max_cell_len: Option<usize>) -> Self {
-        Self {
-            max_cell_len,
-            ..self
-        }
-    }
-
-    pub fn with_binary_placeholder(self, binary_placeholder: Option<String>) -> Self {
-        Self {
-            binary_placeholder,
-            ..self
         }
     }
 
@@ -74,49 +284,42 @@ impl TableWriter {
 
 impl RecordsWriter for TableWriter {
     fn write_batch(&mut self, records: &RecordBatch) -> Result<(), std::io::Error> {
-        if !self.first_row_written {
+        if !self.header_written {
             let mut header = Vec::new();
             for field in records.schema().fields() {
                 header.push(Cell::new(&field.name()).style_spec("bc"));
             }
             self.table.set_titles(Row::new(header));
-            self.first_row_written = true;
+            self.header_written = true;
+            self.num_columns = records.schema().fields().len();
         }
 
         for row in 0..records.num_rows() {
             let mut cells = Vec::new();
             for col in 0..records.num_columns() {
-                let column = records.column(col);
+                let array = records.column(col);
 
-                if let Some(binary_placeholder) = &self.binary_placeholder {
-                    match column.data_type() {
-                        DataType::Binary
-                        | DataType::LargeBinary
-                        | DataType::List(_)
-                        | DataType::LargeList(_) => {
-                            cells.push(Cell::new(binary_placeholder).style_spec("r"));
-                            continue;
-                        }
-                        _ => (),
-                    }
-                }
-
-                let mut value = array_value_to_string(&column, row).unwrap();
-
-                if self.max_cell_len.is_some() && value.len() > self.max_cell_len.unwrap() {
-                    value.truncate(self.max_cell_len.unwrap());
-                    value.push_str("...");
-                }
-
-                cells.push(Cell::new(&value).style_spec("r"));
+                let style_spec = self.format.get_style_spec(row, col, &array);
+                let value = self.format.format(row, col, &array);
+                cells.push(Cell::new(&value).style_spec(style_spec));
             }
             self.table.add_row(Row::new(cells));
+            self.rows_written += 1;
         }
 
         Ok(())
     }
 
     fn finish(&mut self) -> Result<(), std::io::Error> {
+        // BUG: Header doesn't render when there are no data rows in the table
+        // so we add an empty row
+        if self.rows_written == 0 {
+            let row = self.table.add_empty_row();
+            for _ in 0..self.num_columns {
+                row.add_cell(Cell::new(""));
+            }
+        }
+
         self.table.printstd();
         Ok(())
     }

--- a/kamu-core/Cargo.toml
+++ b/kamu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu"
-version = "0.103.0"
+version = "0.104.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/opendatafabric/Cargo.toml
+++ b/opendatafabric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendatafabric"
-version = "0.103.0"
+version = "0.104.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/utils/container-runtime/Cargo.toml
+++ b/utils/container-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-runtime"
-version = "0.103.0"
+version = "0.104.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../../LICENSE.txt"


### PR DESCRIPTION
Previously `kamu list` was using a completely custom output than the rest of the tabular output commands (e.g. `kamu tail`, `kamu sql -c`) because it needed some custom formatting that was not available for `RecordsBatch`es.

This PR unifies tabular output allowing you to specify custom formatting rules per column. This allows `kamu list --output-fromat <json/json-ld/...>` to work, which is very useful for scripting and automation.