### PR TITLE
Push ingest refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `echo '{"city": "Vancouver", "population": 675218}' | kamu ingest cities --stdin`
 - New `/:dataset/data/ingest` REST endpoint also allows you to push data via API, example:
   - Run API server and get JWT token: `kamu ui --http-port 8080 --get-token`
-  - Push data: `echo '{...}' | curl -v -X POST http://localhost:8080/freezer/data/ingest -H 'Authorization:  Bearer <token>'`
+  - Push data: `echo '[{...}]' | curl -v -X POST http://localhost:8080/freezer/data/ingest -H 'Authorization:  Bearer <token>'`
 - The `kamu ui` command now supports `--get-token` flag to print out the access token upon server start that you can use to experiment with API
 ### Changed
 - Upgraded to `arrow v48`, `datafusion v33`, and latest AWS SDK

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,6 +3299,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
+ "indoc 2.0.4",
  "kamu",
  "mockall",
  "opendatafabric",

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -51,6 +51,7 @@ container-runtime = { workspace = true }
 
 env_logger = "0.10"
 fs_extra = "1.3"                                                    # Recursive folder copy
+indoc = "2"
 paste = "1"
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"

--- a/src/adapter/http/src/api_error.rs
+++ b/src/adapter/http/src/api_error.rs
@@ -201,7 +201,7 @@ impl ApiErrorCategorizable for AccessError {
     }
 }
 
-impl ApiErrorCategorizable for IngestError {
+impl ApiErrorCategorizable for PushIngestError {
     fn categorize<'a>(&'a self) -> ApiErrorCategory<'a> {
         match &self {
             Self::Access(e) => ApiErrorCategory::Access(e),

--- a/src/adapter/http/src/api_error.rs
+++ b/src/adapter/http/src/api_error.rs
@@ -84,6 +84,13 @@ impl ApiError {
         AccessError::Forbidden("Forbidden access".into()).api_err()
     }
 
+    pub fn new_unsupported_media_type() -> Self {
+        Self {
+            source: "Unsupported media type".into(),
+            status_code: http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        }
+    }
+
     pub fn not_found(source: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self::new(source, http::StatusCode::NOT_FOUND)
     }

--- a/src/adapter/http/src/data/ingest_handler.rs
+++ b/src/adapter/http/src/data/ingest_handler.rs
@@ -43,7 +43,12 @@ pub async fn dataset_ingest_handler(
     let ingest_svc = catalog.get_one::<dyn PushIngestService>().unwrap();
 
     match ingest_svc
-        .ingest_from_file_stream(&dataset_ref, data, Some(&content_type.to_string()), None)
+        .ingest_from_file_stream(
+            &dataset_ref,
+            data,
+            Some(MediaType(content_type.to_string())),
+            None,
+        )
         .await
     {
         // Per note above, we're not including any extra information about the result

--- a/src/adapter/http/src/data/ingest_handler.rs
+++ b/src/adapter/http/src/data/ingest_handler.rs
@@ -37,9 +37,9 @@ pub async fn dataset_ingest_handler(
 ) -> Result<(), ApiError> {
     let data = Box::new(crate::axum_utils::body_into_async_read(body_stream));
 
-    let ingest_svc = catalog.get_one::<dyn IngestService>().unwrap();
+    let ingest_svc = catalog.get_one::<dyn PushIngestService>().unwrap();
     ingest_svc
-        .push_ingest_from_stream(&dataset_ref, data, None)
+        .ingest_from_file_stream(&dataset_ref, data, IngestMediaTypes::NDJSON, None)
         .await
         .api_err()?;
 

--- a/src/adapter/http/src/data/ingest_handler.rs
+++ b/src/adapter/http/src/data/ingest_handler.rs
@@ -16,7 +16,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use axum::extract::Extension;
+use axum::extract::{Extension, TypedHeader};
 use kamu::domain::*;
 use opendatafabric::DatasetRef;
 
@@ -24,28 +24,36 @@ use crate::api_error::*;
 
 /////////////////////////////////////////////////////////////////////////////////
 
+// TODO: SEC: Enforce a size limit on payload
 // TODO: In future this handler should be putting the data into a queue (e.g.
 // Kafka) and triggering a system event about new data arrival that will
 // schedule an ingest task. Push ingest will be *asynchronous*. Successful
 // response from this endpoint will only guarantee that the input was persisted
 // in an input queue. We will offer a separate mechanism for the caller to wait
-// until their data was processed.
+// until their data was processed. We may still provice a "synchronous" version
+// of push for convenience that waits for passed data to be flushed as part of
+// some block.
 pub async fn dataset_ingest_handler(
     Extension(catalog): Extension<dill::Catalog>,
     Extension(dataset_ref): Extension<DatasetRef>,
+    TypedHeader(content_type): TypedHeader<axum::headers::ContentType>,
     body_stream: axum::extract::BodyStream,
 ) -> Result<(), ApiError> {
     let data = Box::new(crate::axum_utils::body_into_async_read(body_stream));
-
     let ingest_svc = catalog.get_one::<dyn PushIngestService>().unwrap();
-    ingest_svc
-        .ingest_from_file_stream(&dataset_ref, data, IngestMediaTypes::NDJSON, None)
-        .await
-        .api_err()?;
 
-    // Per note above, we're must not include any extra information about the result
-    // of the ingest operation
-    Ok(())
+    match ingest_svc
+        .ingest_from_file_stream(&dataset_ref, data, Some(&content_type.to_string()), None)
+        .await
+    {
+        // Per note above, we're not including any extra information about the result
+        // of the ingest operation at this point to accomodate async execution
+        Ok(_) => Ok(()),
+        Err(PushIngestError::UnsupportedMediaType(_)) => {
+            Err(ApiError::new_unsupported_media_type())
+        }
+        Err(e) => Err(e.api_err()),
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/harness/client_side_harness.rs
+++ b/src/adapter/http/tests/harness/client_side_harness.rs
@@ -90,6 +90,9 @@ impl ClientSideHarness {
         b.add::<ObjectStoreRegistryImpl>()
             .bind::<dyn ObjectStoreRegistry, ObjectStoreRegistryImpl>();
 
+        b.add::<DataFormatRegistryImpl>();
+        b.bind::<dyn DataFormatRegistry, DataFormatRegistryImpl>();
+
         b.add_builder(
             builder_for::<PollingIngestServiceImpl>()
                 .with_run_info_dir(run_info_dir)

--- a/src/adapter/http/tests/harness/client_side_harness.rs
+++ b/src/adapter/http/tests/harness/client_side_harness.rs
@@ -91,11 +91,11 @@ impl ClientSideHarness {
             .bind::<dyn ObjectStoreRegistry, ObjectStoreRegistryImpl>();
 
         b.add_builder(
-            builder_for::<IngestServiceImpl>()
+            builder_for::<PollingIngestServiceImpl>()
                 .with_run_info_dir(run_info_dir)
                 .with_cache_dir(cache_dir),
         )
-        .bind::<dyn IngestService, IngestServiceImpl>();
+        .bind::<dyn PollingIngestService, PollingIngestServiceImpl>();
 
         b.add::<DatasetFactoryImpl>()
             .bind::<dyn DatasetFactory, DatasetFactoryImpl>();

--- a/src/adapter/http/tests/harness/server_side_harness.rs
+++ b/src/adapter/http/tests/harness/server_side_harness.rs
@@ -12,7 +12,13 @@
 use std::sync::Arc;
 
 use kamu::domain::auth::{AccountType, DEFAULT_AVATAR_URL};
-use kamu::domain::{auth, CurrentAccountSubject, DatasetRepository, InternalError};
+use kamu::domain::{
+    auth,
+    CurrentAccountSubject,
+    DatasetRepository,
+    InternalError,
+    SystemTimeSourceStub,
+};
 use kamu::testing::{MockAuthenticationService, MockDatasetActionAuthorizer};
 use kamu::DatasetLayout;
 use opendatafabric::{AccountName, DatasetAlias, DatasetHandle, FAKE_ACCOUNT_ID};
@@ -32,7 +38,13 @@ pub(crate) trait ServerSideHarness {
 
     fn dataset_layout(&self, dataset_handle: &DatasetHandle) -> DatasetLayout;
 
-    fn dataset_url(&self, dataset_alias: &DatasetAlias) -> Url;
+    fn dataset_url_with_scheme(&self, dataset_alias: &DatasetAlias, scheme: &str) -> Url;
+
+    fn dataset_url(&self, dataset_alias: &DatasetAlias) -> Url {
+        self.dataset_url_with_scheme(dataset_alias, "odf+http")
+    }
+
+    fn system_time_source(&self) -> &SystemTimeSourceStub;
 
     async fn api_server_run(self) -> Result<(), InternalError>;
 }
@@ -42,6 +54,7 @@ pub(crate) trait ServerSideHarness {
 pub(crate) struct ServerSideHarnessOptions {
     pub multi_tenant: bool,
     pub authorized_writes: bool,
+    pub base_catalog: Option<dill::Catalog>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/harness/test_api_server.rs
+++ b/src/adapter/http/tests/harness/test_api_server.rs
@@ -35,7 +35,9 @@ impl TestAPIServer {
                     "/:dataset_name"
                 },
                 kamu_adapter_http::add_dataset_resolver_layer(
-                    kamu_adapter_http::smart_transfer_protocol_router(),
+                    axum::Router::new()
+                        .nest("/", kamu_adapter_http::smart_transfer_protocol_router())
+                        .nest("/data", kamu_adapter_http::data::router()),
                     multi_tenant,
                 ),
             )

--- a/src/adapter/http/tests/tests/mod.rs
+++ b/src/adapter/http/tests/tests/mod.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 mod test_authentication_layer;
+mod test_data;
 mod test_dataset_authorization_layer;
 mod test_protocol_dataset_helpers;
 mod test_routing;
@@ -32,6 +33,7 @@ macro_rules! test_client_server_local_fs_harness_permutations {
                     ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
                         multi_tenant: false,
                         authorized_writes: true,
+                        base_catalog: None,
                     }).await,
                 )
                 .await;
@@ -46,6 +48,7 @@ macro_rules! test_client_server_local_fs_harness_permutations {
                     ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
                         multi_tenant: true,
                         authorized_writes: true,
+                        base_catalog: None,
                     }).await,
                 )
                 .await;
@@ -60,6 +63,7 @@ macro_rules! test_client_server_local_fs_harness_permutations {
                     ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
                         multi_tenant: false,
                         authorized_writes: true,
+                        base_catalog: None,
                     }).await,
                 )
                 .await;
@@ -74,6 +78,7 @@ macro_rules! test_client_server_local_fs_harness_permutations {
                     ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
                         multi_tenant: true,
                         authorized_writes: true,
+                        base_catalog: None,
                     }).await,
                 )
                 .await;
@@ -98,6 +103,7 @@ macro_rules! test_client_server_s3_harness_permutations {
                     ServerSideS3Harness::new(ServerSideHarnessOptions {
                         multi_tenant: false,
                         authorized_writes: true,
+                        base_catalog: None,
                     }).await,
                 )
                 .await;
@@ -113,6 +119,7 @@ macro_rules! test_client_server_s3_harness_permutations {
                     ServerSideS3Harness::new(ServerSideHarnessOptions {
                         multi_tenant: true,
                         authorized_writes: true,
+                        base_catalog: None,
                     }).await,
                 )
                 .await;

--- a/src/adapter/http/tests/tests/test_data.rs
+++ b/src/adapter/http/tests/tests/test_data.rs
@@ -26,6 +26,8 @@ async fn test_data_push_ingest_handler() {
     let cache_dir = tempfile::tempdir().unwrap();
 
     let catalog = dill::CatalogBuilder::new()
+        .add::<DataFormatRegistryImpl>()
+        .bind::<dyn DataFormatRegistry, DataFormatRegistryImpl>()
         .add_builder(
             dill::builder_for::<PushIngestServiceImpl>()
                 .with_run_info_dir(run_info_dir.path().to_path_buf())

--- a/src/adapter/http/tests/tests/test_data.rs
+++ b/src/adapter/http/tests/tests/test_data.rs
@@ -1,0 +1,157 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use chrono::{TimeZone, Utc};
+use indoc::indoc;
+use kamu::domain::*;
+use kamu::testing::DatasetDataHelper;
+use kamu::*;
+use opendatafabric::{MergeStrategy, *};
+use serde_json::json;
+
+use crate::harness::*;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_data_push_ingest_handler() {
+    // TODO: Need access to these from harness level
+    let run_info_dir = tempfile::tempdir().unwrap();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let catalog = dill::CatalogBuilder::new()
+        .add_builder(
+            dill::builder_for::<PushIngestServiceImpl>()
+                .with_run_info_dir(run_info_dir.path().to_path_buf())
+                .with_cache_dir(cache_dir.path().to_path_buf()),
+        )
+        .bind::<dyn PushIngestService, PushIngestServiceImpl>()
+        .add::<ObjectStoreRegistryImpl>()
+        .bind::<dyn ObjectStoreRegistry, ObjectStoreRegistryImpl>()
+        .add_value(ObjectStoreBuilderLocalFs::new())
+        .bind::<dyn ObjectStoreBuilder, ObjectStoreBuilderLocalFs>()
+        .build();
+
+    let server_harness = ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
+        multi_tenant: true,
+        authorized_writes: true,
+        base_catalog: Some(catalog),
+    })
+    .await;
+
+    server_harness
+        .system_time_source()
+        .set(Utc.with_ymd_and_hms(2050, 1, 1, 12, 0, 0).unwrap());
+
+    let create_result = server_harness
+        .cli_dataset_repository()
+        .create_dataset_from_snapshot(
+            server_harness.operating_account_name(),
+            DatasetSnapshot {
+                name: "population".try_into().unwrap(),
+                kind: DatasetKind::Root,
+                // TODO: In future this will be replaced by AddPushSource event
+                metadata: vec![MetadataEvent::SetPollingSource(SetPollingSource {
+                    fetch: FetchStep::Url(FetchStepUrl {
+                        url: "http://localhost".to_string(),
+                        event_time: None,
+                        cache: None,
+                        headers: None,
+                    }),
+                    prepare: None,
+                    read: ReadStepNdJson {
+                        schema: Some(vec![
+                            "event_time TIMESTAMP".to_owned(),
+                            "city STRING".to_owned(),
+                            "population BIGINT".to_owned(),
+                        ]),
+                        ..Default::default()
+                    }
+                    .into(),
+                    // TODO: Temporary to force ingest to use new DataFusion engine
+                    preprocess: Some(
+                        TransformSql {
+                            engine: "datafusion".to_string(),
+                            query: Some("select * from input".to_string()),
+                            version: None,
+                            queries: None,
+                            temporal_tables: None,
+                        }
+                        .into(),
+                    ),
+                    merge: MergeStrategy::Ledger(MergeStrategyLedger {
+                        primary_key: vec!["event_time".to_owned(), "city".to_owned()],
+                    }),
+                })],
+            },
+        )
+        .await
+        .unwrap();
+
+    let dataset_url =
+        server_harness.dataset_url_with_scheme(&create_result.dataset_handle.alias, "http");
+
+    let client = async move {
+        let ingest_url = format!("{}/data/ingest", dataset_url);
+        tracing::info!(%ingest_url, "Client request");
+
+        let cl = reqwest::Client::new();
+        let res = cl
+            .execute(
+                cl.post(ingest_url)
+                    .json(&json!(
+                        [
+                            {
+                                "event_time": "2020-01-01T00:00:00",
+                                "city": "A",
+                                "population": 100,
+                            },
+                            {
+                                "event_time": "2020-01-02T00:00:00",
+                                "city": "B",
+                                "population": 200,
+                            }
+                        ]
+                    ))
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), http::StatusCode::OK);
+
+        DatasetDataHelper::new(create_result.dataset)
+            .assert_last_data_eq(
+                indoc!(
+                    r#"
+                    message arrow_schema {
+                      OPTIONAL INT64 offset;
+                      REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
+                      OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                      OPTIONAL BYTE_ARRAY city (STRING);
+                      OPTIONAL INT64 population;
+                    }
+                   "#
+                ),
+                indoc!(
+                    r#"
+                    +--------+----------------------+----------------------+------+------------+
+                    | offset | system_time          | event_time           | city | population |
+                    +--------+----------------------+----------------------+------+------------+
+                    | 0      | 2050-01-01T12:00:00Z | 2020-01-01T00:00:00Z | A    | 100        |
+                    | 1      | 2050-01-01T12:00:00Z | 2020-01-02T00:00:00Z | B    | 200        |
+                    +--------+----------------------+----------------------+------+------------+
+                    "#
+                ),
+            )
+            .await;
+    };
+
+    await_client_server_flow!(server_harness.api_server_run(), client);
+}

--- a/src/adapter/http/tests/tests/test_data.rs
+++ b/src/adapter/http/tests/tests/test_data.rs
@@ -24,15 +24,13 @@ use crate::harness::*;
 async fn test_data_push_ingest_handler() {
     // TODO: Need access to these from harness level
     let run_info_dir = tempfile::tempdir().unwrap();
-    let cache_dir = tempfile::tempdir().unwrap();
 
     let catalog = dill::CatalogBuilder::new()
         .add::<DataFormatRegistryImpl>()
         .bind::<dyn DataFormatRegistry, DataFormatRegistryImpl>()
         .add_builder(
             dill::builder_for::<PushIngestServiceImpl>()
-                .with_run_info_dir(run_info_dir.path().to_path_buf())
-                .with_cache_dir(cache_dir.path().to_path_buf()),
+                .with_run_info_dir(run_info_dir.path().to_path_buf()),
         )
         .bind::<dyn PushIngestService, PushIngestServiceImpl>()
         .add::<ObjectStoreRegistryImpl>()

--- a/src/adapter/http/tests/tests/test_data.rs
+++ b/src/adapter/http/tests/tests/test_data.rs
@@ -19,6 +19,7 @@ use crate::harness::*;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(engine, ingest, datafusion)]
 #[test_log::test(tokio::test)]
 async fn test_data_push_ingest_handler() {
     // TODO: Need access to these from harness level

--- a/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
+++ b/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
@@ -34,6 +34,7 @@ async fn test_object_url_local_fs() {
     let server_harness = ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
         multi_tenant: false,
         authorized_writes: true,
+        base_catalog: None,
     })
     .await;
 
@@ -238,6 +239,7 @@ async fn test_pull_object_url_s3() {
     let server_harness = ServerSideS3Harness::new(ServerSideHarnessOptions {
         multi_tenant: false,
         authorized_writes: true,
+        base_catalog: None,
     })
     .await;
 

--- a/src/adapter/http/tests/tests/tests_pull/test_smart_pull_special.rs
+++ b/src/adapter/http/tests/tests/tests_pull/test_smart_pull_special.rs
@@ -42,6 +42,7 @@ async fn test_smart_pull_unauthenticated() {
         ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
             multi_tenant: false,
             authorized_writes: true,
+            base_catalog: None,
         })
         .await,
     )

--- a/src/adapter/http/tests/tests/tests_push/test_smart_push_special.rs
+++ b/src/adapter/http/tests/tests/tests_push/test_smart_push_special.rs
@@ -34,6 +34,7 @@ async fn test_smart_push_new_dataset_unauthenticated() {
         ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
             multi_tenant: true,
             authorized_writes: true,
+            base_catalog: None,
         })
         .await,
     )
