### PR TITLE
GQL dataset creation and append APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
  "arrow-cast",
  "arrow-data",
  "arrow-schema",
- "flatbuffers 22.9.29",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -454,9 +454,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
+checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -806,7 +806,7 @@ checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "container-runtime"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "dill",
  "regex",
@@ -1515,16 +1515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flatbuffers"
-version = "23.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f5399c2c9c50ae9418e522842ad362f61ee48b346ac106807bd355a8a7c619"
-dependencies = [
- "bitflags",
- "rustc_version",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -2223,7 +2213,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "kamu"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -2287,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -2310,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2460,9 +2450,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libflate"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
+checksum = "97822bf791bd4d5b403713886a5fbe8bf49520fe78e323b0dc480ca1a03e50b0"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -2471,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "libflate_lz77"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
 dependencies = [
  "rle-decode-fast",
 ]
@@ -2988,14 +2978,14 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendatafabric"
-version = "0.111.0"
+version = "0.112.0"
 dependencies = [
  "bs58",
  "byteorder",
  "chrono",
  "digest 0.10.6",
  "ed25519-dalek",
- "flatbuffers 23.1.21",
+ "flatbuffers",
  "hex",
  "indoc",
  "prost",
@@ -4054,7 +4044,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.18",
+ "time 0.3.19",
 ]
 
 [[package]]
@@ -4458,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0097eaf301d576d0b2aead7a59facab6d53cc636340f0291fab8446a2e8613"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "serde",
@@ -4476,9 +4466,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -4795,7 +4785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.18",
+ "time 0.3.19",
  "tracing-subscriber",
 ]
 
@@ -4821,7 +4811,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "time 0.3.18",
+ "time 0.3.19",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -5467,7 +5457,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
  "sha1",
- "time 0.3.18",
+ "time 0.3.19",
  "zstd 0.11.2+zstd.1.5.2",
 ]
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.111.0
+Licensed Work:             Kamu CLI Version 0.112.0
                            The Licensed Work is © 2021 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2027-02-16
+Change Date:               2027-02-17
 
 Change License:            Apache License, Version 2.0
 

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,7 +1,7 @@
 IMAGE_REPO = docker.io/kamudata
 IMAGE_JUPYTER_TAG = 0.5.0
 
-KAMU_VERSION = 0.111.0
+KAMU_VERSION = 0.112.0
 
 
 .PHONY: jupyter

--- a/images/demo/Makefile
+++ b/images/demo/Makefile
@@ -1,5 +1,5 @@
 IMAGE_REPO = docker.io/kamudata
-KAMU_VERSION = 0.111.0
+KAMU_VERSION = 0.112.0
 DEMO_VERSION = 0.6.1
 
 #########################################################################################

--- a/kamu-adapter-graphql/Cargo.toml
+++ b/kamu-adapter-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-adapter-graphql"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 

--- a/kamu-adapter-graphql/src/queries/metadata_chain.rs
+++ b/kamu-adapter-graphql/src/queries/metadata_chain.rs
@@ -79,18 +79,18 @@ impl MetadataChain {
     }
 
     /// Returns a metadata block corresponding to the specified hash and encoded in desired format
