### PR TITLE
chore/dependency management

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,8 +11,8 @@ on:
 env:
   RUST_BACKTRACE: "1"
 jobs:
-  check_fmt:
-    name: Check / Formatting
+  lint_fmt:
+    name: Lint / Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,14 +25,21 @@ jobs:
           command: fmt
           args: --check
 
+  lint_deps:
+    name: Lint / Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
+      - run: cargo install --locked cargo-deny
+      - run: cargo deny check
+
   test_linux:
     name: Test / Linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-        with:
-          components: rustfmt
       - uses: ibnesayeed/setup-ipfs@master
         with:
           ipfs_version: "0.14" # TODO: https://github.com/kamu-data/kamu-cli/issues/108
@@ -58,8 +65,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-        with:
-          components: rustfmt
       # - uses: actions/cache@v3 # Source: https://github.com/actions/cache/blob/main/examples.md#rust---cargo
       #   with:
       #     path: |
@@ -77,8 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-        with:
-          components: rustfmt
       # - uses: actions/cache@v3 # Source: https://github.com/actions/cache/blob/main/examples.md#rust---cargo
       #   with:
       #     path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,7 +527,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -520,7 +560,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -816,40 +856,40 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906f7fe1da4185b7a282b2bc90172a496f9def1aca4545fe7526810741591e14"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351f9ad9688141ed83dfd8f5fb998a06225ef444b48ff4dc43de6d409b7fd10b"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
 dependencies = [
+ "anstream",
+ "anstyle",
  "bitflags",
  "clap_lex",
- "is-terminal",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.1.6"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d3120a421cd111c43f1a6c7d0dd83bb6aaa0659c164468a1654014632a5ec6"
+checksum = "01c22dcfb410883764b29953103d9ef7bb8fe21b3fa1158bc99986c2067294bd"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0807fb6f644c83f3e4ec014fec9858c1c8b26a7db8eb5f0bde5817df9c1df7"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codespan-reporting"
@@ -880,6 +920,21 @@ dependencies = [
  "strum",
  "strum_macros",
  "unicode-width",
+]
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1107,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -1142,7 +1197,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -1159,7 +1214,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -1422,7 +1477,7 @@ checksum = "9d02f0320d022591ffc1a8fbefc75a8419a0da12c0d974f92839f4e7fed0fb08"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -1578,13 +1633,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1623,7 +1678,7 @@ checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "windows-sys 0.45.0",
 ]
 
@@ -1697,9 +1752,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1712,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1722,15 +1777,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1739,38 +1794,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2272,9 +2327,9 @@ checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -2536,6 +2591,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamu-tools"
+version = "0.116.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "glob",
+ "indoc",
+ "regex",
+ "semver",
+ "toml",
+ "toml_edit",
+ "url",
+ "yaml-rust",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,9 +2756,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -2909,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "multer"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed4198ce7a4cbd2a57af78d28c6fbb57d81ac5f1d6ad79ac6c5587419cbdf22"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
  "bytes",
  "encoding_rs",
