### PR TITLE
FlightSQL tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.145.5] - 2023-10-26
+### Changed
+- FlightSQL interface tweaks to simplify integration into `api-server`
+
+## [0.145.4] - 2023-10-24
+### Fixed
+- `kamu ui` should run without specifying any auth secrets
+
 ## [0.145.3] - 2023-10-18
 ### Changed
 - Demanding required env vars to be set before API server / Web UI server startup
 - Custom error messages for non-valid session in GraphQL queries depending on the reason
 ### Fixed
-- If access token points on unsupported login method, it's a client error (4xx), not (5xx).
+- If access token points on unsupported login method, it's a client error (4xx), not (5xx)
 
 ## [0.145.2] - 2023-10-16
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,7 @@ name = "kamu-adapter-flight-sql"
 version = "0.145.4"
 dependencies = [
  "arrow-flight",
+ "async-trait",
  "base64 0.21.5",
  "dashmap",
  "datafusion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "container-runtime"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.145.4"
+version = "0.145.5"
 
 [[package]]
 name = "env_logger"
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "quote",
  "syn 2.0.38",
@@ -2917,7 +2917,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "test-log",
  "thiserror",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-recursion",
  "async-stream",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-trait",
  "dill",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-trait",
  "dill",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "arrow-digest",
  "async-trait",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "chrono",
  "clap",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4095,7 +4095,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendatafabric"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "bs58",
  "byteorder",
@@ -6077,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.145.4"
+version = "0.145.5"
 dependencies = [
  "env_logger",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,30 +31,30 @@ resolver = "2"
 
 [workspace.dependencies]
 # Utils
-container-runtime = { version = "0.145.4", path = "src/utils/container-runtime", default-features = false }
-enum-variants = { version = "0.145.4", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.145.4", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.145.4", path = "src/utils/event-sourcing-macros", default-features = false }
-internal-error = { version = "0.145.4", path = "src/utils/internal-error", default-features = false }
-kamu-data-utils = { version = "0.145.4", path = "src/utils/data-utils", default-features = false }
-tracing-perfetto = { version = "0.145.4", path = "src/utils/tracing-perfetto", default-features = false }
+container-runtime = { version = "0.145.5", path = "src/utils/container-runtime", default-features = false }
+enum-variants = { version = "0.145.5", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.145.5", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.145.5", path = "src/utils/event-sourcing-macros", default-features = false }
+internal-error = { version = "0.145.5", path = "src/utils/internal-error", default-features = false }
+kamu-data-utils = { version = "0.145.5", path = "src/utils/data-utils", default-features = false }
+tracing-perfetto = { version = "0.145.5", path = "src/utils/tracing-perfetto", default-features = false }
 # Domain
-opendatafabric = { version = "0.145.4", path = "src/domain/opendatafabric", default-features = false }
-kamu-core = { version = "0.145.4", path = "src/domain/core", default-features = false }
-kamu-task-system = { version = "0.145.4", path = "src/domain/task-system", default-features = false }
+opendatafabric = { version = "0.145.5", path = "src/domain/opendatafabric", default-features = false }
+kamu-core = { version = "0.145.5", path = "src/domain/core", default-features = false }
+kamu-task-system = { version = "0.145.5", path = "src/domain/task-system", default-features = false }
 # Infra
-kamu = { version = "0.145.4", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.145.4", path = "src/infra/ingest-datafusion", default-features = false }
-kamu-task-system-inmem = { version = "0.145.4", path = "src/infra/task-system-inmem", default-features = false }
+kamu = { version = "0.145.5", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.145.5", path = "src/infra/ingest-datafusion", default-features = false }
+kamu-task-system-inmem = { version = "0.145.5", path = "src/infra/task-system-inmem", default-features = false }
 # Adapters
-kamu-adapter-auth-oso = { version = "0.145.4", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.145.4", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.145.4", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.145.4", path = "src/adapter/http", default-features = false }
-kamu-adapter-oauth = { version = "0.145.4", path = "src/adapter/oauth", defualt-features = false }
+kamu-adapter-auth-oso = { version = "0.145.5", path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { version = "0.145.5", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.145.5", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.145.5", path = "src/adapter/http", default-features = false }
+kamu-adapter-oauth = { version = "0.145.5", path = "src/adapter/oauth", defualt-features = false }
 
 [workspace.package]
-version = "0.145.4"
+version = "0.145.5"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.145.4
+Licensed Work:             Kamu CLI Version 0.145.5
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,

--- a/deny.toml
+++ b/deny.toml
@@ -77,9 +77,5 @@ unsound = "warn"
 yanked = "deny"
 notice = "warn"
 ignore = [
-    # https://rustsec.org/advisories/RUSTSEC-2020-0071
-    # Ignoring it until `chrono` updates to new version of `time` crate.
-    # We are not affected by this voulnerability as `chrono` doesn't call the affected code.
-    "RUSTSEC-2020-0071",
 ]
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+Please see the [Examples](https://docs.kamu.dev/cli/get-started/examples/) section of the documentation for the description and guided tutorials.

--- a/examples/flight-sql/README.md
+++ b/examples/flight-sql/README.md
@@ -1,0 +1,3 @@
+# Examples of connecting to Kamu via FlightSQL protocol
+
+For information about connectivity options see [Integrations](https://docs.kamu.dev/cli/integrations/) section of the documentation.

--- a/examples/flight-sql/python/client_flightsql_dbapi2.py
+++ b/examples/flight-sql/python/client_flightsql_dbapi2.py
@@ -1,0 +1,20 @@
+from flightsql import connect, FlightSQLClient
+
+
+client = FlightSQLClient(
+    host='localhost', 
+    port=50050, 
+    user='kamu', 
+    password='kamu', 
+    insecure=True,
+)
+conn = connect(client)
+cursor = conn.cursor()
+
+cursor.execute('show tables')
+print("columns:", cursor.description)
+print("rows:", [r for r in cursor])
+
+cursor.execute('select * from "co.alphavantage.tickers.daily.spy" limit 10')
+print("columns:", cursor.description)
+print("rows:", [r for r in cursor])

--- a/examples/flight-sql/python/client_flightsql_sqlalchemy.py
+++ b/examples/flight-sql/python/client_flightsql_sqlalchemy.py
@@ -1,0 +1,12 @@
+import flightsql.sqlalchemy
+import sqlalchemy.engine
+import pandas as pd
+
+
+engine = sqlalchemy.engine.create_engine("datafusion+flightsql://kamu:kamu@localhost:50050?insecure=True")
+
+df = pd.read_sql("show tables", engine)
+print(df)
+
+df = pd.read_sql("select * from 'co.alphavantage.tickers.daily.spy' limit 10", engine)
+print(df)

--- a/examples/flight-sql/python/client_jdbc.py
+++ b/examples/flight-sql/python/client_jdbc.py
@@ -1,0 +1,25 @@
+import jpype
+import jpype.dbapi2
+import os
+
+
+classpath = os.path.join(os.getcwd(), "path-to/flight-sql-jdbc-driver-13.0.0.jar")
+jpype.startJVM(
+    "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    classpath=classpath
+)
+
+conn = jpype.dbapi2.connect(
+    "jdbc:arrow-flight-sql://127.0.0.1:50050?useEncryption=false", 
+    driver_args={
+        'user': 'kamu', 
+        'password': 'kamu',
+    }
+)
+
+cursor = conn.cursor()
+res = cursor.execute("show tables").fetchall()
+print(res)
+
+cursor.close()
+conn.close()

--- a/examples/flight-sql/python/requirements.txt
+++ b/examples/flight-sql/python/requirements.txt
@@ -1,0 +1,4 @@
+flightsql-dbapi
+sqlalchemy
+pandas
+jpype1

--- a/src/adapter/flight-sql/Cargo.toml
+++ b/src/adapter/flight-sql/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 
 [dependencies]
 arrow-flight = { version = "46", features = ["flight-sql-experimental"] }
+async-trait = { version = "0.1", default-features = false }
 base64 = { version = "0.21", default-features = false }
 dashmap = { version = "5", default-features = false }
 datafusion = "31"

--- a/src/adapter/flight-sql/src/lib.rs
+++ b/src/adapter/flight-sql/src/lib.rs
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod flight_sql_service;
-mod flight_sql_service_builder;
-pub use flight_sql_service::*;
-pub use flight_sql_service_builder::*;
+mod service;
+mod service_builder;
+mod session_factory;
+pub use service::*;
+pub use service_builder::*;
+pub use session_factory::*;

--- a/src/adapter/flight-sql/src/session_factory.rs
+++ b/src/adapter/flight-sql/src/session_factory.rs
@@ -1,0 +1,29 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+use tonic::Status;
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub type Token = String;
+
+#[async_trait::async_trait]
+#[allow(unused_variables)]
+pub trait SessionFactory: Send + Sync {
+    async fn authenticate(&self, username: &str, password: &str) -> Result<Token, Status> {
+        Err(Status::unauthenticated("Invalid credentials!"))
+    }
+
+    async fn get_context(&self, token: &Token) -> Result<Arc<SessionContext>, Status> {
+        Err(Status::unauthenticated("Invalid credentials!"))?
+    }
+}

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -68,7 +68,7 @@ hyper = "0.14"
 reqwest = { version = "0.11", default-features = false, features = [] }
 serde_json = "1"
 tonic = { version = "0.9", default-features = false }
-tower = "0.4"
+tower = "0.4.3"
 tower-http = { version = "0.4", features = ["trace", "cors"] }
 
 # Web UI


### PR DESCRIPTION
Rustc was choking when my async callback for creating DataFusion sessions per user got a bit complex, so the main change here was to replace a functor with a `SessionFactory` async trait interface.

I also used this opportunity to include python FlightSQL client code into examples.