-    async fn block_by_hash_raw(
+    async fn block_by_hash_encoded(
         &self,
         ctx: &Context<'_>,
         hash: Multihash,
-        block_format: MetadataManifestFormat,
+        format: MetadataManifestFormat,
     ) -> Result<Option<String>> {
         use odf::serde::MetadataBlockSerializer;
 
         let dataset = self.get_dataset(ctx).await?;
         match dataset.as_metadata_chain().try_get_block(&hash).await? {
             None => Ok(None),
-            Some(block) => match block_format {
+            Some(block) => match format {
                 MetadataManifestFormat::Yaml => {
                     let ser = odf::serde::yaml::YamlMetadataBlockSerializer;
                     let buffer = ser.write_manifest(&block)?;
@@ -143,13 +143,13 @@ impl MetadataChain {
     async fn commit_event(
         &self,
         ctx: &Context<'_>,
-        metadata_event: String,
-        metadata_event_format: MetadataManifestFormat,
+        event: String,
+        event_format: MetadataManifestFormat,
     ) -> Result<CommitResult> {
-        let event = match metadata_event_format {
+        let event = match event_format {
             MetadataManifestFormat::Yaml => {
                 let de = odf::serde::yaml::YamlMetadataEventDeserializer;
-                match de.read_manifest(metadata_event.as_bytes()) {
+                match de.read_manifest(event.as_bytes()) {
                     Ok(event) => event,
                     Err(e @ odf::serde::Error::SerdeError { .. }) => {
                         return Ok(CommitResult::Malformed(MetadataManifestMalformed {

--- a/kamu-adapter-graphql/src/scalars/dataset.rs
+++ b/kamu-adapter-graphql/src/scalars/dataset.rs
@@ -94,6 +94,12 @@ impl Deref for DatasetName {
     }
 }
 
+impl std::fmt::Display for DatasetName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[Scalar]
 impl ScalarType for DatasetName {
     fn parse(value: Value) -> InputValueResult<Self> {
@@ -183,11 +189,11 @@ impl DataBatch {
             format,
             content: match format {
                 DataBatchFormat::Csv => String::from(""),
-                DataBatchFormat::Json |
-                DataBatchFormat::JsonLD |
-                DataBatchFormat::JsonSOA => String::from("{}"),
+                DataBatchFormat::Json | DataBatchFormat::JsonLD | DataBatchFormat::JsonSOA => {
+                    String::from("{}")
+                }
             },
-            num_records: 0
+            num_records: 0,
         }
     }
 
@@ -275,8 +281,8 @@ impl DataQueryResult {
 
     pub fn no_schema_yet(format: DataBatchFormat, limit: u64) -> DataQueryResult {
         DataQueryResult::Success(DataQueryResultSuccess {
-            schema: None, 
-            data: DataBatch::empty(format), 
+            schema: None,
+            data: DataBatch::empty(format),
             limit,
         })
     }
@@ -294,7 +300,6 @@ impl DataQueryResult {
             error_kind: DataQueryResultErrorKind::InternalError,
         })
     }
-    
 }
 
 impl From<QueryError> for DataQueryResult {

--- a/kamu-adapter-graphql/src/scalars/odf_generated.rs
+++ b/kamu-adapter-graphql/src/scalars/odf_generated.rs
@@ -178,6 +178,15 @@ impl From<odf::DatasetKind> for DatasetKind {
     }
 }
 
+impl Into<odf::DatasetKind> for DatasetKind {
+    fn into(self) -> odf::DatasetKind {
+        match self {
+            Self::Root => odf::DatasetKind::Root,
+            Self::Derivative => odf::DatasetKind::Derivative,
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // DatasetSnapshot
 // https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#datasetsnapshot-schema
@@ -544,6 +553,15 @@ impl From<odf::SourceOrdering> for SourceOrdering {
     }
 }
 
+impl Into<odf::SourceOrdering> for SourceOrdering {
+    fn into(self) -> odf::SourceOrdering {
+        match self {
+            Self::ByEventTime => odf::SourceOrdering::ByEventTime,
+            Self::ByName => odf::SourceOrdering::ByName,
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // InputSlice
 // https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#inputslice-schema
@@ -770,6 +788,15 @@ impl From<odf::CompressionFormat> for CompressionFormat {
         match v {
             odf::CompressionFormat::Gzip => Self::Gzip,
             odf::CompressionFormat::Zip => Self::Zip,
+        }
+    }
+}
+
+impl Into<odf::CompressionFormat> for CompressionFormat {
+    fn into(self) -> odf::CompressionFormat {
+        match self {
+            Self::Gzip => odf::CompressionFormat::Gzip,
+            Self::Zip => odf::CompressionFormat::Zip,
         }
     }
 }

--- a/kamu-adapter-graphql/tests/tests/mod.rs
+++ b/kamu-adapter-graphql/tests/tests/mod.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod test_api_server_command;
 mod test_gql_data;
+
 mod test_gql_datasets;
+mod test_gql_metadata_chain;
 mod test_gql_search;

--- a/kamu-adapter-graphql/tests/tests/test_api_server_command.rs
+++ b/kamu-adapter-graphql/tests/tests/test_api_server_command.rs
@@ -7,16 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use dill::CatalogBuilder;
 use std::path::PathBuf;
 
 #[test_log::test(tokio::test)]
-async fn test_update_graphql_schema() {
+async fn update_graphql_schema() {
     let mut schema_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     schema_path.push("../resources/schema.gql");
 
-    let cmd = kamu_cli::commands::APIServerGqlSchemaCommand::new(CatalogBuilder::new().build());
-    let schema = cmd.get_schema();
+    let cat = dill::CatalogBuilder::new().build();
 
-    std::fs::write(&schema_path, schema).unwrap();
+    let schema = kamu_adapter_graphql::schema(cat);
+    std::fs::write(&schema_path, schema.sdl()).unwrap();
 }

--- a/kamu-adapter-graphql/tests/tests/test_gql_datasets.rs
+++ b/kamu-adapter-graphql/tests/tests/test_gql_datasets.rs
@@ -174,7 +174,7 @@ async fn dataset_create_from_snapshot() {
         .execute(indoc!(
             r#"{
                 datasets {
-                    createFromSnapshot (accountId: "kamu", datasetSnapshot: "<content>", datasetSnapshotFormat: YAML) {
+                    createFromSnapshot (accountId: "kamu", snapshot: "<content>", snapshotFormat: YAML) {
                         ... on CreateDatasetResultSuccess { 
                             dataset {
                                 name

--- a/kamu-adapter-graphql/tests/tests/test_gql_metadata_chain.rs
+++ b/kamu-adapter-graphql/tests/tests/test_gql_metadata_chain.rs
@@ -58,8 +58,8 @@ async fn metadata_chain_append_event() {
                         metadata {
                             chain {
                                 commitEvent (
-                                    metadataEvent: "<content>", 
-                                    metadataEventFormat: YAML,
+                                    event: "<content>",
+                                    eventFormat: YAML,
                                 ) {
                                     ... on CommitResultSuccess {
                                         oldHead

--- a/kamu-adapter-graphql/tests/tests/test_gql_metadata_chain.rs
+++ b/kamu-adapter-graphql/tests/tests/test_gql_metadata_chain.rs
@@ -1,0 +1,94 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_graphql::*;
+use indoc::indoc;
+use kamu::domain::*;
+use kamu::infra;
+use kamu::testing::MetadataFactory;
+use opendatafabric::serde::yaml::YamlMetadataEventSerializer;
+use opendatafabric::*;
+
+use std::sync::Arc;
+
+#[test_log::test(tokio::test)]
+async fn metadata_chain_append_event() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let workspace_layout = Arc::new(infra::WorkspaceLayout::create(tempdir.path()).unwrap());
+    let local_repo = infra::LocalDatasetRepositoryImpl::new(workspace_layout.clone());
+
+    let cat = dill::CatalogBuilder::new()
+        .add_value(local_repo)
+        .bind::<dyn LocalDatasetRepository, infra::LocalDatasetRepositoryImpl>()
+        .build();
+
+    let local_repo = cat.get_one::<dyn LocalDatasetRepository>().unwrap();
+    let create_result = local_repo
+        .create_dataset_from_snapshot(
+            MetadataFactory::dataset_snapshot()
+                .name("foo")
+                .kind(DatasetKind::Root)
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    let event = MetadataFactory::set_polling_source().build();
+
+    let event_yaml = String::from_utf8_lossy(
+        &YamlMetadataEventSerializer
+            .write_manifest(&MetadataEvent::SetPollingSource(event))
+            .unwrap(),
+    )
+    .to_string();
+
+    let schema = kamu_adapter_graphql::schema(cat);
+    let res = schema
+        .execute(
+            indoc!(
+                r#"{
+                datasets {
+                    byOwnerAndName (accountName: "kamu", datasetName: "foo") {
+                        metadata {
+                            chain {
+                                commitEvent (
+                                    metadataEvent: "<content>", 
+                                    metadataEventFormat: YAML,
+                                ) {
+                                    ... on CommitResultSuccess {
+                                        oldHead
+                                    }
+                                }
+                            }
+                        }
+                    } 
+                } 
+            }"#
+            )
+            .replace("<content>", &event_yaml.escape_default().to_string()),
+        )
+        .await;
+    assert!(res.is_ok(), "{:?}", res);
+    assert_eq!(
+        res.data,
+        value!({
+            "datasets": {
+                "byOwnerAndName": {
+                    "metadata": {
+                        "chain": {
+                            "commitEvent": {
+                                "oldHead": create_result.head.to_string(),
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+}

--- a/kamu-cli/Cargo.toml
+++ b/kamu-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-cli"
-version = "0.111.0"
+version = "0.112.0"
 description = "Decentralized data management tool"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"

--- a/kamu-cli/tests/tests/mod.rs
+++ b/kamu-cli/tests/tests/mod.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod test_api_server_command;
 mod test_complete_command;
 mod test_new_dataset_command;
 mod test_pull_command;

--- a/kamu-core/Cargo.toml
+++ b/kamu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/opendatafabric/Cargo.toml
+++ b/opendatafabric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendatafabric"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"
@@ -26,7 +26,7 @@ ed25519-dalek = "*"
 
 # Serialization
 byteorder = "*"
-flatbuffers = "*"
+flatbuffers = "22"  # TODO: Automate keeping in sync with arrow crate
 hex = "*"
 serde = { version = "*", features = ["derive"] }
 serde_with = "*"

--- a/opendatafabric/src/serde/serdes.rs
+++ b/opendatafabric/src/serde/serdes.rs
@@ -157,8 +157,6 @@ impl From<MetadataBlockVersionError> for Error {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-//    #[error("Unsupported version: manifest has version {manifest_version} while maximum supported version is {supported_version}")]
-//    #[error("Obsolete version: manifest has version {manifest_version} while minimum supported version is {minimum_supported_version}")]
 
 #[derive(Error, PartialEq, Eq, Debug)]
 pub struct UnsupportedVersionError {

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -71,9 +71,50 @@ type Checkpoint {
 	size: Int!
 }
 
+interface CommitResult {
+	message: String!
+}
+
+type CommitResultAppendError implements CommitResult {
+	message: String!
+}
+
+type CommitResultSuccess implements CommitResult {
+	oldHead: Multihash
+	newHead: Multihash!
+	message: String!
+}
+
 enum CompressionFormat {
 	GZIP
 	ZIP
+}
+
+interface CreateDatasetFromSnapshotResult {
+	message: String!
+}
+
+interface CreateDatasetResult {
+	message: String!
+}
+
+type CreateDatasetResultInvalidSnapshot implements CreateDatasetFromSnapshotResult {
+	message: String!
+}
+
+type CreateDatasetResultMissingInputs implements CreateDatasetFromSnapshotResult {
+	missingInputs: [String!]!
+	message: String!
+}
+
+type CreateDatasetResultNameCollision implements CreateDatasetResult & CreateDatasetFromSnapshotResult {
+	datasetName: DatasetName!
+	message: String!
+}
+
+type CreateDatasetResultSuccess implements CreateDatasetResult & CreateDatasetFromSnapshotResult {
+	dataset: Dataset!
+	message: String!
 }
 
 type DataBatch {
@@ -276,6 +317,14 @@ type Datasets {
 	Returns datasets belonging to the specified account
 	"""
 	byAccountName(accountName: AccountName!, page: Int, perPage: Int): DatasetConnection!
+	"""
+	Creates a new empty dataset
+	"""
+	createEmpty(accountId: AccountID!, datasetKind: DatasetKind!, datasetName: DatasetName!): CreateDatasetResult!
+	"""
+	Creates a new dataset from provided DatasetSnapshot manifest
+	"""
+	createFromSnapshot(accountId: AccountID!, datasetSnapshot: String!, datasetSnapshotFormat: MetadataManifestFormat!): CreateDatasetFromSnapshotResult!
 }
 
 """
@@ -404,12 +453,32 @@ type MetadataChain {
 	"""
 	blockByHash(hash: Multihash!): MetadataBlockExtended
 	"""
+	Returns a metadata block corresponding to the specified hash and encoded in desired format
+	"""
+	blockByHashRaw(hash: Multihash!, blockFormat: MetadataManifestFormat!): String
+	"""
 	Iterates all metadata blocks in the reverse chronological order
 	"""
 	blocks(page: Int, perPage: Int): MetadataBlockConnection!
+	"""
+	Commits new event to the metadata chain
+	"""
+	commitEvent(metadataEvent: String!, metadataEventFormat: MetadataManifestFormat!): CommitResult!
 }
 
 union MetadataEvent = AddData | ExecuteQuery | Seed | SetPollingSource | SetTransform | SetVocab | SetWatermark | SetAttachments | SetInfo | SetLicense
+
+enum MetadataManifestFormat {
+	YAML
+}
+
+type MetadataManifestMalformed implements CommitResult & CreateDatasetFromSnapshotResult {
+	message: String!
+}
+
+type MetadataManifestUnsupportedVersion implements CommitResult & CreateDatasetFromSnapshotResult {
+	message: String!
+}
 
 scalar Multihash
 

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -324,7 +324,7 @@ type Datasets {
 	"""
 	Creates a new dataset from provided DatasetSnapshot manifest
 	"""
-	createFromSnapshot(accountId: AccountID!, datasetSnapshot: String!, datasetSnapshotFormat: MetadataManifestFormat!): CreateDatasetFromSnapshotResult!
+	createFromSnapshot(accountId: AccountID!, snapshot: String!, snapshotFormat: MetadataManifestFormat!): CreateDatasetFromSnapshotResult!
 }
 
 """
@@ -455,7 +455,7 @@ type MetadataChain {
 	"""
 	Returns a metadata block corresponding to the specified hash and encoded in desired format
 	"""
-	blockByHashRaw(hash: Multihash!, blockFormat: MetadataManifestFormat!): String
+	blockByHashEncoded(hash: Multihash!, format: MetadataManifestFormat!): String
 	"""
 	Iterates all metadata blocks in the reverse chronological order
 	"""
@@ -463,7 +463,7 @@ type MetadataChain {
 	"""
 	Commits new event to the metadata chain
 	"""
-	commitEvent(metadataEvent: String!, metadataEventFormat: MetadataManifestFormat!): CommitResult!
+	commitEvent(event: String!, eventFormat: MetadataManifestFormat!): CommitResult!
 }
 
 union MetadataEvent = AddData | ExecuteQuery | Seed | SetPollingSource | SetTransform | SetVocab | SetWatermark | SetAttachments | SetInfo | SetLicense

--- a/utils/container-runtime/Cargo.toml
+++ b/utils/container-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-runtime"
-version = "0.111.0"
+version = "0.112.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../../LICENSE.txt"


### PR DESCRIPTION
Adds dataset creation APIs:

```gql
"""
Creates a new empty dataset
"""
createEmpty(accountId: AccountID!, datasetKind: DatasetKind!, datasetName: DatasetName!): CreateDatasetResult!
"""
Creates a new dataset from provided DatasetSnapshot manifest
"""
createFromSnapshot(accountId: AccountID!, datasetSnapshot: String!, datasetSnapshotFormat: MetadataManifestFormat!): CreateDatasetFromSnapshotResult!
```

Also adds a convenience method to get raw metadata block (e.g. in YAML format):
```gql
"""
Returns a metadata block corresponding to the specified hash and encoded in desired format
"""
blockByHashRaw(hash: Multihash!, blockFormat: MetadataManifestFormat!): String
```

And looking ahead - a new method for appending metadata events to a chain:
```gql
"""
Commits new event to the metadata chain
"""
commitEvent(metadataEvent: String!, metadataEventFormat: MetadataManifestFormat!): CommitResult!
```