### PR TITLE
Custom perfetto layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Improved `--trace` feature to output detailed async task breakdown
+### Fixed
+- Data hashing will no longer stall the event main loop thread
+
 ## [0.131.1] - 2023-06-27
 ### Fixed
 - Resolved wrong cache directory setting for ingest tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,8 +2990,8 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-bunyan-formatter",
- "tracing-chrome",
  "tracing-log",
+ "tracing-perfetto",
  "tracing-subscriber",
  "url",
  "urlencoding",
@@ -5423,17 +5423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-chrome"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496b3cd5447f7ff527bbbf19b071ad542a000adf297d4127078b4dfdb931f41a"
-dependencies = [
- "serde_json",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-core"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5452,6 +5441,20 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-perfetto"
+version = "0.131.1"
+dependencies = [
+ "env_logger",
+ "serde",
+ "serde_json",
+ "test-group",
+ "test-log",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "src/utils/event-sourcing-macros",
     "src/utils/internal-error",
     "src/utils/repo-tools",
+    "src/utils/tracing-perfetto",
     # Domain
     "src/domain/opendatafabric",
     "src/domain/core",
@@ -32,6 +33,7 @@ event-sourcing = { version = "0.131.1", path = "src/utils/event-sourcing", defau
 event-sourcing-macros = { version = "0.131.1", path = "src/utils/event-sourcing-macros", default-features = false }
 internal-error = { version = "0.131.1", path = "src/utils/internal-error", default-features = false }
 kamu-data-utils = { version = "0.131.1", path = "src/utils/data-utils", default-features = false }
+tracing-perfetto = { version = "0.131.1", path = "src/utils/tracing-perfetto", default-features = false }
 # Domain
 opendatafabric = { version = "0.131.1", path = "src/domain/opendatafabric", default-features = false }
 kamu-core = { version = "0.131.1", path = "src/domain/core", default-features = false }

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -75,8 +75,8 @@ serde_yaml = "0.9"
 # Tracing / logging / telemetry
 tracing = "0.1"
 tracing-appender = "0.2"
-tracing-chrome = "0.7"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter"] }
+tracing-perfetto = { workspace = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "ansi", "env-filter"] }
 tracing-log = "0.1"
 tracing-bunyan-formatter = "0.3"
 

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -366,14 +366,8 @@ fn configure_logging(output_config: &OutputConfig, workspace_layout: &WorkspaceL
     // Configure Perfetto tracing if enabled
     let (maybe_perfetto_layer, perfetto_guard) = if let Some(trace_file) = &output_config.trace_file
     {
-        let (perfetto_layer, perfetto_guard) = tracing_chrome::ChromeLayerBuilder::new()
-            .file(trace_file)
-            .trace_style(tracing_chrome::TraceStyle::Async)
-            .include_locations(true)
-            .include_args(true)
-            .build();
-
-        (Some(perfetto_layer), Some(perfetto_guard))
+        let (layer, guard) = tracing_perfetto::PerfettoLayer::new(trace_file);
+        (Some(layer), Some(guard))
     } else {
         (None, None)
     };
@@ -485,5 +479,5 @@ fn get_output_format_recursive<'a>(
 #[derive(Default)]
 struct Guards {
     appender: Option<tracing_appender::non_blocking::WorkerGuard>,
-    perfetto: Option<tracing_chrome::FlushGuard>,
+    perfetto: Option<tracing_perfetto::FlushGuard>,
 }

--- a/src/infra/core/src/verification_service_impl.rs
+++ b/src/infra/core/src/verification_service_impl.rs
@@ -100,7 +100,7 @@ impl VerificationServiceImpl {
                     CachedObject::from(&output_slice.physical_hash, dataset.as_data_repo()).await?;
 
                 // Do a fast pass using physical hash
-                let physical_hash_actual = data_hashing_helper.physical_hash().int_err()?;
+                let physical_hash_actual = data_hashing_helper.physical_hash().await.int_err()?;
                 if physical_hash_actual != output_slice.physical_hash {
                     // Root data files are non-reproducible by definition, so
                     // if physical hashes don't match - we can give up right away.
@@ -117,7 +117,8 @@ impl VerificationServiceImpl {
                     } else {
                         // Derivative data may be replayed and produce different binary file
                         // but data must have same logical hash to be valid.
-                        let logical_hash_actual = data_hashing_helper.logical_hash().int_err()?;
+                        let logical_hash_actual =
+                            data_hashing_helper.logical_hash().await.int_err()?;
 
                         if logical_hash_actual != output_slice.logical_hash {
                             return Err(VerificationError::DataDoesNotMatchMetadata(
@@ -159,7 +160,7 @@ impl VerificationServiceImpl {
                             .await?;
 
                     let physical_hash_actual =
-                        checkpoint_hashing_helper.physical_hash().int_err()?;
+                        checkpoint_hashing_helper.physical_hash().await.int_err()?;
 
                     if physical_hash_actual != checkpoint.physical_hash {
                         return Err(VerificationError::CheckpointDoesNotMatchMetadata(

--- a/src/utils/tracing-perfetto/Cargo.toml
+++ b/src/utils/tracing-perfetto/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "tracing-perfetto"
+description = "A tracing layer for recording profiling information in Perfetto format"
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+
+
+[lib]
+doctest = false
+
+
+[dependencies]
+serde = { version = "1", default-features = false }
+serde_json = { version = "1", default-features = false, features = ["std"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
+
+
+[dev-dependencies]
+env_logger = "0.10"
+test-group = { version = "1" }
+test-log = { version = "0.2", features = ["trace"] }
+tokio = { version = "1", default-features = false, features=["rt", "rt-multi-thread", "macros", "time"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/utils/tracing-perfetto/examples/example.rs
+++ b/src/utils/tracing-perfetto/examples/example.rs
@@ -1,0 +1,221 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use tracing::Instrument;
+use tracing_perfetto::*;
+
+#[tokio::main]
+async fn main() {
+    let _g = configure_tracing();
+    root().await;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[tracing::instrument]
+async fn root() {
+    tracing::info!("Started");
+
+    serial().await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    concurrent().await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    parallel().await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    parallel_linked().await;
+
+    tracing::info!("Finished");
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[tracing::instrument]
+async fn serial() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    serial_1().await;
+    serial_2().await;
+}
+
+#[tracing::instrument(fields(foo = "bar"))]
+async fn serial_1() {
+    std::thread::sleep(Duration::from_millis(10));
+    tracing::info!(some = "field", "Test from serial_1");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+#[tracing::instrument(fields(bar = "baz"))]
+async fn serial_2() {
+    std::thread::sleep(Duration::from_millis(10));
+    tracing::info!(some = "otherfield", "Test from serial_2");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    serial_2_1().await;
+    serial_2_2().await;
+}
+
+#[tracing::instrument]
+async fn serial_2_1() {
+    std::thread::sleep(Duration::from_millis(10));
+    tracing::info!("Test from serial_2_1");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+#[tracing::instrument]
+async fn serial_2_2() {
+    std::thread::sleep(Duration::from_millis(10));
+    tracing::info!("Test from serial_2_2");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[tracing::instrument]
+async fn concurrent() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let f1 = concurrent_1();
+    let f2 = concurrent_2();
+    tracing::info!("Test");
+    tokio::join!(f1, f2);
+}
+
+#[tracing::instrument]
+async fn concurrent_1() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    concurrent_1_1().await;
+    concurrent_1_2().await;
+}
+
+#[tracing::instrument]
+async fn concurrent_1_1() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}
+
+#[tracing::instrument]
+async fn concurrent_1_2() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}
+
+#[tracing::instrument]
+async fn concurrent_2() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[tracing::instrument]
+async fn parallel() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let f1 = tokio::task::spawn(parallel_1());
+    let f2 = tokio::task::spawn(parallel_2());
+    tracing::info!("Test");
+    let (r1, r2) = tokio::join!(f1, f2);
+    r1.unwrap();
+    r2.unwrap();
+}
+
+#[tracing::instrument]
+async fn parallel_1() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    parallel_1_1().await;
+    parallel_1_2().await;
+}
+
+#[tracing::instrument]
+async fn parallel_1_1() {
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+#[tracing::instrument]
+async fn parallel_1_2() {
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+#[tracing::instrument]
+async fn parallel_2() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    parallel_2_1().await;
+    parallel_2_2().await;
+}
+
+#[tracing::instrument]
+async fn parallel_2_1() {
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+#[tracing::instrument]
+async fn parallel_2_2() {
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[tracing::instrument]
+async fn parallel_linked() {
+    std::thread::sleep(Duration::from_millis(10));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let f1 = tokio::task::spawn(parallel_1().instrument(tracing::info_span!("task1").or_current()));
+    let f2 = tokio::task::spawn(parallel_2().instrument(tracing::info_span!("task2").or_current()));
+    let (r1, r2) = tokio::join!(f1, f2);
+    r1.unwrap();
+    r2.unwrap();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+fn configure_tracing() -> FlushGuard {
+    //tracing_chrome::FlushGuard {
+    use tracing_subscriber::fmt::format::FmtSpan;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    // Use configuration from RUST_LOG env var if provided
+    //let env_filter = EnvFilter::from_default_env();
+
+    // Configure Perfetto tracing
+    // let (perfetto_layer, perfetto_guard) =
+    // tracing_chrome::ChromeLayerBuilder::new().file("trace.json")
+    //     .trace_style(tracing_chrome::TraceStyle::Async)
+    //     .include_locations(true)
+    //     .include_args(true)
+    //     .build();
+
+    let (perfetto_layer, perfetto_guard) = PerfettoLayer::new("trace.json");
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .with_writer(std::io::stderr)
+        .pretty();
+
+    let subscriber = tracing_subscriber::registry()
+        .with(perfetto_layer)
+        .with(fmt_layer);
+
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to set subscriber");
+
+    perfetto_guard
+}

--- a/src/utils/tracing-perfetto/src/json_writer.rs
+++ b/src/utils/tracing-perfetto/src/json_writer.rs
@@ -1,0 +1,167 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use serde::Serializer;
+
+use super::perfetto_types::*;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct PerfettoWriterJson<W>
+where
+    W: std::io::Write,
+{
+    out: W,
+    entries: usize,
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+impl<W> PerfettoWriterJson<W>
+where
+    W: std::io::Write,
+{
+    pub fn new(mut out: W) -> Self {
+        write!(out, "[").unwrap();
+        Self { out, entries: 0 }
+    }
+
+    pub fn write_event(&mut self, event: PerfettoEvent<'_>) {
+        if self.entries != 0 {
+            writeln!(self.out, ",").unwrap();
+        }
+
+        let ph = match event.phase {
+            Phase::Begin => "B",
+            Phase::End => "E",
+            Phase::Instant => "i",
+            Phase::BeginAsync => "b",
+            Phase::EndAsync => "e",
+            Phase::InstantAsync => "n",
+        };
+
+        write!(self.out, "{{").unwrap();
+        self.write_field_num("ts", event.ts, true);
+        self.write_field_num("pid", event.pid, false);
+        self.write_field_num("tid", event.tid, false);
+        self.write_field_str_safe("ph", ph, false);
+        if let Some(id) = event.id {
+            self.write_field_num("id", id, false);
+        }
+        if let Some(name) = event.name {
+            self.write_field_str("name", name, false);
+        }
+        if let Some(scope) = event.scope {
+            let scope = match scope {
+                InstantScope::Global => "g",
+                InstantScope::Process => "p",
+                InstantScope::Thread => "t",
+            };
+            self.write_field_str_safe("s", scope, false);
+        }
+        if let Some(args) = event.args {
+            write!(self.out, r#","args":{{"#).unwrap();
+            args.visit(&mut ArgsVisitor {
+                out: &mut self.out,
+                entries: 0,
+            });
+            write!(self.out, "}}").unwrap();
+        }
+        write!(self.out, "}}").unwrap();
+
+        self.entries += 1;
+    }
+
+    pub fn write_metadata(&mut self, event: PerfettoMetadata<'_>) {
+        if self.entries != 0 {
+            writeln!(self.out, ",").unwrap();
+        }
+
+        write!(self.out, "{{").unwrap();
+        match event {
+            PerfettoMetadata::ThreadName { tid, name } => {
+                self.write_field_num("pid", 1, true);
+                self.write_field_num("tid", tid, false);
+                self.write_field_str_safe("ph", "M", false);
+                self.write_field_str_safe("name", "thread_name", false);
+
+                write!(self.out, r#","args":{{"#).unwrap();
+                self.write_field_str("name", name, true);
+                write!(self.out, "}}}}").unwrap();
+            }
+        }
+
+        self.entries += 1;
+    }
+
+    pub fn finish(&mut self) {
+        write!(self.out, "]").unwrap();
+    }
+
+    fn write_field_num<T: std::fmt::Display>(&mut self, key: &str, val: T, first: bool) {
+        if !first {
+            write!(self.out, ",").unwrap();
+        }
+        write!(self.out, r#""{key}":{val}"#).unwrap();
+    }
+
+    fn write_field_str(&mut self, key: &str, val: &str, first: bool) {
+        if !first {
+            write!(self.out, ",").unwrap();
+        }
+        write!(self.out, r#""{key}":"#).unwrap();
+        write_str_escaped(&mut self.out, val);
+    }
+
+    fn write_field_str_safe(&mut self, key: &str, val: &str, first: bool) {
+        if !first {
+            write!(self.out, ",").unwrap();
+        }
+        write!(self.out, r#""{key}":"{val}""#).unwrap();
+    }
+}
+
+struct ArgsVisitor<W> {
+    out: W,
+    entries: usize,
+}
+
+impl<W> tracing::field::Visit for ArgsVisitor<W>
+where
+    W: std::io::Write,
+{
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if self.entries != 0 {
+            write!(self.out, ",").unwrap();
+        }
+
+        write_str_escaped(&mut self.out, field.name());
+        write!(self.out, ":").unwrap();
+
+        // TODO: avoid allocating
+        let value = format!("{:?}", value);
+        write_str_escaped(&mut self.out, &value);
+
+        self.entries += 1;
+    }
+}
+
+fn write_str_escaped<W: std::io::Write>(out: W, s: &str) {
+    let mut ser = serde_json::Serializer::new(out);
+    ser.serialize_str(s).unwrap();
+}
+
+impl<W> Drop for PerfettoWriterJson<W>
+where
+    W: std::io::Write,
+{
+    fn drop(&mut self) {
+        self.finish()
+    }
+}

--- a/src/utils/tracing-perfetto/src/layer.rs
+++ b/src/utils/tracing-perfetto/src/layer.rs
@@ -1,0 +1,182 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use tracing::*;
+use tracing_subscriber::*;
+
+use crate::json_writer::*;
+use crate::perfetto_types::*;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+thread_local! {
+    static TID: RefCell<Option<u64>> = RefCell::new(None);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct PerfettoLayer {
+    start: Instant,
+    writer: Arc<Mutex<PerfettoWriterJson<std::fs::File>>>,
+    next_thread_id: AtomicU64,
+    next_span_id: AtomicU64,
+}
+
+impl PerfettoLayer {
+    pub fn new(path: impl Into<std::path::PathBuf>) -> (Self, FlushGuard) {
+        let writer = Arc::new(Mutex::new(PerfettoWriterJson::new(
+            std::fs::File::create(path.into()).unwrap(),
+        )));
+
+        (
+            Self {
+                start: Instant::now(),
+                writer: writer.clone(),
+                next_thread_id: AtomicU64::new(1),
+                next_span_id: AtomicU64::new(1),
+            },
+            FlushGuard {
+                writer: Some(writer),
+            },
+        )
+    }
+
+    fn get_ts(&self) -> f64 {
+        self.start.elapsed().as_nanos() as f64 / 1000.0
+    }
+
+    fn get_tid(&self) -> u64 {
+        let (tid, new) = TID.with(|value| {
+            let tid = *value.borrow();
+            match tid {
+                Some(tid) => (tid, false),
+                None => {
+                    let tid = self.next_thread_id.fetch_add(1, Ordering::SeqCst);
+                    value.replace(Some(tid));
+                    (tid, true)
+                }
+            }
+        });
+
+        if new {
+            let name = format!(
+                "Thread: {}",
+                std::thread::current().name().unwrap_or("<unnamed>")
+            );
+            self.writer
+                .lock()
+                .unwrap()
+                .write_metadata(PerfettoMetadata::ThreadName { tid, name: &name });
+        }
+
+        tid
+    }
+
+    fn write_event(&self, event: PerfettoEvent<'_>) {
+        self.writer.lock().unwrap().write_event(event);
+    }
+}
+
+impl<S> Layer<S> for PerfettoLayer
+where
+    S: Subscriber + for<'span> registry::LookupSpan<'span> + Send + Sync,
+{
+    fn on_enter(&self, id: &span::Id, ctx: layer::Context<'_, S>) {
+        let span: registry::SpanRef<'_, S> = ctx.span(id).unwrap();
+        self.write_event(PerfettoEvent {
+            ts: self.get_ts(),
+            pid: 1,
+            tid: self.get_tid(),
+            phase: Phase::Begin,
+            name: Some(span.metadata().name()),
+            id: None,
+            args: None,
+            scope: None,
+        })
+    }
+
+    fn on_exit(&self, _id: &span::Id, _ctx: layer::Context<'_, S>) {
+        self.write_event(PerfettoEvent {
+            ts: self.get_ts(),
+            pid: 1,
+            tid: self.get_tid(),
+            phase: Phase::End,
+            name: None,
+            id: None,
+            args: None,
+            scope: None,
+        })
+    }
+
+    fn on_new_span(
+        &self,
+        attrs: &span::Attributes<'_>,
+        id: &span::Id,
+        _ctx: layer::Context<'_, S>,
+    ) {
+        let sid = self.next_span_id.fetch_add(1, Ordering::SeqCst);
+        let name = format!("{}: {}", sid, attrs.metadata().name());
+
+        self.write_event(PerfettoEvent {
+            ts: self.get_ts(),
+            pid: 1,
+            tid: self.get_tid(),
+            phase: Phase::BeginAsync,
+            name: Some(&name),
+            id: Some(id.into_u64()),
+            args: Some(Visitable::Span(attrs)),
+            scope: None,
+        })
+    }
+
+    fn on_close(&self, id: span::Id, _ctx: layer::Context<'_, S>) {
+        self.write_event(PerfettoEvent {
+            ts: self.get_ts(),
+            pid: 1,
+            tid: self.get_tid(),
+            phase: Phase::EndAsync,
+            name: None,
+            id: Some(id.into_u64()),
+            args: None,
+            scope: None,
+        })
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: layer::Context<'_, S>) {
+        self.write_event(PerfettoEvent {
+            ts: self.get_ts(),
+            pid: 1,
+            tid: self.get_tid(),
+            phase: Phase::InstantAsync,
+            name: Some(event.metadata().name()),
+            id: ctx.current_span().id().map(|id| id.into_u64()),
+            args: Some(Visitable::Event(event)),
+            scope: None,
+        })
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct FlushGuard {
+    writer: Option<Arc<Mutex<PerfettoWriterJson<std::fs::File>>>>,
+}
+
+impl Drop for FlushGuard {
+    fn drop(&mut self) {
+        if let Some(writer) = self.writer.take() {
+            writer.lock().unwrap().finish();
+        }
+    }
+}

--- a/src/utils/tracing-perfetto/src/lib.rs
+++ b/src/utils/tracing-perfetto/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod json_writer;
+mod layer;
+mod perfetto_types;
+pub use json_writer::*;
+pub use layer::*;
+pub use perfetto_types::*;

--- a/src/utils/tracing-perfetto/src/perfetto_types.rs
+++ b/src/utils/tracing-perfetto/src/perfetto_types.rs
@@ -1,0 +1,56 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub struct PerfettoEvent<'a> {
+    pub ts: f64,
+    pub tid: u64,
+    pub pid: u64,
+    pub phase: Phase,
+    pub name: Option<&'a str>,
+    pub id: Option<u64>,
+    pub args: Option<Visitable<'a>>,
+    pub scope: Option<InstantScope>,
+}
+
+// See: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    Begin,
+    End,
+    Instant,
+    BeginAsync,
+    EndAsync,
+    InstantAsync,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstantScope {
+    Global,
+    Process,
+    Thread,
+}
+
+#[derive(Debug)]
+pub enum PerfettoMetadata<'a> {
+    ThreadName { tid: u64, name: &'a str },
+}
+
+pub enum Visitable<'a> {
+    Span(&'a tracing::span::Attributes<'a>),
+    Event(&'a tracing::Event<'a>),
+}
+
+impl<'a> Visitable<'a> {
+    pub fn visit(&self, v: &mut dyn tracing::field::Visit) {
+        match self {
+            Visitable::Span(attrs) => attrs.record(v),
+            Visitable::Event(event) => event.record(v),
+        }
+    }
+}


### PR DESCRIPTION
After some discussion with the author of `tracing-chrome` crate, and asking around in Perfetto dev Discord I decided to prototype my own tracer.

It works as follows:
* every time span is entered / exited it writes **synchronous** begin/end timelines - thus giving us a nice stacked per-thread flame graph for each time a coroutine was actively running on a CPU
* when span is created / closed it writes **async** begin/end timelines under unique timeline IDs - this gives us independent async timeline per every span in the program (similarly to how Jaeger displays spans)

It's not perfect but much better than what we had before.

Here's an example of pulling two datasets concurrently using old tracer:
![image](https://github.com/kamu-data/kamu-cli/assets/204914/f6ef229d-785f-4ca5-9611-c80ae7c2177f)

and here is the new one:
![image](https://github.com/kamu-data/kamu-cli/assets/204914/829b6cd2-930b-4a84-a34d-a871315cffcb)
