### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,9 +52,8 @@ jobs:
       #       ~/.cargo/git/db/
       #       target/
       #     key: ${{ runner.os }}-cargo
-      - run: cargo build
-      - run: cargo run --bin kamu-cli -- config set --user engine.runtime podman # Podman is default for tests but not for runtime yet
-      - run: cargo run --bin kamu-cli -- init --pull-test-images
+      - run: |
+          echo '{ "kind": "CLIConfig", "version": 1, "content": {"engine": { "runtime": "podman" } } }' > ~/.kamuconfig
       - run: cargo test --verbose --features test_ftp
       - run: git diff
       - run: git diff-index --quiet HEAD # Ensure all generated files are up-to-date

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,7 @@ jobs:
       #     key: ${{ runner.os }}-cargo
       - run: |
           echo '{ "kind": "CLIConfig", "version": 1, "content": {"engine": { "runtime": "podman" } } }' > ~/.kamuconfig
+      - run: cargo build --features test_ftp
       - run: cargo test --verbose --features test_ftp
       - run: git diff
       - run: git diff-index --quiet HEAD # Ensure all generated files are up-to-date
@@ -73,6 +74,7 @@ jobs:
       #       ~/.cargo/git/db/
       #       target/
       #     key: ${{ runner.os }}-cargo
+      - run: cargo build --features skip_docker_tests
       - run: cargo test --verbose --features skip_docker_tests
 
   test_windows:
@@ -93,4 +95,5 @@ jobs:
       #       ~/.cargo/git/db/
       #       target/
       #     key: ${{ runner.os }}-cargo
+      - run: cargo build --features skip_docker_tests
       - run: cargo test --verbose --features skip_docker_tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,10 +54,14 @@ jobs:
       #     key: ${{ runner.os }}-cargo
       - run: |
           echo '{ "kind": "CLIConfig", "version": 1, "content": {"engine": { "runtime": "podman" } } }' > ~/.kamuconfig
-      - run: cargo build --features test_ftp
-      - run: cargo test --verbose --features test_ftp
-      - run: git diff
-      - run: git diff-index --quiet HEAD # Ensure all generated files are up-to-date
+      - name: build
+        run: cargo test --features test_ftp --no-run
+      - name: pull test images
+        run: cargo test test_setup_pull_images --features test_ftp
+      - name: run tests
+        run: cargo test --verbose --features test_ftp
+      - name: check git diff 
+        run: git diff && git diff-index --quiet HEAD # Ensure all generated files are up-to-date
 
   test_macos:
     name: Test / MacOS
@@ -74,15 +78,14 @@ jobs:
       #       ~/.cargo/git/db/
       #       target/
       #     key: ${{ runner.os }}-cargo
-      - run: cargo build --features skip_docker_tests
-      - run: cargo test --verbose --features skip_docker_tests
+      - name: build
+        run: cargo test --features skip_docker_tests --no-run
+      - name: run tests
+        run: cargo test --verbose --features skip_docker_tests
 
   test_windows:
     name: Test / Windows
     runs-on: windows-latest
-    # Disabling until we investigate the cause of linker OOM crash
-    # Issue: https://www.notion.so/CI-Windows-build-is-failing-with-linker-OOM-d6d2fc0cb71543d79ff79539f539c603?pvs=4
-    if: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
@@ -95,5 +98,7 @@ jobs:
       #       ~/.cargo/git/db/
       #       target/
       #     key: ${{ runner.os }}-cargo
-      - run: cargo build --features skip_docker_tests
-      - run: cargo test --verbose --features skip_docker_tests
+      - name: build
+        run: cargo test --features skip_docker_tests --no-run
+      - name: run tests
+        run: cargo test --verbose --features skip_docker_tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         env:
           KAMU_WEB_UI_DIR: "../kamu-web-ui-any"
-        run: cross build --release --target=${{ matrix.target }} --features kamu-cli/web-ui
+        run: cross build -p kamu-cli --release --target=${{ matrix.target }} --features web-ui
       - name: Rename binary
         run: mv target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }} target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
       - uses: actions/upload-artifact@v3
@@ -56,7 +56,7 @@ jobs:
         run: |
           wget https://github.com/kamu-data/kamu-web-ui/releases/download/v${{ env.KAMU_WEB_UI_VERSION }}/kamu-web-ui-any.tar.gz && \
           tar -xf kamu-web-ui-any.tar.gz
