### PR TITLE
Use rust-cache action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,20 +40,14 @@ jobs:
     env:
       KAMU_FEATURES: ftp
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
       - uses: ibnesayeed/setup-ipfs@master
         with:
           ipfs_version: "0.19"
-      # - uses: actions/cache@v3 # Source: https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       target/
-      #     key: ${{ runner.os }}-cargo
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
+      - uses: swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Configure podman runtime
         run: |
           echo '{ "kind": "CLIConfig", "version": 1, "content": {"engine": { "runtime": "podman" } } }' > ~/.kamuconfig
@@ -74,15 +68,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-      # - uses: actions/cache@v3 # Source: https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       target/
-      #     key: ${{ runner.os }}-cargo
+      - uses: swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: build
         run: cargo test --features $KAMU_FEATURES --no-run
       - name: run tests
@@ -96,15 +84,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-      # - uses: actions/cache@v3 # Source: https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       target/
-      #     key: ${{ runner.os }}-cargo
+      - uses: swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: build
         run: cargo test --features ${{ env.KAMU_FEATURES }} --no-run
       - name: run tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
     name: Test / Linux
     runs-on: ubuntu-latest
     env:
-      KAMU_FEATURES: ftp
+      CARGO_FLAGS: --profile ci --features ftp
     steps:
       - uses: ibnesayeed/setup-ipfs@master
         with:
@@ -52,11 +52,11 @@ jobs:
         run: |
           echo '{ "kind": "CLIConfig", "version": 1, "content": {"engine": { "runtime": "podman" } } }' > ~/.kamuconfig
       - name: build
-        run: cargo test --features $KAMU_FEATURES --no-run
+        run: cargo test ${{ env.CARGO_FLAGS }} --no-run
       - name: pull test images
-        run: cargo test --features $KAMU_FEATURES test_setup_pull_images
+        run: cargo test ${{ env.CARGO_FLAGS }} test_setup_pull_images
       - name: run tests
-        run: cargo test --features $KAMU_FEATURES
+        run: cargo test ${{ env.CARGO_FLAGS }}
       - name: check git diff 
         run: git diff && git diff-index --quiet HEAD # Ensure all generated files are up-to-date
 
@@ -64,7 +64,7 @@ jobs:
     name: Test / MacOS
     runs-on: macos-latest
     env:
-      KAMU_FEATURES: skip_docker_tests
+      CARGO_FLAGS: --profile ci --features skip_docker_tests
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
@@ -72,15 +72,15 @@ jobs:
         with:
           cache-on-failure: true
       - name: build
-        run: cargo test --features $KAMU_FEATURES --no-run
+        run: cargo test ${{ env.CARGO_FLAGS }} --no-run
       - name: run tests
-        run: cargo test --features $KAMU_FEATURES
+        run: cargo test ${{ env.CARGO_FLAGS }}
 
   test_windows:
     name: Test / Windows
     runs-on: windows-latest
     env:
-      KAMU_FEATURES: skip_docker_tests
+      CARGO_FLAGS: --profile ci --features skip_docker_tests
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
@@ -88,6 +88,6 @@ jobs:
         with:
           cache-on-failure: true
       - name: build
-        run: cargo test --features ${{ env.KAMU_FEATURES }} --no-run
+        run: cargo test ${{ env.CARGO_FLAGS }} --no-run
       - name: run tests
-        run: cargo test --features ${{ env.KAMU_FEATURES }}
+        run: cargo test ${{ env.CARGO_FLAGS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,6 @@ jobs:
     name: Build / Linux
     runs-on: ubuntu-latest
     env:
-      KAMU_FEATURES: ftp,web-ui
       KAMU_WEB_UI_DIR: "../kamu-web-ui-any"
     strategy:
       matrix:
@@ -23,7 +22,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
         with:
-          components: rustfmt
           target: ${{ matrix.target }}
           override: true
       - name: Install cross
@@ -33,7 +31,7 @@ jobs:
           wget https://github.com/kamu-data/kamu-web-ui/releases/download/v${{ env.KAMU_WEB_UI_VERSION }}/kamu-web-ui-any.tar.gz && \
           tar -xf kamu-web-ui-any.tar.gz
       - name: Build
-        run: cross build -p kamu-cli --release --target=${{ matrix.target }} --features $KAMU_FEATURES
+        run: cross build -p kamu-cli --release --target=${{ matrix.target }} --features ftp,web-ui
       - name: Rename binary
         run: mv target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }} target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
       - uses: actions/upload-artifact@v3
