### PR TITLE
Use KAMU_WORKSPACE envvar to find a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Added `KAMU_WORKSPACE` env var to handle custom workspace path if needed
+
 ## [0.147.2] - 2023-12-19
 ### Fixed
 - Cargo.lock file update to address [RUSTSEC-2023-0074](https://rustsec.org/advisories/RUSTSEC-2023-0074)


### PR DESCRIPTION
Useful for test and debug activities -- to be able to run a debugger with the custom workspace path (e.g. from an IDE)