### PR TITLE
Upgrade flink engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.108.0] - 2023-01-30
+### Fixed
+- Upgrade to Flink engine prevents it from crashing on checkpoints over 5 MiB large
+
 ## [0.107.0] - 2023-01-25
 ### Changed
 - **Breaking:** Major upgrade of Apache Flink version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "container-runtime"
-version = "0.107.0"
+version = "0.108.0"
 dependencies = [
  "dill",
  "regex",
@@ -2232,7 +2232,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "kamu"
-version = "0.107.0"
+version = "0.108.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.107.0"
+version = "0.108.0"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.107.0"
+version = "0.108.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2997,7 +2997,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendatafabric"
-version = "0.107.0"
+version = "0.108.0"
 dependencies = [
  "bs58",
  "byteorder",

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.107.0
+Licensed Work:             Kamu CLI Version 0.108.0
                            The Licensed Work is © 2021 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2027-01-26
+Change Date:               2027-01-30
 
 Change License:            Apache License, Version 2.0
 

--- a/examples/reth-vs-snp500/analysis.ipynb
+++ b/examples/reth-vs-snp500/analysis.ipynb
@@ -65,7 +65,7 @@
    },
    "outputs": [],
    "source": [
-    "%%sql -o reth_pool -n 999999999999999\n",
+    "%%sql -o reth_pool\n",
     "select \n",
     "    block_time, \n",
     "    case \n",
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql -o eth2usd -n 999999999999\n",
+    "%%sql -o eth2usd\n",
     "select * from `cryptocompare.ohlcv.eth-usd` order by event_time"
    ]
   },

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,7 +1,7 @@
 IMAGE_REPO = docker.io/kamudata
 IMAGE_JUPYTER_TAG = 0.5.0
 
-KAMU_VERSION = 0.107.0
+KAMU_VERSION = 0.108.0
 
 
 .PHONY: jupyter

--- a/images/demo/Makefile
+++ b/images/demo/Makefile
@@ -1,5 +1,5 @@
 IMAGE_REPO = docker.io/kamudata
-KAMU_VERSION = 0.107.0
+KAMU_VERSION = 0.108.0
 DEMO_VERSION = 0.6.1
 
 #########################################################################################

--- a/kamu-adapter-graphql/Cargo.toml
+++ b/kamu-adapter-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-adapter-graphql"
-version = "0.107.0"
+version = "0.108.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 

--- a/kamu-cli/Cargo.toml
+++ b/kamu-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-cli"
-version = "0.107.0"
+version = "0.108.0"
 description = "Decentralized data management tool"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"

--- a/kamu-core/Cargo.toml
+++ b/kamu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu"
-version = "0.107.0"
+version = "0.108.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/kamu-core/src/infra/utils/docker_images.rs
+++ b/kamu-core/src/infra/utils/docker_images.rs
@@ -9,7 +9,7 @@
 
 pub const SPARK: &str = "docker.io/kamudata/engine-spark:0.17.0-spark_3.1.2";
 pub const LIVY: &str = SPARK;
-pub const FLINK: &str = "docker.io/kamudata/engine-flink:0.15.0-flink_1.16.0-scala_2.12-java8";
+pub const FLINK: &str = "docker.io/kamudata/engine-flink:0.15.1-flink_1.16.0-scala_2.12-java8";
 pub const JUPYTER: &str = "docker.io/kamudata/jupyter:0.5.0";
 
 // Test Images

--- a/opendatafabric/Cargo.toml
+++ b/opendatafabric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendatafabric"
-version = "0.107.0"
+version = "0.108.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/utils/container-runtime/Cargo.toml
+++ b/utils/container-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-runtime"
-version = "0.107.0"
+version = "0.108.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../../LICENSE.txt"


### PR DESCRIPTION
flink engine 0.15.1 fixes the crash on checkpoints over 5MiB large