@@ -45,7 +43,6 @@ jobs:
     name: Build / MacOS
     runs-on: macos-latest
     env:
-      KAMU_FEATURES: ftp,web-ui
       KAMU_WEB_UI_DIR: "../kamu-web-ui-any"
     strategy:
       matrix:
@@ -54,13 +51,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-        with:
-          components: rustfmt
       - name: Fetch web UI artifacts # TODO: Add target without UI
         run: |
           wget https://github.com/kamu-data/kamu-web-ui/releases/download/v${{ env.KAMU_WEB_UI_VERSION }}/kamu-web-ui-any.tar.gz && \
           tar -xf kamu-web-ui-any.tar.gz
-      - run: cargo build -p kamu-cli --release --target=${{ matrix.target }} --features $KAMU_FEATURES
+      - run: cargo build -p kamu-cli --release --target=${{ matrix.target }} --features ftp,web-ui
       - name: Rename binary
         run: mv target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }} target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
       - uses: actions/upload-artifact@v3
@@ -71,8 +66,6 @@ jobs:
   build_windows:
     name: Build / Windows
     runs-on: windows-latest
-    env:
-      KAMU_FEATURES: ftp
     strategy:
       matrix:
         target:
@@ -80,9 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-        with:
-          components: rustfmt
-      - run: cargo build -p kamu-cli --release --target=${{ matrix.target }} --features ${{ env.KAMU_FEATURES }}
+      - run: cargo build -p kamu-cli --release --target=${{ matrix.target }} --features ftp
       - name: Rename binary
         shell: bash
         run: mv target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }}.exe target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,12 @@ resolver = "2"
 edition = "2021"
 
 
+[profile.dev]
+# Change this to 2 when you need to attach a debugger. In most cases line info
+# is enough and will speed up builds.
+debug = 1
+
+
 # Emit the line info tables for our crates to produce useful crash reports and backtraces.
 # We don't emit info for dependencies as this significantly increases binary size.
 # See: https://doc.rust-lang.org/cargo/reference/profiles.html#debug
@@ -22,3 +28,15 @@ edition = "2021"
 opendatafabric = { debug = 1 }
 kamu = { debug = 1 }
 kamu-cli = { debug = 1 }
+
+
+[profile.ci]
+inherits = "dev"
+# CI builds often are closer to from-scratch builds. Incremental adds an extra
+# dependency-tracking overhead and significantly increases the amount of IO and
+# the size of ./target, which make caching less effective
+# See: https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow
+incremental = false
+# Line info is enough to get good backtraces in CI - we don't need the
+# full debugging symbols that only useful when attacing a debugger.
+debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,5 @@ inherits = "dev"
 # See: https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow
 incremental = false
 # Line info is enough to get good backtraces in CI - we don't need the
-# full debugging symbols that only useful when attacing a debugger.
+# full debugging symbols that are only useful when attaching a debugger.
 debug = 1

--- a/kamu-cli/src/app.rs
+++ b/kamu-cli/src/app.rs
@@ -165,7 +165,7 @@ fn load_config(workspace_layout: &WorkspaceLayout, catalog: &mut CatalogBuilder)
     let config_svc = ConfigService::new(workspace_layout);
     let config = config_svc.load_with_defaults(ConfigScope::Flattened);
 
-    tracing::info!(config = ?config, "Loaded configuration");
+    tracing::info!(?config, "Loaded configuration");
 
     let network_ns = config.engine.as_ref().unwrap().network_ns.unwrap();
 


### PR DESCRIPTION
I previously tried caching unsuccessfully, and this guide provides some info on why caching `./target` dir doesn't work well. This PR uses a rust-specific cache action that is relied upon by >1K projects.

Upon successful hit, caching reduces CI build time by ~8 minutes.

Additionally I'm following [this guide](https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow) to create a custom `ci` profile in cargo that should speed up build further (see `Cargo.toml` changes).