### PR TITLE
Support input limits and `has_more` loop in containerized ingest

### DIFF
--- a/src/app/cli/src/services/workspace/workspace_layout.rs
+++ b/src/app/cli/src/services/workspace/workspace_layout.rs
@@ -84,7 +84,7 @@ pub enum WorkspaceVersion {
     V2_DatasetConfig,
     // Added a `createdAt` field to fetch savepoints
     V3_SavepointCreatedAt,
-    // Added a zero-copy ingest for loca FS files that affected the savepoint schema
+    // Added a zero-copy ingest for local FS files that affected the savepoint schema
     V4_SavepointZeroCopy,
     Unknown(u32),
 }

--- a/src/domain/core/src/services/ingest/polling_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/polling_ingest_service.rs
@@ -158,6 +158,22 @@ impl IngestParameterNotFound {
     }
 }
 
+#[derive(Error, Debug)]
+#[error("Invalid environment variable {name} format '{value}'")]
+pub struct InvalidIngestParameterFormat {
+    pub name: String,
+    pub value: String,
+}
+
+impl InvalidIngestParameterFormat {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+}
+
 // TODO: Revisit error granularity
 #[derive(Debug, Error)]
 pub enum PollingIngestError {
@@ -264,6 +280,13 @@ pub enum PollingIngestError {
         #[from]
         #[backtrace]
         AccessError,
+    ),
+
+    #[error(transparent)]
+    InvalidParameterFormat(
+        #[from]
+        #[backtrace]
+        InvalidIngestParameterFormat,
     ),
 
     #[error(transparent)]

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -23,6 +23,11 @@ use super::*;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+pub const ODF_BATCH_SIZE: &str = "ODF_BATCH_SIZE";
+pub const ODF_BATCH_SIZE_DEFAULT: u32 = 10_000;
+
+////////////////////////////////////////////////////////////////////////////////
+
 pub struct FetchService {
     container_runtime: Arc<ContainerRuntime>,
     container_log_dir: PathBuf,

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -208,6 +208,7 @@ impl FetchService {
 
         let new_etag_path = out_dir.join("new-etag");
         let new_last_modified_path = out_dir.join("new-last-modified");
+        let new_has_more_data_path = out_dir.join("new-has-more-data");
 
         let (prev_etag, prev_last_modified) = match prev_source_state {
             None => (String::new(), String::new()),
@@ -230,6 +231,10 @@ impl FetchService {
                 (
                     "ODF_NEW_LAST_MODIFIED_PATH",
                     "/opt/odf/out/new-last-modified".to_owned(),
+                ),
+                (
+                    "ODF_NEW_HAS_MORE_DATA_PATH",
+                    "/opt/odf/out/new-has-more-data".to_owned(),
                 ),
             ])
             .volume((&out_dir, "/opt/odf/out"))
@@ -255,7 +260,7 @@ impl FetchService {
             }
         }
 
-        // Spawh container
+        // Spawn container
         let mut container = container_builder.spawn().int_err()?;
 
         // Handle output in a task
@@ -329,6 +334,8 @@ impl FetchService {
             None
         };
 
+        let has_more = new_has_more_data_path.exists();
+
         if target_path.metadata().int_err()?.len() == 0
             && prev_source_state == source_state.as_ref()
         {
@@ -337,7 +344,7 @@ impl FetchService {
             Ok(FetchResult::Updated(FetchResultUpdated {
                 source_state,
                 source_event_time: None,
-                has_more: false,
+                has_more,
                 zero_copy_path: None,
             }))
         }

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -237,9 +237,19 @@ impl FetchService {
             container_builder = container_builder.entry_point(command.join(" "));
         }
 
+        let mut batch_size = ODF_BATCH_SIZE_DEFAULT;
+
         if let Some(env) = &fetch.env {
             for env_var in env {
                 if let Some(value) = &env_var.value {
+                    if env_var.name == ODF_BATCH_SIZE {
+                        batch_size = value
+                            .parse()
+                            .map_err(|_| InvalidIngestParameterFormat::new(&env_var.name, value))?;
+
+                        continue;
+                    }
+
                     container_builder = container_builder.environment_var(&env_var.name, value);
                 } else {
                     // TODO: This is insecure

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -224,19 +224,6 @@ impl FetchService {
             .run_attached(&fetch.image)
             .container_name(format!("kamu-fetch-{}", operation_id))
             .args(fetch.args.clone().unwrap_or_default())
-            .environment_vars([
-                ("ODF_ETAG", prev_etag),
-                ("ODF_LAST_MODIFIED", prev_last_modified),
-                ("ODF_NEW_ETAG_PATH", "/opt/odf/out/new-etag".to_owned()),
-                (
-                    "ODF_NEW_LAST_MODIFIED_PATH",
-                    "/opt/odf/out/new-last-modified".to_owned(),
-                ),
-                (
-                    "ODF_NEW_HAS_MORE_DATA_PATH",
-                    "/opt/odf/out/new-has-more-data".to_owned(),
-                ),
-            ])
             .volume((&out_dir, "/opt/odf/out"))
             .stdout(Stdio::piped())
             .stderr(stderr_file);
@@ -259,6 +246,21 @@ impl FetchService {
                 }
             }
         }
+
+        container_builder = container_builder.environment_vars([
+            ("ODF_ETAG", prev_etag),
+            ("ODF_LAST_MODIFIED", prev_last_modified),
+            ("ODF_NEW_ETAG_PATH", "/opt/odf/out/new-etag".to_owned()),
+            (
+                "ODF_NEW_LAST_MODIFIED_PATH",
+                "/opt/odf/out/new-last-modified".to_owned(),
+            ),
+            (
+                "ODF_NEW_HAS_MORE_DATA_PATH",
+                "/opt/odf/out/new-has-more-data".to_owned(),
+            ),
+            (ODF_BATCH_SIZE, batch_size.to_string()),
+        ]);
 
         // Spawn container
         let mut container = container_builder.spawn().int_err()?;

--- a/src/infra/core/src/utils/docker_images.rs
+++ b/src/infra/core/src/utils/docker_images.rs
@@ -18,6 +18,7 @@ pub const JUPYTER: &'static str = "ghcr.io/kamu-data/jupyter:0.5.2";
 // Test Images
 pub const HTTPD: &'static str = "docker.io/httpd:2.4";
 pub const MINIO: &'static str = "docker.io/minio/minio:RELEASE.2021-08-31T05-46-54Z";
+pub const BUSYBOX: &'static str = "docker.io/busybox:latest";
 
 #[cfg(feature = "ftp")]
 pub const FTP: &'static str = "docker.io/bogem/ftp";

--- a/src/infra/core/tests/tests/ingest/test_fetch.rs
+++ b/src/infra/core/tests/tests/ingest/test_fetch.rs
@@ -592,12 +592,9 @@ async fn test_fetch_container_ok() {
     let target_path = tempdir.path().join("fetched.bin");
 
     let fetch_step = FetchStep::Container(FetchStepContainer {
-        image: crate::utils::HttpServer::IMAGE.to_owned(),
-        command: Some(vec!["/bin/bash".to_owned()]),
-        args: Some(vec![
-            "-c".to_owned(),
-            "printf \"city,population\nA,1000\nB,2000\nC,3000\n\"".to_owned(),
-        ]),
+        image: BUSYBOX.to_owned(),
+        command: Some(vec!["printf".to_owned()]),
+        args: Some(vec![CSV_BATCH_OUTPUT.to_owned()]),
         env: None,
     });
 

--- a/src/utils/repo-tools/src/release.rs
+++ b/src/utils/repo-tools/src/release.rs
@@ -51,7 +51,7 @@ fn main() {
             ..current_version.clone()
         }
     } else {
-        panic!("Specivy a --version or --minor flag");
+        panic!("Specify a --version or --minor flag");
     };
 
     eprintln!("New version: {}", new_version);


### PR DESCRIPTION
Related issue: https://github.com/kamu-data/kamu-cli/issues/302