@@ -74,6 +75,7 @@ async fn test_smart_push_new_dataset_wrong_user() {
         ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
             multi_tenant: true,
             authorized_writes: true,
+            base_catalog: None,
         })
         .await,
     )
@@ -119,6 +121,7 @@ async fn test_smart_push_existing_dataset_unauthenticated() {
         ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
             multi_tenant: true,
             authorized_writes: false,
+            base_catalog: None,
         })
         .await,
     )
@@ -157,6 +160,7 @@ async fn test_smart_push_existing_dataset_unauthorized() {
         ServerSideLocalFsHarness::new(ServerSideHarnessOptions {
             multi_tenant: true,
             authorized_writes: false,
+            base_catalog: None,
         })
         .await,
     )

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -516,7 +516,7 @@ fn configure_output_format(
     let format = match format_str {
         Some("csv") => OutputFormat::Csv,
         Some("json") => OutputFormat::Json,
-        Some("json-ld") => OutputFormat::JsonLD,
+        Some("ndjson") => OutputFormat::NdJson,
         Some("json-soa") => OutputFormat::JsonSoA,
         Some("table") => OutputFormat::Table,
         None | Some(_) => {

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -179,6 +179,9 @@ pub fn configure_base_catalog(
     b.add::<ResourceLoaderImpl>();
     b.bind::<dyn ResourceLoader, ResourceLoaderImpl>();
 
+    b.add::<DataFormatRegistryImpl>();
+    b.bind::<dyn DataFormatRegistry, DataFormatRegistryImpl>();
+
     b.add_builder(
         builder_for::<PollingIngestServiceImpl>()
             .with_run_info_dir(workspace_layout.run_info_dir.clone())

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -180,11 +180,18 @@ pub fn configure_base_catalog(
     b.bind::<dyn ResourceLoader, ResourceLoaderImpl>();
 
     b.add_builder(
-        builder_for::<IngestServiceImpl>()
+        builder_for::<PollingIngestServiceImpl>()
             .with_run_info_dir(workspace_layout.run_info_dir.clone())
             .with_cache_dir(workspace_layout.cache_dir.clone()),
     );
-    b.bind::<dyn IngestService, IngestServiceImpl>();
+    b.bind::<dyn PollingIngestService, PollingIngestServiceImpl>();
+
+    b.add_builder(
+        builder_for::<PushIngestServiceImpl>()
+            .with_run_info_dir(workspace_layout.run_info_dir.clone())
+            .with_cache_dir(workspace_layout.cache_dir.clone()),
+    );
+    b.bind::<dyn PushIngestService, PushIngestServiceImpl>();
 
     b.add::<TransformServiceImpl>();
     b.bind::<dyn TransformService, TransformServiceImpl>();

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -191,8 +191,7 @@ pub fn configure_base_catalog(
 
     b.add_builder(
         builder_for::<PushIngestServiceImpl>()
-            .with_run_info_dir(workspace_layout.run_info_dir.clone())
-            .with_cache_dir(workspace_layout.cache_dir.clone()),
+            .with_run_info_dir(workspace_layout.run_info_dir.clone()),
     );
     b.bind::<dyn PushIngestService, PushIngestServiceImpl>();
 

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -120,6 +120,7 @@ pub fn get_command(
                 .map(String::as_str),
             submatches.get_flag("stdin"),
             submatches.get_flag("recursive"),
+            submatches.get_one("input-format").map(String::as_str),
         )),
         Some(("init", submatches)) => {
             if submatches.get_flag("pull-images") {

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -110,6 +110,7 @@ pub fn get_command(
             cli_catalog.get_one()?,
             cli_catalog.get_one()?,
             cli_catalog.get_one()?,
+            cli_catalog.get_one()?,
             validate_dataset_ref(
                 cli_catalog,
                 submatches.get_one::<DatasetRef>("dataset").unwrap().clone(),

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -19,7 +19,7 @@ fn tabular_output_params<'a>(app: Command) -> Command {
             .short('o')
             .value_name("FMT")
             .value_parser([
-                "table", "csv", "json", "json-ld",
+                "table", "csv", "json", "ndjson",
                 "json-soa",
                 // "vertical",
                 // "tsv",
@@ -347,6 +347,19 @@ pub fn cli() -> Command {
                             .long("recursive")
                             .action(ArgAction::SetTrue)
                             .help("Recursively propagate the updates into all downstream datasets"),
+                        Arg::new("input-format")
+                            .long("input-format")
+                            .value_name("FMT")
+                            .value_parser([
+                                "csv",
+                                "json",
+                                "ndjson",
+                                "geojson",
+                                "ndgeojson",
+                                "parquet",
+                                "esrishapefile",
+                            ])
+                            .help("Overrides the media type of the data expected by the push source"),
                     ]).after_help(indoc::indoc!(
                         r#"
                         ### Examples ###
@@ -355,9 +368,13 @@ pub fn cli() -> Command {
 
                             kamu ingest org.example.data path/to/data.csv
 
-                        Ingest data from standard input:
+                        Ingest data from standard input (assumes source is defined to use NDJSON):
 
                             echo '{"key": "value1"}\n{"key": "value2"}' | kamu ingest org.example.data --stdin
+
+                        Ingest data with format conversion:
+
+                            echo '[{"key": "value1"}, {"key": "value2"}]' | kamu ingest org.example.data --stdin --input-format json
                         "#
                     )),
                 Command::new("init")

--- a/src/app/cli/src/commands/ingest_command.rs
+++ b/src/app/cli/src/commands/ingest_command.rs
@@ -209,11 +209,11 @@ impl PushIngestProgress {
     ) -> Self {
         Self {
             state: Mutex::new(PushIngestProgressState {
-                stage: PushIngestStage::CheckSource,
+                stage: PushIngestStage::Read,
                 curr_progress: multi_progress.add(Self::new_spinner(&Self::spinner_message(
                     dataset_handle,
                     0,
-                    "Checking source for updates",
+                    "Reading data",
                 ))),
             }),
             dataset_handle: dataset_handle.clone(),
@@ -249,8 +249,6 @@ impl PushIngestProgress {
 
     fn message_for_stage(&self, stage: PushIngestStage) -> String {
         let msg = match stage {
-            PushIngestStage::CheckSource => "Checking source for updates",
-            PushIngestStage::Fetch => "Downloading data",
             PushIngestStage::Read => "Reading data",
             PushIngestStage::Preprocess => "Preprocessing data",
             PushIngestStage::Merge => "Merging data",

--- a/src/app/cli/src/commands/ingest_command.rs
+++ b/src/app/cli/src/commands/ingest_command.rs
@@ -8,7 +8,8 @@
 // by the Apache License, Version 2.0.
 
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use kamu::domain::*;
 use opendatafabric::*;
@@ -22,7 +23,7 @@ use crate::OutputConfig;
 
 pub struct IngestCommand {
     dataset_repo: Arc<dyn DatasetRepository>,
-    ingest_svc: Arc<dyn IngestService>,
+    push_ingest_svc: Arc<dyn PushIngestService>,
     output_config: Arc<OutputConfig>,
     remote_alias_reg: Arc<dyn RemoteAliasesRegistry>,
     dataset_ref: DatasetRef,
@@ -34,7 +35,7 @@ pub struct IngestCommand {
 impl IngestCommand {
     pub fn new<'s, I>(
         dataset_repo: Arc<dyn DatasetRepository>,
-        ingest_svc: Arc<dyn IngestService>,
+        push_ingest_svc: Arc<dyn PushIngestService>,
         output_config: Arc<OutputConfig>,
         remote_alias_reg: Arc<dyn RemoteAliasesRegistry>,
         dataset_ref: DatasetRef,
@@ -47,7 +48,7 @@ impl IngestCommand {
     {
         Self {
             dataset_repo,
-            ingest_svc,
+            push_ingest_svc,
             output_config,
             remote_alias_reg,
             dataset_ref,
@@ -119,24 +120,28 @@ impl Command for IngestCommand {
         {
             None
         } else {
-            Some(Arc::new(crate::PrettyIngestProgress::new(
+            Some(Arc::new(PushIngestProgress::new(
                 &dataset_handle,
                 Arc::new(indicatif::MultiProgress::new()),
-                false,
-            )) as Arc<dyn IngestListener>)
+            )) as Arc<dyn PushIngestListener>)
         };
 
         let mut updated = 0;
         for url in urls {
             let result = self
-                .ingest_svc
-                .push_ingest_from_url(&self.dataset_ref, url, listener.clone())
+                .push_ingest_svc
+                .ingest_from_url(
+                    &self.dataset_ref,
+                    url,
+                    IngestMediaTypes::NDJSON,
+                    listener.clone(),
+                )
                 .await
                 .map_err(|e| CLIError::failure(e))?;
 
             match result {
-                IngestResult::UpToDate { .. } => (),
-                IngestResult::Updated { .. } => updated += 1,
+                PushIngestResult::UpToDate { .. } => (),
+                PushIngestResult::Updated { .. } => updated += 1,
             }
         }
 
@@ -147,5 +152,188 @@ impl Command for IngestCommand {
         }
 
         Ok(())
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub(crate) struct PushIngestProgress {
+    dataset_handle: DatasetHandle,
+    multi_progress: Arc<indicatif::MultiProgress>,
+    state: Mutex<PushIngestProgressState>,
+}
+
+struct PushIngestProgressState {
+    stage: PushIngestStage,
+    curr_progress: indicatif::ProgressBar,
+}
+
+impl PushIngestProgress {
+    pub fn new(
+        dataset_handle: &DatasetHandle,
+        multi_progress: Arc<indicatif::MultiProgress>,
+    ) -> Self {
+        Self {
+            state: Mutex::new(PushIngestProgressState {
+                stage: PushIngestStage::CheckSource,
+                curr_progress: multi_progress.add(Self::new_spinner(&Self::spinner_message(
+                    dataset_handle,
+                    0,
+                    "Checking source for updates",
+                ))),
+            }),
+            dataset_handle: dataset_handle.clone(),
+            multi_progress,
+        }
+    }
+
+    fn new_spinner(msg: &str) -> indicatif::ProgressBar {
+        let pb = indicatif::ProgressBar::hidden();
+        let style = indicatif::ProgressStyle::default_spinner()
+            .template("{spinner:.cyan} {msg}")
+            .unwrap();
+        pb.set_style(style);
+        pb.set_message(msg.to_owned());
+        pb.enable_steady_tick(Duration::from_millis(100));
+        pb
+    }
+
+    fn spinner_message<T: std::fmt::Display>(
+        dataset_handle: &DatasetHandle,
+        step: u32,
+        msg: T,
+    ) -> String {
+        let step_str = format!("[{}/7]", step + 1);
+        let dataset = format!("({})", dataset_handle.alias);
+        format!(
+            "{} {} {}",
+            console::style(step_str).bold().dim(),
+            msg,
+            console::style(dataset).dim(),
+        )
+    }
+
+    fn message_for_stage(&self, stage: PushIngestStage) -> String {
+        let msg = match stage {
+            PushIngestStage::CheckSource => "Checking source for updates",
+            PushIngestStage::Fetch => "Downloading data",
+            PushIngestStage::Read => "Reading data",
+            PushIngestStage::Preprocess => "Preprocessing data",
+            PushIngestStage::Merge => "Merging data",
+            PushIngestStage::Commit => "Committing data",
+        };
+        Self::spinner_message(&self.dataset_handle, stage as u32, msg)
+    }
+}
+
+impl PushIngestListener for PushIngestProgress {
+    fn on_stage_progress(&self, stage: PushIngestStage, _n: u64, _out_of: TotalSteps) {
+        let mut state = self.state.lock().unwrap();
+        state.stage = stage;
+
+        if state.curr_progress.is_finished() {
+            state.curr_progress.finish();
+            state.curr_progress = self
+                .multi_progress
+                .add(Self::new_spinner(&self.message_for_stage(stage)));
+        } else {
+            state
+                .curr_progress
+                .set_message(self.message_for_stage(stage));
+        }
+    }
+
+    fn success(&self, result: &PushIngestResult) {
+        let state = self.state.lock().unwrap();
+
+        match result {
+            PushIngestResult::UpToDate => {
+                state
+                    .curr_progress
+                    .finish_with_message(Self::spinner_message(
+                        &self.dataset_handle,
+                        PushIngestStage::Commit as u32,
+                        console::style("Dataset is up-to-date".to_owned()).yellow(),
+                    ));
+            }
+            PushIngestResult::Updated {
+                old_head: _,
+                ref new_head,
+                num_blocks: _,
+            } => {
+                state
+                    .curr_progress
+                    .finish_with_message(Self::spinner_message(
+                        &self.dataset_handle,
+                        PollingIngestStage::Commit as u32,
+                        console::style(format!("Committed new block {}", new_head.short())).green(),
+                    ));
+            }
+        };
+    }
+
+    fn error(&self, _error: &PushIngestError) {
+        let state = self.state.lock().unwrap();
+        state
+            .curr_progress
+            .finish_with_message(Self::spinner_message(
+                &self.dataset_handle,
+                state.stage as u32,
+                console::style("Failed to update root dataset").red(),
+            ));
+    }
+
+    fn get_pull_image_listener(self: Arc<Self>) -> Option<Arc<dyn PullImageListener>> {
+        Some(self)
+    }
+
+    fn get_engine_provisioning_listener(
+        self: Arc<Self>,
+    ) -> Option<Arc<dyn EngineProvisioningListener>> {
+        Some(self)
+    }
+}
+
+impl EngineProvisioningListener for PushIngestProgress {
+    fn begin(&self, engine_id: &str) {
+        let state = self.state.lock().unwrap();
+
+        // This currently happens during the Read stage
+        state.curr_progress.set_message(Self::spinner_message(
+            &self.dataset_handle,
+            PollingIngestStage::Read as u32,
+            format!("Waiting for engine {}", engine_id),
+        ));
+    }
+
+    fn success(&self) {
+        self.on_stage_progress(PushIngestStage::Read, 0, TotalSteps::Exact(0));
+    }
+
+    fn get_pull_image_listener(self: Arc<Self>) -> Option<Arc<dyn PullImageListener>> {
+        Some(self)
+    }
+}
+
+impl PullImageListener for PushIngestProgress {
+    fn begin(&self, image: &str) {
+        let state = self.state.lock().unwrap();
+
+        // This currently happens during the Read stage
+        state.curr_progress.set_message(Self::spinner_message(
+            &self.dataset_handle,
+            PollingIngestStage::Read as u32,
+            format!("Pulling image {}", image),
+        ));
+    }
+
+    fn success(&self) {
+        // Careful not to deadlock
+        let stage = {
+            let state = self.state.lock().unwrap();
+            state.curr_progress.finish();
+            state.stage
+        };
+        self.on_stage_progress(stage, 0, TotalSteps::Exact(0));
     }
 }

--- a/src/app/cli/src/commands/sql_shell_command.rs
+++ b/src/app/cli/src/commands/sql_shell_command.rs
@@ -86,7 +86,7 @@ impl SqlShellCommand {
                 match self.output_config.format {
                     OutputFormat::Csv => Some("csv"),
                     OutputFormat::Json => Some("json"),
-                    OutputFormat::JsonLD => {
+                    OutputFormat::NdJson => {
                         unimplemented!("Line-delimited Json is not yet supported by this command")
                     }
                     OutputFormat::JsonSoA => {

--- a/src/app/cli/src/output/output_config.rs
+++ b/src/app/cli/src/output/output_config.rs
@@ -35,7 +35,7 @@ impl OutputConfig {
                     .build(std::io::stdout()),
             ),
             OutputFormat::Json => Box::new(JsonArrayWriter::new(std::io::stdout())),
-            OutputFormat::JsonLD => Box::new(JsonLineDelimitedWriter::new(std::io::stdout())),
+            OutputFormat::NdJson => Box::new(JsonLineDelimitedWriter::new(std::io::stdout())),
             OutputFormat::JsonSoA => unimplemented!("SoA Json format is not yet implemented"),
             OutputFormat::Table => Box::new(TableWriter::new(fmt)),
         }
@@ -50,7 +50,7 @@ pub enum OutputFormat {
     /// Array of Structures format
     Json,
     /// One Json object per line - easily splittable format
-    JsonLD,
+    NdJson,
     /// Structure of arrays - more compact and efficient format for encoding
     /// entire dataframe
     JsonSoA,

--- a/src/app/cli/tests/tests/mod.rs
+++ b/src/app/cli/tests/tests/mod.rs
@@ -11,7 +11,7 @@ mod test_access_token_registry_svc;
 mod test_add_command;
 mod test_complete_command;
 mod test_di_graph;
+mod test_ingest_command;
 mod test_new_dataset_command;
-mod test_pull_command;
 mod test_system_info_command;
 mod test_workspace_svc;

--- a/src/domain/core/src/services/ingest/data_format_registry.rs
+++ b/src/domain/core/src/services/ingest/data_format_registry.rs
@@ -1,0 +1,106 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+use opendatafabric as odf;
+
+use super::{ReadError, Reader, UnsupportedMediaTypeError};
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[async_trait::async_trait]
+pub trait DataFormatRegistry: Send + Sync {
+    fn list_formats(&self) -> Vec<DataFormatDesc>;
+
+    fn format_of(&self, conf: &odf::ReadStep) -> DataFormatDesc;
+
+    // TODO: Avoid `async` poisoning by datafusion
+    // TODO: Avoid passing `temp_path` here
+    async fn get_reader(
+        &self,
+        ctx: SessionContext,
+        conf: odf::ReadStep,
+        temp_path: PathBuf,
+    ) -> Result<Arc<dyn Reader>, ReadError>;
+
+    /// Attempts to provide the most compatible reader configuration based on
+    /// base configuration of the source and the provided media type of the
+    /// actual data
+    fn get_compatible_read_config(
+        &self,
+        base_conf: odf::ReadStep,
+        actual_media_type: &MediaType,
+    ) -> Result<odf::ReadStep, UnsupportedMediaTypeError>;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone, Copy)]
+pub struct DataFormatDesc {
+    pub short_name: &'static str,
+    pub media_type: MediaTypeRef<'static>,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// TODO: Consider a crate
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaType(pub String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MediaTypeRef<'a>(pub &'a str);
+
+impl MediaType {
+    // We use IANA types where we can, otherwise see comments:
+    // https://www.iana.org/assignments/media-types/media-types.xhtml
+    pub const CSV: MediaTypeRef<'static> = MediaTypeRef("text/csv");
+    pub const JSON: MediaTypeRef<'static> = MediaTypeRef("application/json");
+    /// Unofficial but used by several software projects
+    pub const NDJSON: MediaTypeRef<'static> = MediaTypeRef("application/x-ndjson");
+    pub const GEOJSON: MediaTypeRef<'static> = MediaTypeRef("application/geo+json");
+    /// No standard found
+    pub const NDGEOJSON: MediaTypeRef<'static> = MediaTypeRef("application/x-ndgeojson");
+    /// See: https://issues.apache.org/jira/browse/PARQUET-1889
+    pub const PARQUET: MediaTypeRef<'static> = MediaTypeRef("application/vnd.apache.parquet");
+    /// No standard found
+    pub const ESRI_SHAPEFILE: MediaTypeRef<'static> =
+        MediaTypeRef("application/vnd.esri.shapefile");
+}
+
+impl<'a> MediaTypeRef<'a> {
+    pub fn to_owned(&self) -> MediaType {
+        MediaType(self.0.to_string())
+    }
+}
+
+impl std::fmt::Display for MediaType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'a> std::fmt::Display for MediaTypeRef<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'a> std::cmp::PartialEq<MediaTypeRef<'a>> for MediaType {
+    fn eq(&self, other: &MediaTypeRef<'a>) -> bool {
+        self.0 == other.0
+    }
+}
+impl<'a> std::cmp::PartialEq<MediaType> for MediaTypeRef<'a> {
+    fn eq(&self, other: &MediaType) -> bool {
+        self.0 == other.0
+    }
+}

--- a/src/domain/core/src/services/ingest/mod.rs
+++ b/src/domain/core/src/services/ingest/mod.rs
@@ -7,12 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod data_format_registry;
 mod data_writer;
 mod merge_strategy;
 mod polling_ingest_service;
 mod push_ingest_service;
 mod reader;
 
+pub use data_format_registry::*;
 pub use data_writer::*;
 pub use merge_strategy::*;
 pub use polling_ingest_service::*;

--- a/src/domain/core/src/services/ingest/mod.rs
+++ b/src/domain/core/src/services/ingest/mod.rs
@@ -9,8 +9,12 @@
 
 mod data_writer;
 mod merge_strategy;
+mod polling_ingest_service;
+mod push_ingest_service;
 mod reader;
 
 pub use data_writer::*;
 pub use merge_strategy::*;
+pub use polling_ingest_service::*;
+pub use push_ingest_service::*;
 pub use reader::*;

--- a/src/domain/core/src/services/ingest/polling_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/polling_ingest_service.rs
@@ -226,6 +226,13 @@ pub enum PollingIngestError {
     ),
 
     #[error(transparent)]
+    BadInputSchema(
+        #[from]
+        #[backtrace]
+        BadInputSchemaError,
+    ),
+
+    #[error(transparent)]
     MergeError(
         #[from]
         #[backtrace]

--- a/src/domain/core/src/services/ingest/push_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_service.rs
@@ -62,8 +62,6 @@ pub enum PushIngestResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PushIngestStage {
-    CheckSource,
-    Fetch,
     Read,
     Preprocess,
     Merge,

--- a/src/domain/core/src/services/ingest/push_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_service.rs
@@ -29,7 +29,7 @@ pub trait PushIngestService: Send + Sync {
         &self,
         dataset_ref: &DatasetRef,
         url: url::Url,
-        media_type: &str,
+        media_type: Option<&str>,
         listener: Option<Arc<dyn PushIngestListener>>,
     ) -> Result<PushIngestResult, PushIngestError>;
 
@@ -41,7 +41,7 @@ pub trait PushIngestService: Send + Sync {
         &self,
         dataset_ref: &DatasetRef,
         data: Box<dyn AsyncRead + Send + Unpin>,
-        media_type: &str,
+        media_type: Option<&str>,
         listener: Option<Arc<dyn PushIngestListener>>,
     ) -> Result<PushIngestResult, PushIngestError>;
 }

--- a/src/domain/core/src/services/ingest/push_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_service.rs
@@ -1,0 +1,220 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use opendatafabric::*;
+use thiserror::Error;
+use tokio::io::AsyncRead;
+
+use crate::*;
+
+///////////////////////////////////////////////////////////////////////////////
+// Service
+///////////////////////////////////////////////////////////////////////////////
+
+#[async_trait::async_trait]
+pub trait PushIngestService: Send + Sync {
+    /// Uses push source defenition in metadata to ingest data from the
+    /// specified source.
+    ///
+    /// See also [IngestMediaTypes].
+    async fn ingest_from_url(
+        &self,
+        dataset_ref: &DatasetRef,
+        url: url::Url,
+        media_type: &str,
+        listener: Option<Arc<dyn PushIngestListener>>,
+    ) -> Result<PushIngestResult, PushIngestError>;
+
+    /// Uses push source defenition in metadata to ingest data passessed
+    /// in-band as a file stream.
+    ///
+    /// See also [IngestMediaTypes].
+    async fn ingest_from_file_stream(
+        &self,
+        dataset_ref: &DatasetRef,
+        data: Box<dyn AsyncRead + Send + Unpin>,
+        media_type: &str,
+        listener: Option<Arc<dyn PushIngestListener>>,
+    ) -> Result<PushIngestResult, PushIngestError>;
+}
+
+/// Some media types of data formats acceptable by the ingest.
+///
+/// We use IANA types where we can:
+///     https://www.iana.org/assignments/media-types/media-types.xhtml
+pub struct IngestMediaTypes;
+impl IngestMediaTypes {
+    pub const CSV: &str = "text/csv";
+    pub const JSON: &str = "application/json";
+    /// Unofficial but used by several software projects
+    pub const NDJSON: &str = "application/x-ndjson";
+    pub const GEOJSON: &str = "application/geo+json";
+    /// No standard found
+    pub const NDGEOJSON: &str = "application/x-ndgeojson";
+    /// See: https://issues.apache.org/jira/browse/PARQUET-1889
+    pub const PARQUET: &str = "application/vnd.apache.parquet";
+    /// No standard found
+    pub const ESRISHAPEFILE: &str = "application/vnd.esri.shapefile";
+}
+
+#[derive(Debug)]
+pub enum PushIngestResult {
+    UpToDate,
+    Updated {
+        old_head: Multihash,
+        new_head: Multihash,
+        num_blocks: usize,
+    },
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Listener
+///////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushIngestStage {
+    CheckSource,
+    Fetch,
+    Read,
+    Preprocess,
+    Merge,
+    Commit,
+}
+
+#[allow(unused_variables)]
+pub trait PushIngestListener: Send + Sync {
+    fn begin(&self) {}
+    fn on_stage_progress(&self, stage: PushIngestStage, _progress: u64, _out_of: TotalSteps) {}
+    fn success(&self, result: &PushIngestResult) {}
+    fn error(&self, error: &PushIngestError) {}
+
+    fn get_pull_image_listener(self: Arc<Self>) -> Option<Arc<dyn PullImageListener>> {
+        None
+    }
+
+    fn get_engine_provisioning_listener(
+        self: Arc<Self>,
+    ) -> Option<Arc<dyn EngineProvisioningListener>> {
+        None
+    }
+}
+
+pub struct NullPushIngestListener;
+impl PushIngestListener for NullPushIngestListener {}
+
+///////////////////////////////////////////////////////////////////////////////
+// Errors
+///////////////////////////////////////////////////////////////////////////////
+
+// TODO: Revisit error granularity
+#[derive(Debug, Error)]
+pub enum PushIngestError {
+    #[error(transparent)]
+    DatasetNotFound(
+        #[from]
+        #[backtrace]
+        DatasetNotFoundError,
+    ),
+
+    #[error(transparent)]
+    SourceNotFound(
+        #[from]
+        #[backtrace]
+        PushSourceNotFoundError,
+    ),
+
+    #[error(transparent)]
+    UnsupportedMediaType(
+        #[from]
+        #[backtrace]
+        UnsupportedMediaTypeError,
+    ),
+
+    #[error("Engine error")]
+    EngineError(
+        #[from]
+        #[backtrace]
+        crate::engine::EngineError,
+    ),
+
+    #[error(transparent)]
+    ReadError(
+        #[from]
+        #[backtrace]
+        ingest::ReadError,
+    ),
+
+    #[error(transparent)]
+    MergeError(
+        #[from]
+        #[backtrace]
+        ingest::MergeError,
+    ),
+
+    #[error(transparent)]
+    CommitError(
+        #[from]
+        #[backtrace]
+        CommitError,
+    ),
+
+    #[error(transparent)]
+    Access(
+        #[from]
+        #[backtrace]
+        AccessError,
+    ),
+
+    #[error(transparent)]
+    Internal(
+        #[from]
+        #[backtrace]
+        InternalError,
+    ),
+}
+
+impl From<GetDatasetError> for PushIngestError {
+    fn from(v: GetDatasetError) -> Self {
+        match v {
+            GetDatasetError::NotFound(e) => Self::DatasetNotFound(e),
+            GetDatasetError::Internal(e) => Self::Internal(e),
+        }
+    }
+}
+
+impl From<auth::DatasetActionUnauthorizedError> for PushIngestError {
+    fn from(v: auth::DatasetActionUnauthorizedError) -> Self {
+        match v {
+            auth::DatasetActionUnauthorizedError::Access(e) => Self::Access(e),
+            auth::DatasetActionUnauthorizedError::Internal(e) => Self::Internal(e),
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Error)]
+#[error("Dataset does not define a push source")]
+pub struct PushSourceNotFoundError;
+
+#[derive(Debug, Error)]
+#[error("Unsupported media type {media_type}")]
+pub struct UnsupportedMediaTypeError {
+    pub media_type: String,
+}
+
+impl UnsupportedMediaTypeError {
+    pub fn new(media_type: impl Into<String>) -> Self {
+        Self {
+            media_type: media_type.into(),
+        }
+    }
+}

--- a/src/domain/core/src/services/ingest/push_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_service.rs
@@ -24,45 +24,26 @@ pub trait PushIngestService: Send + Sync {
     /// Uses push source defenition in metadata to ingest data from the
     /// specified source.
     ///
-    /// See also [IngestMediaTypes].
+    /// See also [MediaType].
     async fn ingest_from_url(
         &self,
         dataset_ref: &DatasetRef,
         url: url::Url,
-        media_type: Option<&str>,
+        media_type: Option<MediaType>,
         listener: Option<Arc<dyn PushIngestListener>>,
     ) -> Result<PushIngestResult, PushIngestError>;
 
     /// Uses push source defenition in metadata to ingest data passessed
     /// in-band as a file stream.
     ///
-    /// See also [IngestMediaTypes].
+    /// See also [MediaType].
     async fn ingest_from_file_stream(
         &self,
         dataset_ref: &DatasetRef,
         data: Box<dyn AsyncRead + Send + Unpin>,
-        media_type: Option<&str>,
+        media_type: Option<MediaType>,
         listener: Option<Arc<dyn PushIngestListener>>,
     ) -> Result<PushIngestResult, PushIngestError>;
-}
-
-/// Some media types of data formats acceptable by the ingest.
-///
-/// We use IANA types where we can:
-///     https://www.iana.org/assignments/media-types/media-types.xhtml
-pub struct IngestMediaTypes;
-impl IngestMediaTypes {
-    pub const CSV: &str = "text/csv";
-    pub const JSON: &str = "application/json";
-    /// Unofficial but used by several software projects
-    pub const NDJSON: &str = "application/x-ndjson";
-    pub const GEOJSON: &str = "application/geo+json";
-    /// No standard found
-    pub const NDGEOJSON: &str = "application/x-ndgeojson";
-    /// See: https://issues.apache.org/jira/browse/PARQUET-1889
-    pub const PARQUET: &str = "application/vnd.apache.parquet";
-    /// No standard found
-    pub const ESRISHAPEFILE: &str = "application/vnd.esri.shapefile";
 }
 
 #[derive(Debug)]
@@ -215,13 +196,11 @@ pub struct PushSourceNotFoundError;
 #[derive(Debug, Error)]
 #[error("Unsupported media type {media_type}")]
 pub struct UnsupportedMediaTypeError {
-    pub media_type: String,
+    pub media_type: MediaType,
 }
 
 impl UnsupportedMediaTypeError {
-    pub fn new(media_type: impl Into<String>) -> Self {
-        Self {
-            media_type: media_type.into(),
-        }
+    pub fn new(media_type: MediaType) -> Self {
+        Self { media_type }
     }
 }

--- a/src/domain/core/src/services/ingest/push_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_service.rs
@@ -153,6 +153,13 @@ pub enum PushIngestError {
     ),
 
     #[error(transparent)]
+    BadInputSchema(
+        #[from]
+        #[backtrace]
+        BadInputSchemaError,
+    ),
+
+    #[error(transparent)]
     MergeError(
         #[from]
         #[backtrace]

--- a/src/domain/core/src/services/ingest/reader.rs
+++ b/src/domain/core/src/services/ingest/reader.rs
@@ -21,9 +21,9 @@ use opendatafabric::ReadStep;
 /// defined in the [ReadStep].
 #[async_trait::async_trait]
 pub trait Reader: Send + Sync {
-    /// Returns schema that the output will be coerced into, if such schema is
-    /// defined in the [ReadStep].
-    async fn output_schema(
+    /// Returns schema that the read output will be coerced into, if such schema
+    /// is defined in the [ReadStep].
+    async fn read_schema(
         &self,
         ctx: &SessionContext,
         conf: &ReadStep,

--- a/src/domain/core/src/services/ingest/reader.rs
+++ b/src/domain/core/src/services/ingest/reader.rs
@@ -13,7 +13,6 @@ use std::path::Path;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::prelude::*;
 use internal_error::*;
-use opendatafabric::ReadStep;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -21,26 +20,17 @@ use opendatafabric::ReadStep;
 /// defined in the [ReadStep].
 #[async_trait::async_trait]
 pub trait Reader: Send + Sync {
-    /// Returns schema that the read output will be coerced into, if such schema
-    /// is defined in the [ReadStep].
-    async fn read_schema(
-        &self,
-        ctx: &SessionContext,
-        conf: &ReadStep,
-    ) -> Result<Option<Schema>, ReadError>;
+    /// Returns schema that the input will be coerced into, if such schema
+    /// is defined explicitly.
+    async fn input_schema(&self) -> Option<Schema>;
 
-    /// Returns a [DataFrame] that is ready to read the data.
+    /// Returns a [DataFrame] with a logical plan set up to read the data.
     ///
-    /// Note that [DataFrame] represents a physical plan, and no data has been
-    /// read yet when function returs, so you will need to handle read errors
-    /// when consuming the data. Some input data may be touched to infer the
-    /// schema if one was not specified explicilty.
-    async fn read(
-        &self,
-        ctx: &SessionContext,
-        path: &Path,
-        conf: &ReadStep,
-    ) -> Result<DataFrame, ReadError>;
+    /// Note that [DataFrame] represents a logical plan, and data has not been
+    /// fully read yet when function returs, so you will need to handle read
+    /// errors when consuming the data. Some input data may be touched to
+    /// infer the schema if one was not specified explicilty.
+    async fn read(&self, path: &Path) -> Result<DataFrame, ReadError>;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/domain/core/src/services/mod.rs
+++ b/src/domain/core/src/services/mod.rs
@@ -12,7 +12,6 @@ pub use container_runtime::{NullPullImageListener, PullImageListener};
 
 pub mod engine_provisioner;
 pub mod ingest;
-pub mod ingest_service;
 pub mod provenance_service;
 pub mod pull_service;
 pub mod push_service;
@@ -28,7 +27,7 @@ pub mod transform_service;
 pub mod verification_service;
 
 pub use engine_provisioner::*;
-pub use ingest_service::*;
+pub use ingest::*;
 pub use provenance_service::*;
 pub use pull_service::*;
 pub use push_service::*;

--- a/src/domain/core/src/services/pull_service.rs
+++ b/src/domain/core/src/services/pull_service.rs
@@ -147,13 +147,13 @@ impl Default for PullMultiOptions {
 ///////////////////////////////////////////////////////////////////////////////
 
 pub trait PullListener: Send + Sync {
-    fn get_ingest_listener(self: Arc<Self>) -> Option<Arc<dyn IngestListener>>;
+    fn get_ingest_listener(self: Arc<Self>) -> Option<Arc<dyn PollingIngestListener>>;
     fn get_transform_listener(self: Arc<Self>) -> Option<Arc<dyn TransformListener>>;
     fn get_sync_listener(self: Arc<Self>) -> Option<Arc<dyn SyncListener>>;
 }
 
 pub trait PullMultiListener: Send + Sync {
-    fn get_ingest_listener(self: Arc<Self>) -> Option<Arc<dyn IngestMultiListener>>;
+    fn get_ingest_listener(self: Arc<Self>) -> Option<Arc<dyn PollingIngestMultiListener>>;
     fn get_transform_listener(self: Arc<Self>) -> Option<Arc<dyn TransformMultiListener>>;
     fn get_sync_listener(self: Arc<Self>) -> Option<Arc<dyn SyncMultiListener>>;
 }
@@ -170,14 +170,14 @@ pub enum PullResult {
     },
 }
 
-impl From<IngestResult> for PullResult {
-    fn from(other: IngestResult) -> Self {
+impl From<PollingIngestResult> for PullResult {
+    fn from(other: PollingIngestResult) -> Self {
         match other {
-            IngestResult::UpToDate {
-                no_polling_source: _,
+            PollingIngestResult::UpToDate {
+                no_source_defined: _,
                 uncacheable: _,
             } => PullResult::UpToDate,
-            IngestResult::Updated {
+            PollingIngestResult::Updated {
                 old_head,
                 new_head,
                 num_blocks,
@@ -245,10 +245,10 @@ pub enum PullError {
     #[error("{0}")]
     InvalidOperation(String),
     #[error(transparent)]
-    IngestError(
+    PollingIngestError(
         #[from]
         #[backtrace]
-        IngestError,
+        PollingIngestError,
     ),
     #[error(transparent)]
     TransformError(

--- a/src/infra/core/src/ingest/data_format_registry_impl.rs
+++ b/src/infra/core/src/ingest/data_format_registry_impl.rs
@@ -1,0 +1,149 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+use kamu_core::ingest::*;
+use kamu_ingest_datafusion::*;
+use opendatafabric::*;
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub struct DataFormatRegistryImpl {}
+
+#[dill::component(pub)]
+impl DataFormatRegistryImpl {
+    pub const FMT_CSV: DataFormatDesc = DataFormatDesc {
+        short_name: "CSV",
+        media_type: MediaType::CSV,
+    };
+    pub const FMT_JSON: DataFormatDesc = DataFormatDesc {
+        short_name: "JSON",
+        media_type: MediaType::JSON,
+    };
+    pub const FMT_NDJSON: DataFormatDesc = DataFormatDesc {
+        short_name: "NDJSON",
+        media_type: MediaType::NDJSON,
+    };
+    pub const FMT_GEOJSON: DataFormatDesc = DataFormatDesc {
+        short_name: "GeoJSON",
+        media_type: MediaType::GEOJSON,
+    };
+    pub const FMT_NDGEOJSON: DataFormatDesc = DataFormatDesc {
+        short_name: "NDGeoJSON",
+        media_type: MediaType::NDGEOJSON,
+    };
+    pub const FMT_PARQUET: DataFormatDesc = DataFormatDesc {
+        short_name: "Parquet",
+        media_type: MediaType::PARQUET,
+    };
+    pub const FMT_ESRI_SHAPEFILE: DataFormatDesc = DataFormatDesc {
+        short_name: "Shapefile",
+        media_type: MediaType::ESRI_SHAPEFILE,
+    };
+
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl DataFormatRegistry for DataFormatRegistryImpl {
+    fn list_formats(&self) -> Vec<DataFormatDesc> {
+        vec![
+            Self::FMT_CSV,
+            Self::FMT_JSON,
+            Self::FMT_NDJSON,
+            Self::FMT_GEOJSON,
+            Self::FMT_NDGEOJSON,
+            Self::FMT_PARQUET,
+            Self::FMT_ESRI_SHAPEFILE,
+        ]
+    }
+
+    fn format_of(&self, conf: &ReadStep) -> DataFormatDesc {
+        match conf {
+            ReadStep::Csv(_) => Self::FMT_CSV,
+            ReadStep::Json(_) => Self::FMT_JSON,
+            ReadStep::NdJson(_) => Self::FMT_NDJSON,
+            ReadStep::JsonLines(_) => Self::FMT_NDJSON,
+            ReadStep::GeoJson(_) => Self::FMT_GEOJSON,
+            ReadStep::NdGeoJson(_) => Self::FMT_NDGEOJSON,
+            ReadStep::Parquet(_) => Self::FMT_PARQUET,
+            ReadStep::EsriShapefile(_) => Self::FMT_ESRI_SHAPEFILE,
+        }
+    }
+
+    async fn get_reader(
+        &self,
+        ctx: SessionContext,
+        conf: ReadStep,
+        temp_path: PathBuf,
+    ) -> Result<Arc<dyn Reader>, ReadError> {
+        let reader: Arc<dyn Reader> = match conf {
+            ReadStep::Csv(conf) => Arc::new(ReaderCsv::new(ctx, conf).await?),
+            ReadStep::Json(conf) => Arc::new(ReaderJson::new(ctx, conf, temp_path).await?),
+            ReadStep::NdJson(conf) => Arc::new(ReaderNdJson::new(ctx, conf).await?),
+            ReadStep::JsonLines(conf) => Arc::new(ReaderNdJson::new_compat(ctx, conf).await?),
+            ReadStep::GeoJson(conf) => Arc::new(ReaderGeoJson::new(ctx, conf, temp_path).await?),
+            ReadStep::NdGeoJson(conf) => {
+                Arc::new(ReaderNdGeoJson::new(ctx, conf, temp_path).await?)
+            }
+            ReadStep::EsriShapefile(conf) => {
+                Arc::new(ReaderEsriShapefile::new(ctx, conf, temp_path).await?)
+            }
+            ReadStep::Parquet(conf) => Arc::new(ReaderParquet::new(ctx, conf).await?),
+        };
+
+        Ok(reader)
+    }
+
+    fn get_compatible_read_config(
+        &self,
+        base_conf: ReadStep,
+        actual_media_type: &MediaType,
+    ) -> Result<ReadStep, UnsupportedMediaTypeError> {
+        let base_format = self.format_of(&base_conf);
+
+        if base_format.media_type == *actual_media_type {
+            return Ok(base_conf);
+        }
+
+        // Perform best-effort conversion
+        let schema = base_conf.schema().cloned();
+        match MediaTypeRef(actual_media_type.0.as_str()) {
+            MediaType::CSV => Ok(ReadStepCsv {
+                schema,
+                ..Default::default()
+            }
+            .into()),
+            MediaType::JSON => Ok(ReadStepJson {
+                schema,
+                ..Default::default()
+            }
+            .into()),
+            MediaType::NDJSON => Ok(ReadStepNdJson {
+                schema,
+                ..Default::default()
+            }
+            .into()),
+            MediaType::GEOJSON => Ok(ReadStepGeoJson { schema }.into()),
+            MediaType::NDGEOJSON => Ok(ReadStepNdGeoJson { schema }.into()),
+            MediaType::PARQUET => Ok(ReadStepParquet { schema }.into()),
+            MediaType::ESRI_SHAPEFILE => Ok(ReadStepEsriShapefile {
+                schema,
+                ..Default::default()
+            }
+            .into()),
+            _ => Err(UnsupportedMediaTypeError::new(actual_media_type.clone()).into()),
+        }
+    }
+}

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -642,7 +642,7 @@ impl FetchService {
         target_path: &Path,
         system_time: DateTime<Utc>,
         listener: &dyn FetchProgressListener,
-    ) -> Result<FetchResult, IngestError> {
+    ) -> Result<FetchResult, PollingIngestError> {
         use std::io::prelude::*;
 
         let target_path_tmp = target_path.with_extension("tmp");
@@ -686,10 +686,10 @@ impl FetchService {
                 std::fs::remove_file(&target_path_tmp).unwrap();
                 match e.code() {
                     curl_sys::CURLE_COULDNT_RESOLVE_HOST => {
-                        IngestError::unreachable(url.as_str(), Some(e.into()))
+                        PollingIngestError::unreachable(url.as_str(), Some(e.into()))
                     }
                     curl_sys::CURLE_COULDNT_CONNECT => {
-                        IngestError::unreachable(url.as_str(), Some(e.into()))
+                        PollingIngestError::unreachable(url.as_str(), Some(e.into()))
                     }
                     _ => e.int_err().into(),
                 }

--- a/src/infra/core/src/ingest/ingest_common.rs
+++ b/src/infra/core/src/ingest/ingest_common.rs
@@ -1,0 +1,135 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::prelude::*;
+use internal_error::*;
+use kamu_core::engine::*;
+use kamu_core::ObjectStoreRegistry;
+use opendatafabric::*;
+
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) async fn preprocess(
+    ctx: &SessionContext,
+    transform: Transform,
+    df: DataFrame,
+) -> Result<DataFrame, EngineError> {
+    let Transform::Sql(transform) = transform;
+
+    // TODO: Support other engines
+    assert_eq!(transform.engine.to_lowercase(), "datafusion");
+
+    let transform = transform.normalize_queries(Some("output".to_string()));
+
+    // Setup input
+    ctx.register_table("input", df.into_view()).int_err()?;
+
+    // Setup queries
+    for query_step in transform.queries.unwrap_or_default() {
+        register_view_for_step(ctx, &query_step).await?;
+    }
+
+    // Get result's execution plan
+    let df = ctx.table("output").await.int_err()?;
+
+    tracing::debug!(
+        schema = ?df.schema(),
+        logical_plan = ?df.logical_plan(),
+        "Performing preprocess step",
+    );
+
+    Ok(df)
+}
+
+async fn register_view_for_step(
+    ctx: &SessionContext,
+    step: &SqlQueryStep,
+) -> Result<(), EngineError> {
+    use datafusion::logical_expr::*;
+    use datafusion::sql::TableReference;
+
+    let name = step.alias.as_ref().unwrap();
+
+    tracing::debug!(
+        %name,
+        query = %step.query,
+        "Creating view for a query",
+    );
+
+    let logical_plan = match ctx.state().create_logical_plan(&step.query).await {
+        Ok(plan) => plan,
+        Err(error) => {
+            tracing::error!(
+                error = &error as &dyn std::error::Error,
+                query = %step.query,
+                "Error when setting up query"
+            );
+            return Err(InvalidQueryError::new(error.to_string(), Vec::new()).into());
+        }
+    };
+
+    let create_view = LogicalPlan::Ddl(DdlStatement::CreateView(CreateView {
+        name: TableReference::bare(step.alias.as_ref().unwrap()).to_owned_reference(),
+        input: Arc::new(logical_plan),
+        or_replace: false,
+        definition: Some(step.query.clone()),
+    }));
+
+    ctx.execute_logical_plan(create_view).await.int_err()?;
+    Ok(())
+}
+
+pub(crate) fn new_session_context(
+    object_store_registry: Arc<dyn ObjectStoreRegistry>,
+) -> SessionContext {
+    use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+    use datafusion::prelude::*;
+
+    let config = SessionConfig::new().with_default_catalog_and_schema("kamu", "kamu");
+
+    let runtime_config = RuntimeConfig {
+        object_store_registry: object_store_registry.as_datafusion_registry(),
+        ..RuntimeConfig::default()
+    };
+
+    let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
+
+    SessionContext::new_with_config_rt(config, runtime)
+}
+
+pub(crate) fn next_operation_id() -> String {
+    use rand::distributions::Alphanumeric;
+    use rand::Rng;
+
+    let mut name = String::with_capacity(16);
+    name.extend(
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .map(char::from),
+    );
+
+    name
+}
+
+pub(crate) fn get_random_cache_key(prefix: &str) -> String {
+    use rand::distributions::Alphanumeric;
+    use rand::Rng;
+
+    let mut name = String::with_capacity(10 + prefix.len());
+    name.push_str(prefix);
+    name.extend(
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .map(char::from),
+    );
+    name
+}

--- a/src/infra/core/src/ingest/ingest_common.rs
+++ b/src/infra/core/src/ingest/ingest_common.rs
@@ -15,6 +15,8 @@ use kamu_core::engine::*;
 use kamu_core::ObjectStoreRegistry;
 use opendatafabric::*;
 
+///////////////////////////////////////////////////////////////////////////////
+
 #[tracing::instrument(level = "info", skip_all)]
 pub(crate) async fn preprocess(
     ctx: &SessionContext,
@@ -47,6 +49,8 @@ pub(crate) async fn preprocess(
 
     Ok(df)
 }
+
+///////////////////////////////////////////////////////////////////////////////
 
 async fn register_view_for_step(
     ctx: &SessionContext,
@@ -86,6 +90,8 @@ async fn register_view_for_step(
     Ok(())
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
 pub(crate) fn new_session_context(
     object_store_registry: Arc<dyn ObjectStoreRegistry>,
 ) -> SessionContext {
@@ -104,6 +110,8 @@ pub(crate) fn new_session_context(
     SessionContext::new_with_config_rt(config, runtime)
 }
 
+///////////////////////////////////////////////////////////////////////////////
+
 pub(crate) fn next_operation_id() -> String {
     use rand::distributions::Alphanumeric;
     use rand::Rng;
@@ -118,6 +126,8 @@ pub(crate) fn next_operation_id() -> String {
 
     name
 }
+
+///////////////////////////////////////////////////////////////////////////////
 
 pub(crate) fn get_random_cache_key(prefix: &str) -> String {
     use rand::distributions::Alphanumeric;

--- a/src/infra/core/src/ingest/mod.rs
+++ b/src/infra/core/src/ingest/mod.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 mod fetch_service;
+mod ingest_common;
 mod ingest_task;
 mod polling_ingest_service_impl;
 mod polling_source_state;

--- a/src/infra/core/src/ingest/mod.rs
+++ b/src/infra/core/src/ingest/mod.rs
@@ -9,10 +9,14 @@
 
 mod fetch_service;
 mod ingest_task;
+mod polling_ingest_service_impl;
 mod polling_source_state;
 mod prep_service;
+mod push_ingest_service_impl;
 
 pub use fetch_service::*;
 pub use ingest_task::*;
+pub use polling_ingest_service_impl::*;
 pub use polling_source_state::*;
 pub use prep_service::*;
+pub use push_ingest_service_impl::*;

--- a/src/infra/core/src/ingest/mod.rs
+++ b/src/infra/core/src/ingest/mod.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod data_format_registry_impl;
 mod fetch_service;
 mod ingest_common;
 mod ingest_task;
@@ -15,6 +16,7 @@ mod polling_source_state;
 mod prep_service;
 mod push_ingest_service_impl;
 
+pub use data_format_registry_impl::*;
 pub use fetch_service::*;
 pub use ingest_task::*;
 pub use polling_ingest_service_impl::*;

--- a/src/infra/core/src/ingest/push_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/push_ingest_service_impl.rs
@@ -1,0 +1,584 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use datafusion::prelude::{DataFrame, SessionContext};
+use dill::*;
+use kamu_core::ingest::*;
+use kamu_core::{engine, *};
+use kamu_ingest_datafusion::*;
+use opendatafabric::*;
+use tokio::io::AsyncRead;
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub struct PushIngestServiceImpl {
+    dataset_repo: Arc<dyn DatasetRepository>,
+    dataset_action_authorizer: Arc<dyn auth::DatasetActionAuthorizer>,
+    object_store_registry: Arc<dyn ObjectStoreRegistry>,
+    run_info_dir: PathBuf,
+    cache_dir: PathBuf,
+    time_source: Arc<dyn SystemTimeSource>,
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[component(pub)]
+impl PushIngestServiceImpl {
+    pub fn new(
+        dataset_repo: Arc<dyn DatasetRepository>,
+        dataset_action_authorizer: Arc<dyn auth::DatasetActionAuthorizer>,
+        object_store_registry: Arc<dyn ObjectStoreRegistry>,
+        run_info_dir: PathBuf,
+        cache_dir: PathBuf,
+        time_source: Arc<dyn SystemTimeSource>,
+    ) -> Self {
+        Self {
+            dataset_repo,
+            dataset_action_authorizer,
+            object_store_registry,
+            run_info_dir,
+            cache_dir,
+            time_source,
+        }
+    }
+
+    async fn do_ingest(
+        &self,
+        dataset_ref: &DatasetRef,
+        url: url::Url,
+        media_type: &str,
+        listener: Arc<dyn PushIngestListener>,
+    ) -> Result<PushIngestResult, PushIngestError> {
+        let dataset_handle = self.dataset_repo.resolve_dataset_ref(&dataset_ref).await?;
+
+        self.dataset_action_authorizer
+            .check_action_allowed(&dataset_handle, auth::DatasetAction::Write)
+            .await?;
+
+        let dataset = self
+            .dataset_repo
+            .get_dataset(&dataset_handle.as_local_ref())
+            .await?;
+
+        // TODO: Temporarily relying on SetPollingSource event
+        let Some(polling_source) = dataset
+            .as_metadata_chain()
+            .last_of_type::<SetPollingSource>()
+            .await
+            .int_err()?
+            .map(|(_, b)| b.event)
+        else {
+            let err = PushIngestError::SourceNotFound(PushSourceNotFoundError);
+            listener.begin();
+            listener.error(&err);
+            return Err(err);
+        };
+
+        let operation_id = Self::next_operation_id();
+        let operation_dir = self.run_info_dir.join(format!("ingest-{}", operation_id));
+        std::fs::create_dir_all(&operation_dir).int_err()?;
+
+        let ctx: SessionContext = self.new_session_context();
+        let data_writer = DataWriterDataFusion::builder(dataset.clone(), ctx.clone())
+            .with_metadata_state_scanned()
+            .await?
+            .build()
+            .await?;
+
+        let args = PushIngestArgs {
+            operation_id,
+            operation_dir,
+            system_time: self.time_source.now(),
+            url,
+            media_type: media_type.to_string(),
+            listener,
+            ctx,
+            data_writer,
+            polling_source,
+        };
+
+        let listener = args.listener.clone();
+        listener.begin();
+
+        match self.do_ingest_inner(args).await {
+            Ok(res) => {
+                tracing::info!(result = ?res, "Ingest iteration successful");
+                listener.success(&res);
+                Ok(res)
+            }
+            Err(err) => {
+                tracing::error!(error = ?err, "Ingest iteration failed");
+                listener.error(&err);
+                Err(err)
+            }
+        }
+    }
+
+    #[tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(
+            operation_id = %args.operation_id,
+        )
+    )]
+    async fn do_ingest_inner(
+        &self,
+        mut args: PushIngestArgs,
+    ) -> Result<PushIngestResult, PushIngestError> {
+        args.listener
+            .on_stage_progress(PushIngestStage::CheckSource, 0, TotalSteps::Exact(1));
+        args.listener
+            .on_stage_progress(PushIngestStage::Fetch, 0, TotalSteps::Exact(1));
+        args.listener
+            .on_stage_progress(PushIngestStage::Read, 0, TotalSteps::Exact(1));
+
+        let df = if let Some(df) = self.read(&args).await? {
+            let df = self.preprocess(&args, df).await?;
+            self.validate_new_data(&df, args.data_writer.vocab())?;
+            Some(df)
+        } else {
+            tracing::info!("Read produced an empty data frame");
+            None
+        };
+
+        let out_dir = args.operation_dir.join("out");
+        let data_staging_path = out_dir.join("data");
+        std::fs::create_dir(&out_dir).int_err()?;
+
+        let stage_result = args
+            .data_writer
+            .stage(
+                df,
+                WriteDataOpts {
+                    system_time: args.system_time.clone(),
+                    source_event_time: args.system_time.clone(),
+                    source_state: None,
+                    data_staging_path,
+                },
+            )
+            .await;
+
+        match stage_result {
+            Ok(staged) => {
+                args.listener
+                    .on_stage_progress(PushIngestStage::Commit, 0, TotalSteps::Exact(1));
+
+                let res = args.data_writer.commit(staged).await?;
+
+                Ok(PushIngestResult::Updated {
+                    old_head: res.old_head,
+                    new_head: res.new_head,
+                    num_blocks: 1,
+                })
+            }
+            Err(StageDataError::EmptyCommit(_)) => Ok(PushIngestResult::UpToDate),
+            Err(StageDataError::MergeError(e)) => Err(e.into()),
+            Err(StageDataError::Internal(e)) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(level = "info", skip_all)]
+    async fn read(&self, args: &PushIngestArgs) -> Result<Option<DataFrame>, PushIngestError> {
+        // TODO: Support S3
+        let input_data_path: PathBuf = match args.url.scheme() {
+            "file" => {
+                let p = args
+                    .url
+                    .to_file_path()
+                    .map_err(|_| format!("Invalid file URL {}", args.url).int_err())?;
+
+                // TODO: In case of STDIN (/dev/fd/0) or other pipes and special device files
+                // we have to copy data into a temporary file, as DataFusion cannot read from
+                // them directly.
+                cfg_if::cfg_if! {
+                    if #[cfg(unix)] {
+                        use std::os::unix::fs::FileTypeExt;
+                        let ft = p.metadata().int_err()?.file_type();
+                        if ft.is_fifo() || ft.is_char_device() || ft.is_block_device() {
+                            let temp_path = args.operation_dir.join(self.get_random_cache_key("read-"));
+                            tracing::info!(
+                                from_path = %p.display(),
+                                to_path = %temp_path.display(),
+                                "Detected a special file type - copying into temporary path first",
+                            );
+                            Self::copy_special_file(&p, &temp_path).await?;
+                            Ok(temp_path)
+                        } else {
+                            Ok(p)
+                        }
+                    } else {
+                        Ok(p)
+                    }
+                }
+            }
+            _ => Err(format!("Unsupported source: {}", args.url).int_err()),
+        }?;
+
+        if input_data_path.metadata().int_err()?.len() == 0 {
+            tracing::info!(path = ?input_data_path, "Early return due to an empty file");
+            return Ok(None);
+        }
+
+        let read_step = if Self::media_type_for(&args.polling_source.read) == args.media_type {
+            // Can use read step from source
+            args.polling_source.read.clone()
+        } else {
+            // Pushing with different format than the source - will have to perform
+            // best-effort conversion
+            Self::get_read_step_for(&args.media_type, &args.polling_source.read)?
+        };
+        let reader = Self::get_reader_for(&read_step, &args.operation_dir);
+        let df = reader.read(&args.ctx, &input_data_path, &read_step).await?;
+
+        Ok(Some(df))
+    }
+
+    // TODO: This is needed because tokio::fs::copy refuses to work with special
+    // files
+    async fn copy_special_file(
+        source_path: &Path,
+        target_path: &Path,
+    ) -> Result<(), InternalError> {
+        let mut source = std::fs::File::open(source_path).int_err()?;
+        let mut target = std::fs::File::create(target_path).int_err()?;
+
+        tokio::task::spawn_blocking(move || -> Result<(), std::io::Error> {
+            use std::io::{Read, Write};
+            let mut buf = [0u8; 2048];
+            loop {
+                let read = source.read(&mut buf)?;
+                if read == 0 {
+                    break;
+                }
+                target.write_all(&buf[..read])?;
+            }
+            Ok(())
+        })
+        .await
+        .int_err()?
+        .int_err()
+    }
+
+    fn media_type_for(source_read_step: &ReadStep) -> &'static str {
+        match source_read_step {
+            ReadStep::Csv(_) => IngestMediaTypes::CSV,
+            ReadStep::Json(_) => IngestMediaTypes::JSON,
+            ReadStep::NdJson(_) => IngestMediaTypes::NDJSON,
+            ReadStep::JsonLines(_) => IngestMediaTypes::NDJSON,
+            ReadStep::GeoJson(_) => IngestMediaTypes::GEOJSON,
+            ReadStep::NdGeoJson(_) => IngestMediaTypes::NDGEOJSON,
+            ReadStep::Parquet(_) => IngestMediaTypes::PARQUET,
+            ReadStep::EsriShapefile(_) => IngestMediaTypes::ESRISHAPEFILE,
+        }
+    }
+
+    fn get_read_step_for(
+        media_type: &str,
+        source_read_step: &ReadStep,
+    ) -> Result<ReadStep, PushIngestError> {
+        let schema = source_read_step.schema().cloned();
+        match media_type {
+            IngestMediaTypes::CSV => Ok(ReadStepCsv {
+                schema,
+                ..Default::default()
+            }
+            .into()),
+            IngestMediaTypes::JSON => Ok(ReadStepJson {
+                schema,
+                ..Default::default()
+            }
+            .into()),
+            IngestMediaTypes::NDJSON => Ok(ReadStepNdJson {
+                schema,
+                ..Default::default()
+            }
+            .into()),
+            IngestMediaTypes::GEOJSON => Ok(ReadStepGeoJson { schema }.into()),
+            IngestMediaTypes::NDGEOJSON => Ok(ReadStepNdGeoJson { schema }.into()),
+            IngestMediaTypes::PARQUET => Ok(ReadStepParquet { schema }.into()),
+            IngestMediaTypes::ESRISHAPEFILE => Ok(ReadStepEsriShapefile {
+                schema,
+                ..Default::default()
+            }
+            .into()),
+            _ => Err(UnsupportedMediaTypeError::new(media_type).into()),
+        }
+    }
+
+    // TODO: Replace with DI
+    fn get_reader_for(conf: &ReadStep, operation_dir: &Path) -> Arc<dyn Reader> {
+        use kamu_ingest_datafusion::readers::*;
+
+        let temp_path = operation_dir.join("reader.tmp");
+        match conf {
+            ReadStep::Csv(_) => Arc::new(ReaderCsv {}),
+            ReadStep::Json(_) => Arc::new(ReaderJson::new(temp_path)),
+            ReadStep::NdJson(_) => Arc::new(ReaderNdJson {}),
+            ReadStep::JsonLines(_) => Arc::new(ReaderNdJson {}),
+            ReadStep::GeoJson(_) => Arc::new(ReaderGeoJson::new(temp_path)),
+            ReadStep::NdGeoJson(_) => Arc::new(ReaderNdGeoJson::new(temp_path)),
+            ReadStep::EsriShapefile(_) => Arc::new(ReaderEsriShapefile::new(temp_path)),
+            ReadStep::Parquet(_) => Arc::new(ReaderParquet {}),
+        }
+    }
+
+    #[tracing::instrument(level = "info", skip_all)]
+    async fn preprocess(
+        &self,
+        args: &PushIngestArgs,
+        df: DataFrame,
+    ) -> Result<DataFrame, PushIngestError> {
+        let Some(preprocess) = args.polling_source.preprocess.clone() else {
+            return Ok(df);
+        };
+
+        let Transform::Sql(preprocess) = preprocess;
+
+        // TODO: Support other engines
+        assert_eq!(preprocess.engine.to_lowercase(), "datafusion");
+
+        let preprocess = preprocess.normalize_queries(Some("output".to_string()));
+
+        // Setup input
+        args.ctx.register_table("input", df.into_view()).int_err()?;
+
+        // Setup queries
+        for query_step in preprocess.queries.unwrap_or_default() {
+            self.register_view_for_step(&args.ctx, &query_step).await?;
+        }
+
+        // Get result's execution plan
+        let df = args.ctx.table("output").await.int_err()?;
+
+        tracing::debug!(
+            schema = ?df.schema(),
+            logical_plan = ?df.logical_plan(),
+            "Performing preprocess step",
+        );
+
+        Ok(df)
+    }
+
+    async fn register_view_for_step(
+        &self,
+        ctx: &SessionContext,
+        step: &SqlQueryStep,
+    ) -> Result<(), engine::EngineError> {
+        use datafusion::logical_expr::*;
+        use datafusion::sql::TableReference;
+
+        let name = step.alias.as_ref().unwrap();
+
+        tracing::debug!(
+            %name,
+            query = %step.query,
+            "Creating view for a query",
+        );
+
+        let logical_plan = match ctx.state().create_logical_plan(&step.query).await {
+            Ok(plan) => plan,
+            Err(error) => {
+                tracing::error!(
+                    error = &error as &dyn std::error::Error,
+                    query = %step.query,
+                    "Error when setting up query"
+                );
+                return Err(engine::InvalidQueryError::new(error.to_string(), Vec::new()).into());
+            }
+        };
+
+        let create_view = LogicalPlan::Ddl(DdlStatement::CreateView(CreateView {
+            name: TableReference::bare(step.alias.as_ref().unwrap()).to_owned_reference(),
+            input: Arc::new(logical_plan),
+            or_replace: false,
+            definition: Some(step.query.clone()),
+        }));
+
+        ctx.execute_logical_plan(create_view).await.int_err()?;
+        Ok(())
+    }
+
+    fn validate_new_data(
+        &self,
+        df: &DataFrame,
+        vocab: &DatasetVocabularyResolved<'_>,
+    ) -> Result<(), engine::EngineError> {
+        use datafusion::arrow::datatypes::DataType;
+        use datafusion::common::SchemaError;
+        use datafusion::error::DataFusionError;
+
+        let system_columns = [&vocab.offset_column, &vocab.system_time_column];
+        for system_column in system_columns {
+            if df.schema().has_column_with_unqualified_name(system_column) {
+                return Err(engine::InvalidQueryError::new(
+                    format!(
+                        "Transformed data contains a column that conflicts with the system column \
+                         name, you should either rename the data column or configure the dataset \
+                         vocabulary to use a different name: {}",
+                        system_column
+                    ),
+                    Vec::new(),
+                )
+                .into());
+            }
+        }
+
+        // Event time: If present must be a TIMESTAMP or DATE
+        let event_time_col = match df
+            .schema()
+            .field_with_unqualified_name(&vocab.event_time_column)
+        {
+            Ok(f) => Some(f),
+            Err(DataFusionError::SchemaError(SchemaError::FieldNotFound { .. })) => None,
+            Err(err) => return Err(err.int_err().into()),
+        };
+
+        if let Some(event_time_col) = event_time_col {
+            match event_time_col.data_type() {
+                DataType::Date32 | DataType::Date64 => {}
+                DataType::Timestamp(_, _) => {}
+                typ => {
+                    return Err(engine::InvalidQueryError::new(
+                        format!(
+                            "Event time column '{}' should be either Date or Timestamp, but \
+                             found: {}",
+                            vocab.event_time_column, typ
+                        ),
+                        Vec::new(),
+                    )
+                    .into());
+                }
+            }
+        };
+
+        Ok(())
+    }
+
+    fn new_session_context(&self) -> SessionContext {
+        use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+        use datafusion::prelude::*;
+
+        let config = SessionConfig::new().with_default_catalog_and_schema("kamu", "kamu");
+
+        let runtime_config = RuntimeConfig {
+            object_store_registry: self.object_store_registry.clone().as_datafusion_registry(),
+            ..RuntimeConfig::default()
+        };
+
+        let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
+
+        SessionContext::new_with_config_rt(config, runtime)
+    }
+
+    fn next_operation_id() -> String {
+        use rand::distributions::Alphanumeric;
+        use rand::Rng;
+
+        let mut name = String::with_capacity(16);
+        name.extend(
+            rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .map(char::from),
+        );
+
+        name
+    }
+
+    fn get_random_cache_key(&self, prefix: &str) -> String {
+        use rand::distributions::Alphanumeric;
+        use rand::Rng;
+
+        let mut name = String::with_capacity(10 + prefix.len());
+        name.push_str(prefix);
+        name.extend(
+            rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .map(char::from),
+        );
+        name
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[async_trait::async_trait]
+impl PushIngestService for PushIngestServiceImpl {
+    #[tracing::instrument(level = "info", skip_all, fields(%dataset_ref, %url, %media_type))]
+    async fn ingest_from_url(
+        &self,
+        dataset_ref: &DatasetRef,
+        url: url::Url,
+        media_type: &str,
+        listener: Option<Arc<dyn PushIngestListener>>,
+    ) -> Result<PushIngestResult, PushIngestError> {
+        let listener = listener.unwrap_or_else(|| Arc::new(NullPushIngestListener));
+
+        self.do_ingest(dataset_ref, url, media_type, listener).await
+    }
+
+    #[tracing::instrument(level = "info", skip_all, fields(%dataset_ref, %media_type))]
+    async fn ingest_from_file_stream(
+        &self,
+        dataset_ref: &DatasetRef,
+        mut data: Box<dyn AsyncRead + Send + Unpin>,
+        media_type: &str,
+        listener: Option<Arc<dyn PushIngestListener>>,
+    ) -> Result<PushIngestResult, PushIngestError> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Save stream to a file in cache
+        //
+        // TODO: Breaking all architecture layers here - need to extract cache into a
+        // service
+        let path = self
+            .cache_dir
+            .join(self.get_random_cache_key("push-ingest-"));
+
+        {
+            let mut file = tokio::fs::File::create(&path).await.int_err()?;
+            let mut buf = [0u8; 2048];
+            loop {
+                let read = data.read(&mut buf).await.int_err()?;
+                if read == 0 {
+                    break;
+                }
+                file.write_all(&buf[..read]).await.int_err()?;
+            }
+            file.flush().await.int_err()?;
+        }
+
+        let listener = listener.unwrap_or_else(|| Arc::new(NullPushIngestListener));
+        let url: url::Url = url::Url::from_file_path(&path).unwrap();
+
+        let res = self.do_ingest(dataset_ref, url, media_type, listener).await;
+
+        // Clean up the file in cache as it's non-reusable
+        std::fs::remove_file(path).int_err()?;
+
+        res
+    }
+}
+
+struct PushIngestArgs {
+    operation_id: String,
+    operation_dir: PathBuf,
+    system_time: DateTime<Utc>,
+    url: url::Url,
+    media_type: String,
+    listener: Arc<dyn PushIngestListener>,
+    ctx: SessionContext,
+    data_writer: DataWriterDataFusion,
+    polling_source: SetPollingSource,
+}

--- a/src/infra/core/src/lib.rs
+++ b/src/infra/core/src/lib.rs
@@ -25,7 +25,6 @@ pub mod utils;
 
 mod dataset_config;
 mod dataset_layout;
-mod ingest_service_impl;
 mod provenance_service_impl;
 mod pull_service_impl;
 mod push_service_impl;
@@ -43,7 +42,7 @@ pub use auth::*;
 pub use dataset_config::*;
 pub use dataset_layout::*;
 pub use engine::*;
-pub use ingest_service_impl::*;
+pub use ingest::*;
 pub use provenance_service_impl::*;
 pub use pull_service_impl::*;
 pub use push_service_impl::*;

--- a/src/infra/core/src/testing/dataset_data_helper.rs
+++ b/src/infra/core/src/testing/dataset_data_helper.rs
@@ -1,0 +1,88 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use datafusion::prelude::*;
+use kamu_core::*;
+use opendatafabric::*;
+
+pub struct DatasetDataHelper {
+    dataset: Arc<dyn Dataset>,
+    ctx: SessionContext,
+}
+
+impl DatasetDataHelper {
+    pub fn new(dataset: Arc<dyn Dataset>) -> Self {
+        let ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+        Self { dataset, ctx }
+    }
+
+    pub fn new_with_context(dataset: Arc<dyn Dataset>, ctx: SessionContext) -> Self {
+        Self { dataset, ctx }
+    }
+
+    pub async fn get_last_data_block(&self) -> MetadataBlockTyped<AddData> {
+        use futures::StreamExt;
+
+        let mut stream = self.dataset.as_metadata_chain().iter_blocks();
+        while let Some(v) = stream.next().await {
+            let (_, b) = v.unwrap();
+            if let Some(b) = b.into_typed::<AddData>() {
+                return b;
+            }
+        }
+        unreachable!()
+    }
+
+    pub async fn get_last_data_file(&self) -> PathBuf {
+        let block = self.get_last_data_block().await;
+        kamu_data_utils::data::local_url::into_local_path(
+            self.dataset
+                .as_data_repo()
+                .get_internal_url(&block.event.output_data.unwrap().physical_hash)
+                .await,
+        )
+        .unwrap()
+    }
+
+    pub async fn get_last_data(&self) -> DataFrame {
+        let part_file = self.get_last_data_file().await;
+        self.ctx
+            .read_parquet(
+                part_file.to_string_lossy().as_ref(),
+                ParquetReadOptions {
+                    file_extension: part_file
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or_default(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+    }
+
+    pub async fn assert_last_data_schema_eq(&self, expected: &str) {
+        let df = self.get_last_data().await;
+        kamu_data_utils::testing::assert_schema_eq(df.schema(), expected);
+    }
+
+    pub async fn assert_last_data_records_eq(&self, expected: &str) {
+        let df = self.get_last_data().await;
+        kamu_data_utils::testing::assert_data_eq(df, expected).await;
+    }
+
+    pub async fn assert_last_data_eq(&self, schema: &str, records: &str) {
+        let df = self.get_last_data().await;
+        kamu_data_utils::testing::assert_schema_eq(df.schema(), schema);
+        kamu_data_utils::testing::assert_data_eq(df, records).await;
+    }
+}

--- a/src/infra/core/src/testing/metadata_factory.rs
+++ b/src/infra/core/src/testing/metadata_factory.rs
@@ -215,9 +215,9 @@ impl SetPollingSourceBuilder {
         }
     }
 
-    pub fn fetch(mut self, fetch_step: FetchStep) -> Self {
+    pub fn fetch(mut self, fetch_step: impl Into<FetchStep>) -> Self {
         self.v = SetPollingSource {
-            fetch: fetch_step,
+            fetch: fetch_step.into(),
             ..self.v
         };
         self

--- a/src/infra/core/src/testing/mod.rs
+++ b/src/infra/core/src/testing/mod.rs
@@ -7,29 +7,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod dataset_data_helper;
 mod dataset_test_helper;
-pub use dataset_test_helper::*;
-
 mod id_factory;
-pub use id_factory::*;
-
 mod metadata_factory;
-pub use metadata_factory::*;
-
 mod minio_server;
-pub use minio_server::*;
-
 mod mock_authentication_service;
-pub use mock_authentication_service::*;
-
 mod mock_dataset_action_authorizer;
-pub use mock_dataset_action_authorizer::*;
-
 mod mock_odf_server_access_token_resolver;
-pub use mock_odf_server_access_token_resolver::*;
-
 mod parquet_reader_helper;
-pub use parquet_reader_helper::*;
-
 mod parquet_writer_helper;
+
+pub use dataset_data_helper::*;
+pub use dataset_test_helper::*;
+pub use id_factory::*;
+pub use metadata_factory::*;
+pub use minio_server::*;
+pub use mock_authentication_service::*;
+pub use mock_dataset_action_authorizer::*;
+pub use mock_odf_server_access_token_resolver::*;
+pub use parquet_reader_helper::*;
 pub use parquet_writer_helper::*;

--- a/src/infra/core/tests/tests/auth/test_authentication_service.rs
+++ b/src/infra/core/tests/tests/auth/test_authentication_service.rs
@@ -136,7 +136,7 @@ fn make_catalog() -> dill::Catalog {
         .bind::<dyn AuthenticationProvider, DummyAuthenticationProviderB>()
         .add::<AuthenticationServiceImpl>()
         .bind::<dyn AuthenticationService, AuthenticationServiceImpl>()
-        .add_value(SystemTimeSourceStub::new(Utc::now()))
+        .add_value(SystemTimeSourceStub::new_set(Utc::now()))
         .bind::<dyn SystemTimeSource, SystemTimeSourceStub>()
         .build()
 }

--- a/src/infra/core/tests/tests/engine/mod.rs
+++ b/src/infra/core/tests/tests/engine/mod.rs
@@ -7,6 +7,5 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod test_engine_ingest;
 mod test_engine_io;
 mod test_engine_transform;

--- a/src/infra/core/tests/tests/engine/test_engine_io.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_io.rs
@@ -34,7 +34,7 @@ async fn test_engine_io_common(
 
     let dataset_action_authorizer = Arc::new(auth::AlwaysHappyDatasetActionAuthorizer::new());
 
-    let ingest_svc = IngestServiceImpl::new(
+    let ingest_svc = PollingIngestServiceImpl::new(
         dataset_repo.clone(),
         dataset_action_authorizer.clone(),
         engine_provisioner.clone(),
@@ -111,7 +111,7 @@ async fn test_engine_io_common(
         .unwrap();
 
     ingest_svc
-        .polling_ingest(
+        .ingest(
             &root_alias.as_local_ref(),
             PollingIngestOptions::default(),
             None,
@@ -183,7 +183,7 @@ async fn test_engine_io_common(
     .unwrap();
 
     ingest_svc
-        .polling_ingest(
+        .ingest(
             &root_alias.as_local_ref(),
             PollingIngestOptions::default(),
             None,

--- a/src/infra/core/tests/tests/engine/test_engine_io.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_io.rs
@@ -39,6 +39,7 @@ async fn test_engine_io_common(
         dataset_action_authorizer.clone(),
         engine_provisioner.clone(),
         Arc::new(ObjectStoreRegistryImpl::new(object_stores)),
+        Arc::new(DataFormatRegistryImpl::new()),
         Arc::new(ContainerRuntime::default()),
         run_info_dir.to_path_buf(),
         cache_dir.to_path_buf(),

--- a/src/infra/core/tests/tests/engine/test_engine_transform.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_transform.rs
@@ -252,7 +252,7 @@ async fn test_transform_common(transform: Transform) {
 
     let dataset_action_authorizer = Arc::new(auth::AlwaysHappyDatasetActionAuthorizer::new());
 
-    let ingest_svc = IngestServiceImpl::new(
+    let ingest_svc = PollingIngestServiceImpl::new(
         dataset_repo.clone(),
         dataset_action_authorizer.clone(),
         engine_provisioner.clone(),
@@ -325,7 +325,7 @@ async fn test_transform_common(transform: Transform) {
         .unwrap();
 
     ingest_svc
-        .polling_ingest(
+        .ingest(
             &root_alias.as_local_ref(),
             PollingIngestOptions::default(),
             None,
@@ -418,7 +418,7 @@ async fn test_transform_common(transform: Transform) {
     .unwrap();
 
     ingest_svc
-        .polling_ingest(
+        .ingest(
             &root_alias.as_local_ref(),
             PollingIngestOptions::default(),
             None,

--- a/src/infra/core/tests/tests/engine/test_engine_transform.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_transform.rs
@@ -259,6 +259,7 @@ async fn test_transform_common(transform: Transform) {
         Arc::new(ObjectStoreRegistryImpl::new(vec![Arc::new(
             ObjectStoreBuilderLocalFs::new(),
         )])),
+        Arc::new(DataFormatRegistryImpl::new()),
         Arc::new(ContainerRuntime::default()),
         run_info_dir,
         cache_dir,

--- a/src/infra/core/tests/tests/ingest/mod.rs
+++ b/src/infra/core/tests/tests/ingest/mod.rs
@@ -8,5 +8,7 @@
 // by the Apache License, Version 2.0.
 
 mod test_fetch;
+mod test_polling_ingest;
 mod test_prep;
+mod test_push_ingest;
 mod test_writer;

--- a/src/infra/core/tests/tests/ingest/test_fetch.rs
+++ b/src/infra/core/tests/tests/ingest/test_fetch.rs
@@ -47,7 +47,7 @@ async fn test_fetch_url_file() {
         fetch_svc
             .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
             .await,
-        Err(IngestError::NotFound { .. })
+        Err(PollingIngestError::NotFound { .. })
     );
     assert!(!target_path.exists());
 
@@ -130,7 +130,7 @@ async fn test_fetch_url_http_unreachable() {
         fetch_svc
             .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
             .await,
-        Err(IngestError::Unreachable { .. })
+        Err(PollingIngestError::Unreachable { .. })
     );
     assert!(!target_path.exists());
 }
@@ -159,7 +159,7 @@ async fn test_fetch_url_http_not_found() {
         fetch_svc
             .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
             .await,
-        Err(IngestError::NotFound { .. })
+        Err(PollingIngestError::NotFound { .. })
     );
     assert!(!target_path.exists());
 }
@@ -271,7 +271,7 @@ async fn test_fetch_url_http_ok() {
                 None
             )
             .await,
-        Err(IngestError::NotFound { .. })
+        Err(PollingIngestError::NotFound { .. })
     );
 
     assert!(target_path.exists());
@@ -455,7 +455,7 @@ async fn test_fetch_files_glob() {
         fetch_svc
             .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
             .await,
-        Err(IngestError::NotFound { .. })
+        Err(PollingIngestError::NotFound { .. })
     );
     assert!(!target_path.exists());
 

--- a/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
@@ -1054,6 +1054,7 @@ impl IngestTestHarness {
             Arc::new(ObjectStoreRegistryImpl::new(vec![Arc::new(
                 ObjectStoreBuilderLocalFs::new(),
             )])),
+            Arc::new(DataFormatRegistryImpl::new()),
             Arc::new(ContainerRuntime::default()),
             run_info_dir,
             cache_dir,

--- a/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
@@ -17,7 +17,6 @@ use datafusion::prelude::*;
 use indoc::indoc;
 use itertools::Itertools;
 use kamu::domain::auth::DatasetActionAuthorizer;
-use kamu::domain::engine::*;
 use kamu::domain::*;
 use kamu::testing::*;
 use kamu::*;
@@ -765,12 +764,7 @@ async fn test_ingest_polling_datafusion_event_time_of_invalid_type() {
     .unwrap();
 
     let res = harness.ingest(&dataset_name).await;
-    assert_matches!(
-        res,
-        Err(PollingIngestError::EngineError(EngineError::InvalidQuery(
-            _
-        )))
-    );
+    assert_matches!(res, Err(PollingIngestError::BadInputSchema(_)));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/core/tests/tests/ingest/test_prep.rs
+++ b/src/infra/core/tests/tests/ingest/test_prep.rs
@@ -11,7 +11,7 @@ use std::assert_matches::assert_matches;
 use std::io::prelude::*;
 
 use indoc::indoc;
-use kamu::domain::IngestError;
+use kamu::domain::PollingIngestError;
 use kamu::ingest::*;
 use opendatafabric::*;
 
@@ -124,7 +124,7 @@ fn test_prep_decompress_zip_bad_file() {
     let prep_svc = PrepService::new();
 
     let res = prep_svc.prepare(&prep_steps, &src_path, &target_path);
-    assert_matches!(res, Err(IngestError::Internal(_)));
+    assert_matches!(res, Err(PollingIngestError::Internal(_)));
 }
 
 #[test]

--- a/src/infra/core/tests/tests/ingest/test_push_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_push_ingest.rs
@@ -247,7 +247,7 @@ async fn test_ingest_push_media_type_override() {
         .ingest_from_url(
             &dataset_ref,
             url::Url::from_file_path(&src_path).unwrap(),
-            Some(IngestMediaTypes::CSV),
+            Some(MediaType::CSV.to_owned()),
             None,
         )
         .await
@@ -295,7 +295,7 @@ async fn test_ingest_push_media_type_override() {
         .ingest_from_url(
             &dataset_ref,
             url::Url::from_file_path(&src_path).unwrap(),
-            Some(IngestMediaTypes::NDJSON),
+            Some(MediaType::NDJSON.to_owned()),
             None,
         )
         .await
@@ -345,7 +345,7 @@ async fn test_ingest_push_media_type_override() {
         .ingest_from_url(
             &dataset_ref,
             url::Url::from_file_path(&src_path).unwrap(),
-            Some(IngestMediaTypes::JSON),
+            Some(MediaType::JSON.to_owned()),
             None,
         )
         .await
@@ -420,6 +420,7 @@ impl IngestTestHarness {
             Arc::new(ObjectStoreRegistryImpl::new(vec![Arc::new(
                 ObjectStoreBuilderLocalFs::new(),
             )])),
+            Arc::new(DataFormatRegistryImpl::new()),
             run_info_dir,
             cache_dir,
             time_source,

--- a/src/infra/core/tests/tests/ingest/test_push_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_push_ingest.rs
@@ -422,7 +422,6 @@ impl IngestTestHarness {
             )])),
             Arc::new(DataFormatRegistryImpl::new()),
             run_info_dir,
-            cache_dir,
             time_source,
         ));
 

--- a/src/infra/core/tests/tests/ingest/test_push_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_push_ingest.rs
@@ -1,0 +1,518 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::{TimeZone, Utc};
+use datafusion::prelude::*;
+use futures::StreamExt;
+use indoc::indoc;
+use kamu::domain::auth::DatasetActionAuthorizer;
+use kamu::domain::*;
+use kamu::testing::*;
+use kamu::*;
+use opendatafabric::*;
+use tempfile::TempDir;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, ingest, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_ingest_push_url_stream() {
+    let harness = IngestTestHarness::new();
+
+    let dataset_snapshot = MetadataFactory::dataset_snapshot()
+        .name("foo.bar")
+        .kind(DatasetKind::Root)
+        .push_event(
+            // TODO: This will be replaced with `AddPushSource` event in future
+            MetadataFactory::set_polling_source()
+                .fetch(FetchStepUrl {
+                    url: "http://localhost".to_string(),
+                    event_time: Some(EventTimeSource::FromSystemTime),
+                    cache: None,
+                    headers: None,
+                })
+                .read(ReadStepCsv {
+                    header: Some(true),
+                    schema: Some(
+                        ["date TIMESTAMP", "city STRING", "population BIGINT"]
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect(),
+                    ),
+                    ..ReadStepCsv::default()
+                })
+                // TODO: This will be default engine in future
+                .preprocess(TransformSql {
+                    engine: "datafusion".to_string(),
+                    version: None,
+                    query: Some("select * from input".to_string()),
+                    queries: None,
+                    temporal_tables: None,
+                })
+                .merge(MergeStrategyLedger {
+                    primary_key: vec!["date".to_string(), "city".to_string()],
+                })
+                .build(),
+        )
+        .push_event(SetVocab {
+            system_time_column: None,
+            event_time_column: Some("date".to_string()),
+            offset_column: None,
+        })
+        .build();
+
+    let dataset_name = dataset_snapshot.name.clone();
+    let dataset_ref = DatasetAlias::new(None, dataset_name.clone()).as_local_ref();
+
+    harness.create_dataset(dataset_snapshot).await;
+
+    // Round 1: Push from URL
+    let src_path = harness.temp_dir.path().join("data.csv");
+    std::fs::write(
+        &src_path,
+        indoc!(
+            "
+            date,city,population
+            2020-01-01,A,1000
+            2020-01-01,B,2000
+            2020-01-01,C,3000
+            "
+        ),
+    )
+    .unwrap();
+
+    harness
+        .push_ingest_svc
+        .ingest_from_url(
+            &dataset_ref,
+            url::Url::from_file_path(&src_path).unwrap(),
+            IngestMediaTypes::CSV,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let df = harness.get_last_data(&dataset_name).await;
+    kamu_data_utils::testing::assert_schema_eq(
+        df.schema(),
+        indoc!(
+            r#"
+            message arrow_schema {
+              OPTIONAL INT64 offset;
+              REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
+              OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+              OPTIONAL BYTE_ARRAY city (STRING);
+              OPTIONAL INT64 population;
+            }
+            "#
+        ),
+    );
+
+    kamu_data_utils::testing::assert_data_eq(
+        df,
+        indoc!(
+            r#"
+            +--------+----------------------+----------------------+------+------------+
+            | offset | system_time          | date                 | city | population |
+            +--------+----------------------+----------------------+------+------------+
+            | 0      | 2050-01-01T12:00:00Z | 2020-01-01T00:00:00Z | A    | 1000       |
+            | 1      | 2050-01-01T12:00:00Z | 2020-01-01T00:00:00Z | B    | 2000       |
+            | 2      | 2050-01-01T12:00:00Z | 2020-01-01T00:00:00Z | C    | 3000       |
+            +--------+----------------------+----------------------+------+------------+
+            "#
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        harness
+            .get_last_data_block(&dataset_name)
+            .await
+            .event
+            .output_watermark
+            .map(|dt| dt.to_rfc3339()),
+        Some("2020-01-01T00:00:00+00:00".to_string())
+    );
+
+    // Round 2: Push from Stream
+    let data = std::io::Cursor::new(indoc!(
+        "
+        date,city,population
+        2020-01-01,B,2000
+        2020-01-01,C,3000
+        2021-01-01,C,4000
+        "
+    ));
+
+    harness
+        .push_ingest_svc
+        .ingest_from_file_stream(&dataset_ref, Box::new(data), IngestMediaTypes::CSV, None)
+        .await
+        .unwrap();
+
+    let df = harness.get_last_data(&dataset_name).await;
+    kamu_data_utils::testing::assert_data_eq(
+        df,
+        indoc!(
+            r#"
+            +--------+----------------------+----------------------+------+------------+
+            | offset | system_time          | date                 | city | population |
+            +--------+----------------------+----------------------+------+------------+
+            | 3      | 2050-01-01T12:00:00Z | 2021-01-01T00:00:00Z | C    | 4000       |
+            +--------+----------------------+----------------------+------+------------+
+            "#
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        harness
+            .get_last_data_block(&dataset_name)
+            .await
+            .event
+            .output_watermark
+            .map(|dt| dt.to_rfc3339()),
+        Some("2021-01-01T00:00:00+00:00".to_string())
+    );
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, ingest, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_ingest_push_content_type_conversion() {
+    let harness = IngestTestHarness::new();
+
+    let dataset_snapshot = MetadataFactory::dataset_snapshot()
+        .name("foo.bar")
+        .kind(DatasetKind::Root)
+        .push_event(
+            // TODO: This will be replaced with `AddPushSource` event in future
+            MetadataFactory::set_polling_source()
+                .fetch(FetchStepUrl {
+                    url: "http://localhost".to_string(),
+                    event_time: Some(EventTimeSource::FromSystemTime),
+                    cache: None,
+                    headers: None,
+                })
+                .read(ReadStepNdJson {
+                    schema: Some(
+                        ["date TIMESTAMP", "city STRING", "population BIGINT"]
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect(),
+                    ),
+                    ..Default::default()
+                })
+                // TODO: This will be default engine in future
+                .preprocess(TransformSql {
+                    engine: "datafusion".to_string(),
+                    version: None,
+                    query: Some("select * from input".to_string()),
+                    queries: None,
+                    temporal_tables: None,
+                })
+                .merge(MergeStrategyLedger {
+                    primary_key: vec!["date".to_string(), "city".to_string()],
+                })
+                .build(),
+        )
+        .push_event(SetVocab {
+            system_time_column: None,
+            event_time_column: Some("date".to_string()),
+            offset_column: None,
+        })
+        .build();
+
+    let dataset_name = dataset_snapshot.name.clone();
+    let dataset_ref = DatasetAlias::new(None, dataset_name.clone()).as_local_ref();
+
+    harness.create_dataset(dataset_snapshot).await;
+
+    // Push CSV conversion
+    let src_path = harness.temp_dir.path().join("data.csv");
+    std::fs::write(
+        &src_path,
+        indoc!(
+            "
+            2020-01-01,A,1000
+            "
+        ),
+    )
+    .unwrap();
+
+    harness
+        .push_ingest_svc
+        .ingest_from_url(
+            &dataset_ref,
+            url::Url::from_file_path(&src_path).unwrap(),
+            IngestMediaTypes::CSV,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let df = harness.get_last_data(&dataset_name).await;
+    kamu_data_utils::testing::assert_schema_eq(
+        df.schema(),
+        indoc!(
+            r#"
+            message arrow_schema {
+              OPTIONAL INT64 offset;
+              REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
+              OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+              OPTIONAL BYTE_ARRAY city (STRING);
+              OPTIONAL INT64 population;
+            }
+            "#
+        ),
+    );
+
+    kamu_data_utils::testing::assert_data_eq(
+        df,
+        indoc!(
+            r#"
+            +--------+----------------------+----------------------+------+------------+
+            | offset | system_time          | date                 | city | population |
+            +--------+----------------------+----------------------+------+------------+
+            | 0      | 2050-01-01T12:00:00Z | 2020-01-01T00:00:00Z | A    | 1000       |
+            +--------+----------------------+----------------------+------+------------+
+            "#
+        ),
+    )
+    .await;
+
+    // Push NDJSON native
+    let src_path = harness.temp_dir.path().join("data.json");
+    std::fs::write(
+        &src_path,
+        indoc!(
+            r#"
+            {"date": "2020-01-01", "city": "B", "population": 2000}
+            "#
+        ),
+    )
+    .unwrap();
+
+    harness
+        .push_ingest_svc
+        .ingest_from_url(
+            &dataset_ref,
+            url::Url::from_file_path(&src_path).unwrap(),
+            IngestMediaTypes::NDJSON,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let df = harness.get_last_data(&dataset_name).await;
+    kamu_data_utils::testing::assert_schema_eq(
+        df.schema(),
+        indoc!(
+            r#"
+            message arrow_schema {
+              OPTIONAL INT64 offset;
+              REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
+              OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+              OPTIONAL BYTE_ARRAY city (STRING);
+              OPTIONAL INT64 population;
+            }
+            "#
+        ),
+    );
+
+    kamu_data_utils::testing::assert_data_eq(
+        df,
+        indoc!(
+            r#"
+            +--------+----------------------+----------------------+------+------------+
+            | offset | system_time          | date                 | city | population |
+            +--------+----------------------+----------------------+------+------------+
+            | 1      | 2050-01-01T12:00:00Z | 2020-01-01T00:00:00Z | B    | 2000       |
+            +--------+----------------------+----------------------+------+------------+
+            "#
+        ),
+    )
+    .await;
+
+    // Push JSON conversion
+    let src_path = harness.temp_dir.path().join("data.json");
+    std::fs::write(
+        &src_path,
+        indoc!(
+            r#"
+            [
+                {"date": "2020-01-01", "city": "C", "population": 3000}
+            ]
+            "#
+        ),
+    )
+    .unwrap();
+
+    harness
+        .push_ingest_svc
+        .ingest_from_url(
+            &dataset_ref,
+            url::Url::from_file_path(&src_path).unwrap(),
+            IngestMediaTypes::JSON,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let df = harness.get_last_data(&dataset_name).await;
+    kamu_data_utils::testing::assert_schema_eq(
+        df.schema(),
+        indoc!(
+            r#"
+            message arrow_schema {
+              OPTIONAL INT64 offset;
+              REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
+              OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+              OPTIONAL BYTE_ARRAY city (STRING);
+              OPTIONAL INT64 population;
+            }
+            "#
+        ),
+    );
+
+    kamu_data_utils::testing::assert_data_eq(
+        df,
+        indoc!(
+            r#"
+            +--------+----------------------+----------------------+------+------------+
+            | offset | system_time          | date                 | city | population |
+            +--------+----------------------+----------------------+------+------------+
+            | 2      | 2050-01-01T12:00:00Z | 2020-01-01T00:00:00Z | C    | 3000       |
+            +--------+----------------------+----------------------+------+------------+
+            "#
+        ),
+    )
+    .await;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+struct IngestTestHarness {
+    temp_dir: TempDir,
+    dataset_repo: Arc<DatasetRepositoryLocalFs>,
+    push_ingest_svc: Arc<PushIngestServiceImpl>,
+    ctx: SessionContext,
+}
+
+impl IngestTestHarness {
+    fn new() -> Self {
+        Self::new_with_authorizer(Arc::new(
+            kamu_core::auth::AlwaysHappyDatasetActionAuthorizer::new(),
+        ))
+    }
+
+    fn new_with_authorizer(dataset_action_authorizer: Arc<dyn DatasetActionAuthorizer>) -> Self {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let run_info_dir = temp_dir.path().join("run");
+        let cache_dir = temp_dir.path().join("cache");
+        std::fs::create_dir(&run_info_dir).unwrap();
+        std::fs::create_dir(&cache_dir).unwrap();
+
+        let dataset_repo = Arc::new(
+            DatasetRepositoryLocalFs::create(
+                temp_dir.path().join("datasets"),
+                Arc::new(CurrentAccountSubject::new_test()),
+                dataset_action_authorizer.clone(),
+                false,
+            )
+            .unwrap(),
+        );
+
+        let time_source = Arc::new(SystemTimeSourceStub::new(
+            Utc.with_ymd_and_hms(2050, 1, 1, 12, 0, 0).unwrap(),
+        ));
+
+        let push_ingest_svc = Arc::new(PushIngestServiceImpl::new(
+            dataset_repo.clone(),
+            dataset_action_authorizer,
+            Arc::new(ObjectStoreRegistryImpl::new(vec![Arc::new(
+                ObjectStoreBuilderLocalFs::new(),
+            )])),
+            run_info_dir,
+            cache_dir,
+            time_source,
+        ));
+
+        Self {
+            temp_dir,
+            dataset_repo,
+            push_ingest_svc,
+            ctx: SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1)),
+        }
+    }
+
+    async fn create_dataset(&self, dataset_snapshot: DatasetSnapshot) {
+        self.dataset_repo
+            .create_dataset_from_snapshot(None, dataset_snapshot)
+            .await
+            .unwrap();
+    }
+
+    async fn get_last_data_block(&self, dataset_name: &DatasetName) -> MetadataBlockTyped<AddData> {
+        let dataset = self
+            .dataset_repo
+            .get_dataset(&dataset_name.as_local_ref())
+            .await
+            .unwrap();
+
+        let mut stream = dataset.as_metadata_chain().iter_blocks();
+        while let Some(v) = stream.next().await {
+            let (_, b) = v.unwrap();
+            if let Some(b) = b.into_typed::<AddData>() {
+                return b;
+            }
+        }
+
+        unreachable!()
+    }
+
+    async fn get_last_data_file(&self, dataset_name: &DatasetName) -> PathBuf {
+        let dataset = self
+            .dataset_repo
+            .get_dataset(&dataset_name.as_local_ref())
+            .await
+            .unwrap();
+
+        let block = self.get_last_data_block(dataset_name).await;
+
+        kamu_data_utils::data::local_url::into_local_path(
+            dataset
+                .as_data_repo()
+                .get_internal_url(&block.event.output_data.unwrap().physical_hash)
+                .await,
+        )
+        .unwrap()
+    }
+
+    async fn get_last_data(&self, dataset_name: &DatasetName) -> DataFrame {
+        let part_file = self.get_last_data_file(dataset_name).await;
+        self.ctx
+            .read_parquet(
+                part_file.to_string_lossy().as_ref(),
+                ParquetReadOptions {
+                    file_extension: part_file
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or_default(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+    }
+}

--- a/src/infra/core/tests/tests/ingest/test_writer.rs
+++ b/src/infra/core/tests/tests/ingest/test_writer.rs
@@ -502,18 +502,19 @@ impl Harness {
             let data_path = self.temp_dir.path().join("data.bin");
             std::fs::write(&data_path, data).unwrap();
 
-            let df = ReaderCsv::new()
-                .read(
-                    &self.ctx,
-                    &data_path,
-                    &odf::ReadStep::Csv(odf::ReadStepCsv {
-                        header: Some(true),
-                        schema: Some(schema.split(',').map(|s| s.to_string()).collect()),
-                        ..Default::default()
-                    }),
-                )
-                .await
-                .unwrap();
+            let df = ReaderCsv::new(
+                self.ctx.clone(),
+                odf::ReadStepCsv {
+                    header: Some(true),
+                    schema: Some(schema.split(',').map(|s| s.to_string()).collect()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .read(&data_path)
+            .await
+            .unwrap();
 
             Some(df)
         };

--- a/src/infra/core/tests/tests/test_pull_service_impl.rs
+++ b/src/infra/core/tests/tests/test_pull_service_impl.rs
@@ -1093,28 +1093,28 @@ impl TestIngestService {
 
 // TODO: Replace with a mock
 #[async_trait::async_trait]
-impl IngestService for TestIngestService {
-    async fn polling_ingest(
+impl PollingIngestService for TestIngestService {
+    async fn ingest(
         &self,
         _dataset_ref: &DatasetRef,
         _ingest_options: PollingIngestOptions,
-        _maybe_listener: Option<Arc<dyn IngestListener>>,
-    ) -> Result<IngestResult, IngestError> {
+        _maybe_listener: Option<Arc<dyn PollingIngestListener>>,
+    ) -> Result<PollingIngestResult, PollingIngestError> {
         unimplemented!();
     }
 
-    async fn polling_ingest_multi(
+    async fn ingest_multi(
         &self,
         dataset_refs: Vec<DatasetRef>,
         _options: PollingIngestOptions,
-        _listener: Option<Arc<dyn IngestMultiListener>>,
-    ) -> Vec<IngestResponse> {
+        _listener: Option<Arc<dyn PollingIngestMultiListener>>,
+    ) -> Vec<PollingIngestResponse> {
         let results = dataset_refs
             .iter()
-            .map(|r| IngestResponse {
+            .map(|r| PollingIngestResponse {
                 dataset_ref: r.clone(),
-                result: Ok(IngestResult::UpToDate {
-                    no_polling_source: false,
+                result: Ok(PollingIngestResult::UpToDate {
+                    no_source_defined: false,
                     uncacheable: false,
                 }),
             })
@@ -1123,24 +1123,6 @@ impl IngestService for TestIngestService {
             dataset_refs.into_iter().map(|r| r.into()).collect(),
         ));
         results
-    }
-
-    async fn push_ingest_from_url(
-        &self,
-        _dataset_ref: &DatasetRef,
-        _data_url: url::Url,
-        _listener: Option<Arc<dyn IngestListener>>,
-    ) -> Result<IngestResult, IngestError> {
-        unimplemented!()
-    }
-
-    async fn push_ingest_from_stream(
-        &self,
-        _dataset_ref: &DatasetRef,
-        _data: Box<dyn tokio::io::AsyncRead + Send + Unpin>,
-        _listener: Option<Arc<dyn IngestListener>>,
-    ) -> Result<IngestResult, IngestError> {
-        unimplemented!()
     }
 }
 

--- a/src/infra/ingest-datafusion/src/readers/csv.rs
+++ b/src/infra/ingest-datafusion/src/readers/csv.rs
@@ -33,12 +33,12 @@ impl ReaderCsv {
 
 #[async_trait::async_trait]
 impl Reader for ReaderCsv {
-    async fn output_schema(
+    async fn read_schema(
         &self,
         ctx: &SessionContext,
         conf: &ReadStep,
     ) -> Result<Option<datafusion::arrow::datatypes::Schema>, ReadError> {
-        super::output_schema_common(ctx, conf).await
+        super::read_schema_common(ctx, conf).await
     }
 
     async fn read(
@@ -47,7 +47,7 @@ impl Reader for ReaderCsv {
         path: &Path,
         conf: &ReadStep,
     ) -> Result<DataFrame, ReadError> {
-        let schema = self.output_schema(ctx, conf).await?;
+        let schema = self.read_schema(ctx, conf).await?;
 
         let ReadStep::Csv(conf) = conf else {
             unreachable!()

--- a/src/infra/ingest-datafusion/src/readers/geojson.rs
+++ b/src/infra/ingest-datafusion/src/readers/geojson.rs
@@ -86,12 +86,12 @@ impl ReaderGeoJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderGeoJson {
-    async fn output_schema(
+    async fn read_schema(
         &self,
         ctx: &SessionContext,
         conf: &ReadStep,
     ) -> Result<Option<datafusion::arrow::datatypes::Schema>, ReadError> {
-        super::output_schema_common(ctx, conf).await
+        super::read_schema_common(ctx, conf).await
     }
 
     async fn read(

--- a/src/infra/ingest-datafusion/src/readers/json.rs
+++ b/src/infra/ingest-datafusion/src/readers/json.rs
@@ -82,12 +82,12 @@ impl ReaderJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderJson {
-    async fn output_schema(
+    async fn read_schema(
         &self,
         ctx: &SessionContext,
         conf: &ReadStep,
     ) -> Result<Option<datafusion::arrow::datatypes::Schema>, ReadError> {
-        super::output_schema_common(ctx, conf).await
+        super::read_schema_common(ctx, conf).await
     }
 
     async fn read(

--- a/src/infra/ingest-datafusion/src/readers/mod.rs
+++ b/src/infra/ingest-datafusion/src/readers/mod.rs
@@ -23,17 +23,17 @@ pub use ndjson::*;
 pub use parquet::*;
 pub use shapefile::*;
 
-pub(crate) async fn read_schema_common(
+pub(crate) async fn from_ddl_schema(
     ctx: &datafusion::prelude::SessionContext,
-    conf: &opendatafabric::ReadStep,
+    ddl_schema: &Option<Vec<String>>,
 ) -> Result<Option<datafusion::arrow::datatypes::Schema>, kamu_core::ingest::ReadError> {
     use internal_error::*;
 
-    let Some(ddl_parts) = conf.schema() else {
+    let Some(ddl_schema) = ddl_schema else {
         return Ok(None);
     };
 
-    let ddl = ddl_parts.join(", ");
+    let ddl = ddl_schema.join(", ");
 
     let schema = kamu_data_utils::schema::parse::parse_ddl_to_arrow_schema(ctx, &ddl, true)
         .await

--- a/src/infra/ingest-datafusion/src/readers/mod.rs
+++ b/src/infra/ingest-datafusion/src/readers/mod.rs
@@ -23,7 +23,7 @@ pub use ndjson::*;
 pub use parquet::*;
 pub use shapefile::*;
 
-pub(crate) async fn output_schema_common(
+pub(crate) async fn read_schema_common(
     ctx: &datafusion::prelude::SessionContext,
     conf: &opendatafabric::ReadStep,
 ) -> Result<Option<datafusion::arrow::datatypes::Schema>, kamu_core::ingest::ReadError> {

--- a/src/infra/ingest-datafusion/src/readers/ndgeojson.rs
+++ b/src/infra/ingest-datafusion/src/readers/ndgeojson.rs
@@ -9,6 +9,7 @@
 
 use std::path::{Path, PathBuf};
 
+use datafusion::arrow::datatypes::Schema;
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::ReadError;
@@ -20,16 +21,29 @@ use crate::*;
 
 pub struct ReaderNdGeoJson {
     temp_path: PathBuf,
+    inner: ReaderNdJson,
 }
 
 impl ReaderNdGeoJson {
     // TODO: This is an ugly API that leaves it to the caller to clean up our temp
     // file mess. Ideally we should not produce any temp files at all and stream in
     // all data.
-    pub fn new(temp_path: impl Into<PathBuf>) -> Self {
-        Self {
+    pub async fn new(
+        ctx: SessionContext,
+        conf: ReadStepNdGeoJson,
+        temp_path: impl Into<PathBuf>,
+    ) -> Result<Self, ReadError> {
+        let inner_conf = ReadStepNdJson {
+            schema: conf.schema,
+            date_format: None,
+            encoding: None,
+            timestamp_format: None,
+        };
+
+        Ok(Self {
+            inner: ReaderNdJson::new(ctx, inner_conf).await?,
             temp_path: temp_path.into(),
-        }
+        })
     }
 
     fn convert_to_ndjson_blocking(in_path: &Path, out_path: &Path) -> Result<(), ReadError> {
@@ -90,24 +104,11 @@ impl ReaderNdGeoJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderNdGeoJson {
-    async fn read_schema(
-        &self,
-        ctx: &SessionContext,
-        conf: &ReadStep,
-    ) -> Result<Option<datafusion::arrow::datatypes::Schema>, ReadError> {
-        super::read_schema_common(ctx, conf).await
+    async fn input_schema(&self) -> Option<Schema> {
+        self.inner.input_schema().await
     }
 
-    async fn read(
-        &self,
-        ctx: &SessionContext,
-        path: &Path,
-        conf: &ReadStep,
-    ) -> Result<DataFrame, ReadError> {
-        let ReadStep::NdGeoJson(conf) = conf else {
-            unreachable!()
-        };
-
+    async fn read(&self, path: &Path) -> Result<DataFrame, ReadError> {
         // TODO: PERF: This is a temporary, highly inefficient implementation that
         // re-encodes NdGeoJson into NdJson which DataFusion can read natively
         let in_path = path.to_path_buf();
@@ -116,13 +117,6 @@ impl Reader for ReaderNdGeoJson {
             .await
             .int_err()??;
 
-        let conf = ReadStep::NdJson(ReadStepNdJson {
-            schema: conf.schema.clone(),
-            date_format: None,
-            encoding: None,
-            timestamp_format: None,
-        });
-
-        ReaderNdJson::new().read(ctx, &self.temp_path, &conf).await
+        self.inner.read(&self.temp_path).await
     }
 }

--- a/src/infra/ingest-datafusion/src/readers/ndgeojson.rs
+++ b/src/infra/ingest-datafusion/src/readers/ndgeojson.rs
@@ -90,12 +90,12 @@ impl ReaderNdGeoJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderNdGeoJson {
-    async fn output_schema(
+    async fn read_schema(
         &self,
         ctx: &SessionContext,
         conf: &ReadStep,
     ) -> Result<Option<datafusion::arrow::datatypes::Schema>, ReadError> {
-        super::output_schema_common(ctx, conf).await
+        super::read_schema_common(ctx, conf).await
     }
 
     async fn read(

--- a/src/infra/ingest-datafusion/src/readers/ndjson.rs
+++ b/src/infra/ingest-datafusion/src/readers/ndjson.rs
@@ -31,12 +31,12 @@ impl ReaderNdJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderNdJson {
-    async fn output_schema(
+    async fn read_schema(
         &self,
         ctx: &SessionContext,
         conf: &ReadStep,
     ) -> Result<Option<datafusion::arrow::datatypes::Schema>, ReadError> {
-        super::output_schema_common(ctx, conf).await
+        super::read_schema_common(ctx, conf).await
     }
 
     async fn read(
@@ -45,7 +45,7 @@ impl Reader for ReaderNdJson {
         path: &Path,
         conf: &ReadStep,
     ) -> Result<DataFrame, ReadError> {
-        let schema = self.output_schema(ctx, conf).await?;
+        let schema = self.read_schema(ctx, conf).await?;
 
         let conf = match conf.clone() {
             ReadStep::JsonLines(v) => ReadStepNdJson {

--- a/src/infra/ingest-datafusion/src/readers/parquet.rs
+++ b/src/infra/ingest-datafusion/src/readers/parquet.rs
@@ -30,12 +30,12 @@ impl ReaderParquet {
 
 #[async_trait::async_trait]
 impl Reader for ReaderParquet {
-    async fn output_schema(
+    async fn read_schema(
         &self,
         ctx: &SessionContext,
         conf: &ReadStep,
     ) -> Result<Option<datafusion::arrow::datatypes::Schema>, ReadError> {
-        super::output_schema_common(ctx, conf).await
+        super::read_schema_common(ctx, conf).await
     }
 
     async fn read(
@@ -44,7 +44,7 @@ impl Reader for ReaderParquet {
         path: &Path,
         conf: &ReadStep,
     ) -> Result<DataFrame, ReadError> {
-        let schema = self.output_schema(ctx, conf).await?;
+        let schema = self.read_schema(ctx, conf).await?;
 
         let ReadStep::Parquet(_) = conf else {
             unreachable!()

--- a/src/infra/ingest-datafusion/src/readers/shapefile.rs
+++ b/src/infra/ingest-datafusion/src/readers/shapefile.rs
@@ -207,12 +207,12 @@ impl ReaderEsriShapefile {
 
 #[async_trait::async_trait]
 impl Reader for ReaderEsriShapefile {
-    async fn output_schema(
+    async fn read_schema(
         &self,
         ctx: &SessionContext,
         conf: &ReadStep,
     ) -> Result<Option<datafusion::arrow::datatypes::Schema>, ReadError> {
-        super::output_schema_common(ctx, conf).await
+        super::read_schema_common(ctx, conf).await
     }
 
     async fn read(

--- a/src/infra/ingest-datafusion/tests/tests/test_reader_csv.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_reader_csv.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use datafusion::prelude::SessionContext;
 use indoc::indoc;
 use kamu_ingest_datafusion::*;
 use opendatafabric::*;
@@ -19,15 +20,19 @@ use super::test_reader_common;
 #[test_log::test(tokio::test)]
 async fn test_read_csv_with_schema() {
     test_reader_common::test_reader_success_textual(
-        ReaderCsv {},
-        ReadStepCsv {
-            header: Some(true),
-            schema: Some(vec![
-                "city string not null".to_string(),
-                "population int not null".to_string(),
-            ]),
-            ..Default::default()
-        },
+        ReaderCsv::new(
+            SessionContext::new(),
+            ReadStepCsv {
+                header: Some(true),
+                schema: Some(vec![
+                    "city string not null".to_string(),
+                    "population int not null".to_string(),
+                ]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             city,population
@@ -65,11 +70,15 @@ async fn test_read_csv_with_schema() {
 #[test_log::test(tokio::test)]
 async fn test_read_csv_no_schema_no_infer() {
     test_reader_common::test_reader_success_textual(
-        ReaderCsv {},
-        ReadStepCsv {
-            header: Some(true),
-            ..Default::default()
-        },
+        ReaderCsv::new(
+            SessionContext::new(),
+            ReadStepCsv {
+                header: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             city,population
@@ -107,12 +116,16 @@ async fn test_read_csv_no_schema_no_infer() {
 #[test_log::test(tokio::test)]
 async fn test_read_csv_no_schema_infer() {
     test_reader_common::test_reader_success_textual(
-        ReaderCsv {},
-        ReadStepCsv {
-            header: Some(true),
-            infer_schema: Some(true),
-            ..Default::default()
-        },
+        ReaderCsv::new(
+            SessionContext::new(),
+            ReadStepCsv {
+                header: Some(true),
+                infer_schema: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             city,population
@@ -150,14 +163,18 @@ async fn test_read_csv_no_schema_infer() {
 #[test_log::test(tokio::test)]
 async fn test_read_csv_no_header() {
     test_reader_common::test_reader_success_textual(
-        ReaderCsv {},
-        ReadStepCsv {
-            schema: Some(vec![
-                "city STRING".to_string(),
-                "population BIGINT".to_string(),
-            ]),
-            ..Default::default()
-        },
+        ReaderCsv::new(
+            SessionContext::new(),
+            ReadStepCsv {
+                schema: Some(vec![
+                    "city STRING".to_string(),
+                    "population BIGINT".to_string(),
+                ]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             A,1000
@@ -194,12 +211,16 @@ async fn test_read_csv_no_header() {
 #[test_log::test(tokio::test)]
 async fn test_read_csv_null_values() {
     test_reader_common::test_reader_success_textual(
-        ReaderCsv {},
-        ReadStepCsv {
-            header: Some(true),
-            infer_schema: Some(true),
-            ..Default::default()
-        },
+        ReaderCsv::new(
+            SessionContext::new(),
+            ReadStepCsv {
+                header: Some(true),
+                infer_schema: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             city,population
@@ -237,18 +258,22 @@ async fn test_read_csv_null_values() {
 #[test_log::test(tokio::test)]
 async fn test_read_tsv_null_values() {
     test_reader_common::test_reader_success_textual(
-        ReaderCsv {},
-        ReadStepCsv {
-            header: Some(false),
-            separator: Some("\t".to_string()),
-            schema: Some(vec![
-                "a INT".to_string(),
-                "b INT".to_string(),
-                "c INT".to_string(),
-                "d INT".to_string(),
-            ]),
-            ..Default::default()
-        },
+        ReaderCsv::new(
+            SessionContext::new(),
+            ReadStepCsv {
+                header: Some(false),
+                separator: Some("\t".to_string()),
+                schema: Some(vec![
+                    "a INT".to_string(),
+                    "b INT".to_string(),
+                    "c INT".to_string(),
+                    "d INT".to_string(),
+                ]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             "
             1\t2\t3\t4

--- a/src/infra/ingest-datafusion/tests/tests/test_reader_geojson.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_reader_geojson.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use datafusion::prelude::SessionContext;
 use indoc::indoc;
 use kamu_ingest_datafusion::*;
 use opendatafabric::*;
@@ -21,15 +22,20 @@ async fn test_read_geojson_with_schema() {
     let temp_dir: tempfile::TempDir = tempfile::tempdir().unwrap();
 
     test_reader_common::test_reader_success_textual(
-        ReaderGeoJson::new(temp_dir.path().join("reader-tmp")),
-        ReadStepGeoJson {
-            schema: Some(vec![
-                "id int not null".to_string(),
-                "zipcode string not null".to_string(),
-                "name string not null".to_string(),
-                "geometry string not null".to_string(),
-            ]),
-        },
+        ReaderGeoJson::new(
+            SessionContext::new(),
+            ReadStepGeoJson {
+                schema: Some(vec![
+                    "id int not null".to_string(),
+                    "zipcode string not null".to_string(),
+                    "name string not null".to_string(),
+                    "geometry string not null".to_string(),
+                ]),
+            },
+            temp_dir.path().join("reader-tmp")
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {"type":"FeatureCollection","features":[
@@ -70,10 +76,15 @@ async fn test_read_geojson_infer_schema() {
     let temp_dir: tempfile::TempDir = tempfile::tempdir().unwrap();
 
     test_reader_common::test_reader_success_textual(
-        ReaderGeoJson::new(temp_dir.path().join("reader-tmp")),
-        ReadStepGeoJson {
-            schema: None,
-        },
+        ReaderGeoJson::new(
+            SessionContext::new(),
+            ReadStepGeoJson {
+                schema: None,
+            },
+            temp_dir.path().join("reader-tmp"),
+            )
+            .await
+            .unwrap(),
         indoc!(
             r#"
             {"type":"FeatureCollection","features":[

--- a/src/infra/ingest-datafusion/tests/tests/test_reader_json.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_reader_json.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use datafusion::prelude::SessionContext;
 use indoc::indoc;
 use kamu_ingest_datafusion::*;
 use opendatafabric::*;
@@ -21,15 +22,20 @@ async fn test_read_json_object() {
     let temp_dir: tempfile::TempDir = tempfile::tempdir().unwrap();
 
     test_reader_common::test_reader_success_textual(
-        ReaderJson::new(temp_dir.path().join("reader-tmp")),
-        ReadStepJson {
-            sub_path: Some("result.cities".to_string()),
-            schema: Some(vec![
-                "city string not null".to_string(),
-                "population int not null".to_string(),
-            ]),
-            ..Default::default()
-        },
+        ReaderJson::new(
+            SessionContext::new(),
+            ReadStepJson {
+                sub_path: Some("result.cities".to_string()),
+                schema: Some(vec![
+                    "city string not null".to_string(),
+                    "population int not null".to_string(),
+                ]),
+                ..Default::default()
+            },
+            temp_dir.path().join("reader-tmp"),
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {
@@ -74,15 +80,20 @@ async fn test_read_json_array() {
     let temp_dir: tempfile::TempDir = tempfile::tempdir().unwrap();
 
     test_reader_common::test_reader_success_textual(
-        ReaderJson::new(temp_dir.path().join("reader-tmp")),
-        ReadStepJson {
-            sub_path: None,
-            schema: Some(vec![
-                "city string not null".to_string(),
-                "population int not null".to_string(),
-            ]),
-            ..Default::default()
-        },
+        ReaderJson::new(
+            SessionContext::new(),
+            ReadStepJson {
+                sub_path: None,
+                schema: Some(vec![
+                    "city string not null".to_string(),
+                    "population int not null".to_string(),
+                ]),
+                ..Default::default()
+            },
+            temp_dir.path().join("reader-tmp"),
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             [

--- a/src/infra/ingest-datafusion/tests/tests/test_reader_ndgeojson.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_reader_ndgeojson.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use datafusion::prelude::SessionContext;
 use indoc::indoc;
 use kamu_ingest_datafusion::*;
 use opendatafabric::*;
@@ -21,15 +22,20 @@ async fn test_read_ndgeojson_with_schema() {
     let temp_dir: tempfile::TempDir = tempfile::tempdir().unwrap();
 
     test_reader_common::test_reader_success_textual(
-        ReaderNdGeoJson::new(temp_dir.path().join("reader-tmp")),
-        ReadStepNdGeoJson {
-            schema: Some(vec![
-                "id int not null".to_string(),
-                "zipcode string not null".to_string(),
-                "name string not null".to_string(),
-                "geometry string not null".to_string(),
-            ]),
-        },
+        ReaderNdGeoJson::new(
+            SessionContext::new(),
+            ReadStepNdGeoJson {
+                schema: Some(vec![
+                    "id int not null".to_string(),
+                    "zipcode string not null".to_string(),
+                    "name string not null".to_string(),
+                    "geometry string not null".to_string(),
+                ]),
+            },
+            temp_dir.path().join("reader-tmp")
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {"type": "Feature", "properties": {"id": 0, "zipcode": "00101", "name": "A"}, "geometry": {"type": "Polygon", "coordinates": [[[0.0, 0.0],[10.0, 0.0],[10.0, 10.0],[0.0, 10.0],[0.0, 0.0]]]}}
@@ -68,10 +74,15 @@ async fn test_read_ndgeojson_infer_schema() {
     let temp_dir: tempfile::TempDir = tempfile::tempdir().unwrap();
 
     test_reader_common::test_reader_success_textual(
-        ReaderNdGeoJson::new(temp_dir.path().join("reader-tmp")),
-        ReadStepNdGeoJson {
-            schema: None,
-        },
+        ReaderNdGeoJson::new(
+            SessionContext::new(),
+            ReadStepNdGeoJson {
+                schema: None,
+            },
+            temp_dir.path().join("reader-tmp"),
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {"type": "Feature", "properties": {"id": 0, "zipcode": "00101", "name": "A"}, "geometry": {"type": "Polygon", "coordinates": [[[0.0, 0.0],[10.0, 0.0],[10.0, 10.0],[0.0, 10.0],[0.0, 0.0]]]}}

--- a/src/infra/ingest-datafusion/tests/tests/test_reader_ndjson.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_reader_ndjson.rs
@@ -10,6 +10,7 @@
 use std::assert_matches::assert_matches;
 
 use datafusion::error::DataFusionError;
+use datafusion::prelude::SessionContext;
 use indoc::indoc;
 use kamu_ingest_datafusion::*;
 use opendatafabric::*;
@@ -22,14 +23,18 @@ use super::test_reader_common;
 #[test_log::test(tokio::test)]
 async fn test_read_ndjson_with_schema() {
     test_reader_common::test_reader_success_textual(
-        ReaderNdJson {},
-        ReadStepJsonLines {
-            schema: Some(vec![
-                "city string not null".to_string(),
-                "population int not null".to_string(),
-            ]),
-            ..Default::default()
-        },
+        ReaderNdJson::new(
+            SessionContext::new(),
+            ReadStepNdJson {
+                schema: Some(vec![
+                    "city string not null".to_string(),
+                    "population int not null".to_string(),
+                ]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {"city": "A", "population": 1000}
@@ -66,10 +71,14 @@ async fn test_read_ndjson_with_schema() {
 #[test_log::test(tokio::test)]
 async fn test_read_ndjson_infer_schema() {
     test_reader_common::test_reader_success_textual(
-        ReaderNdJson {},
-        ReadStepJsonLines {
-            ..Default::default()
-        },
+        ReaderNdJson::new(
+            SessionContext::new(),
+            ReadStepNdJson {
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {"city": "A", "population": 1000}
@@ -106,11 +115,15 @@ async fn test_read_ndjson_infer_schema() {
 #[test_log::test(tokio::test)]
 async fn test_read_ndjson_format_date() {
     test_reader_common::test_reader_success_textual(
-        ReaderNdJson {},
-        ReadStepJsonLines {
-            schema: Some(vec!["date date not null".to_string()]),
-            ..Default::default()
-        },
+        ReaderNdJson::new(
+            SessionContext::new(),
+            ReadStepNdJson {
+                schema: Some(vec!["date date not null".to_string()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {"date": "2022-09-25"}
@@ -148,11 +161,15 @@ async fn test_read_ndjson_format_timestamp() {
     // - naive date-times are treated as UTC
     // - different timezones are normalized to UTC with TZ information getting lost
     test_reader_common::test_reader_success_textual(
-        ReaderNdJson {},
-        ReadStepJsonLines {
-            schema: Some(vec!["event_time timestamp not null".to_string()]),
-            ..Default::default()
-        },
+        ReaderNdJson::new(
+            SessionContext::new(),
+            ReadStepNdJson {
+                schema: Some(vec!["event_time timestamp not null".to_string()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {"event_time": "2022-09-25 01:02:03"}
@@ -196,11 +213,15 @@ async fn test_read_ndjson_format_timestamp_parse_failed() {
     // - naive date-times are treated as UTC
     // - different timezones are normalized to UTC with TZ information getting lost
     test_reader_common::test_reader_textual(
-        ReaderNdJson {},
-        ReadStepJsonLines {
-            schema: Some(vec!["event_time timestamp not null".to_string()]),
-            ..Default::default()
-        },
+        ReaderNdJson::new(
+            SessionContext::new(),
+            ReadStepNdJson {
+                schema: Some(vec!["event_time timestamp not null".to_string()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap(),
         indoc!(
             r#"
             {"event_time": "9/25/2022 1:02:03"}

--- a/src/infra/ingest-datafusion/tests/tests/test_reader_parquet.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_reader_parquet.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use chrono::DateTime;
+use datafusion::prelude::SessionContext;
 use indoc::indoc;
 use kamu_ingest_datafusion::*;
 use opendatafabric::*;
@@ -92,8 +93,9 @@ fn write_test_data(path: impl AsRef<Path>) {
 #[test_log::test(tokio::test)]
 async fn test_read_parquet() {
     test_reader_common::test_reader_success(
-        ReaderParquet {},
-        ReadStepParquet { schema: None },
+        ReaderParquet::new(SessionContext::new(), ReadStepParquet { schema: None })
+            .await
+            .unwrap(),
         |path| async {
             write_test_data(path);
         },
@@ -129,14 +131,18 @@ async fn test_read_parquet() {
 #[test_log::test(tokio::test)]
 async fn test_read_parquet_schema_coercion() {
     test_reader_common::test_reader_success(
-        ReaderParquet {},
-        ReadStepParquet {
-            schema: Some(vec![
-                "event_time string not null".to_string(),
-                "city string not null".to_string(),
-                "population int not null".to_string(),
-            ]),
-        },
+        ReaderParquet::new(
+            SessionContext::new(),
+            ReadStepParquet {
+                schema: Some(vec![
+                    "event_time string not null".to_string(),
+                    "city string not null".to_string(),
+                    "population int not null".to_string(),
+                ]),
+            },
+        )
+        .await
+        .unwrap(),
         |path| async {
             write_test_data(path);
         },


### PR DESCRIPTION
In this PR we:
- Add tests for push ingest REST API
- Separate ingest into two services `PollingIngestService` and `PushIngestService`
- Remove `fetch_override` support from polling path
- Add support for multiple media types on push
  - e.g. a source can be defined to read NDJSON, but you now will be able to push CSV / JSON etc. into it and ingest will do best-effort conversion
  - CLI adds `--input-type` parameter for this
  - API endpoint will use `Content-Type` header
- Introduce `MediaType` and a `DataFormatRegistry` that can construct `ingest::Reader` based on it
- Refactor `kamu_ingest_datafusion::Reader*` API slightly to do all configuration upon construction, not at runtime