### PR TITLE
Bug/fetch error on empty file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.141.0] - 2023-08-28
+### Fixed
+- `datafusion` ingest will not crash on empty inputs when schema inference is enabled
+### Added
+- Added a warning when fetch cache is used to resume ingest: `Using cached data from X minutes ago (use kamu system gc to clear cache)`
+
 ## [0.140.0] - 2023-08-27
 ### Added
 - **Experimental:** Data ingest using `DataFusion` engine

--- a/src/app/cli/src/services/workspace_layout.rs
+++ b/src/app/cli/src/services/workspace_layout.rs
@@ -36,7 +36,7 @@ pub struct WorkspaceLayout {
 }
 
 impl WorkspaceLayout {
-    pub const VERSION: WorkspaceVersion = WorkspaceVersion::V2_DatasetConfig;
+    pub const VERSION: WorkspaceVersion = WorkspaceVersion::V3_SavepointCreatedAt;
 
     pub fn new(root: impl Into<PathBuf>) -> Self {
         let root_dir = root.into();
@@ -82,6 +82,8 @@ pub enum WorkspaceVersion {
     V0_Initial,
     V1_WorkspaceCacheDir,
     V2_DatasetConfig,
+    // Added a `createdAt` field to fetch savepoints
+    V3_SavepointCreatedAt,
     Unknown(u32),
 }
 
@@ -98,6 +100,7 @@ impl From<u32> for WorkspaceVersion {
             0 => WorkspaceVersion::V0_Initial,
             1 => WorkspaceVersion::V1_WorkspaceCacheDir,
             2 => WorkspaceVersion::V2_DatasetConfig,
+            3 => WorkspaceVersion::V3_SavepointCreatedAt,
             _ => WorkspaceVersion::Unknown(value),
         }
     }
@@ -109,6 +112,7 @@ impl Into<u32> for WorkspaceVersion {
             Self::V0_Initial => 0,
             Self::V1_WorkspaceCacheDir => 1,
             Self::V2_DatasetConfig => 2,
+            Self::V3_SavepointCreatedAt => 3,
             Self::Unknown(value) => value,
         }
     }

--- a/src/domain/core/src/services/ingest/data_writer.rs
+++ b/src/domain/core/src/services/ingest/data_writer.rs
@@ -24,9 +24,12 @@ use crate::CommitError;
 /// to commit data into a dataset in bitemporal ledger form.
 #[async_trait::async_trait]
 pub trait DataWriter {
+    // TODO: Avoid using Option<> and create empty DataFrame instead.
+    // This would require us always knowing what the schema of data is (e.g. before
+    // the first ingest run).
     async fn write(
         &mut self,
-        new_data: DataFrame,
+        new_data: Option<DataFrame>,
         opts: WriteDataOpts,
     ) -> Result<WriteDataResult, WriteDataError>;
 }

--- a/src/domain/core/src/services/ingest_service.rs
+++ b/src/domain/core/src/services/ingest_service.rs
@@ -10,6 +10,7 @@
 use std::backtrace::Backtrace;
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use container_runtime::ImagePullError;
 use opendatafabric::*;
 use thiserror::Error;
@@ -107,12 +108,13 @@ pub enum IngestStage {
     Commit,
 }
 
