### PR TITLE
System info command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,9 @@ jobs:
         with:
           command: fmt
           args: --check
+      - name: license headers
+        run: |
+          cargo test -p kamu-repo-tools -- license_header
 
   lint_deps:
     name: Lint / Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- New `kamu version` command that outputs detailed build information in JSON or YAML
+  - `kamu --version` remains for compatibility and will be removed in future versions
+- New `kamu system info` command that outputs detailed system information
+  - Currently only contains build info but will be in future expanded with host environment info, docker/podman versions, and other things useful for diagnostics
+
 ## [0.134.0] - 2023-07-27
 ### Changed
 - New engine I/O strategies allow ingest/transform to run over datasets in remote storage (e.g. S3) even when engine does not support remote inputs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,6 +3021,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
+ "vergen",
  "webbrowser",
  "whoami",
 ]
@@ -3607,6 +3608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -5126,6 +5136,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -5697,6 +5709,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
+dependencies = [
+ "anyhow",
+ "rustc_version",
+ "rustversion",
+ "time 0.3.23",
+]
 
 [[package]]
 name = "version_check"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,6 @@
 [build.env]
 passthrough = [
+    "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc",
+    "RUSTFLAGS",
     "KAMU_WEB_UI_DIR",
 ]

--- a/installer/kamu-install.sh
+++ b/installer/kamu-install.sh
@@ -243,6 +243,8 @@ kamu_installed_version() {
     if ! check_cmd "$_bin"; then
         version=""
     else
+        # TODO: As of 2023-07-28 the `--version` flag is considered deprecated.
+        # We should switch to `version` command after a grace period of ~6 months.
         version=$($_bin --version)
         version=$(echo $version | sed 's/^kamu //')
     fi

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -15,6 +15,7 @@ publish = { workspace = true }
 
 # Disabling examples discovery as we need them very rarely but they significantly slow down build times
 autoexamples = false 
+build = "build.rs"
 
 
 [lib]
@@ -117,3 +118,7 @@ env_logger = "0.10"
 rand = "0.8"
 test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
+
+
+[build-dependencies]
+vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl", "rustc"] }

--- a/src/app/cli/build.rs
+++ b/src/app/cli/build.rs
@@ -7,10 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod test_add_command;
-mod test_complete_command;
-mod test_di_graph;
-mod test_new_dataset_command;
-mod test_pull_command;
-mod test_system_info_command;
-mod test_workspace_svc;
+use std::error::Error;
+
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    EmitBuilder::builder()
+        .all_build()
+        .all_git()
+        .all_rustc()
+        .all_cargo()
+        .emit()?;
+    Ok(())
+}

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -392,6 +392,10 @@ pub fn get_command(
                 )),
                 _ => return Err(CommandInterpretationFailed.into()),
             },
+            Some(("info", info_matches)) => Box::new(SystemInfoCommand::new(
+                catalog.get_one()?,
+                info_matches.get_one("output-format").map(String::as_str),
+            )),
             Some(("ipfs", ipfs_matches)) => match ipfs_matches.subcommand() {
                 Some(("add", add_matches)) => Box::new(SystemIpfsAddCommand::new(
                     catalog.get_one()?,
@@ -433,6 +437,10 @@ pub fn get_command(
             .into_iter(),
             submatches.get_flag("recursive"),
             submatches.get_flag("integrity"),
+        )),
+        Some(("version", submatches)) => Box::new(VersionCommand::new(
+            catalog.get_one()?,
+            submatches.get_one("output-format").map(String::as_str),
         )),
         _ => return Err(CommandInterpretationFailed.into()),
     };

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -1094,6 +1094,15 @@ pub fn cli() -> Command {
                                     kamu system api-server gql-schema
                                 "#
                             )),
+                        Command::new("info")
+                            .about("Summary of the system information")
+                            .args([
+                                Arg::new("output-format")
+                                    .long("output-format")
+                                    .short('o')
+                                    .value_name("FMT")
+                                    .value_parser(["shell", "json", "yaml"]),
+                            ]),
                         Command::new("ipfs")
                             .about("IPFS helpers")
                             .subcommand_required(true)
@@ -1207,6 +1216,15 @@ pub fn cli() -> Command {
                             kamu verify --integrity com.example.deriv
                         "#
                     )),
+                Command::new("version")
+                    .about("Outputs build information")
+                    .args([
+                        Arg::new("output-format")
+                            .long("output-format")
+                            .short('o')
+                            .value_name("FMT")
+                            .value_parser(["shell", "json", "yaml"]),
+                    ]),
             ],
         )
 }

--- a/src/app/cli/src/commands/mod.rs
+++ b/src/app/cli/src/commands/mod.rs
@@ -7,123 +7,88 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-pub use super::error::*;
-
-mod common;
-
 mod add_command;
-pub use add_command::*;
-
 mod alias_add_command;
-pub use alias_add_command::*;
-
 mod alias_delete_command;