@@ -3249,7 +3320,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
@@ -3262,7 +3333,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -3352,9 +3423,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3362,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81186863f3d0a27340815be8f2078dd8050b14cd71913db9fbda795e5f707d7"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3372,22 +3443,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3b284b1f13a20dc5ebc90aff59a51b8d7137c221131b52a7260c08cbc1cc80"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
 dependencies = [
  "once_cell",
  "pest",
@@ -3704,9 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f851a03551ceefd30132e447f07f96cb7011d6b658374f3aed847333adb5559"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rdrand"
@@ -3733,13 +3804,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.8",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -3841,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuf"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ca10b9c9e53ac855a2d6953bce34cef6edbac32c4b13047a4d59d67299420a"
+checksum = "79abed428d1fd2a128201cec72c5f6938e2da607c6f3745f769fabea399d950a"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4002,9 +4082,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849"
 dependencies = [
  "bitflags",
  "errno",
@@ -4174,7 +4254,7 @@ checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -4506,9 +4586,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4534,15 +4614,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4602,7 +4682,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -4725,7 +4805,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -4834,14 +4914,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "1395a90742867024769551f906de147d352fb7cbdb4fd1cdbffe17734cfb124c"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4853,31 +4932,12 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tools"
-version = "0.116.0"
-dependencies = [
- "chrono",
- "clap",
- "glob",
- "indoc",
- "regex",
- "semver",
- "toml",
- "toml_edit",
- "url",
- "yaml-rust",
 ]
 
 [[package]]
@@ -4974,9 +5034,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-bunyan-formatter"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fa7c4b548e5c79a0300396f36f175da001e9933dfb5960b326db25fddbaee7"
+checksum = "25a348912d4e90923cb93343691d3be97e3409607363706c400fc935bb032fb0"
 dependencies = [
  "ahash",
  "gethostname",
@@ -4998,16 +5058,6 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -5224,6 +5274,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -5605,22 +5661,22 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25588073e5216b50bca71d61cb8595cdb9745e87032a58c199730def2862c934"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,12 +1745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,12 +1832,6 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -3209,7 +3197,6 @@ dependencies = [
  "indoc",
  "prost",
  "rand 0.7.3",
- "rust-crypto",
  "serde",
  "serde_with",
  "serde_yaml",
@@ -3666,29 +3653,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3733,21 +3697,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -3778,15 +3727,6 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
 
 [[package]]
 name = "read_input"
@@ -4017,19 +3957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time 0.1.45",
-]
-
-[[package]]
 name = "rust-embed"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4064,12 +3991,6 @@ dependencies = [
  "sha2 0.10.6",
  "walkdir",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,66 @@ members = [
     "utils/container-runtime",
 ]
 resolver = "2"
+
+
+[workspace.package]
+edition = "2021"
+
+
+[workspace.dependencies]
+# Utils
+async-trait = "0.1"
+async-recursion = "1"
+bytes = "1.4"
+chrono = "0.4"
+clap = "4"
+digest = "0.10"
+dill = "0.5"
+indoc = "2"
+itertools = "0.10"
+regex = "1"
+serde = "1"
+serde_with = "2"
+serde_json = "1"
+serde_yaml = "0.9"
+sha3 = "0.10"
+thiserror = "1"
+tempfile = "3"
+url = "2"
+
+# Tracing
+env_logger = "0.10"
+test-log = "0.2"
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-bunyan-formatter = "0.3"
+tracing-log = "0.1"
+tracing-subscriber = "0.3"
+
+# Arrow / Datafusion
+arrow = "34"
+arrow-digest = "34"  # Data hashing (in-house library)
+datafusion = "21"
+flatbuffers = "23"
+object_store = "0.5"  # Datafusion internals
+
+# Async
+async-stream = "0.3"
+futures = "0.3"
+pin-project = "1"
+reqwest = "0.11"
+tokio = "1"
+tokio-stream = "0.1"
+tokio-util = "0.7"
+
+# HTTP
+http = "0.2"
+hyper = "0.14"
+tower = "0.4"
+tower-http = "0.4"
+axum = "0.6"
+axum-extra = "0.7"
+
+# GQL
+async-graphql = "5"
+async-graphql-axum = "5"

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,152 @@
+# Developer Guide <!-- omit in toc -->
+- [Building Locally](#building-locally)
+  - [Run Tests with Podman (Recommended)](#run-tests-with-podman-recommended)
+  - [Run Tests with Docker (Alternative)](#run-tests-with-docker-alternative)
+  - [Using Nextest test runner (Optional)](#using-nextest-test-runner-optional)
+  - [Build Speed Tweaks (Optional)](#build-speed-tweaks-optional)
+  - [Building with Web UI (Optional)](#building-with-web-ui-optional)
+  - [Code Generation](#code-generation)
+- [Release Procedure](#release-procedure)
+
+
+## Building Locally
+Prerequisites:
+* Docker or Podman (note: unit tests run with Podman by default)
+  * If using `docker` - make sure it's usable without `sudo` ([guidelines](https://docs.docker.com/engine/install/linux-postinstall))
+  * If using `podman` - make sure it's setup to run root-less containers ([guidelines](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md))
+* Rust toolset
+  * Install `rustup`
+  * The correct toolchain version will be automatically installed based on the `rust-toolchain` file in the repository
+* Tools used by tests
+  * Install [`jq`](https://stedolan.github.io/jq) - used to query and format JSON files
+  * Install [`kubo`](https://docs.ipfs.io/install/command-line/#official-distributions) (formerly known as `go-ipfs`) - for IPFS-related tests
+* Code generation tools (optional - needed if you will be updating schemas)
+  * Install [`flatc`](https://github.com/google/flatbuffers)
+  * Install [`protoc`](https://github.com/protocolbuffers/protobuf) followed by:
+    * `cargo install protoc-gen-prost` - to install [prost protobuf plugin](https://crates.io/crates/protoc-gen-prost)
+    * `cargo install protoc-gen-tonic` - to install [tonic protobuf plugin](https://crates.io/crates/protoc-gen-tonic)
+* Cargo toolbelt (optional - if you will be doing releases)
+  * `cargo install cargo-update` - to easily keep your tools up-to-date
+  * `cargo install cargo-binstall` - to install binaries without compiling
+  * `cargo binstall cargo-binstall --force` - make future updates to use precompiled version
+  * `cargo binstall cargo-edit` - for setting crate versions during release
+  * `cargo binstall cargo-update` - for keeping up with major dependency updates
+  * `cargo binstall cargo-deny` - for linting dependencies
+  * `cargo binstall cargo-llvm-cov` - for coverage
+
+Clone the repository:
+```shell
+git clone git@github.com:kamu-data/kamu-cli.git
+```
+
+Build it:
+```shell
+cd kamu-cli
+cargo build
+```
+
+To use your locally-built `kamu` executable link it as so:
+```shell
+ln -s $PWD/target/debug/kamu-cli ~/.local/bin/kamu
+```
+
+When needing to test against a specific official release you can install it under a different alias:
+
+```shell
+curl -s "https://get.kamu.dev" | KAMU_ALIAS=kamu-release sh
+```
+
+
+### Run Tests with Podman (Recommended)
+
+Prepare test containers once before running tests:
+```shell
+cargo run --bin kamu-cli -- config set --user engine.runtime podman
+kamu init --pull-test-images
+```
+
+Then run tests:
+```shell
+cargo test
+```
+
+
+### Run Tests with Docker (Alternative)
+
+Prepare test containers once before running tests:
+```shell
+kamu init --pull-test-images
+```
+
+Then run tests:
+```shell
+KAMU_CONTAINER_RUNTIME_TYPE=docker cargo test
+
+```
+
+### Using Nextest test runner (Optional)
+[Nextest](https://nexte.st/) is a better test runner.
+
+To use it run:
+
+```sh
+cargo binstall cargo-nextest
+cargo nextest run
+```
+
+
+### Build Speed Tweaks (Optional)
+Consider configuring Rust to use `lld` linker, which is much faster than the default `ld` (may improve link times by ~10-20x).
+
+To do so install `lld`, then create `~/.cargo/config.toml` file with the following contents:
+
+```toml
+[build]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+```
+
+One more alternative is to use `mold` linker, which is also much faster than the default `ld`.
+
+To do so install `mold` or build it with `clang++` compiler from [mold sources](https://github.com/rui314/mold#how-to-build) then create `~/.cargo/config.toml` file with the following contents:
+
+```toml
+[build]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+```
+
+
+### Building with Web UI (Optional)
+To build the tool with embedded Web UI you will need to clone and build [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui) repo or use pre-built release. Now build the tool while enabling the optional feature and passing the location of the web root directory:
+
+```shell
+KAMU_WEB_UI_DIR=`pwd`/../kamu-web-ui/dist/kamu-platform/ cargo build --features kamu-cli/web-ui
+```
+
+Note: `KAMU_WEB_UI_DIR` requires absolute path
+
+Note: in debug mode the directory content is not actually being embedded into the executable but accessed from the specified directory.
+
+
+### Code Generation
+Many core types in `kamu` are generated from schemas and IDLs in the [open-data-fabric](https://github.com/open-data-fabric/open-data-fabric) repository. If your work involves making changes to those - you will need to re-run the code generation tasks using:
+
+```sh
+make codegen
+```
+
+Make sure you have all related dependencies installed (see above) and that ODF repo is checked out in the same directory as `kamu-cli` repo.
+
+
+## Release Procedure
+1. While on the feature branch, bump the crates versions using `release` tool, e.g. `cargo run --bin release -- --major / --minor / --patch`
+2. We try to stay up-to-date with all dependencies, so:
+   1. Run `cargo update` to pull in any minor releases
+   2. Run `cargo upgrade --dry-run` and see which packages have major upgrades - either perform them or ticket them up
+   3. Run `cargo deny check` to audit updated dependencies for licenses, security advisories etc.
+3. Create a `CHANGELOG` entry for the new version
+4. Create PR, wait for tests, then merge
+5. Checkout and pull `master`
+6. Tag the latest commit with a new version: `git tag vX.Y.Z`
+7. Push the tag to repo: `git push origin tag vX.Y.Z`
+8. Github Actions will pick up the new tag and create a new GitHub release from it

--- a/README.md
+++ b/README.md
@@ -229,6 +229,6 @@ If you'd like to contribute [start here](https://docs.kamu.dev/contrib/).
 [FAQ]: https://docs.kamu.dev/cli/get-started/faq/
 [Chat]: https://discord.gg/nU6TXRQNXC
 [Contributing]: https://docs.kamu.dev/contrib/
-[Developer Guide]: https://docs.kamu.dev/cli/developer-guide/
+[Developer Guide]: ./DEVELOPER.md
 [License]: https://docs.kamu.dev/contrib/license/
 [Website]: https://kamu.dev

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,55 @@
+[bans]
+# TODO: Change to "deny" once we crack down on duplication
+multiple-versions = "warn"
+# Avoid adding dependencies to this list as this slows down compilation.
+# Find another ways to avoid duplication.
+skip = []
+deny = [
+    # Use `md-5` instead, which is part of the RustCrypto ecosystem
+    { name = "md5" },
+    # TODO: We should decide whether to stick with OpenSSL
+    # { name = "rustls" },
+]
+
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "CC0-1.0",
+    "0BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Zlib",
+    "OpenSSL",
+]
+copyleft = "deny"
+private = { ignore = true }
+
+[[licenses.exceptions]]
+allow = ["Unicode-DFS-2016"]
+name = "unicode-ident"
+
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+
+[sources]
+unknown-git = "deny"
+unknown-registry = "deny"
+allow-git = []
+
+
+[advisories]
+vulnerability = "warn"
+unmaintained = "warn"
+unsound = "warn"
+yanked = "deny"
+notice = "warn"

--- a/kamu-adapter-graphql/Cargo.toml
+++ b/kamu-adapter-graphql/Cargo.toml
@@ -2,39 +2,37 @@
 name = "kamu-adapter-graphql"
 version = "0.116.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
-edition = "2021"
+edition.workspace = true
+publish = false
 
 [lib]
 doctest = false
 
 [dependencies]
 # Kamu
-dill = ">= 0.5.0"
+dill = { workspace = true }
 opendatafabric = { path = "../opendatafabric" }
 kamu = { path = "../kamu-core" }
 
 # HTTP
-# TODO: Remove from this crate
-reqwest = { version = "*", features = ["json"] }
+# TODO: Remove from this crate (needed by GitHub auth)
+reqwest = { workspace = true, features = ["json"] }
 
 # GraphQL
-async-graphql = { version = "*", features = ["chrono", "url", "apollo_tracing"] }
+async-graphql = { workspace = true, features = ["chrono", "url", "apollo_tracing"] }
 
 # Utils
-indoc = "*"
-chrono = "*"
-datafusion = "21"  # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
-futures = "*"
-serde = "*"
-serde_json = "*"
-tracing = "*"
-# tokio = { version = "*", features = ["macros"] }
-# url = "*"
-
+indoc = { workspace = true }
+chrono = { workspace = true }
+datafusion = { workspace = true }  # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-tempfile = "*"
-tokio = { version = "*" }
-env_logger = "*"
-test-log = { version = "*", features = ["trace"] }
-tracing-subscriber = { version = "*", features = ["env-filter"] }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+env_logger = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/kamu-adapter-http/Cargo.toml
+++ b/kamu-adapter-http/Cargo.toml
@@ -2,7 +2,8 @@
 name = "kamu-adapter-http"
 version = "0.116.0"
 authors = ["Sergei Zaychenko <szaychenko@kamu.dev>"]
-edition = "2021"
+edition.workspace = true
+publish = false
 
 [lib]
 doctest = false
@@ -12,43 +13,43 @@ skip_docker_tests = []
 
 [dependencies]
 # Kamu
-dill = ">= 0.5.0"
+dill = { workspace = true }
 opendatafabric = { path = "../opendatafabric" }
 kamu = { path = "../kamu-core" }
 container-runtime = { path = "../utils/container-runtime" }
 
 # HTTP
-tower = { version = "*" }
-axum = { version = "*", features = ["ws", "headers"] }
-axum-extra = { version = "*", features = ["async-read-body"] }
-reqwest = { version = "*", features = ["json"] }
+tower = { workspace = true }
+axum = { workspace = true, features = ["ws", "headers"] }
+axum-extra = { workspace = true, features = ["async-read-body"] }
+reqwest = { workspace = true, features = ["json"] }
 
 # IO
-futures = "*"
-tokio = { version = "*"}
-tokio-stream = { version = "*" }
-tokio-util = { version = "*", features=["codec", "compat", "io"] }
-tokio-tungstenite = { version = "*" }
-bytes = "*"
-flate2 = "*"  # GZip decoder
-tar = "*" 
+futures = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features=["codec", "compat", "io"] }
+tokio-tungstenite = { version = "0.18" }
+bytes = { workspace = true }
+flate2 = "1"  # GZip decoder
+tar = "0.4" 
 
 # Utils
-async-trait = "*"
-chrono = { version = "*", features = ["serde"] }
-url = { version = "*", features = ["serde"] }
-thiserror = "*"  # Structured error derivations
-serde = "*"
-serde_json = "*"
-tracing = "*"
+async-trait = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+url = { workspace = true, features = ["serde"] }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-tempfile = "*"
-env_logger = "*"
-test-log = { version = "*", features = ["trace"] }
-tracing-subscriber = { version = "*", features = ["env-filter"] }
-hyper = "*"
-tower = { version = "*" }
-tower-http = { version = "*", features = ["trace", "cors"] }
-serde = { version = "*", features = ["derive"] }
-fs_extra = "*"  # Recursive folder copy
+tempfile = { workspace = true }
+env_logger = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+hyper = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["trace", "cors"] }
+serde = { workspace = true, features = ["derive"] }
+fs_extra = "1.3"  # Recursive folder copy

--- a/kamu-cli/Cargo.toml
+++ b/kamu-cli/Cargo.toml
@@ -3,9 +3,10 @@ name = "kamu-cli"
 version = "0.116.0"
 description = "Decentralized data management tool"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
-edition = "2021"
+edition.workspace = true
 readme = "../README.md"
 license-file = "../LICENSE.txt"
+publish = false
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"
 keywords = ["cli", "data", "collaboration", "pipeline", "management", "provenance"]
@@ -20,8 +21,7 @@ web-ui = []
 skip_docker_tests = []
 
 [dependencies]
-dill = ">= 0.5.0"
-# dill = { path = "../../dill" }
+dill = { workspace = true }
 opendatafabric = { path = "../opendatafabric" }
 kamu = { path = "../kamu-core" }
 kamu-adapter-graphql = { path = "../kamu-adapter-graphql" }
@@ -29,75 +29,75 @@ kamu-adapter-http = { path = "../kamu-adapter-http" }
 container-runtime = { path = "../utils/container-runtime" }
 
 # CLI
-read_input = "*"  # Basic user input
-chrono-humanize = "*"  # Human readable durations
-clap = "*"
-clap_complete = "*"
-console = "*"  # Terminal colors
-humansize = "*"  # Human readable data sizes
-indicatif = "*"  # Progress bars and spinners
+read_input = "0.8"  # Basic user input
+chrono-humanize = "0.2"  # Human readable durations
+clap = { workspace = true }
+clap_complete = "4.2"
+console = "0.15"  # Terminal colors
+humansize = "2"  # Human readable data sizes
+indicatif = "0.17"  # Progress bars and spinners
 minus = { version = "5", features = ["static_output", "search"] }
-num-format = "*"  # Human-readable number formatting
-prettytable-rs = "*"  # ASCII table formatting
-webbrowser = "*"  # For opening URLs in default system browser
+num-format = "0.4"  # Human-readable number formatting
+prettytable-rs = "0.10"  # ASCII table formatting
+webbrowser = "0.8"  # For opening URLs in default system browser
 
 # API / GraphQL
-http = "*"
-hyper = "*"
-tower = { version = "*" }
-tower-http = { version = "*", features = ["trace", "cors"] }
-axum = { version = "*", features = ["ws"] }
-axum-extra = { version = "*", features = ["async-read-body"] }
-async-graphql = { version = "*", features = ["chrono", "url", "apollo_tracing"] }
-async-graphql-axum = "*"
-serde_json = "*"
+http = { workspace = true }
+hyper = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["trace", "cors"] }
+axum = { workspace = true, features = ["ws"] }
+axum-extra = { workspace = true, features = ["async-read-body"] }
+async-graphql = { workspace = true, features = ["chrono", "url", "apollo_tracing"] }
+async-graphql-axum = { workspace = true }
+serde_json = { workspace = true }
 
 # Web UI
-rust-embed = { version = "*", features = ["interpolate-folder-path", "compression"] }
-mime = "*"
-mime_guess = "*"
+rust-embed = { version = "6", features = ["interpolate-folder-path", "compression"] }
+mime = "0.3"
+mime_guess = "2"
 
 # Config
-merge = "*"
-serde = { version = "*", features = ["derive"] }
-serde_with = "*"
-serde_yaml = "*"
-duration-string = { version = "*", features = ["serde"] }
+merge = "0.1"
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true }
+serde_yaml = { workspace = true }
+duration-string = { version = "0.3", features = ["serde"] }
 
 # Tracing / logging / telemetry
-tracing = "*"
-tracing-appender = "*"
-tracing-subscriber = { version = "*", features = ["env-filter"] }
-tracing-log = "*"
-tracing-bunyan-formatter = "*"
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-log = { workspace = true }
+tracing-bunyan-formatter = { workspace = true }
 
 # Utils
-async-trait = "*"
-chrono = "*"
-cfg-if = "*"  # Conditional compilation
-glob = "*"  # Used for path completions
-datafusion = "21"
-dirs = "*"
-futures = "*"
-indoc = "*"
-itertools = "*"
-libc = "*"  # Signal names
-regex = "*"
-shlex = "*"  # Parsing partial input for custom completions
-signal-hook = "*"  # Signal handling
-tokio = { version = "*", features = [] }
-tempfile = "*"
-thiserror = "*"  # Structured error derivations
-url = "*"
-urlencoding = "*"
+async-trait = { workspace = true }
+chrono = { workspace = true }
+cfg-if = "1"  # Conditional compilation
+glob = "0.3"  # Used for path completions
+datafusion = { workspace = true }
+dirs = "5"
+futures = { workspace = true }
+indoc = { workspace = true }
+itertools = { workspace = true }
+libc = "0.2"  # Signal names
+regex = { workspace = true }
+shlex = "1"  # Parsing partial input for custom completions
+signal-hook = "0.3"  # Signal handling
+tokio = { workspace = true, features = [] }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+urlencoding = "2"
 
 
 [target.'cfg(unix)'.dependencies]
-users = "*"  # For getting uid:gid
+users = "0.11"  # For getting uid:gid
 
 
 [dev-dependencies]
-rand = "^0.8"
-indoc = "*"  # Compile-time unindent
-env_logger = "*"
-test-log = { version = "*", features = ["trace"] }
+rand = "0.8"
+indoc = { workspace = true }
+env_logger = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }

--- a/kamu-core/Cargo.toml
+++ b/kamu-core/Cargo.toml
@@ -2,8 +2,9 @@
 name = "kamu"
 version = "0.116.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
-edition = "2021"
+edition.workspace = true
 license-file = "../LICENSE.txt"
+publish = false
 
 [lib]
 doctest = false
@@ -12,82 +13,81 @@ doctest = false
 skip_docker_tests = []
 
 [dependencies]
-dill = ">= 0.5.0"
-# dill = { path = "../../dill" }
+dill = { workspace = true }
 opendatafabric = { path = "../opendatafabric" }
 container-runtime = { path = "../utils/container-runtime" }
 
 # Domain
-chrono = { version = "*", features = ["serde"] }
-url = { version = "*", features = ["serde"] }
+chrono = { workspace = true, features = ["serde"] }
+url = { workspace = true, features = ["serde"] }
 
 # Serialization
-hex = "*"
-serde = { version = "*", features = ["derive"] }
-serde_with = "*"
-serde_yaml = "*"
-json = "*"
+hex = "0.4"
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true }
+serde_yaml = { workspace = true }
+json = "0.12"
 
 # Ingest
-flate2 = "*"  # GZip decoder
-fs_extra = "*"  # Copy files with progress, get directory sizes
-curl = { version = "*", features = ["http2", "protocol-ftp", "static-curl", "static-ssl"] }  # TODO: reconsider static linking
-curl-sys = "*"
-reqwest = { version  = "*", features = ["rustls-tls", "gzip", "deflate", "stream"] }
-ringbuf = "*"
-tar = "*"  # Checkpoint archival
-zip = "*"
+flate2 = "1"  # GZip decoder
+fs_extra = "1.3"  # Copy files with progress, get directory sizes
+curl = { version = "0.4", features = ["http2", "protocol-ftp", "static-curl", "static-ssl"] }  # TODO: reconsider static linking
+curl-sys = "0.4"
+reqwest = { workspace = true, features = ["rustls-tls", "gzip", "deflate", "stream"] }
+ringbuf = "0.3"
+tar = "0.4"  # Checkpoint archival
+zip = "0.6"
 
 # Data
-arrow = { version = "34", features = ["chrono-tz"] }
-arrow-digest = "34"  # Data hashing (in-house library)
-datafusion = "21"  # Reading data + SQL
-object_store = "*"  # Datafusion internals
-digest = "*"
-sha3 = "*"
+arrow = { workspace = true, features = ["chrono-tz"] }
+arrow-digest = { workspace = true }
+datafusion = { workspace = true }
+object_store = { workspace = true }
+digest = { workspace = true }
+sha3 = { workspace = true }
 
 # Repositories
-bytes = "*"
-futures = "*"
-async-stream = "*"
-tokio = { version = "*", features=["fs"] }
-tokio-stream = { version = "*" }
-tokio-util = { version = "*", features=["codec", "compat", "io"] }
-trust-dns-resolver = "*"  # TODO: Needed for DNSLink resolution with IPFS
-rusoto_core = {version = "0.47.0", default_features = false, features=["rustls"] }  # TODO: Pinned due to https://github.com/rusoto/rusoto/issues/1980
-rusoto_s3 = {version = "0.47.0", default_features = false, features=["rustls"] }  # TODO: Pinned due to https://github.com/rusoto/rusoto/issues/1980
+bytes = { workspace = true }
+futures = { workspace = true }
+async-stream = { workspace = true }
+tokio = { workspace = true, features=["fs"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features=["codec", "compat", "io"] }
+trust-dns-resolver = "0.22"  # TODO: Needed for DNSLink resolution with IPFS
+rusoto_core = { version = "0.47.0", default-features = false, features=["rustls"] }  # TODO: Pinned due to https://github.com/rusoto/rusoto/issues/1980
+rusoto_s3 = { version = "0.47.0", default-features = false, features=["rustls"] }  # TODO: Pinned due to https://github.com/rusoto/rusoto/issues/1980
 
 # Utils
-async-trait = "*"
-async-recursion = "*"
-cfg-if = "*"  # Conditional compilation
-glob = "*"  # Used for glob fetch
-rand = "^0.8"
-regex = "*"
-indoc = "*"  # Compile-time unindent
-itertools = "*"
-libc = "*"  # Signal names
-pathdiff = "*"  # Relative paths
-pin-project = "*"
-strum = "*"  # Enum from string
-strum_macros = "*"
-thiserror = "*"  # Structured error derivations
-tracing = "*"
-tempfile = "*"
-walkdir = "*"
+async-trait = { workspace = true }
+async-recursion = { workspace = true }
+cfg-if = "1"  # Conditional compilation
+glob = "0.3"  # Used for glob fetch
+rand = "0.8"
+regex = { workspace = true }
+indoc = { workspace = true }
+itertools = { workspace = true }
+libc = "0.2"  # Signal names
+pathdiff = "0.2"  # Relative paths
+pin-project = { workspace = true }
+strum = "0.24"  # Enum from string
+strum_macros = "0.24"
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tempfile = { workspace = true }
+walkdir = "2"
 
 [target.'cfg(unix)'.dependencies]
-users = "*"  # For getting uid:gid
+users = "0.11"  # For getting uid:gid
 
 [dev-dependencies]
-filetime = "*"
-env_logger = "*"
-test-log = { version = "*", features = ["trace"] }
-tracing-subscriber = { version = "*", features = ["env-filter"] }
+filetime = "0.2"
+env_logger = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 # Http file server
-http = "*"
-hyper = "*"
-tower = { version = "*" }
-tower-http = { version = "*", features = ["fs", "trace"] }
-axum = { version = "*" }
+http = { workspace = true }
+hyper = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["fs", "trace"] }
+axum = { workspace = true }

--- a/opendatafabric/Cargo.toml
+++ b/opendatafabric/Cargo.toml
@@ -2,40 +2,40 @@
 name = "opendatafabric"
 version = "0.116.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
-edition = "2021"
-license-file = "../LICENSE.txt"
+edition.workspace = true
+license = "Apache-2.0"
 
 [lib]
 doctest = false
 
 [dependencies]
 # Domain
-chrono = { version = "*", features = ["serde"] }
-rust-crypto = "*"  # Data and metadata hashing
+chrono = { workspace = true, features = ["serde"] }
+rust-crypto = "0.2"  # Data and metadata hashing
 
 # Multiformats
-bs58 = "*"  # base58 codec
-digest = "*"
-sha3 = "*"
-unsigned-varint = "*"
-url = "*"
+bs58 = "0.4"  # base58 codec
+digest = { workspace = true }
+sha3 = { workspace = true }
+unsigned-varint = "0.7"
+url = { workspace = true }
 
 # Crypto
 rand = "0.7"  # TODO: Pinned for ed25519-dalek compatibility
-ed25519-dalek = "*"
+ed25519-dalek = "1"
 
 # Serialization
-byteorder = "*"
-flatbuffers = "23"  # TODO: Automate keeping in sync with arrow crate
-hex = "*"
-serde = { version = "*", features = ["derive"] }
-serde_with = "*"
-serde_yaml = "*"
+byteorder = "1"
+flatbuffers = { workspace = true }
+hex = "0.4"
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true }
+serde_yaml = { workspace = true }
 
 # gRPC
-tonic = "*"
-prost = "*"
+tonic = "0.9"
+prost = "0.11"
 
 # Utils
-indoc = "*"  # Compile-time unindent
-thiserror = "*"  # Structured error derivations
+indoc = { workspace = true }
+thiserror = { workspace = true }

--- a/opendatafabric/Cargo.toml
+++ b/opendatafabric/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies]
 # Domain
 chrono = { workspace = true, features = ["serde"] }
-rust-crypto = "0.2"  # Data and metadata hashing
 
 # Multiformats
 bs58 = "0.4"  # base58 codec

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-name = "tools"
+name = "kamu-tools"
 version = "0.116.0"
 description = "Tools for managing this repo"
-edition = "2021"
+edition.workspace = true
+publish = false
 
 [[bin]]
 name = "release"
@@ -13,15 +14,15 @@ name = "create-test-workspace"
 path = "src/create_test_workspace.rs"
 
 [dependencies]
-clap = "*"
-chrono = "*"
-glob = "*"
-regex = "*"
-semver = "*"
-toml = "*"
-toml_edit = "*"
-url = "*"
-yaml-rust = "*"
+clap = { workspace = true }
+chrono = { workspace = true }
+glob = "0.3"
+regex = { workspace = true }
+semver = "1"
+toml = "0.7"
+toml_edit = "0.19"
+url = { workspace = true }
+yaml-rust = "0.4"
 
 [dev-dependencies]
-indoc = "*"
+indoc = { workspace = true }

--- a/utils/container-runtime/Cargo.toml
+++ b/utils/container-runtime/Cargo.toml
@@ -2,15 +2,15 @@
 name = "container-runtime"
 version = "0.116.0"
 authors = ["Sergii Mikhtoniuk <mikhtoniuk@gmail.com>"]
-edition = "2021"
-license-file = "../../LICENSE.txt"
+edition.workspace = true
+license = "Apache-2.0"
 
 [features]
 skip_docker_tests = []
 
 [dependencies]
-dill = ">= 0.5.0"
-regex = "*"
-serde = { version = "*", features = ["derive"] }
-thiserror = "*"
-url = "*"
+dill = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+url = { workspace = true }


### PR DESCRIPTION
In this PR:
- Extracted most widely used dependencies (`tokio`, `axum`, `arrow`, etc.) into workspace `Cargo.toml` to set version in one place
- Avoiding `dep = "*"` and specifying versions explicitly
  - `cargo upgrade --dry-run` makes upgrading both easy and explicit
- Integrated `cargo-deny` linter to check for incompatible licenses, security advisories, duplicated deps, and allow banning crates
  - Currently it only warns about duplicates and unmaintained libs, but we should soon switch it to error (major step would be getting rid of `rusoto` in favor AWS SDK as that crate is unmaintained and pulls in a bunch of duplicate dependencies (e.g. entire `rustls`)
- Moved `DEVELOPER.md` back into the repo from `kamu-docs` for convenience