+#[allow(unused_variables)]
 pub trait IngestListener: Send + Sync {
     fn begin(&self) {}
-    fn on_stage_progress(&self, _stage: IngestStage, _progress: u64, _out_of: TotalSteps) {}
-
-    fn success(&self, _result: &IngestResult) {}
-    fn error(&self, _error: &IngestError) {}
+    fn on_cache_hit(&self, created_at: &DateTime<Utc>) {}
+    fn on_stage_progress(&self, stage: IngestStage, _progress: u64, _out_of: TotalSteps) {}
+    fn success(&self, result: &IngestResult) {}
+    fn error(&self, error: &IngestError) {}
 
     fn get_pull_image_listener(self: Arc<Self>) -> Option<Arc<dyn PullImageListener>> {
         None

--- a/src/domain/core/src/utils/time_source.rs
+++ b/src/domain/core/src/utils/time_source.rs
@@ -31,11 +31,11 @@ impl SystemTimeSource for SystemTimeSourceDefault {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-pub struct SystemTimeSourceMock {
+pub struct SystemTimeSourceStub {
     t: Mutex<DateTime<Utc>>,
 }
 
-impl SystemTimeSourceMock {
+impl SystemTimeSourceStub {
     pub fn new(t: DateTime<Utc>) -> Self {
         Self { t: Mutex::new(t) }
     }
@@ -45,7 +45,7 @@ impl SystemTimeSourceMock {
     }
 }
 
-impl SystemTimeSource for SystemTimeSourceMock {
+impl SystemTimeSource for SystemTimeSourceStub {
     fn now(&self) -> DateTime<Utc> {
         (*self.t.lock().unwrap()).clone()
     }

--- a/src/infra/core/src/ingest/ingest_task.rs
+++ b/src/infra/core/src/ingest/ingest_task.rs
@@ -288,6 +288,9 @@ impl IngestTask {
 
         if let Some(savepoint) = savepoint {
             tracing::info!(?savepoint_path, "Resuming from savepoint");
+
+            self.listener.on_cache_hit(&savepoint.created_at);
+
             Ok(FetchStepResult::Updated(savepoint))
         } else {
             // Just in case user deleted it manually
@@ -316,7 +319,8 @@ impl IngestTask {
                 FetchResult::UpToDate => Ok(FetchStepResult::UpToDate),
                 FetchResult::Updated(upd) => {
                     let savepoint = FetchSavepoint {
-                        // If fetch source was overridden we don't want to put its
+                        created_at: self.request.system_time.clone(),
+                        // If fetch source was overridden, we don't want to put its
                         // source state into the metadata.
                         source_state: if self.fetch_override.is_none() {
                             upd.source_state

--- a/src/infra/core/src/ingest/polling_source_state.rs
+++ b/src/infra/core/src/ingest/polling_source_state.rs
@@ -9,7 +9,7 @@
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use kamu_core::{InternalError, ResultIntoInternal};
-use opendatafabric::serde::yaml::{datetime_rfc3339_opt, SourceStateDef};
+use opendatafabric::serde::yaml::{datetime_rfc3339, datetime_rfc3339_opt, SourceStateDef};
 use opendatafabric::SourceState;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::skip_serializing_none;
@@ -93,12 +93,14 @@ impl PollingSourceState {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Used to cache the fetch results te resume without re-downloading data
+/// Used to cache the fetch results to resume without re-downloading data
 /// in case of errors in further ingestion steps.
 #[skip_serializing_none]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct FetchSavepoint {
+    #[serde(with = "datetime_rfc3339")]
+    pub created_at: DateTime<Utc>,
     #[serde(default, with = "PollingSourceState")]
     pub source_state: Option<PollingSourceState>,
     #[serde(default, with = "datetime_rfc3339_opt")]

--- a/src/infra/core/src/ingest_service_impl.rs
+++ b/src/infra/core/src/ingest_service_impl.rs
@@ -340,6 +340,9 @@ impl IngestServiceImpl {
 
         if let Some(savepoint) = savepoint {
             tracing::info!(?savepoint_path, "Resuming from savepoint");
+
+            args.listener.on_cache_hit(&savepoint.created_at);
+
             Ok(FetchStepResult::Updated(savepoint))
         } else {
             // Just in case user deleted it manually
@@ -370,6 +373,7 @@ impl IngestServiceImpl {
                 FetchResult::UpToDate => Ok(FetchStepResult::UpToDate),
                 FetchResult::Updated(upd) => {
                     let savepoint = FetchSavepoint {
+                        created_at: args.system_time.clone(),
                         // If fetch source was overridden we don't want to put its
                         // source state into the metadata.
                         source_state: if args.fetch_override.is_none() {

--- a/src/infra/core/tests/tests/ingest/test_writer.rs
+++ b/src/infra/core/tests/tests/ingest/test_writer.rs
@@ -426,21 +426,27 @@ impl Harness {
         schema: &str,
         source_state: Option<odf::SourceState>,
     ) -> Result<WriteDataResult, WriteDataError> {
-        let data_path = self.temp_dir.path().join("data.bin");
-        std::fs::write(&data_path, data).unwrap();
+        let df = if data.len() == 0 {
+            None
+        } else {
+            let data_path = self.temp_dir.path().join("data.bin");
+            std::fs::write(&data_path, data).unwrap();
 
-        let df = ReaderCsv::new()
-            .read(
-                &self.ctx,
-                &data_path,
-                &odf::ReadStep::Csv(odf::ReadStepCsv {
-                    header: Some(true),
-                    schema: Some(schema.split(',').map(|s| s.to_string()).collect()),
-                    ..Default::default()
-                }),
-            )
-            .await
-            .unwrap();
+            let df = ReaderCsv::new()
+                .read(
+                    &self.ctx,
+                    &data_path,
+                    &odf::ReadStep::Csv(odf::ReadStepCsv {
+                        header: Some(true),
+                        schema: Some(schema.split(',').map(|s| s.to_string()).collect()),
+                        ..Default::default()
+                    }),
+                )
+                .await
+                .unwrap();
+
+            Some(df)
+        };
 
         self.writer
             .write(

--- a/src/infra/ingest-datafusion/tests/tests/test_reader_csv.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_reader_csv.rs
@@ -148,6 +148,50 @@ async fn test_read_csv_no_schema_infer() {
 
 #[test_group::group(engine, ingest, datafusion)]
 #[test_log::test(tokio::test)]
+async fn test_read_csv_no_header() {
+    test_reader_common::test_reader_success_textual(
+        ReaderCsv {},
+        ReadStepCsv {
+            schema: Some(vec![
+                "city STRING".to_string(),
+                "population BIGINT".to_string(),
+            ]),
+            ..Default::default()
+        },
+        indoc!(
+            r#"
+            A,1000
+            B,2000
+            C,3000
+            "#
+        ),
+        indoc!(
+            r#"
+            message arrow_schema {
+              OPTIONAL BYTE_ARRAY city (STRING);
+              OPTIONAL INT64 population;
+            }
+            "#
+        ),
+        indoc!(
+            r#"
+            +------+------------+
+            | city | population |
+            +------+------------+
+            | A    | 1000       |
+            | B    | 2000       |
+            | C    | 3000       |
+            +------+------------+
+            "#
+        ),
+    )
+    .await;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, ingest, datafusion)]
+#[test_log::test(tokio::test)]
 async fn test_read_csv_null_values() {
     test_reader_common::test_reader_success_textual(
         ReaderCsv {},


### PR DESCRIPTION
- Fix `datafusion` ingest crash on empty inputs when schema inference is enabled
- Added a warning when fetch cache is used to resume ingest: `Using cached data from X minutes ago (use kamu system gc to clear cache)`
- Renamed `SystemTimeSourceMock` to `SystemTimeSourceStub`
- Restored ingest service test for auth