### PR TITLE
Support kamu add from STDIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.114.0] - 2023-03-12
+### Added
+- `kamu add` command now supports reading from STDIN
+
 ## [0.113.0] - 2023-03-11
 ### Changed
 - Upgraded major dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.2.4",
+ "constant_time_eq 0.2.5",
  "digest 0.10.6",
 ]
 
@@ -829,13 +829,13 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "container-runtime"
-version = "0.113.0"
+version = "0.114.0"
 dependencies = [
  "dill",
  "regex",
@@ -2236,7 +2236,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "kamu"
-version = "0.113.0"
+version = "0.114.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.113.0"
+version = "0.114.0"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.113.0"
+version = "0.114.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2972,7 +2972,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opendatafabric"
-version = "0.113.0"
+version = "0.114.0"
 dependencies = [
  "bs58",
  "byteorder",

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.113.0
+Licensed Work:             Kamu CLI Version 0.114.0
                            The Licensed Work is © 2021 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,7 +1,7 @@
 IMAGE_REPO = docker.io/kamudata
 IMAGE_JUPYTER_TAG = 0.5.0
 
-KAMU_VERSION = 0.113.0
+KAMU_VERSION = 0.114.0
 
 
 .PHONY: jupyter

--- a/images/demo/Makefile
+++ b/images/demo/Makefile
@@ -1,5 +1,5 @@
 IMAGE_REPO = docker.io/kamudata
-KAMU_VERSION = 0.113.0
+KAMU_VERSION = 0.114.0
 DEMO_VERSION = 0.6.1
 
 #########################################################################################

--- a/kamu-adapter-graphql/Cargo.toml
+++ b/kamu-adapter-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-adapter-graphql"
-version = "0.113.0"
+version = "0.114.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 

--- a/kamu-cli/Cargo.toml
+++ b/kamu-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-cli"
-version = "0.113.0"
+version = "0.114.0"
 description = "Decentralized data management tool"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"

--- a/kamu-cli/src/app.rs
+++ b/kamu-cli/src/app.rs
@@ -84,7 +84,8 @@ pub async fn run(
 // Catalog
 /////////////////////////////////////////////////////////////////////////////////////////
 
-fn configure_catalog() -> CatalogBuilder {
+// Public only for tests
+pub fn configure_catalog() -> CatalogBuilder {
     let mut b = CatalogBuilder::new();
 
     b.add::<ConfigService>();

--- a/kamu-cli/src/cli_commands.rs
+++ b/kamu-cli/src/cli_commands.rs
@@ -26,9 +26,13 @@ pub fn get_command(
         Some(("add", submatches)) => Box::new(AddCommand::new(
             catalog.get_one()?,
             catalog.get_one()?,
-            submatches.get_many("manifest").unwrap().map(String::as_str), // required
+            submatches
+                .get_many("manifest")
+                .unwrap_or_default()
+                .map(String::as_str),
             submatches.get_flag("recursive"),
             submatches.get_flag("replace"),
+            submatches.get_flag("stdin"),
         )),
         Some(("complete", submatches)) => Box::new(CompleteCommand::new(
             if in_workspace(catalog.get_one()?) {

--- a/kamu-cli/src/cli_parser.rs
+++ b/kamu-cli/src/cli_parser.rs
@@ -111,9 +111,12 @@ pub fn cli() -> Command {
                             .long("replace")
                             .action(ArgAction::SetTrue)
                             .help("Delete and re-add datasets that already exist"),
+                        Arg::new("stdin")
+                            .long("stdin")
+                            .action(ArgAction::SetTrue)
+                            .help("Read manifests from standard input"),
                         Arg::new("manifest")
                             .action(ArgAction::Append)
-                            .required(true)
                             .index(1)
                             .help("Dataset manifest reference(s) (path, or URL)"),
                     ])

--- a/kamu-cli/tests/tests/mod.rs
+++ b/kamu-cli/tests/tests/mod.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod test_add_command;
 mod test_complete_command;
 mod test_new_dataset_command;
 mod test_pull_command;

--- a/kamu-cli/tests/tests/test_add_command.rs
+++ b/kamu-cli/tests/tests/test_add_command.rs
@@ -1,0 +1,89 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::utils::Kamu;
+use futures::TryStreamExt;
+use kamu::domain;
+use kamu::testing::MetadataFactory;
+use opendatafabric as odf;
+
+#[test_log::test(tokio::test)]
+async fn test_add_recursive() {
+    let kamu = Kamu::new_workspace_tmp().await;
+
+    // Plain manifest
+    let snapshot = MetadataFactory::dataset_snapshot().name("plain").build();
+    let manifest = odf::serde::yaml::YamlDatasetSnapshotSerializer
+        .write_manifest_str(&snapshot)
+        .unwrap();
+    std::fs::write(kamu.workspace_path().join("plain.yaml"), manifest).unwrap();
+
+    // Manifest with lots of comments
+    let snapshot = MetadataFactory::dataset_snapshot()
+        .name("commented")
+        .build();
+    let manifest = odf::serde::yaml::YamlDatasetSnapshotSerializer
+        .write_manifest_str(&snapshot)
+        .unwrap();
+    std::fs::write(
+        kamu.workspace_path().join("commented.yaml"),
+        format!(
+            indoc::indoc!(
+                r"
+
+                # Some
+                
+                # Weird
+                #
+                # Comment
+                {}
+                "
+            ),
+            &manifest
+        ),
+    )
+    .unwrap();
+
+    // Non-manifest YAML file
+    std::fs::write(
+        kamu.workspace_path().join("non-manifest.yaml"),
+        indoc::indoc!(
+            r"
+            foo:
+            - bar
+            ",
+        ),
+    )
+    .unwrap();
+
+    kamu.execute([
+        "-v",
+        "add",
+        "--recursive",
+        kamu.workspace_path().as_os_str().to_str().unwrap(),
+    ])
+    .await
+    .unwrap();
+
+    let local_repo = kamu
+        .catalog()
+        .get_one::<dyn domain::LocalDatasetRepository>()
+        .unwrap();
+
+    let mut datasets: Vec<_> = local_repo
+        .get_all_datasets()
+        .map_ok(|h| h.name)
+        .try_collect()
+        .await
+        .unwrap();
+
+    datasets.sort();
+
+    assert_eq!(datasets, ["commented", "plain"]);
+}

--- a/kamu-cli/tests/utils/kamu.rs
+++ b/kamu-cli/tests/utils/kamu.rs
@@ -150,6 +150,12 @@ impl Kamu {
 
         self.execute(["add".as_ref(), f.path().as_os_str()]).await
     }
+
+    pub fn catalog(&self) -> dill::Catalog {
+        let mut builder = kamu_cli::configure_catalog();
+        builder.add_value(self.workspace_layout.clone());
+        builder.build()
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/kamu-core/Cargo.toml
+++ b/kamu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu"
-version = "0.113.0"
+version = "0.114.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/opendatafabric/Cargo.toml
+++ b/opendatafabric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opendatafabric"
-version = "0.113.0"
+version = "0.114.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../LICENSE.txt"

--- a/utils/container-runtime/Cargo.toml
+++ b/utils/container-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container-runtime"
-version = "0.113.0"
+version = "0.114.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
 edition = "2021"
 license-file = "../../LICENSE.txt"


### PR DESCRIPTION
- Adds `--stdin` flag to `kamu add` command
- Improved heuristics that detects if YAML file is a `DatasetSnapshot` during `kamu add --recursive <dir>` to ignore comments