### PR TITLE
Use nextest runner

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,20 @@
+[test-groups]
+setup = { max-threads = 1 }  # Serialize the setup steps
+containerized = { max-threads = 8 }  # Don't use too much memory
+engine = { max-threads = 2 }  # Engine tests are very memory-hungry
+
+[[profile.default.overrides]]
+filter = "test(::setup::)"
+test-group = "setup"
+
+[[profile.default.overrides]]
+filter = "test(::containerized::)"
+test-group = "containerized"
+
+[[profile.default.overrides]]
+filter = "test(::engine::)"
+test-group = "engine"
+
+[[profile.default.overrides]]
+filter = 'test(::flaky::)'
+retries = 3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
+      - uses: actions-rs/toolchain@v1
         with:
           components: rustfmt
       - name: cargo fmt --check
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
+      - uses: actions-rs/toolchain@v1
       - run: cargo install --locked cargo-deny
       - run: cargo deny check
 
@@ -41,55 +41,67 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_FLAGS: --profile ci --features ftp
+      NEXTEST_FLAGS: --cargo-profile ci --features ftp
     steps:
       - uses: ibnesayeed/setup-ipfs@master
         with:
           ipfs_version: "0.19"
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
+      - uses: actions-rs/toolchain@v1
       - uses: swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Install cargo tools
+        run: |
+          cargo install --locked cargo-nextest
       - name: Configure podman runtime
         run: |
           echo '{ "kind": "CLIConfig", "version": 1, "content": {"engine": { "runtime": "podman" } } }' > ~/.kamuconfig
       - name: build
         run: cargo test ${{ env.CARGO_FLAGS }} --no-run
       - name: pull test images
-        run: cargo test ${{ env.CARGO_FLAGS }} test_setup_pull_images -- --nocapture
+        run: cargo nextest run ${{ env.NEXTEST_FLAGS }} -E 'test(::setup::)' --no-capture
       - name: run tests
-        run: cargo test ${{ env.CARGO_FLAGS }}
-      - name: check git diff 
-        run: git diff && git diff-index --quiet HEAD # Ensure all generated files are up-to-date
+        run: cargo nextest run ${{ env.NEXTEST_FLAGS }}
+      - name: check git diff  # Ensures all generated files are up-to-date
+        run: git diff && git diff-index --quiet HEAD
 
   test_macos:
     name: Test / MacOS
     runs-on: macos-latest
     env:
-      CARGO_FLAGS: --profile ci --features skip_docker_tests
+      CARGO_FLAGS: --profile ci
+      NEXTEST_FLAGS: --cargo-profile ci -E '!test(::containerized::)'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
+      - uses: actions-rs/toolchain@v1
       - uses: swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Install cargo tools
+        run: |
+          cargo install --locked cargo-nextest
       - name: build
         run: cargo test ${{ env.CARGO_FLAGS }} --no-run
       - name: run tests
-        run: cargo test ${{ env.CARGO_FLAGS }}
+        run: cargo nextest run ${{ env.NEXTEST_FLAGS }}
 
   test_windows:
     name: Test / Windows
     runs-on: windows-latest
     env:
-      CARGO_FLAGS: --profile ci --features skip_docker_tests
+      CARGO_FLAGS: --profile ci
+      NEXTEST_FLAGS: --cargo-profile ci -E '!test(::containerized::)'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
+      - uses: actions-rs/toolchain@v1
       - uses: swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Install cargo tools
+        run: |
+          cargo install --locked cargo-nextest
       - name: build
         run: cargo test ${{ env.CARGO_FLAGS }} --no-run
       - name: run tests