-pub use alias_delete_command::*;
-
 mod alias_list_command;
-pub use alias_list_command::*;
-
+mod common;
 mod complete_command;
-pub use complete_command::*;
-
 mod completions_command;
-pub use completions_command::*;
-
 mod config_command;
-pub use config_command::*;
-
 mod delete_command;
-pub use delete_command::*;
-
 mod gc_command;
-pub use gc_command::*;
-
 mod init_command;
-pub use init_command::*;
-
 mod inspect_query_command;
-pub use inspect_query_command::*;
-
 mod inspect_schema_command;
-pub use inspect_schema_command::*;
-
-mod list_command;
-pub use list_command::*;
-
 mod lineage_command;
-pub use lineage_command::*;
-
+mod list_command;
 mod log_command;
-pub use log_command::*;
-
 mod new_dataset_command;
-pub use new_dataset_command::*;
-
 mod notebook_command;
-pub use notebook_command::*;
-
 mod pull_command;
-pub use pull_command::*;
-
 mod pull_images_command;
-pub use pull_images_command::*;
-
 mod push_command;
-pub use push_command::*;
-
 mod rename_command;
-pub use rename_command::*;
-
 mod repository_add_command;
-pub use repository_add_command::*;
-
 mod repository_delete_command;
-pub use repository_delete_command::*;
-
 mod repository_list_command;
-pub use repository_list_command::*;
-
 mod reset_command;
-pub use reset_command::*;
-
 mod search_command;
-pub use search_command::*;
-
 mod set_watermark_command;
-pub use set_watermark_command::*;
-
 mod sql_server_command;
-pub use sql_server_command::*;
-
 mod sql_server_livy_command;
-pub use sql_server_livy_command::*;
-
 mod sql_shell_command;
-pub use sql_shell_command::*;
-
-mod tail_command;
-pub use tail_command::*;
-
 mod system_api_server_gql_query_command;
-pub use system_api_server_gql_query_command::*;
-
 mod system_api_server_gql_schema_command;
-pub use system_api_server_gql_schema_command::*;
-
 mod system_api_server_run_command;
-pub use system_api_server_run_command::*;
-
+mod system_info_command;
 mod system_ipfs_add_command;
-pub use system_ipfs_add_command::*;
-
+mod tail_command;
 mod ui_command;
-pub use ui_command::*;
-
 mod upgrade_workspace_command;
-pub use upgrade_workspace_command::*;
-
 mod verify_command;
+
+pub use add_command::*;
+pub use alias_add_command::*;
+pub use alias_delete_command::*;
+pub use alias_list_command::*;
+pub use complete_command::*;
+pub use completions_command::*;
+pub use config_command::*;
+pub use delete_command::*;
+pub use gc_command::*;
+pub use init_command::*;
+pub use inspect_query_command::*;
+pub use inspect_schema_command::*;
+pub use lineage_command::*;
+pub use list_command::*;
+pub use log_command::*;
+pub use new_dataset_command::*;
+pub use notebook_command::*;
+pub use pull_command::*;
+pub use pull_images_command::*;
+pub use push_command::*;
+pub use rename_command::*;
+pub use repository_add_command::*;
+pub use repository_delete_command::*;
+pub use repository_list_command::*;
+pub use reset_command::*;
+pub use search_command::*;
+pub use set_watermark_command::*;
+pub use sql_server_command::*;
+pub use sql_server_livy_command::*;
+pub use sql_shell_command::*;
+pub use system_api_server_gql_query_command::*;
+pub use system_api_server_gql_schema_command::*;
+pub use system_api_server_run_command::*;
+pub use system_info_command::*;
+pub use system_ipfs_add_command::*;
+pub use tail_command::*;
+pub use ui_command::*;
+pub use upgrade_workspace_command::*;
 pub use verify_command::*;
