### PR TITLE
Bug: GQL empty json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.105.0] - 2023-01-13
 ### Fixed
 - Upgraded `sparkmagic` dependency and removed hacks to make it work with latest `pandas`.
+- Returning `[]` instead of empty string for no data in GQL
+### Changed
+- Improved testing utilities
+- Refactored commit procedure
 
 ## [0.104.0] - 2022-12-28
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
  "chrono",
  "comfy-table",
  "half",
- "hashbrown 0.13.1",
+ "hashbrown 0.13.2",
  "multiversion",
  "num",
  "regex",
@@ -139,7 +139,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.13.1",
+ "hashbrown 0.13.2",
  "num",
 ]
 
@@ -313,21 +313,22 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "5.0.4"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d56592fdc896f45ca73e04f9562033f95ab38b33878155464003187190bb4ba"
+checksum = "6c7c1f9bf1a875b047e97404d16313b3dde09ea06d0639800c9657138e38a441"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
  "async-graphql-value",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "fast_chemail",
  "fnv",
  "futures-util",
+ "handlebars",
  "http",
  "indexmap",
  "mime",
@@ -347,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-axum"
-version = "5.0.4"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ede00c2c015686678e91181253b8811c405e17c9185cddb6ff29b84849516a9"
+checksum = "7376168771050c81d948df67fdabccf0ed9a238e565c6ca8065af6eccc570d84"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -364,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "5.0.4"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbc24a7c61fb52fa8eb563b8ca60ec890d54778be644796ef72047a07c555b2"
+checksum = "381ed1575c53cfc864013932bb5a5df05c21802781dfa6dd27c57068eac9a80d"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -380,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "5.0.4"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dd090476ce5300418018518c25f2247576a214ffadc504f2af1f074939daf8"
+checksum = "41a7ec217e184ca3034c806957842afb28914f894b69cb5a76b4a57e64f44506"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -392,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "5.0.4"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305055a67bece03b7c870544b38d5ed87aaa4d6792f14e4aabdd33e5e43120fa"
+checksum = "e294ef57859c27d31a9bb23edf1db948f7534445df30115d8672314f65451858"
 dependencies = [
  "bytes",
  "indexmap",
@@ -436,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -453,13 +454,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
+checksum = "1304eab461cf02bd70b083ed8273388f9724c549b316ba3d1e213ce0e9e7fb7e"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64",
+ "base64 0.20.0",
  "bitflags",
  "bytes",
  "futures-util",
@@ -478,7 +479,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha-1",
+ "sha1",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -490,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
+checksum = "f487e40dc9daee24d8a1779df88522f159a54a980f99cfbe43db0be0bd3444a8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -510,6 +511,18 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
@@ -626,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -753,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.3"
+version = "6.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e621e7e86c46fd8a14c32c6ae3cb95656621b4743a27d0cffedb831d46e7ad21"
+checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
 dependencies = [
  "strum",
  "strum_macros",
@@ -764,15 +777,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
+checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
 dependencies = [
  "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -811,7 +824,7 @@ checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "container-runtime"
-version = "0.104.0"
+version = "0.105.0"
 dependencies = [
  "dill",
  "regex",
@@ -1007,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
+checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1019,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
+checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1034,15 +1047,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
+checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
+checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1129,7 +1142,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.6",
 ]
 
 [[package]]
@@ -1160,7 +1173,7 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "hashbrown 0.13.1",
+ "hashbrown 0.13.2",
  "itertools",
  "lazy_static",
  "log",
@@ -1218,7 +1231,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "hashbrown 0.13.1",
+ "hashbrown 0.13.2",
  "log",
 ]
 
@@ -1238,7 +1251,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-row",
  "half",
- "hashbrown 0.13.1",
+ "hashbrown 0.13.2",
  "itertools",
  "lazy_static",
  "md-5 0.10.5",
@@ -1366,9 +1379,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "duration-string"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed54458e2c14ff3f2241c0ad1c199ae9674c4e050104ad8dc0803415331bf932"
+checksum = "c5d74010fd35f37054de1eb72485be4f562b0815e0e7b477e578581d3998fa47"
 dependencies = [
  "serde",
 ]
@@ -1496,7 +1509,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1700,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1725,12 +1738,26 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
 dependencies = [
  "crunchy",
  "num-traits",
+]
+
+[[package]]
+name = "handlebars"
+version = "4.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "035ef95d03713f2c347a72547b7cd38cbc9af7cd51e6099fb62d586d4a6dee3a"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1741,9 +1768,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
@@ -1754,7 +1781,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1866,9 +1893,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humansize"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e682e2bd70ecbcce5209f11a992a4ba001fea8e60acf7860ce007629e6d2756"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
 ]
@@ -1928,7 +1955,7 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls 0.23.4",
 ]