-        run: cargo test ${{ env.CARGO_FLAGS }}
+        run: cargo nextest run ${{ env.NEXTEST_FLAGS }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
@@ -1336,6 +1336,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "serde",
+ "test-group",
  "test-log",
  "thiserror",
  "tokio",
@@ -2811,6 +2812,7 @@ dependencies = [
  "strum_macros",
  "tar",
  "tempfile",
+ "test-group",
  "test-log",
  "thiserror",
  "tokio",
@@ -2878,6 +2880,7 @@ dependencies = [
  "sha3",
  "tar",
  "tempfile",
+ "test-group",
  "test-log",
  "thiserror",
  "tokio",
@@ -2946,6 +2949,7 @@ dependencies = [
  "shlex",
  "signal-hook",
  "tempfile",
+ "test-group",
  "test-log",
  "thiserror",
  "tokio",
@@ -3848,9 +3852,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3858,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3868,9 +3872,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3881,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
 dependencies = [
  "once_cell",
  "pest",
@@ -4977,6 +4981,19 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "test-group"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710211810efd63fc5fe6d800bf73f2f91bd69a9215e18ff7ca90beeb0bef98b4"
+dependencies = [
+ "hex",
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.7",
+ "syn 2.0.18",
+]
 
 [[package]]
 name = "test-log"

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,8 +1,7 @@
 # Developer Guide <!-- omit in toc -->
 - [Building Locally](#building-locally)
-  - [Run Tests with Podman (Recommended)](#run-tests-with-podman-recommended)
-  - [Run Tests with Docker (Alternative)](#run-tests-with-docker-alternative)
-  - [Using Nextest test runner (Optional)](#using-nextest-test-runner-optional)
+  - [Configure Podman as Default Runtime (Recommended)](#configure-podman-as-default-runtime-recommended)
+  - [Run Tests](#run-tests)
   - [Build Speed Tweaks (Optional)](#build-speed-tweaks-optional)
   - [Building with Web UI (Optional)](#building-with-web-ui-optional)
   - [Code Generation](#code-generation)
@@ -36,15 +35,19 @@ Prerequisites:
   * Install [`protoc`](https://github.com/protocolbuffers/protobuf) followed by:
     * `cargo install protoc-gen-prost` - to install [prost protobuf plugin](https://crates.io/crates/protoc-gen-prost)
     * `cargo install protoc-gen-tonic` - to install [tonic protobuf plugin](https://crates.io/crates/protoc-gen-tonic)
-* Cargo toolbelt (optional - if you will be doing releases)
-  * `cargo install cargo-update` - to easily keep your tools up-to-date
-  * `cargo install cargo-binstall` - to install binaries without compiling
-  * `cargo binstall cargo-binstall --force` - make future updates to use precompiled version
-  * `cargo binstall cargo-edit` - for setting crate versions during release
-  * `cargo binstall cargo-update` - for keeping up with major dependency updates
-  * `cargo binstall cargo-deny` - for linting dependencies
-  * `cargo binstall cargo-llvm-cov` - for coverage
-  * `cargo binstall bunyan` - for pretty-printing the JSON logs
+* Cargo toolbelt
+  * Prerequisites:
+    * `cargo install cargo-update` - to easily keep your tools up-to-date
+    * `cargo install cargo-binstall` - to install binaries without compiling
+    * `cargo binstall cargo-binstall --force` - make future updates of `binstall` to use precompiled version
+  * Recommended:
+    * `cargo binstall cargo-nextest` - advanced test runner
+    * `cargo binstall bunyan` - for pretty-printing the JSON logs
+    * `cargo binstall cargo-llvm-cov` - for test coverage
+  * Optional - if you will be doing releases:
+    * `cargo binstall cargo-edit` - for setting crate versions during release
+    * `cargo binstall cargo-update` - for keeping up with major dependency updates
+    * `cargo binstall cargo-deny` - for linting dependencies
 
 Clone the repository:
 ```shell
@@ -71,35 +74,36 @@ curl -s "https://get.kamu.dev" | KAMU_ALIAS=kamu-release sh
 New to Rust? Check out these [IDE configuration tip](#ide-tips).
 
 
-### Run Tests with Podman (Recommended)
-
+### Configure Podman as Default Runtime (Recommended)
 Set podman as preferred runtime for your user:
 ```shell
 cargo run --bin kamu-cli -- config set --user engine.runtime podman
 ```
 
-Run tests (note: upon first run the tests will need to pull extra images and will run longer):
+When you run tests or use `kamu` anywhere in your user directory you will now use `podman` runtime.
+
+If you need to run some tests under `Docker` use:
 ```shell
-cargo test
+KAMU_CONTAINER_RUNTIME_TYPE=docker cargo test <some_test>
 ```
 
 
-### Run Tests with Docker (Alternative)
-
-Run tests (note: upon first run the tests will need to pull extra images and will run longer):
-```shell
-KAMU_CONTAINER_RUNTIME_TYPE=docker cargo test
-
-```
-
-### Using Nextest test runner (Optional)
-[Nextest](https://nexte.st/) is a better test runner.
-
-To use it run:
-
+### Run Tests
+You can run all tests as:
 ```sh
-cargo binstall cargo-nextest
-cargo nextest run
+make test
+```
+
+In most cases you can skip tests invlolving very heavy Spark and Flink engines by running:
+```sh
+make test-fast
+```
+
+These are just wappers on top of [Nextest](https://nexte.st/) that [control](/.config/nextest.toml) test concurrency and retries. 
+
+To run tests for a specific crate, e.g. `opendatafabric` use:
+```sh
+cargo nextest run -p opendatafabric
 ```
 
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,21 @@ lint:
 
 
 ###############################################################################
+# Test
+###############################################################################
+
+# Run all tests using nextest and configured concurrency limits
+.PHONY: test
+test:
+	RUST_LOG_SPAN_EVENTS=new,close RUST_LOG=debug cargo nextest run
+
+# Run all tests excluding the heavy engines
+.PHONY: test-fast
+test-fast:
+	RUST_LOG_SPAN_EVENTS=new,close RUST_LOG=debug cargo nextest run -E '!test(::engine::)'
+
+
+###############################################################################
 # Release
 ###############################################################################
 

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -17,10 +17,6 @@ publish = { workspace = true }
 doctest = false
 
 
-[features]
-skip_docker_tests = []
-
-
 [dependencies]
 opendatafabric = { workspace = true }
 kamu-data-utils = { workspace = true }

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -17,10 +17,6 @@ publish = { workspace = true }
 doctest = false
 
 
-[features]
-skip_docker_tests = []
-
-
 [dependencies]
 opendatafabric = { workspace = true }
 # TODO: Adapters should depend only on kamu-domain crate and be implementation-agnostic
@@ -56,6 +52,7 @@ env_logger = "0.10"
 fs_extra = "1.3"                                                    # Recursive folder copy
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"
+test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-http = { version = "0.4", features = ["trace", "cors"] }

--- a/src/adapter/http/tests/tests/tests_pull/test_smart_pull_s3.rs
+++ b/src/adapter/http/tests/tests/tests_pull/test_smart_pull_s3.rs
@@ -12,8 +12,8 @@ use crate::tests::tests_pull::test_smart_pull_shared;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_pull_s3_new_dataset() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_pull_shared::test_smart_pull_new_dataset(server_harness).await;
@@ -21,8 +21,8 @@ async fn test_smart_pull_s3_new_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_pull_s3_existing_up_to_date_dataset() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_pull_shared::test_smart_pull_existing_up_to_date_dataset(server_harness).await;
@@ -30,8 +30,8 @@ async fn test_smart_pull_s3_existing_up_to_date_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_pull_s3_existing_evolved_dataset() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_pull_shared::test_smart_pull_existing_evolved_dataset(server_harness).await;
@@ -39,8 +39,8 @@ async fn test_smart_pull_s3_existing_evolved_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_pull_s3_existing_advanced_dataset_fails() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_pull_shared::test_smart_pull_existing_advanced_dataset_fails(server_harness).await;
@@ -48,8 +48,8 @@ async fn test_smart_pull_s3_existing_advanced_dataset_fails() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_pull_s3_aborted_read_of_new_reread_succeeds() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_pull_shared::test_smart_pull_aborted_read_of_new_reread_succeeds(server_harness)
@@ -58,8 +58,8 @@ async fn test_smart_pull_s3_aborted_read_of_new_reread_succeeds() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_pull_s3_aborted_read_of_existing_evolved_dataset_reread_succeeds() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_pull_shared::test_smart_pull_aborted_read_of_existing_evolved_dataset_reread_succeeds(server_harness)

--- a/src/adapter/http/tests/tests/tests_push/test_smart_push_s3.rs
+++ b/src/adapter/http/tests/tests/tests_push/test_smart_push_s3.rs
@@ -12,8 +12,8 @@ use crate::tests::tests_push::test_smart_push_shared;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_push_s3_new_dataset() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_push_shared::test_smart_push_new_dataset(server_harness).await;
@@ -21,8 +21,8 @@ async fn test_smart_push_s3_new_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_push_s3_existing_up_to_date_dataset() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_push_shared::test_smart_push_existing_up_to_date_dataset(server_harness).await;
@@ -30,8 +30,8 @@ async fn test_smart_push_s3_existing_up_to_date_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_push_s3_existing_evolved_dataset() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_push_shared::test_smart_push_existing_evolved_dataset(server_harness).await;
@@ -39,8 +39,8 @@ async fn test_smart_push_s3_existing_evolved_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_push_s3_existing_dataset_fails_as_server_advanced() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_push_shared::test_smart_push_existing_dataset_fails_as_server_advanced(
@@ -51,8 +51,8 @@ async fn test_smart_push_s3_existing_dataset_fails_as_server_advanced() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_push_s3_aborted_write_of_new_rewrite_succeeds() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_push_shared::test_smart_push_aborted_write_of_new_rewrite_succeeds(server_harness)
@@ -61,8 +61,8 @@ async fn test_smart_push_s3_aborted_write_of_new_rewrite_succeeds() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_smart_push_s3_aborted_write_of_updated_rewrite_succeeds() {
     let server_harness = ServerSideS3Harness::new().await;
     test_smart_push_shared::test_smart_push_aborted_write_of_updated_rewrite_succeeds(

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -24,8 +24,6 @@ default = []
 web-ui = []
 ftp = ["kamu/ftp"]
 
-skip_docker_tests = []
-
 
 [dependencies]
 # Kamu
@@ -113,4 +111,5 @@ libc = "0.2"  # For getting uid:gid
 [dev-dependencies]
 env_logger = "0.10"
 rand = "0.8"
+test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }

--- a/src/app/cli/tests/tests/test_pull_command.rs
+++ b/src/app/cli/tests/tests/test_pull_command.rs
@@ -17,8 +17,8 @@ use url::Url;
 
 use crate::utils::Kamu;
 
+#[test_group::group(containerized, engine)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_pull_ingest_from_file() {
     let kamu = Kamu::new_workspace_tmp().await;
 

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -22,8 +22,6 @@ default = []
 
 ftp = ["dep:curl", "dep:curl-sys"]
 
-skip_docker_tests = []
-
 
 [dependencies]
 # Kamu
@@ -102,6 +100,7 @@ libc = "0.2"  # For getting uid:gid
 [dev-dependencies]
 env_logger = "0.10"
 filetime = "0.2"
+test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/infra/core/tests/tests/engine/test_ingest_engine.rs
+++ b/src/infra/core/tests/tests/engine/test_ingest_engine.rs
@@ -26,8 +26,8 @@ use kamu::*;
 use opendatafabric::*;
 use tempfile::TempDir;
 
+#[test_group::group(containerized, engine)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_ingest_csv_with_engine() {
     let harness = IngestTestHarness::new();
 
@@ -92,8 +92,8 @@ async fn test_ingest_csv_with_engine() {
     );
 }
 
+#[test_group::group(containerized, engine)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_ingest_parquet_with_engine() {
     let harness = IngestTestHarness::new();
 

--- a/src/infra/core/tests/tests/engine/test_transform_engine.rs
+++ b/src/infra/core/tests/tests/engine/test_transform_engine.rs
@@ -429,8 +429,8 @@ async fn test_transform_common(transform: Transform) {
     );
 }
 
+#[test_group::group(containerized, engine)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_transform_with_engine_spark() {
     test_transform_common(
         MetadataFactory::transform()
@@ -441,8 +441,8 @@ async fn test_transform_with_engine_spark() {
     .await
 }
 
+#[test_group::group(containerized, engine)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_transform_with_engine_flink() {
     test_transform_common(
         MetadataFactory::transform()
@@ -453,8 +453,8 @@ async fn test_transform_with_engine_flink() {
     .await
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_transform_with_engine_datafusion() {
     test_transform_common(
         MetadataFactory::transform()

--- a/src/infra/core/tests/tests/ingest/test_fetch.rs
+++ b/src/infra/core/tests/tests/ingest/test_fetch.rs
@@ -132,8 +132,8 @@ async fn test_fetch_url_http_unreachable() {
     assert!(!target_path.exists());
 }
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_fetch_url_http_not_found() {
     let tempdir = tempfile::tempdir().unwrap();
     let workspace_layout = Arc::new(WorkspaceLayout::new(tempdir.path()));
@@ -160,8 +160,8 @@ async fn test_fetch_url_http_not_found() {
     assert!(!target_path.exists());
 }
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_fetch_url_http_ok() {
     let tempdir = tempfile::tempdir().unwrap();
     let workspace_layout = Arc::new(WorkspaceLayout::new(tempdir.path()));
@@ -261,8 +261,8 @@ async fn test_fetch_url_http_ok() {
     assert!(target_path.exists());
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_fetch_url_http_env_interpolation() {
     let tempdir = tempfile::tempdir().unwrap();
     let workspace_layout = Arc::new(WorkspaceLayout::new(tempdir.path()));
@@ -331,8 +331,8 @@ async fn test_fetch_url_http_env_interpolation() {
 ///////////////////////////////////////////////////////////////////////////////
 
 #[cfg(feature = "ftp")]
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_fetch_url_ftp_ok() {
     let tempdir = tempfile::tempdir().unwrap();
     let workspace_layout = Arc::new(WorkspaceLayout::new(tempdir.path()));
@@ -588,8 +588,8 @@ async fn test_fetch_files_glob() {
 // Container
 ///////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_fetch_container_ok() {
     let tempdir = tempfile::tempdir().unwrap();
     let workspace_layout = Arc::new(WorkspaceLayout::new(tempdir.path()));

--- a/src/infra/core/tests/tests/repos/test_dataset_repository_local_fs.rs
+++ b/src/infra/core/tests/tests/repos/test_dataset_repository_local_fs.rs
@@ -53,8 +53,8 @@ async fn test_rename_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_delete_dataset() {
     let tempdir = tempfile::tempdir().unwrap();
     let repo = local_fs_repo(&tempdir);

--- a/src/infra/core/tests/tests/repos/test_dataset_repository_s3.rs
+++ b/src/infra/core/tests/tests/repos/test_dataset_repository_s3.rs
@@ -59,8 +59,8 @@ async fn s3_repo(s3: &S3) -> DatasetRepositoryS3 {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_create_dataset() {
     let s3 = run_s3_server().await;
     let repo = s3_repo(&s3).await;
@@ -70,8 +70,8 @@ async fn test_create_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_create_dataset_from_snapshot() {
     let s3 = run_s3_server().await;
     let repo = s3_repo(&s3).await;
@@ -81,8 +81,8 @@ async fn test_create_dataset_from_snapshot() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_rename_dataset() {
     let s3 = run_s3_server().await;
     let repo = s3_repo(&s3).await;
@@ -92,8 +92,8 @@ async fn test_rename_dataset() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_delete_dataset() {
     let s3 = run_s3_server().await;
     let repo = s3_repo(&s3).await;

--- a/src/infra/core/tests/tests/repos/test_named_object_repository.rs
+++ b/src/infra/core/tests/tests/repos/test_named_object_repository.rs
@@ -7,14 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::assert_matches::assert_matches;
+
 use kamu::domain::repos::named_object_repository::GetError;
 use kamu::domain::*;
 use kamu::infra::*;
 use reqwest::Url;
 
-use crate::utils::HttpFileServer;
-use crate::utils::MinioServer;
-use std::assert_matches::assert_matches;
+use crate::utils::{HttpFileServer, MinioServer};
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -51,8 +51,8 @@ async fn test_basics_local_fs() {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_basics_s3() {
     let s3_srv = run_s3_server();
     let repo = NamedObjectRepositoryS3::from_url(&s3_srv.url);

--- a/src/infra/core/tests/tests/repos/test_object_repository_s3.rs
+++ b/src/infra/core/tests/tests/repos/test_object_repository_s3.rs
@@ -54,9 +54,9 @@ async fn run_s3_server() -> S3 {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(containerized)]
 #[ignore = "We do not yet handle unauthorized errors correctly"]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_unauthorized() {
     let s3 = run_s3_server().await;
     std::env::set_var("AWS_SECRET_ACCESS_KEY", "BAD_KEY");
@@ -68,16 +68,16 @@ async fn test_unauthorized() {
     );
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_insert_bytes() {
     let s3 = run_s3_server().await;
     let repo = ObjectRepositoryS3::<sha3::Sha3_256, 0x16>::new(S3Context::from_url(&s3.url).await);
     test_object_repository_shared::test_insert_bytes(&repo).await;
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_insert_bytes_long() {
     let s3 = run_s3_server().await;
     let repo = ObjectRepositoryS3::<sha3::Sha3_256, 0x16>::new(S3Context::from_url(&s3.url).await);
@@ -99,8 +99,8 @@ async fn test_insert_bytes_long() {
     assert_eq!(&repo.get_bytes(&hash).await.unwrap()[..], data);
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_insert_stream() {
     let s3 = run_s3_server().await;
     let repo = ObjectRepositoryS3::<sha3::Sha3_256, 0x16>::new(S3Context::from_url(&s3.url).await);
@@ -136,8 +136,8 @@ async fn test_insert_stream() {
     assert_eq!(data, b"foobar");
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_insert_stream_long() {
     let s3 = run_s3_server().await;
     let repo = ObjectRepositoryS3::<sha3::Sha3_256, 0x16>::new(S3Context::from_url(&s3.url).await);
@@ -170,24 +170,24 @@ async fn test_insert_stream_long() {
     assert_eq!(data, data_received[..]);
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_delete() {
     let s3 = run_s3_server().await;
     let repo = ObjectRepositoryS3::<sha3::Sha3_256, 0x16>::new(S3Context::from_url(&s3.url).await);
     test_object_repository_shared::test_delete(&repo).await;
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_insert_precomputed() {
     let s3 = run_s3_server().await;
     let repo = ObjectRepositoryS3::<sha3::Sha3_256, 0x16>::new(S3Context::from_url(&s3.url).await);
     test_object_repository_shared::test_insert_precomputed(&repo).await;
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_insert_expect() {
     let s3 = run_s3_server().await;
     let repo = ObjectRepositoryS3::<sha3::Sha3_256, 0x16>::new(S3Context::from_url(&s3.url).await);

--- a/src/infra/core/tests/tests/test_query_service_impl.rs
+++ b/src/infra/core/tests/tests/test_query_service_impl.rs
@@ -203,8 +203,8 @@ async fn test_dataset_schema_local_fs() {
     test_dataset_schema_common(catalog, &tempdir).await;
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_dataset_schema_s3() {
     let s3 = run_s3_server().await;
     let catalog = create_catalog_with_s3_workspace(&s3).await;
@@ -240,8 +240,8 @@ async fn test_dataset_tail_local_fs() {
     test_dataset_tail_common(catalog, &tempdir).await;
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_dataset_tail_s3() {
     let s3 = run_s3_server().await;
     let catalog = create_catalog_with_s3_workspace(&s3).await;

--- a/src/infra/core/tests/tests/test_search_service_impl.rs
+++ b/src/infra/core/tests/tests/test_search_service_impl.rs
@@ -89,8 +89,8 @@ async fn test_search_local_fs() {
     do_test_search(tmp_workspace_dir.path(), repo_url).await;
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_search_s3() {
     let access_key = "AKIAIOSFODNN7EXAMPLE";
     let secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";

--- a/src/infra/core/tests/tests/test_setup.rs
+++ b/src/infra/core/tests/tests/test_setup.rs
@@ -12,7 +12,7 @@ use kamu::utils::docker_images;
 
 // Not really a test - used by CI to separate pulling of test images
 // into its own phase
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
+#[test_group::group(setup, containerized)]
 #[test_log::test(tokio::test)]
 async fn test_setup_pull_images() {
     let container_runtime = ContainerRuntime::default();

--- a/src/infra/core/tests/tests/test_sync_service_impl.rs
+++ b/src/infra/core/tests/tests/test_sync_service_impl.rs
@@ -355,8 +355,8 @@ async fn test_sync_to_from_local_fs() {
     .await;
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_sync_to_from_s3() {
     let access_key = "AKIAIOSFODNN7EXAMPLE";
     let secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
@@ -405,8 +405,8 @@ async fn test_sync_from_http() {
     .await;
 }
 
+#[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_sync_to_from_ipfs() {
     let tmp_workspace_dir = tempfile::tempdir().unwrap();
 

--- a/src/utils/container-runtime/Cargo.toml
+++ b/src/utils/container-runtime/Cargo.toml
@@ -17,10 +17,6 @@ publish = { workspace = true }
 doctest = false
 
 
-[features]
-skip_docker_tests = []
-
-
 [dependencies]
 async-trait = "0.1"
 cfg-if = "1"
@@ -37,6 +33,7 @@ url = "2"
 
 [dev-dependencies]
 env_logger = "0.10"
+test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features=["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/utils/container-runtime/tests/tests/test_container.rs
+++ b/src/utils/container-runtime/tests/tests/test_container.rs
@@ -30,8 +30,8 @@ fn dump_state(hint: &str) {
     tracing::warn!("{}", std::str::from_utf8(&ps.stdout).unwrap());
 }
 
+#[test_group::group(containerized, flaky)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_container_terminate_not_called() {
     let rt = ContainerRuntime::default();
 
@@ -70,8 +70,8 @@ async fn test_container_terminate_not_called() {
     );
 }
 
+#[test_group::group(containerized, flaky)]
 #[test_log::test(tokio::test)]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_container_terminate_awaited() {
     let rt = ContainerRuntime::default();
 

--- a/src/utils/container-runtime/tests/tests/test_network.rs
+++ b/src/utils/container-runtime/tests/tests/test_network.rs
@@ -11,8 +11,8 @@ use container_runtime::ContainerRuntime;
 
 use crate::common;
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_network_handle_free_not_called() {
     let rt = ContainerRuntime::default();
 
@@ -29,8 +29,8 @@ async fn test_network_handle_free_not_called() {
     assert!(!rt.has_network(&network_name).await.unwrap());
 }
 
+#[test_group::group(containerized)]
 #[tokio::test]
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
 async fn test_network_handle_free_awaited() {
     let rt = ContainerRuntime::default();
 

--- a/src/utils/container-runtime/tests/tests/test_setup.rs
+++ b/src/utils/container-runtime/tests/tests/test_setup.rs
@@ -13,7 +13,7 @@ use super::test_container::TEST_IMAGE;
 
 // Not really a test - used by CI to separate pulling of test images
 // into its own phase
-#[cfg_attr(feature = "skip_docker_tests", ignore)]
+#[test_group::group(containerized, setup)]
 #[test_log::test(tokio::test)]
 async fn test_setup_pull_images() {
     let container_runtime = ContainerRuntime::default();


### PR DESCRIPTION
Using `nextest` to control concurrency of tests (esp. those that start engines) and add retries to our "flaky" container tests.

To group tests without changing our module structure or hard-coding tests names I created a tiny [test-group](https://crates.io/crates/test-group) crate.