+
+pub use super::error::*;
 
 #[async_trait::async_trait(?Send)]
 pub trait Command {

--- a/src/app/cli/src/commands/system_info_command.rs
+++ b/src/app/cli/src/commands/system_info_command.rs
@@ -1,0 +1,166 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use internal_error::*;
+
+use super::{CLIError, Command};
+use crate::output::*;
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub struct SystemInfoCommand {
+    output_config: Arc<OutputConfig>,
+    output_format: Option<String>,
+}
+
+impl SystemInfoCommand {
+    pub fn new<S>(output_config: Arc<OutputConfig>, output_format: Option<S>) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            output_config,
+            output_format: output_format.map(|s| s.into()),
+        }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl Command for SystemInfoCommand {
+    fn needs_workspace(&self) -> bool {
+        false
+    }
+
+    async fn run(&mut self) -> Result<(), CLIError> {
+        write_output(
+            SystemInfo::collect(),
+            &self.output_config,
+            self.output_format.as_ref(),
+        )?;
+        Ok(())
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub struct VersionCommand {
+    output_config: Arc<OutputConfig>,
+    output_format: Option<String>,
+}
+
+impl VersionCommand {
+    pub fn new<S>(output_config: Arc<OutputConfig>, output_format: Option<S>) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            output_config,
+            output_format: output_format.map(|s| s.into()),
+        }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl Command for VersionCommand {
+    fn needs_workspace(&self) -> bool {
+        false
+    }
+
+    async fn run(&mut self) -> Result<(), CLIError> {
+        write_output(
+            BuildInfo::collect(),
+            &self.output_config,
+            self.output_format.as_ref(),
+        )?;
+        Ok(())
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+fn write_output<T: serde::Serialize>(
+    value: T,
+    output_config: &OutputConfig,
+    output_format: Option<impl AsRef<str>>,
+) -> Result<(), InternalError> {
+    let output_format = if let Some(fmt) = &output_format {
+        fmt.as_ref()
+    } else {
+        if output_config.is_tty {
+            "shell"
+        } else {
+            "json"
+        }
+    };
+
+    // TODO: Generalize this code in output config, just like we do for tabular
+    // output
+    match output_format {
+        "json" => serde_json::to_writer_pretty(std::io::stdout(), &value).int_err()?,
+        "shell" | "yaml" | _ => serde_yaml::to_writer(std::io::stdout(), &value).int_err()?,
+    }
+
+    Ok(())
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemInfo {
+    pub build: BuildInfo,
+}
+
+impl SystemInfo {
+    pub fn collect() -> Self {
+        Self {
+            build: BuildInfo::collect(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildInfo {
+    pub app_version: &'static str,
+    pub build_timestamp: Option<&'static str>,
+    pub git_describe: Option<&'static str>,
+    pub git_sha: Option<&'static str>,
+    pub git_commit_date: Option<&'static str>,
+    pub git_branch: Option<&'static str>,
+    pub rustc_semver: Option<&'static str>,
+    pub rustc_channel: Option<&'static str>,
+    pub rustc_host_triple: Option<&'static str>,
+    pub rustc_commit_sha: Option<&'static str>,
+    pub cargo_target_triple: Option<&'static str>,
+    pub cargo_features: Option<&'static str>,
+    pub cargo_opt_level: Option<&'static str>,
+}
+
+impl BuildInfo {
+    pub fn collect() -> Self {
+        Self {
+            app_version: env!("CARGO_PKG_VERSION"),
+            build_timestamp: option_env!("VERGEN_BUILD_TIMESTAMP"),
+            git_describe: option_env!("VERGEN_GIT_DESCRIBE"),
+            git_sha: option_env!("VERGEN_GIT_SHA"),
+            git_commit_date: option_env!("VERGEN_GIT_COMMIT_DATE"),
+            git_branch: option_env!("VERGEN_GIT_BRANCH"),
+            rustc_semver: option_env!("VERGEN_RUSTC_SEMVER"),
+            rustc_channel: option_env!("VERGEN_RUSTC_CHANNEL"),
+            rustc_host_triple: option_env!("VERGEN_RUSTC_HOST_TRIPLE"),
+            rustc_commit_sha: option_env!("VERGEN_RUSTC_COMMIT_HASH"),
+            cargo_target_triple: option_env!("VERGEN_CARGO_TARGET_TRIPLE"),
+            cargo_features: option_env!("VERGEN_CARGO_FEATURES"),
+            cargo_opt_level: option_env!("VERGEN_CARGO_OPT_LEVEL"),
+        }
+    }
+}

--- a/src/app/cli/tests/tests/test_system_info_command.rs
+++ b/src/app/cli/tests/tests/test_system_info_command.rs
@@ -1,0 +1,38 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::assert_matches::assert_matches;
+
+use kamu_cli::*;
+
+#[test_log::test(tokio::test)]
+async fn test_system_info() {
+    assert_matches!(
+        SystemInfo::collect(),
+        SystemInfo {
+            build: BuildInfo {
+                app_version: kamu_cli::VERSION,
+                // We trust vergen to do its job and simply ensure that we detect any incompatible
+                // env var name changes
+                build_timestamp: Some(_),
+                git_describe: Some(_),
+                git_sha: Some(_),
+                git_commit_date: Some(_),
+                git_branch: Some(_),
+                rustc_semver: Some(_),
+                rustc_channel: Some(_),
+                rustc_host_triple: Some(_),
+                rustc_commit_sha: Some(_),
+                cargo_target_triple: Some(_),
+                cargo_features: Some(_),
+                cargo_opt_level: Some(_),
+            }
+        }
+    )
+}


### PR DESCRIPTION
Something I wanted to add for a long time.

Example output:
![image](https://github.com/kamu-data/kamu-cli/assets/204914/f39c6996-ee41-46b6-8ac6-647ce96d5f9d)

After this is in place we can add a github issue template to this repo asking people to always submit this info when reporting problems.

I'm planning to add a similar (admin-only) endpoint to the `api-server` as well.