@@ -2089,12 +2116,12 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2104,16 +2131,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
 dependencies = [
  "socket2",
- "widestring 0.5.1",
+ "widestring",
  "winapi",
  "winreg",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
@@ -2124,7 +2151,7 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2194,7 +2221,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "kamu"
-version = "0.104.0"
+version = "0.105.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -2258,12 +2285,13 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.104.0"
+version = "0.105.0"
 dependencies = [
  "async-graphql",
  "chrono",
  "datafusion",
  "dill",
+ "env_logger",
  "futures",
  "indoc",
  "kamu",
@@ -2272,12 +2300,15 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "test-log",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "kamu-cli"
-version = "0.104.0"
+version = "0.105.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2654,12 +2685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,7 +2729,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2789,12 +2814,11 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom8"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d908f0297c3526d34e478d438b07eefe3d7b0416494d7ffccb17f1c7f7262c"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2930,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0014545954c5023b5fb8260415e54467cde434db6c824c9028a4b329f1b28e48"
+checksum = "b4201837dc4c27a8670f0363b1255cd3845a4f0c521211cced1ed14c1d0cc6d2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2950,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -2962,7 +2986,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendatafabric"
-version = "0.104.0"
+version = "0.105.0"
 dependencies = [
  "bs58",
  "byteorder",
@@ -3079,7 +3103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.6",
 ]
 
 [[package]]
@@ -3098,15 +3122,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3123,13 +3147,13 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.13.1",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
  "futures",
- "hashbrown 0.13.1",
+ "hashbrown 0.13.2",
  "lz4",
  "num",
  "num-bigint",
@@ -3139,7 +3163,7 @@ dependencies = [
  "thrift",
  "tokio",
  "twox-hash",
- "zstd 0.12.1+zstd.1.5.2",
+ "zstd 0.12.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -3185,12 +3209,46 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
 dependencies = [
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -3309,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3319,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3500,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3540,7 +3598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3559,7 +3617,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3624,7 +3682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "crc32fast",
  "futures",
@@ -3679,7 +3737,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "digest 0.9.0",
@@ -3774,7 +3832,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3783,7 +3841,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "log",
  "ring",
  "sct 0.6.1",
@@ -3792,9 +3850,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -3816,11 +3874,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -3846,12 +3904,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3975,11 +4032,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
+checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chrono",
  "hex",
  "indexmap",
@@ -3991,9 +4048,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
+checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
 dependencies = [
  "darling 0.14.2",
  "proc-macro2",
@@ -4012,17 +4069,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -4439,9 +4485,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4454,7 +4500,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4505,7 +4551,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -4523,9 +4569,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
@@ -4565,9 +4611,9 @@ checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
 
 [[package]]
 name = "toml_edit"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c040d7eb2b695a2a39048f9d8e7ee865ef1c57cd9c44ba9b4a4d389095f7e6a"
+checksum = "a34cc558345efd7e88b9eda9626df2138b80bb46a7606f695e751c892bc7dac6"
 dependencies = [
  "indexmap",
  "itertools",
@@ -4584,7 +4630,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4718,10 +4764,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-bunyan-formatter"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2445962f94a813b2aaea29ceeccb6dce9fd3aa5b1cb45595cde755b00d021ad"
+checksum = "78fa7c4b548e5c79a0300396f36f175da001e9933dfb5960b326db25fddbaee7"
 dependencies = [
+ "ahash",
  "gethostname",
  "log",
  "serde",
@@ -4829,24 +4876,24 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
@@ -5118,18 +5165,20 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0cc7962b5aaa0dfcebaeef0161eec6edf5f4606c12e6777fd7d392f52033a5"
+checksum = "e74f5ff7786c4c21f61ba8e30ea29c9745f06fca0a4a02d083b3c662583399e8"
 dependencies = [
+ "core-foundation",
+ "dirs",
  "jni",
+ "log",
  "ndk-context",
  "objc",
  "raw-window-handle",
  "url",
  "web-sys",
- "widestring 1.0.2",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -5168,12 +5217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
-name = "widestring"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5205,16 +5248,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.36.1"
+name = "windows"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5224,85 +5269,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"
@@ -5398,9 +5413,9 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.1+zstd.1.5.2"
+version = "0.12.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c947d2adc84ff9a59f2e3c03b81aa4128acf28d6ad7d56273f7e8af14e47bea"
+checksum = "e9262a83dc741c0b0ffec209881b45dbc232c21b02a2b9cb1adb93266e41303d"
 dependencies = [
  "zstd-safe 6.0.2+zstd.1.5.2",
 ]
@@ -5427,10 +5442,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.4+zstd.1.5.2"
+version = "2.0.5+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+checksum = "edc50ffce891ad571e9f9afe5039c4837bede781ac4bb13052ed7ae695518596"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.104.0
+Licensed Work:             Kamu CLI Version 0.105.0
                            The Licensed Work is © 2021 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2026-12-28
+Change Date:               2027-01-13
 
 Change License:            Apache License, Version 2.0
 

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,7 +1,7 @@
 IMAGE_REPO = docker.io/kamudata
 IMAGE_JUPYTER_TAG = 0.5.0
 
-KAMU_VERSION = 0.104.0
+KAMU_VERSION = 0.105.0
 
 
 .PHONY: jupyter

--- a/images/demo/Makefile
+++ b/images/demo/Makefile
@@ -1,5 +1,5 @@
 IMAGE_REPO = docker.io/kamudata
-KAMU_VERSION = 0.104.0
+KAMU_VERSION = 0.105.0
 DEMO_VERSION = 0.6.1
 
 #########################################################################################

--- a/kamu-adapter-graphql/Cargo.toml
+++ b/kamu-adapter-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-adapter-graphql"
-version = "0.104.0"
+version = "0.105.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 
@@ -28,6 +28,7 @@ datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "975ff1
 futures = "*"
 serde = "*"
 serde_json = "*"
+tracing = "*"
 # tokio = { version = "*", features = ["macros"] }
 # url = "*"
 
@@ -35,3 +36,6 @@ serde_json = "*"
 [dev-dependencies]
 tempfile = "*"
 tokio = { version = "*" }
+env_logger = "*"
+test-log = { version = "*", features = ["trace"] }
+tracing-subscriber = { version = "*", features = ["env-filter"] }

--- a/kamu-adapter-graphql/src/queries/dataset.rs
+++ b/kamu-adapter-graphql/src/queries/dataset.rs
@@ -75,7 +75,7 @@ impl Dataset {
     async fn kind(&self, ctx: &Context<'_>) -> Result<DatasetKind> {
         let dataset = self.get_dataset(ctx).await?;
         let summary = dataset
-            .get_summary(domain::SummaryOptions::default())
+            .get_summary(domain::GetSummaryOpts::default())
             .await?;
         Ok(summary.kind.into())
     }

--- a/kamu-adapter-graphql/src/queries/dataset_data.rs
+++ b/kamu-adapter-graphql/src/queries/dataset_data.rs
@@ -12,8 +12,9 @@ use crate::utils::*;
 
 use async_graphql::*;
 use kamu::domain;
-use kamu::domain::SummaryOptions;
+use kamu::domain::GetSummaryOpts;
 use opendatafabric as odf;
+use tracing::debug;
 
 pub struct DatasetData {
     dataset_handle: odf::DatasetHandle,
@@ -34,7 +35,7 @@ impl DatasetData {
         let dataset = local_repo
             .get_dataset(&self.dataset_handle.as_local_ref())
             .await?;
-        let summary = dataset.get_summary(SummaryOptions::default()).await?;
+        let summary = dataset.get_summary(GetSummaryOpts::default()).await?;
         Ok(summary.num_records)
     }
 
@@ -44,7 +45,7 @@ impl DatasetData {
         let dataset = local_repo
             .get_dataset(&self.dataset_handle.as_local_ref())
             .await?;
-        let summary = dataset.get_summary(SummaryOptions::default()).await?;
+        let summary = dataset.get_summary(GetSummaryOpts::default()).await?;
         Ok(summary.data_size)
     }
 
@@ -68,7 +69,10 @@ impl DatasetData {
             .await
         {
             Ok(r) => r,
-            Err(e) => return Ok(e.into()),
+            Err(err) => {
+                debug!(?err, "Query error");
+                return Ok(err.into());
+            }
         };
 
         let schema = DataSchema::from_data_frame_schema(df.schema(), schema_format)?;

--- a/kamu-adapter-graphql/src/queries/dataset_metadata.rs
+++ b/kamu-adapter-graphql/src/queries/dataset_metadata.rs
@@ -91,7 +91,7 @@ impl DatasetMetadata {
     async fn current_upstream_dependencies(&self, ctx: &Context<'_>) -> Result<Vec<Dataset>> {
         let dataset = self.get_dataset(ctx).await?;
         let summary = dataset
-            .get_summary(domain::SummaryOptions::default())
+            .get_summary(domain::GetSummaryOpts::default())
             .await?;
         Ok(summary
             .dependencies

--- a/kamu-adapter-graphql/src/scalars/dataset.rs
+++ b/kamu-adapter-graphql/src/scalars/dataset.rs
@@ -192,7 +192,18 @@ impl DataBatch {
                 DataBatchFormat::Csv => {
                     Box::new(CsvWriterBuilder::new().has_headers(true).build(&mut buf))
                 }
-                DataBatchFormat::Json => Box::new(JsonArrayWriter::new(&mut buf)),
+                DataBatchFormat::Json => {
+                    // HACK: JsonArrayWriter should be producing [] when there are no rows
+                    if num_records != 0 {
+                        Box::new(JsonArrayWriter::new(&mut buf))
+                    } else {
+                        return Ok(DataBatch {
+                            format,
+                            content: "[]".to_string(),
+                            num_records: num_records as u64,
+                        });
+                    }
+                }
                 DataBatchFormat::JsonLD => Box::new(JsonLineDelimitedWriter::new(&mut buf)),
                 DataBatchFormat::JsonSOA => {
                     unimplemented!("SoA Json format is not yet implemented")

--- a/kamu-adapter-graphql/tests/tests/mod.rs
+++ b/kamu-adapter-graphql/tests/tests/mod.rs
@@ -7,5 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod test_gql_data;
 mod test_gql_datasets;
 mod test_gql_search;

--- a/kamu-adapter-graphql/tests/tests/test_gql_data.rs
+++ b/kamu-adapter-graphql/tests/tests/test_gql_data.rs
@@ -1,0 +1,189 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use datafusion::arrow::array::*;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::datatypes::Field;
+use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::record_batch::RecordBatch;
+use kamu::domain::*;
+use kamu::infra;
+use kamu::testing::MetadataFactory;
+use kamu::testing::ParquetWriterHelper;
+use opendatafabric::*;
+
+use std::path::Path;
+use std::sync::Arc;
+
+async fn create_test_dataset(tempdir: &Path) -> dill::Catalog {
+    let workspace_layout = Arc::new(infra::WorkspaceLayout::create(tempdir).unwrap());
+    let local_repo = infra::LocalDatasetRepositoryImpl::new(workspace_layout.clone());
+
+    let cat = dill::CatalogBuilder::new()
+        .add_value(local_repo)
+        .add_value(workspace_layout.as_ref().clone())
+        .bind::<dyn LocalDatasetRepository, infra::LocalDatasetRepositoryImpl>()
+        .add::<infra::QueryServiceImpl>()
+        .bind::<dyn QueryService, infra::QueryServiceImpl>()
+        .build();
+
+    let local_repo = cat.get_one::<dyn LocalDatasetRepository>().unwrap();
+    let dataset_builder = local_repo
+        .create_dataset(&DatasetName::new_unchecked("foo"))
+        .await
+        .unwrap();
+
+    let ds = dataset_builder.as_dataset();
+    ds.commit_event(
+        MetadataEvent::Seed(MetadataFactory::seed(DatasetKind::Root).build()),
+        CommitOpts::default(),
+    )
+    .await
+    .unwrap();
+
+    let tmp_data_path = tempdir.join("data");
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("offset", DataType::UInt64, false),
+        Field::new("blah", DataType::Utf8, false),
+    ]));
+    let a: Arc<dyn Array> = Arc::new(UInt64Array::from(vec![0, 1, 2]));
+    let b: Arc<dyn Array> = Arc::new(StringArray::from(vec!["a", "b", "c"]));
+    let record_batch =
+        RecordBatch::try_new(Arc::clone(&schema), vec![Arc::clone(&a), Arc::clone(&b)]).unwrap();
+    ParquetWriterHelper::from_record_batch(&tmp_data_path, &record_batch).unwrap();
+
+    ds.commit_add_data(
+        None,
+        Some(OffsetInterval { start: 0, end: 3 }),
+        Some(tmp_data_path),
+        None,
+        None,
+        CommitOpts::default(),
+    )
+    .await
+    .unwrap();
+
+    dataset_builder.finish().await.unwrap();
+
+    cat
+}
+
+#[test_log::test(tokio::test)]
+async fn test_dataset_schema() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let cat = create_test_dataset(tempdir.path()).await;
+
+    let schema = kamu_adapter_graphql::schema(cat);
+    let res = schema
+        .execute(indoc::indoc!(
+            "{
+                datasets {
+                    byOwnerAndName(accountName: \"kamu\", datasetName: \"foo\") {
+                        name 
+                        data {
+                            tail(limit: 1, schemaFormat: PARQUET_JSON, dataFormat: JSON) {
+                                ... on DataQueryResultSuccess {
+                                    schema { content } 
+                                }
+                            }
+                        }
+                    }
+                }
+            }"
+        ))
+        .await;
+    assert!(res.is_ok(), "{:?}", res);
+    let json = serde_json::to_string(&res.data).unwrap();
+    let json = serde_json::from_str::<serde_json::Value>(&json).unwrap();
+    let data_schema = &json["datasets"]["byOwnerAndName"]["data"]["tail"]["schema"]["content"];
+    let data_schema =
+        serde_json::from_str::<serde_json::Value>(data_schema.as_str().unwrap()).unwrap();
+    assert_eq!(
+        data_schema,
+        serde_json::json!({
+            "name": "arrow_schema",
+            "type": "struct",
+            "fields": [{
+                "name": "offset",
+                "repetition": "REQUIRED",
+                "type": "INT64",
+                "logicalType": "INTEGER(64,false)"
+            }, {
+                "name": "blah",
+                "repetition": "REQUIRED",
+                "type": "BYTE_ARRAY",
+                "logicalType": "STRING"
+            }]
+        })
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_dataset_tail() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let cat = create_test_dataset(tempdir.path()).await;
+
+    let schema = kamu_adapter_graphql::schema(cat);
+    let res = schema
+        .execute(indoc::indoc!(
+            "{
+                datasets {
+                    byOwnerAndName(accountName: \"kamu\", datasetName: \"foo\") {
+                        name 
+                        data {
+                            tail(limit: 1, schemaFormat: PARQUET_JSON, dataFormat: JSON) {
+                                ... on DataQueryResultSuccess {
+                                    data { content }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"
+        ))
+        .await;
+    assert!(res.is_ok(), "{:?}", res);
+    let json = serde_json::to_string(&res.data).unwrap();
+    let json = serde_json::from_str::<serde_json::Value>(&json).unwrap();
+    let data = &json["datasets"]["byOwnerAndName"]["data"]["tail"]["data"]["content"];
+    let data = serde_json::from_str::<serde_json::Value>(data.as_str().unwrap()).unwrap();
+    assert_eq!(data, serde_json::json!([{"blah":"c","offset":2}]));
+}
+
+#[test_log::test(tokio::test)]
+async fn test_dataset_tail_empty() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let cat = create_test_dataset(tempdir.path()).await;
+
+    let schema = kamu_adapter_graphql::schema(cat);
+    let res = schema
+        .execute(indoc::indoc!(
+            "{
+                datasets {
+                    byOwnerAndName(accountName: \"kamu\", datasetName: \"foo\") {
+                        name 
+                        data {
+                            tail(limit: 0, schemaFormat: PARQUET_JSON, dataFormat: JSON) {
+                                ... on DataQueryResultSuccess {
+                                    data { content }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"
+        ))
+        .await;
+    assert!(res.is_ok(), "{:?}", res);
+    let json = serde_json::to_string(&res.data).unwrap();
+    let json = serde_json::from_str::<serde_json::Value>(&json).unwrap();
+    let data = &json["datasets"]["byOwnerAndName"]["data"]["tail"]["data"]["content"];
+    let data = serde_json::from_str::<serde_json::Value>(data.as_str().unwrap()).unwrap();
+    assert_eq!(data, serde_json::json!([]));
+}

--- a/kamu-adapter-graphql/tests/tests/test_gql_data.rs
+++ b/kamu-adapter-graphql/tests/tests/test_gql_data.rs
@@ -75,6 +75,7 @@ async fn create_test_dataset(tempdir: &Path) -> dill::Catalog {
 }
 
 #[test_log::test(tokio::test)]
+#[cfg_attr(not(unix), ignore)] // TODO: DataFusion crashes on windows
 async fn test_dataset_schema() {
     let tempdir = tempfile::tempdir().unwrap();
     let cat = create_test_dataset(tempdir.path()).await;
@@ -125,6 +126,7 @@ async fn test_dataset_schema() {
 }
 
 #[test_log::test(tokio::test)]
+#[cfg_attr(not(unix), ignore)] // TODO: DataFusion crashes on windows
 async fn test_dataset_tail() {
     let tempdir = tempfile::tempdir().unwrap();
     let cat = create_test_dataset(tempdir.path()).await;
@@ -157,6 +159,7 @@ async fn test_dataset_tail() {
 }
 
 #[test_log::test(tokio::test)]
+#[cfg_attr(not(unix), ignore)] // TODO: DataFusion crashes on windows
 async fn test_dataset_tail_empty() {
     let tempdir = tempfile::tempdir().unwrap();
     let cat = create_test_dataset(tempdir.path()).await;

--- a/kamu-cli/Cargo.toml
+++ b/kamu-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-cli"
-version = "0.104.0"
+version = "0.105.0"
 description = "Decentralized data management tool"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"

--- a/kamu-cli/src/commands/list_command.rs
+++ b/kamu-cli/src/commands/list_command.rs
@@ -179,7 +179,7 @@ impl Command for ListCommand {
         for hdl in datasets.iter() {
             let dataset = self.local_repo.get_dataset(&hdl.as_local_ref()).await?;
             let current_head = dataset.as_metadata_chain().get_ref(&BlockRef::Head).await?;
-            let summary = dataset.get_summary(SummaryOptions::default()).await?;
+            let summary = dataset.get_summary(GetSummaryOpts::default()).await?;
 
             name.push(hdl.name.to_string());
             kind.push(self.get_kind(hdl, &summary).await?);

--- a/kamu-cli/src/commands/pull_command.rs
+++ b/kamu-cli/src/commands/pull_command.rs
@@ -116,7 +116,7 @@ impl PullCommand {
             .local_repo
             .get_dataset(&dataset_handle.as_local_ref())
             .await?
-            .get_summary(SummaryOptions::default())
+            .get_summary(GetSummaryOpts::default())
             .await?;
 
         if summary.kind != DatasetKind::Root {

--- a/kamu-cli/tests/tests/test_pull_command.rs
+++ b/kamu-cli/tests/tests/test_pull_command.rs
@@ -79,16 +79,15 @@ async fn test_pull_ingest_from_file() {
             parquet
                 .get_row_iter()
                 .map(|r| (
-                    r.get_long(0).unwrap(),
                     r.get_string(3).unwrap().clone(),
                     r.get_long(4).unwrap()
                 ))
                 .sorted()
                 .collect::<Vec<_>>(),
             [
-                (0, "A".to_owned(), 1000),
-                (1, "B".to_owned(), 2000),
-                (2, "C".to_owned(), 3000)
+                ("A".to_owned(), 1000),
+                ("B".to_owned(), 2000),
+                ("C".to_owned(), 3000)
             ]
         );
     }
@@ -122,16 +121,15 @@ async fn test_pull_ingest_from_file() {
             parquet
                 .get_row_iter()
                 .map(|r| (
-                    r.get_long(0).unwrap(),
                     r.get_string(3).unwrap().clone(),
                     r.get_long(4).unwrap()
                 ))
                 .sorted()
                 .collect::<Vec<_>>(),
             [
-                (0, "A".to_owned(), 1100),
-                (1, "B".to_owned(), 2100),
-                (2, "C".to_owned(), 3100)
+                ("A".to_owned(), 1100),
+                ("B".to_owned(), 2100),
+                ("C".to_owned(), 3100)
             ]
         );
     }

--- a/kamu-cli/tests/tests/test_pull_command.rs
+++ b/kamu-cli/tests/tests/test_pull_command.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 
 use datafusion::parquet::record::RowAccessor;
 use indoc::indoc;
+use itertools::Itertools;
 use opendatafabric::*;
 use url::Url;
 
@@ -71,15 +72,23 @@ async fn test_pull_ingest_from_file() {
             .get_last_data_slice(&DatasetName::new_unchecked("population"))
             .await;
         assert_eq!(
-            parquet.column_names(),
+            parquet.get_column_names(),
             ["offset", "system_time", "event_time", "city", "population"]
         );
         assert_eq!(
-            parquet.records(|r| (r.get_string(3).unwrap().clone(), r.get_long(4).unwrap())),
+            parquet
+                .get_row_iter()
+                .map(|r| (
+                    r.get_long(0).unwrap(),
+                    r.get_string(3).unwrap().clone(),
+                    r.get_long(4).unwrap()
+                ))
+                .sorted()
+                .collect::<Vec<_>>(),
             [
-                ("A".to_owned(), 1000),
-                ("B".to_owned(), 2000),
-                ("C".to_owned(), 3000)
+                (0, "A".to_owned(), 1000),
+                (1, "B".to_owned(), 2000),
+                (2, "C".to_owned(), 3000)
             ]
         );
     }
@@ -106,15 +115,23 @@ async fn test_pull_ingest_from_file() {
             .get_last_data_slice(&DatasetName::new_unchecked("population"))
             .await;
         assert_eq!(
-            parquet.column_names(),
+            parquet.get_column_names(),
             ["offset", "system_time", "event_time", "city", "population"]
         );
         assert_eq!(
-            parquet.records(|r| (r.get_string(3).unwrap().clone(), r.get_long(4).unwrap())),
+            parquet
+                .get_row_iter()
+                .map(|r| (
+                    r.get_long(0).unwrap(),
+                    r.get_string(3).unwrap().clone(),
+                    r.get_long(4).unwrap()
+                ))
+                .sorted()
+                .collect::<Vec<_>>(),
             [
-                ("A".to_owned(), 1100),
-                ("B".to_owned(), 2100),
-                ("C".to_owned(), 3100)
+                (0, "A".to_owned(), 1100),
+                (1, "B".to_owned(), 2100),
+                (2, "C".to_owned(), 3100)
             ]
         );
     }

--- a/kamu-core/Cargo.toml
+++ b/kamu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu"
-version = "0.104.0"
+version = "0.105.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/kamu-core/src/domain/repos/dataset.rs
+++ b/kamu-core/src/domain/repos/dataset.rs
@@ -7,33 +7,37 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::path::Path;
+
 use crate::domain::*;
-use opendatafabric::Multihash;
+use opendatafabric::*;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use thiserror::Error;
+use tracing::{error, info, info_span};
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[async_trait]
 pub trait Dataset: Send + Sync {
-    /// Returns a brief summary of the dataset
-    async fn get_summary(&self, opts: SummaryOptions) -> Result<DatasetSummary, GetSummaryError>;
-
     fn as_metadata_chain(&self) -> &dyn MetadataChain;
     fn as_data_repo(&self) -> &dyn ObjectRepository;
     fn as_checkpoint_repo(&self) -> &dyn ObjectRepository;
     fn as_cache_repo(&self) -> &dyn NamedObjectRepository;
+
+    /// Returns a brief summary of the dataset
+    async fn get_summary(&self, opts: GetSummaryOpts) -> Result<DatasetSummary, GetSummaryError>;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Clone, Debug)]
-pub struct SummaryOptions {
+pub struct GetSummaryOpts {
     pub update_if_stale: bool,
 }
 
-impl Default for SummaryOptions {
+impl Default for GetSummaryOpts {
     fn default() -> Self {
         Self {
             update_if_stale: true,
@@ -42,11 +46,212 @@ impl Default for SummaryOptions {
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
+// Helpers
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[async_trait]
+pub trait DatasetExt: Dataset {
+    /// Helper function to append a generic event to metadata chain.
+    ///
+    /// Warning: Don't use when synchronizing blocks from another dataset.
+    async fn commit_event(
+        &self,
+        event: MetadataEvent,
+        opts: CommitOpts<'_>,
+    ) -> Result<CommitResult, CommitError> {
+        let chain = self.as_metadata_chain();
+
+        let prev_block_hash = if let Some(prev_block_hash) = opts.prev_block_hash {
+            prev_block_hash.cloned()
+        } else {
+            match chain.get_ref(opts.block_ref).await {
+                Ok(h) => Some(h),
+                Err(GetRefError::NotFound(_)) => None,
+                Err(e) => return Err(e.int_err().into()),
+            }
+        };
+
+        let sequence_number = if let Some(prev_block_hash) = &prev_block_hash {
+            chain
+                .get_block(prev_block_hash)
+                .await
+                .int_err()?
+                .sequence_number
+                + 1
+        } else {
+            0
+        };
+
+        let block = MetadataBlock {
+            prev_block_hash: prev_block_hash.clone(),
+            sequence_number,
+            system_time: opts.system_time.unwrap_or_else(|| Utc::now()),
+            event,
+        };
+
+        info!(?block, "Committing new block");
+
+        let new_head = chain
+            .append(
+                block,
+                AppendOpts {
+                    update_ref: Some(opts.block_ref),
+                    check_ref_is_prev_block: true,
+                    ..AppendOpts::default()
+                },
+            )
+            .await?;
+
+        info!(%new_head, "Committed new block");
+
+        Ok(CommitResult {
+            old_head: prev_block_hash,
+            new_head,
+        })
+    }
+
+    /// Helper function to commit AddData event into a local dataset.
+    ///
+    /// Will attempt to atomically move data and checkpoint files, so those have to be on the same file system as the workspace.
+    async fn commit_add_data<P: AsRef<Path> + Send + Sync>(
+        &self,
+        input_checkpoint: Option<Multihash>,
+        data_interval: Option<OffsetInterval>,
+        movable_data_file: Option<P>,
+        movable_checkpoint_file: Option<P>,
+        watermark: Option<DateTime<Utc>>,
+        opts: CommitOpts<'_>,
+    ) -> Result<CommitResult, CommitError> {
+        // New block might not contain anything new, so we check for data
+        // and watermark differences to see if commit should be skipped
+        let metadata_event = if let Some(data_interval) = data_interval {
+            let span = info_span!("Computing data hashes");
+            let _span_guard = span.enter();
+
+            let from_data_path = movable_data_file.unwrap();
+
+            let output_data = DataSlice {
+                logical_hash: crate::infra::utils::data_utils::get_parquet_logical_hash(
+                    from_data_path.as_ref(),
+                )
+                .int_err()?,
+                physical_hash: crate::infra::utils::data_utils::get_file_physical_hash(
+                    from_data_path.as_ref(),
+                )
+                .int_err()?,
+                interval: data_interval,
+                size: std::fs::metadata(&from_data_path).int_err()?.len() as i64,
+            };
+
+            // Commit data
+            self.as_data_repo()
+                .insert_file_move(
+                    from_data_path.as_ref(),
+                    InsertOpts {
+                        precomputed_hash: Some(&output_data.physical_hash),
+                        expected_hash: None,
+                        size_hint: Some(output_data.size as usize),
+                    },
+                )
+                .await
+                .int_err()?;
+
+            // Commit checkpoint
+            //
+            // TODO: Should checkpoint be committed even when there is no data?
+            // Postpone changes until we revisit ingest checkpoints
+            let output_checkpoint = if let Some(from_checkpoint_path) = movable_checkpoint_file {
+                let physical_hash = crate::infra::utils::data_utils::get_file_physical_hash(
+                    from_checkpoint_path.as_ref(),
+                )
+                .int_err()?;
+
+                let size = std::fs::metadata(&from_checkpoint_path).int_err()?.len() as i64;
+
+                self.as_checkpoint_repo()
+                    .insert_file_move(
+                        from_checkpoint_path.as_ref(),
+                        InsertOpts {
+                            precomputed_hash: Some(&physical_hash),
+                            expected_hash: None,
+                            size_hint: Some(size as usize),
+                        },
+                    )
+                    .await
+                    .int_err()?;
+
+                Some(Checkpoint {
+                    physical_hash,
+                    size,
+                })
+            } else {
+                None
+            };
+
+            MetadataEvent::AddData(AddData {
+                input_checkpoint,
+                output_data,
+                output_checkpoint,
+                output_watermark: watermark,
+            })
+        } else {
+            let prev_watermark = self
+                .as_metadata_chain()
+                .iter_blocks()
+                .filter_data_stream_blocks()
+                .filter_map_ok(|(_, b)| b.event.output_watermark)
+                .try_first()
+                .await
+                .int_err()?;
+
+            if watermark.is_none() || watermark == prev_watermark {
+                info!(concat!(
+                    "Skipping commit of new block as ",
+                    "it neither has new data nor an updated watermark"
+                ));
+                return Err(CommitError::EmptyCommit);
+            }
+
+            // TODO: Should this be here?
+            MetadataEvent::SetWatermark(SetWatermark {
+                output_watermark: watermark.unwrap(),
+            })
+        };
+
+        self.commit_event(metadata_event, opts).await
+    }
+}
+
+impl<T> DatasetExt for T where T: Dataset + ?Sized {}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Clone, Debug)]
+pub struct CommitOpts<'a> {
+    /// Which reference to advance upon commit
+    pub block_ref: &'a BlockRef,
+    /// Override system time of the new block
+    pub system_time: Option<DateTime<Utc>>,
+    /// Compare-and-swap semantics to ensure there were no concurrent updates
+    pub prev_block_hash: Option<Option<&'a Multihash>>,
+}
+
+impl<'a> Default for CommitOpts<'a> {
+    fn default() -> Self {
+        Self {
+            block_ref: &BlockRef::Head,
+            system_time: None,
+            prev_block_hash: None,
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Clone, Debug)]
 pub struct CommitResult {
+    pub old_head: Option<Multihash>,
     pub new_head: Multihash,
-    pub old_head: Multihash,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -84,6 +289,10 @@ pub enum GetSummaryError {
 
 #[derive(Error, Debug)]
 pub enum CommitError {
+    #[error("Empty commit")]
+    EmptyCommit,
+    #[error(transparent)]
+    MetadataAppendError(#[from] AppendError),
     #[error(transparent)]
     Internal(
         #[from]

--- a/kamu-core/src/domain/repos/metadata_chain.rs
+++ b/kamu-core/src/domain/repos/metadata_chain.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fmt::Display;
+
 use super::metadata_stream::DynMetadataStream;
 use crate::domain::*;
 use opendatafabric::{MetadataBlock, Multihash};
@@ -400,11 +402,28 @@ pub enum AppendValidationError {
 ///////////////////////////////////////////////////////////////////////////////
 
 #[derive(Error, PartialEq, Eq, Debug)]
-#[error("Block {block_hash} with sequence number {block_sequence_number} cannot be followed by block with sequence number {next_block_sequence_number}")]
 pub struct SequenceIntegrityError {
-    pub block_hash: Multihash,
-    pub block_sequence_number: i32,
+    pub prev_block_hash: Option<Multihash>,
+    pub prev_block_sequence_number: Option<i32>,
     pub next_block_sequence_number: i32,
+}
+
+impl Display for SequenceIntegrityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(prev_block_hash) = &self.prev_block_hash {
+            write!(
+                f,
+                "Block {} with sequence number {} cannot be followed by block with sequence number {}",
+                prev_block_hash, self.prev_block_sequence_number.unwrap(), self.next_block_sequence_number
+            )
+        } else {
+            write!(
+                f,
+                "Block sequence has to start with zero, not {}",
+                self.next_block_sequence_number
+            )
+        }
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/kamu-core/src/infra/provenance_service_impl.rs
+++ b/kamu-core/src/infra/provenance_service_impl.rs
@@ -41,7 +41,7 @@ impl ProvenanceServiceImpl {
         {
             Some(
                 dataset
-                    .get_summary(SummaryOptions::default())
+                    .get_summary(GetSummaryOpts::default())
                     .await
                     .int_err()?,
             )

--- a/kamu-core/src/infra/repos/dataset_impl.rs
+++ b/kamu-core/src/infra/repos/dataset_impl.rs
@@ -250,7 +250,7 @@ where
     CacheRepo: NamedObjectRepository + Sync + Send,
     InfoRepo: NamedObjectRepository + Sync + Send,
 {
-    async fn get_summary(&self, opts: SummaryOptions) -> Result<DatasetSummary, GetSummaryError> {
+    async fn get_summary(&self, opts: GetSummaryOpts) -> Result<DatasetSummary, GetSummaryError> {
         let summary = self.read_summary().await?;
 
         let summary = if opts.update_if_stale {

--- a/kamu-core/src/infra/repos/local_dataset_repository_impl.rs
+++ b/kamu-core/src/infra/repos/local_dataset_repository_impl.rs
@@ -181,7 +181,7 @@ impl LocalDatasetRepositoryImpl {
         staging_path: &Path,
         dataset_name: &DatasetName,
     ) -> Result<DatasetHandle, CreateDatasetError> {
-        let summary = match dataset.get_summary(SummaryOptions::default()).await {
+        let summary = match dataset.get_summary(GetSummaryOpts::default()).await {
             Ok(s) => Ok(s),
             Err(GetSummaryError::EmptyDataset) => unreachable!(),
             Err(GetSummaryError::Access(e)) => Err(e.int_err().into()),
@@ -259,7 +259,7 @@ impl LocalDatasetRepositoryImpl {
                     .get_dataset(&hdl.as_local_ref())
                     .await
                     .int_err()?
-                    .get_summary(SummaryOptions::default())
+                    .get_summary(GetSummaryOpts::default())
                     .await
                     .int_err()?;
 
@@ -315,7 +315,7 @@ impl LocalDatasetRepository for LocalDatasetRepositoryImpl {
 
                 let dataset = self.get_dataset_impl(name)?;
                 let summary = dataset
-                    .get_summary(SummaryOptions::default())
+                    .get_summary(GetSummaryOpts::default())
                     .await
                     .int_err()?;
 
@@ -339,7 +339,7 @@ impl LocalDatasetRepository for LocalDatasetRepositoryImpl {
                     let summary = self
                         .get_dataset_impl(&name)
                         .int_err()?
-                        .get_summary(SummaryOptions::default())
+                        .get_summary(GetSummaryOpts::default())
                         .await
                         .int_err()?;
                     if summary.id == *id {
@@ -676,7 +676,7 @@ impl<D> Dataset for DatasetBuilderImpl<D>
 where
     D: Dataset,
 {
-    async fn get_summary(&self, opts: SummaryOptions) -> Result<DatasetSummary, GetSummaryError> {
+    async fn get_summary(&self, opts: GetSummaryOpts) -> Result<DatasetSummary, GetSummaryError> {
         self.dataset.get_summary(opts).await
     }
 

--- a/kamu-core/src/infra/repos/object_repository_http.rs
+++ b/kamu-core/src/infra/repos/object_repository_http.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::path::Path;
+
 use crate::domain::*;
 use opendatafabric::Multihash;
 
@@ -140,6 +142,14 @@ impl ObjectRepository for ObjectRepositoryHttp {
     async fn insert_stream<'a>(
         &'a self,
         _src: Box<AsyncReadObj>,
+        _options: InsertOpts<'a>,
+    ) -> Result<InsertResult, InsertError> {
+        Err(AccessError::ReadOnly(None).into())
+    }
+
+    async fn insert_file_move<'a>(
+        &'a self,
+        _src: &Path,
         _options: InsertOpts<'a>,
     ) -> Result<InsertResult, InsertError> {
         Err(AccessError::ReadOnly(None).into())

--- a/kamu-core/src/infra/repos/object_repository_in_memory.rs
+++ b/kamu-core/src/infra/repos/object_repository_in_memory.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{collections::HashMap, sync::Mutex};
+use std::{collections::HashMap, path::Path, sync::Mutex};
 
 use crate::domain::*;
 use async_trait::async_trait;
@@ -91,6 +91,14 @@ impl ObjectRepository for ObjectRepositoryInMemory {
     async fn insert_stream<'a>(
         &'a self,
         _src: Box<AsyncReadObj>,
+        _options: InsertOpts<'a>,
+    ) -> Result<InsertResult, InsertError> {
+        unimplemented!()
+    }
+
+    async fn insert_file_move<'a>(
+        &'a self,
+        _src: &Path,
         _options: InsertOpts<'a>,
     ) -> Result<InsertResult, InsertError> {
         unimplemented!()

--- a/kamu-core/src/infra/repos/object_repository_s3.rs
+++ b/kamu-core/src/infra/repos/object_repository_s3.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use rusoto_core::{Region, RusotoError};
 use rusoto_s3::*;
-use std::marker::PhantomData;
+use std::{marker::PhantomData, path::Path};
 use tokio::io::AsyncRead;
 use tracing::debug;
 use url::Url;
@@ -289,6 +289,14 @@ where
             hash,
             already_existed: false,
         })
+    }
+
+    async fn insert_file_move<'a>(
+        &'a self,
+        _src: &Path,
+        _options: InsertOpts<'a>,
+    ) -> Result<InsertResult, InsertError> {
+        unimplemented!()
     }
 
     async fn delete(&self, hash: &Multihash) -> Result<(), DeleteError> {

--- a/kamu-core/src/infra/verification_service_impl.rs
+++ b/kamu-core/src/infra/verification_service_impl.rs
@@ -266,7 +266,7 @@ impl VerificationService for VerificationServiceImpl {
         let _span_guard = span.enter();
 
         let dataset_kind = dataset
-            .get_summary(SummaryOptions::default())
+            .get_summary(GetSummaryOpts::default())
             .await
             .int_err()?
             .kind;

--- a/kamu-core/src/testing/mod.rs
+++ b/kamu-core/src/testing/mod.rs
@@ -12,3 +12,9 @@ pub use id_factory::*;
 
 mod metadata_factory;
 pub use metadata_factory::*;
+
+mod parquet_reader_helper;
+pub use parquet_reader_helper::*;
+
+mod parquet_writer_helper;
+pub use parquet_writer_helper::*;

--- a/kamu-core/src/testing/parquet_reader_helper.rs
+++ b/kamu-core/src/testing/parquet_reader_helper.rs
@@ -1,3 +1,12 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 use std::path::Path;
 
 use datafusion::parquet::{

--- a/kamu-core/src/testing/parquet_reader_helper.rs
+++ b/kamu-core/src/testing/parquet_reader_helper.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use datafusion::parquet::{
+    file::{reader::FileReader, serialized_reader::SerializedFileReader},
+    record::reader::RowIter,
+};
+
+pub struct ParquetReaderHelper {
+    pub reader: SerializedFileReader<std::fs::File>,
+}
+
+impl ParquetReaderHelper {
+    pub fn new(reader: SerializedFileReader<std::fs::File>) -> Self {
+        Self { reader }
+    }
+
+    pub fn open(path: &Path) -> Self {
+        Self::new(SerializedFileReader::new(std::fs::File::open(&path).unwrap()).unwrap())
+    }
+
+    pub fn get_column_names(&self) -> Vec<String> {
+        self.reader
+            .metadata()
+            .file_metadata()
+            .schema_descr()
+            .columns()
+            .iter()
+            .map(|cd| cd.path().string())
+            .collect()
+    }
+
+    pub fn get_row_iter(&self) -> RowIter {
+        self.reader.get_row_iter(None).unwrap()
+    }
+}

--- a/kamu-core/src/testing/parquet_writer_helper.rs
+++ b/kamu-core/src/testing/parquet_writer_helper.rs
@@ -1,3 +1,12 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 use std::path::Path;
 
 use arrow::record_batch::RecordBatch;

--- a/kamu-core/src/testing/parquet_writer_helper.rs
+++ b/kamu-core/src/testing/parquet_writer_helper.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+use arrow::record_batch::RecordBatch;
+use datafusion::parquet::errors::ParquetError;
+
+pub struct ParquetWriterHelper;
+
+impl ParquetWriterHelper {
+    pub fn from_record_batch(path: &Path, record_batch: &RecordBatch) -> Result<(), ParquetError> {
+        use datafusion::parquet::arrow::ArrowWriter;
+
+        let mut arrow_writer = ArrowWriter::try_new(
+            std::fs::File::create(path).unwrap(),
+            record_batch.schema(),
+            None,
+        )?;
+
+        arrow_writer.write(&record_batch)?;
+        arrow_writer.close()?;
+
+        Ok(())
+    }
+}

--- a/kamu-core/tests/tests/repos/test_dataset_impl.rs
+++ b/kamu-core/tests/tests/repos/test_dataset_impl.rs
@@ -21,7 +21,7 @@ async fn test_summary_updates() {
     let ds = DatasetFactoryImpl::get_local_fs(layout);
 
     assert_matches!(
-        ds.get_summary(SummaryOptions::default()).await,
+        ds.get_summary(GetSummaryOpts::default()).await,
         Err(GetSummaryError::EmptyDataset)
     );
 
@@ -39,7 +39,7 @@ async fn test_summary_updates() {
         .unwrap();
 
     assert_eq!(
-        ds.get_summary(SummaryOptions::default()).await.unwrap(),
+        ds.get_summary(GetSummaryOpts::default()).await.unwrap(),
         DatasetSummary {
             id: DatasetID::from_pub_key_ed25519(b"foo"),
             kind: DatasetKind::Root,
@@ -70,7 +70,7 @@ async fn test_summary_updates() {
 
     // Get stale
     assert_eq!(
-        ds.get_summary(SummaryOptions {
+        ds.get_summary(GetSummaryOpts {
             update_if_stale: false,
             ..Default::default()
         })
@@ -89,7 +89,7 @@ async fn test_summary_updates() {
     );
 
     assert_eq!(
-        ds.get_summary(SummaryOptions::default()).await.unwrap(),
+        ds.get_summary(GetSummaryOpts::default()).await.unwrap(),
         DatasetSummary {
             id: DatasetID::from_pub_key_ed25519(b"foo"),
             kind: DatasetKind::Root,

--- a/kamu-core/tests/tests/repos/test_metadata_chain_impl.rs
+++ b/kamu-core/tests/tests/repos/test_metadata_chain_impl.rs
@@ -207,12 +207,12 @@ async fn test_append_prev_block_sequence_integrity_broken() {
         chain.append(block_too_low, AppendOpts::default()).await,
         Err(AppendError::InvalidBlock(
             AppendValidationError::SequenceIntegrity(SequenceIntegrityError {
-                block_hash,
-                block_sequence_number,
+                prev_block_hash,
+                prev_block_sequence_number,
                 next_block_sequence_number
             })
         ))
-        if block_hash == hash_2 && block_sequence_number == 1 && next_block_sequence_number == 1
+        if prev_block_hash.as_ref() == Some(&hash_2) && prev_block_sequence_number == Some(1) && next_block_sequence_number == 1
     );
 
     let block_too_high = MetadataFactory::metadata_block(MetadataFactory::add_data().build())
@@ -223,12 +223,12 @@ async fn test_append_prev_block_sequence_integrity_broken() {
         chain.append(block_too_high, AppendOpts::default()).await,
         Err(AppendError::InvalidBlock(
             AppendValidationError::SequenceIntegrity(SequenceIntegrityError {
-                block_hash,
-                block_sequence_number,
+                prev_block_hash,
+                prev_block_sequence_number,
                 next_block_sequence_number
             })
         ))
-        if block_hash == hash_2 && block_sequence_number == 1 && next_block_sequence_number == 3
+        if prev_block_hash.as_ref() == Some(&hash_2) && prev_block_sequence_number == Some(1) && next_block_sequence_number == 3
     );
 
     let block_just_right = MetadataFactory::metadata_block(MetadataFactory::add_data().build())

--- a/kamu-core/tests/tests/test_reset_service_impl.rs
+++ b/kamu-core/tests/tests/test_reset_service_impl.rs
@@ -192,7 +192,7 @@ impl ResetTestHarness {
     async fn get_dataset_summary(&self, dataset_handle: &DatasetHandle) -> DatasetSummary {
         let dataset = self.resolve_dataset(dataset_handle).await;
         dataset
-            .get_summary(SummaryOptions::default())
+            .get_summary(GetSummaryOpts::default())
             .await
             .unwrap()
     }

--- a/opendatafabric/Cargo.toml
+++ b/opendatafabric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendatafabric"
-version = "0.104.0"
+version = "0.105.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/utils/container-runtime/Cargo.toml
+++ b/utils/container-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-runtime"
-version = "0.104.0"
+version = "0.105.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../../LICENSE.txt"


### PR DESCRIPTION
It all started with a small fix for when `DataFusion`'s JSON array serializer returns empty string for zero rows datasets instead of `[]` (which causes kamu ui to crash).

To write a test for it I needed dataset with some data...

This led to refactoring Parquet reading/writing helpers.

Then to extracting commit procedure into `DatasetExt` trait in order to easily setup the dataset state in tests.