### PR TITLE
Handling situations when dataset schema is not yet defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2023-02-09
+### Changed
+- Improved reaction of `kamu inspect schema` and `kamu tail` on datasets without schema yet
+- GraphQL schema and corresponding schema/tail responses now assume there might not be a dataset schema yet
+
 ## [0.109.0] - 2023-02-05
 ### Fixed
 - Lineage and transform now respect names of datasets in the `SetTransform` metadata events, that may be different from names in a workspace

--- a/kamu-adapter-graphql/src/queries/data.rs
+++ b/kamu-adapter-graphql/src/queries/data.rs
@@ -58,6 +58,6 @@ impl DataQueries {
         };
         let data = DataBatch::from_records(&record_batches, data_format)?;
 
-        Ok(DataQueryResult::success(schema, data, limit))
+        Ok(DataQueryResult::success(Some(schema), data, limit))
     }
 }

--- a/kamu-adapter-graphql/src/queries/dataset_data.rs
+++ b/kamu-adapter-graphql/src/queries/dataset_data.rs
@@ -72,7 +72,7 @@ impl DatasetData {
             Ok(r) => r,
             Err(err) => {
                 if let QueryError::DatasetSchemaNotAvailable(_) = err {
-                    return Ok(DataQueryResult::success(None, DataBatch::empty(data_format), limit));
+                    return Ok(DataQueryResult::no_schema_yet(data_format, limit));
                 } else {
                     debug!(?err, "Query error");
                     return Ok(err.into());

--- a/kamu-adapter-graphql/src/queries/dataset_metadata.rs
+++ b/kamu-adapter-graphql/src/queries/dataset_metadata.rs
@@ -80,11 +80,14 @@ impl DatasetMetadata {
         let format = format.unwrap_or(DataSchemaFormat::Parquet);
 
         let query_svc = from_catalog::<dyn domain::QueryService>(ctx).unwrap();
-        let schema = query_svc
+        let res_schema = query_svc
             .get_schema(&self.dataset_handle.as_local_ref())
             .await?;
 
-        Ok(Some(DataSchema::from_parquet_schema(&schema, format)?))
+        match res_schema {
+            Some(schema) => Ok(Some(DataSchema::from_parquet_schema(&schema, format)?)),
+            None => Ok(None)
+        }
     }
 
     /// Current upstream dependencies of a dataset

--- a/kamu-adapter-graphql/src/queries/dataset_metadata.rs
+++ b/kamu-adapter-graphql/src/queries/dataset_metadata.rs
@@ -76,7 +76,7 @@ impl DatasetMetadata {
         &self,
         ctx: &Context<'_>,
         format: Option<DataSchemaFormat>,
-    ) -> Result<DataSchema> {
+    ) -> Result<Option<DataSchema>> {
         let format = format.unwrap_or(DataSchemaFormat::Parquet);
 
         let query_svc = from_catalog::<dyn domain::QueryService>(ctx).unwrap();
@@ -84,7 +84,7 @@ impl DatasetMetadata {
             .get_schema(&self.dataset_handle.as_local_ref())
             .await?;
 
-        Ok(DataSchema::from_parquet_schema(&schema, format)?)
+        Ok(Some(DataSchema::from_parquet_schema(&schema, format)?))
     }
 
     /// Current upstream dependencies of a dataset

--- a/kamu-adapter-graphql/src/scalars/dataset.rs
+++ b/kamu-adapter-graphql/src/scalars/dataset.rs
@@ -181,7 +181,12 @@ impl DataBatch {
     pub fn empty(format: DataBatchFormat) -> DataBatch {
         DataBatch {
             format,
-            content: String::from("{}"),
+            content: match format {
+                DataBatchFormat::Csv => String::from(""),
+                DataBatchFormat::Json |
+                DataBatchFormat::JsonLD |
+                DataBatchFormat::JsonSOA => String::from("{}"),
+            },
             num_records: 0
         }
     }
@@ -264,6 +269,14 @@ impl DataQueryResult {
         DataQueryResult::Success(DataQueryResultSuccess {
             schema,
             data,
+            limit,
+        })
+    }
+
+    pub fn no_schema_yet(format: DataBatchFormat, limit: u64) -> DataQueryResult {
+        DataQueryResult::Success(DataQueryResultSuccess {
+            schema: None, 
+            data: DataBatch::empty(format), 
             limit,
         })
     }

--- a/kamu-cli/src/commands/inspect_schema_command.rs
+++ b/kamu-cli/src/commands/inspect_schema_command.rs
@@ -104,26 +104,41 @@ impl InspectSchemaCommand {
         )?;
         Ok(())
     }
+
+    fn print_schema_unavailable(&self) {
+        eprintln!(
+            "{}: Dataset schema is not available yet: {}",
+            console::style("Warning").yellow(),
+            self.dataset_ref.name().unwrap(),
+        );
+    }
+
 }
 
 #[async_trait::async_trait(?Send)]
 impl Command for InspectSchemaCommand {
     async fn run(&mut self) -> Result<(), CLIError> {
-        let schema = self
+        let schema_or_none = self
             .query_svc
             .get_schema(&self.dataset_ref)
             .await
             .map_err(|e| match e {
                 QueryError::DatasetNotFound(e) => CLIError::usage_error_from(e),
+                QueryError::DatasetSchemaNotAvailable(_) => unreachable!(),
                 e @ QueryError::DataFusionError(_) => CLIError::failure(e),
                 e @ QueryError::Internal(_) => CLIError::critical(e),
             })?;
 
-        match self.output_format.as_ref().map(|s| s.as_str()) {
-            None | Some("ddl") => self.print_schema_ddl(&schema),
-            Some("parquet") => self.print_schema_parquet(&schema)?,
-            Some("json") => self.print_schema_json(&schema)?,
-            _ => unreachable!(),
+        match schema_or_none {
+            Some(schema) => {
+                match self.output_format.as_ref().map(|s| s.as_str()) {
+                    None | Some("ddl") => self.print_schema_ddl(&schema),
+                    Some("parquet") => self.print_schema_parquet(&schema)?,
+                    Some("json") => self.print_schema_json(&schema)?,
+                    _ => unreachable!(),
+                }
+            }
+            None => self.print_schema_unavailable(),
         }
 
         Ok(())

--- a/kamu-cli/src/commands/inspect_schema_command.rs
+++ b/kamu-cli/src/commands/inspect_schema_command.rs
@@ -107,7 +107,7 @@ impl InspectSchemaCommand {
 
     fn print_schema_unavailable(&self) {
         eprintln!(
-            "{}: Dataset schema is not available yet: {}",
+            "{}: Dataset schema is not yet available: {}",
             console::style("Warning").yellow(),
             self.dataset_ref.name().unwrap(),
         );
@@ -118,7 +118,7 @@ impl InspectSchemaCommand {
 #[async_trait::async_trait(?Send)]
 impl Command for InspectSchemaCommand {
     async fn run(&mut self) -> Result<(), CLIError> {
-        let schema_or_none = self
+        let maybe_schema = self
             .query_svc
             .get_schema(&self.dataset_ref)
             .await
@@ -129,7 +129,7 @@ impl Command for InspectSchemaCommand {
                 e @ QueryError::Internal(_) => CLIError::critical(e),
             })?;
 
-        match schema_or_none {
+        match maybe_schema {
             Some(schema) => {
                 match self.output_format.as_ref().map(|s| s.as_str()) {
                     None | Some("ddl") => self.print_schema_ddl(&schema),

--- a/kamu-core/src/domain/query_service.rs
+++ b/kamu-core/src/domain/query_service.rs
@@ -85,7 +85,7 @@ pub enum QueryError {
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Error, Clone, PartialEq, Eq, Debug)]
-#[error("Dataset schema is not available yet: {dataset_ref}")]
+#[error("Dataset schema is not yet available: {dataset_ref}")]
 pub struct DatasetSchemaNotAvailableError {
     pub dataset_ref: DatasetRefLocal,
 }

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -109,7 +109,7 @@ enum DataQueryResultErrorKind {
 }
 
 type DataQueryResultSuccess {
-	schema: DataSchema!
+	schema: DataSchema
 	data: DataBatch!
 	limit: Int!
 }

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -222,7 +222,7 @@ type DatasetMetadata {
 	"""
 	Latest data schema
 	"""
-	currentSchema(format: DataSchemaFormat): DataSchema!
+	currentSchema(format: DataSchemaFormat): DataSchema
 	"""
 	Current upstream dependencies of a dataset
 	"""


### PR DESCRIPTION
CLI:
- kamu inspect schema prints a warning
- kamu tail prints an error

GraphQL adapter:
- optional schema access taken into account
- empty tail when there is no schema