-      - run: cargo build --release --target=${{ matrix.target }} --features kamu-cli/web-ui
+      - run: cargo build -p kamu-cli --release --target=${{ matrix.target }} --features web-ui
         env:
           KAMU_WEB_UI_DIR: "../kamu-web-ui-any"
       - name: Rename binary
@@ -78,7 +78,7 @@ jobs:
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
         with:
           components: rustfmt
-      - run: cargo build --release --target=${{ matrix.target }}
+      - run: cargo build -p kamu-cli --release --target=${{ matrix.target }}
       - name: Rename binary
         shell: bash
         run: mv target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }}.exe target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.123.1] - 2023-05-13
+### Changed
+- Build improvements
+- Excluding most of `openssl` from the build
+- Removed `--pull-test-images` flag from `kamu init` command in favor of pulling images directly during tests
+
 ## [0.123.0] - 2023-05-12
 ### Fixed
 - Verification of data through reproducibility should ignore differences in data and checkpoint sizes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,12 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
+
+
+# Emit the line info tables for our crates to produce useful crash reports and backtraces.
+# We don't emit info for dependencies as this significantly increases binary size.
+# See: https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+[profile.release.package]
+opendatafabric = { debug = 1 }
+kamu = { debug = 1 }
+kamu-cli = { debug = 1 }

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -62,13 +62,12 @@ New to Rust? Check out these [IDE configuration tip](#ide-tips).
 
 ### Run Tests with Podman (Recommended)
 
-Prepare test containers once before running tests:
+Set podman as preferred runtime for your user:
 ```shell
 cargo run --bin kamu-cli -- config set --user engine.runtime podman
-kamu init --pull-test-images
 ```
 
-Then run tests:
+Run tests (note: upon first run the tests will need to pull extra images and will run longer):
 ```shell
 cargo test
 ```
@@ -76,12 +75,7 @@ cargo test
 
 ### Run Tests with Docker (Alternative)
 
-Prepare test containers once before running tests:
-```shell
-kamu init --pull-test-images
-```
-
-Then run tests:
+Run tests (note: upon first run the tests will need to pull extra images and will run longer):
 ```shell
 KAMU_CONTAINER_RUNTIME_TYPE=docker cargo test
 

--- a/kamu-cli/src/cli_commands.rs
+++ b/kamu-cli/src/cli_commands.rs
@@ -94,10 +94,11 @@ pub fn get_command(
             submatches.get_flag("yes"),
         )),
         Some(("init", submatches)) => {
-            if submatches.get_flag("pull-images") || submatches.get_flag("pull-test-images") {
+            if submatches.get_flag("pull-images") {
                 Box::new(PullImagesCommand::new(
                     catalog.get_one()?,
-                    submatches.get_flag("pull-test-images"),
+                    catalog.get_one()?,
+                    catalog.get_one()?,
                     submatches.get_flag("list-only"),
                 ))
             } else {

--- a/kamu-cli/src/cli_parser.rs
+++ b/kamu-cli/src/cli_parser.rs
@@ -341,11 +341,6 @@ pub fn cli() -> Command {
                             .long("pull-images")
                             .action(ArgAction::SetTrue)
                             .help("Only pull container images and exit"),
-                        Arg::new("pull-test-images")
-                            .long("pull-test-images")
-                            .action(ArgAction::SetTrue)
-                            .hide(true)
-                            .help("Only pull test-related container images and exit"),
                         Arg::new("list-only")
                             .long("list-only")
                             .action(ArgAction::SetTrue)

--- a/kamu-core/src/testing/minio_server.rs
+++ b/kamu-core/src/testing/minio_server.rs
@@ -30,6 +30,7 @@ impl MinioServer {
         use rand::Rng;
 
         let container_runtime = ContainerRuntime::default();
+        container_runtime.ensure_image(Self::IMAGE, None);
 
         let mut server_name = "kamu-test-minio-".to_owned();
         server_name.extend(
@@ -43,12 +44,6 @@ impl MinioServer {
         if !server_dir.exists() {
             std::fs::create_dir(&server_dir).unwrap();
         }
-
-        assert!(
-            container_runtime.has_image(Self::IMAGE),
-            "Please pull {} image before running this test",
-            Self::IMAGE
-        );
 
         let process = container_runtime
             .run_cmd(RunArgs {

--- a/kamu-core/tests/tests/mod.rs
+++ b/kamu-core/tests/tests/mod.rs
@@ -16,6 +16,7 @@ mod test_resource_loader_impl;
 mod test_schema_utils;
 mod test_search_service_impl;
 mod test_serde_yaml;
+mod test_setup;
 mod test_sync_service_impl;
 mod test_transform_service_impl;
 mod test_verification_service_impl;

--- a/kamu-core/tests/tests/test_setup.rs
+++ b/kamu-core/tests/tests/test_setup.rs
@@ -1,0 +1,29 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use container_runtime::ContainerRuntime;
+use kamu::infra::utils::docker_images;
+
+// Not really a test - used by CI to separate pulling of test images
+// into its own phase
+#[cfg_attr(feature = "skip_docker_tests", ignore)]
+#[test_log::test]
+fn test_setup_pull_images() {
+    let container_runtime = ContainerRuntime::default();
+    container_runtime.ensure_image(docker_images::SPARK, None);
+    container_runtime.ensure_image(docker_images::FLINK, None);
+    container_runtime.ensure_image(docker_images::HTTPD, None);
+    container_runtime.ensure_image(docker_images::MINIO, None);
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "test_ftp")] {
+            container_runtime.ensure_image(docker_images::FTP, None);
+        }
+    }
+}

--- a/kamu-core/tests/utils/ftp_server.rs
+++ b/kamu-core/tests/utils/ftp_server.rs
@@ -28,6 +28,7 @@ impl FtpServer {
         use rand::Rng;
 
         let container_runtime = ContainerRuntime::default();
+        container_runtime.ensure_image(Self::IMAGE, None);
 
         let mut server_name = "kamu-test-ftp-".to_owned();
         server_name.extend(
@@ -40,12 +41,6 @@ impl FtpServer {
         if !server_dir.exists() {
             std::fs::create_dir(&server_dir).unwrap();
         }
-
-        assert!(
-            container_runtime.has_image(Self::IMAGE),
-            "Please pull {} image before running this test",
-            Self::IMAGE
-        );
 
         // TODO: this is likely very brittle because of all the port mapping
         // FTP is a crazy protocol :(

--- a/kamu-core/tests/utils/http_server.rs
+++ b/kamu-core/tests/utils/http_server.rs
@@ -29,6 +29,7 @@ impl HttpServer {
         use rand::Rng;
 
         let container_runtime = ContainerRuntime::default();
+        container_runtime.ensure_image(Self::IMAGE, None);
 
         let mut server_name = "kamu-test-http-".to_owned();
         server_name.extend(
@@ -42,12 +43,6 @@ impl HttpServer {
         if !server_dir.exists() {
             std::fs::create_dir(&server_dir).unwrap();
         }
-
-        assert!(
-            container_runtime.has_image(Self::IMAGE),
-            "Please pull {} image before running this test",
-            Self::IMAGE
-        );
 
         let process = container_runtime
             .run_cmd(RunArgs {

--- a/utils/installer/kamu-install.sh
+++ b/utils/installer/kamu-install.sh
@@ -216,13 +216,12 @@ main() {
 
 print_header() {
     logoclr="${cyanbr}"
-    printf "
-${logoclr}    ◢◣◥◣         ${red}${bold}           KAMU${reset}
-${logoclr}   ◢◤◥◣◥◣        ${magenta}${bold}Planet-scale data pipeline${reset}
-${logoclr}  ◢◤◢🭬◥◣◥◣       ${reset}
-${logoclr} ◢◤◢◤  🭭 ◥◣      ${magenta}    https://kamu.dev${reset}
-${logoclr}🭮◤◢◤🬯🬰🬰🬰🬰🬰🬒${reset}
-
+    printf \
+"${logoclr}${green}${bold}Kamu: Planet-scale data pipeline${reset}
+${logoclr}${reset}
+${logoclr}${magenta}Website: https://kamu.dev${reset}
+${logoclr}${magenta}Docs: https://docs.kamu.dev/cli/${reset}
+${logoclr}${magenta}Discord: https://discord.gg/nU6TXRQNXC${reset}
 
 " 1>&2
 }


### PR DESCRIPTION
In this PR:
- Avoiding multiple recompilations in Linux CI build job by avoiding calls to `cargo run --bin kamu-cli`
- Avoiding workspace feature unification in CI release job by compiling a specific crate
- Using `debug=1` on our crates in release build to have line information in backtraces