### PR TITLE
Update to ODF schema changes

### DIFF
--- a/src/adapter/graphql/src/mutations/datasets_mut.rs
+++ b/src/adapter/graphql/src/mutations/datasets_mut.rs
@@ -38,13 +38,13 @@ impl DatasetsMut {
         &self,
         ctx: &Context<'_>,
         dataset_kind: DatasetKind,
-        dataset_name: DatasetName,
+        dataset_alias: DatasetAlias,
     ) -> Result<CreateDatasetResult> {
         match self
             .create_from_snapshot_impl(
                 ctx,
                 odf::DatasetSnapshot {
-                    name: dataset_name.into(),
+                    name: dataset_alias.into(),
                     kind: dataset_kind.into(),
                     metadata: Vec::new(),
                 },
@@ -109,10 +109,7 @@ impl DatasetsMut {
     ) -> Result<CreateDatasetFromSnapshotResult> {
         let dataset_repo = from_catalog::<dyn domain::DatasetRepository>(ctx).unwrap();
 
-        let result = match dataset_repo
-            .create_dataset_from_snapshot(None, snapshot)
-            .await
-        {
+        let result = match dataset_repo.create_dataset_from_snapshot(snapshot).await {
             Ok(result) => {
                 let dataset = Dataset::from_ref(ctx, &result.dataset_handle.as_local_ref()).await?;
                 CreateDatasetFromSnapshotResult::Success(CreateDatasetResultSuccess { dataset })

--- a/src/adapter/graphql/src/queries/datasets/dataset_metadata.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_metadata.rs
@@ -64,7 +64,7 @@ impl DatasetMetadata {
             .as_metadata_chain()
             .iter_blocks_ref(&domain::BlockRef::Head)
             .filter_data_stream_blocks()
-            .filter_map_ok(|(_, b)| b.event.output_watermark)
+            .filter_map_ok(|(_, b)| b.event.new_watermark)
             .try_first()
             .await
             .int_err()?)

--- a/src/adapter/graphql/src/scalars/metadata.rs
+++ b/src/adapter/graphql/src/scalars/metadata.rs
@@ -24,7 +24,7 @@ pub struct MetadataBlockExtended {
     pub system_time: DateTime<Utc>,
     pub author: Account,
     pub event: MetadataEvent,
-    pub sequence_number: i32,
+    pub sequence_number: u64,
 }
 
 impl MetadataBlockExtended {

--- a/src/adapter/graphql/tests/tests/test_gql_data.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_data.rs
@@ -82,10 +82,11 @@ async fn create_test_dataset(catalog: &dill::Catalog, tempdir: &Path) {
     dataset
         .commit_add_data(
             AddDataParams {
-                input_checkpoint: None,
-                output_data: Some(OffsetInterval { start: 0, end: 3 }),
-                output_watermark: None,
-                source_state: None,
+                prev_checkpoint: None,
+                prev_offset: None,
+                new_offset_interval: Some(OffsetInterval { start: 0, end: 3 }),
+                new_watermark: None,
+                new_source_state: None,
             },
             Some(OwnedFile::new(tmp_data_path)),
             None,

--- a/src/adapter/graphql/tests/tests/test_gql_datasets.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_datasets.rs
@@ -590,9 +590,8 @@ impl GraphQLDatasetsHarness {
             .unwrap();
         dataset_repo
             .create_dataset_from_snapshot(
-                None,
                 MetadataFactory::dataset_snapshot()
-                    .name(name)
+                    .name(DatasetAlias::new(None, name))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .build(),
@@ -612,12 +611,12 @@ impl GraphQLDatasetsHarness {
             .unwrap();
         dataset_repo
             .create_dataset_from_snapshot(
-                None,
                 MetadataFactory::dataset_snapshot()
-                    .name(name)
+                    .name(DatasetAlias::new(None, name))
                     .kind(DatasetKind::Derivative)
                     .push_event(
-                        MetadataFactory::set_transform_aliases(vec![input_dataset.alias.clone()])
+                        MetadataFactory::set_transform()
+                            .inputs_from_refs(vec![input_dataset.alias.clone()])
                             .build(),
                     )
                     .build(),

--- a/src/adapter/graphql/tests/tests/test_gql_metadata.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_metadata.rs
@@ -48,7 +48,6 @@ async fn test_current_push_sources() {
         .unwrap();
     let create_result = dataset_repo
         .create_dataset_from_snapshot(
-            None,
             MetadataFactory::dataset_snapshot()
                 .kind(DatasetKind::Root)
                 .name("foo")

--- a/src/adapter/graphql/tests/tests/test_gql_metadata_chain.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_metadata_chain.rs
@@ -63,10 +63,10 @@ async fn test_metadata_chain_events() {
         .dataset
         .commit_event(
             MetadataFactory::add_data()
-                .some_output_data_with_offset(0, 9)
-                .some_output_checkpoint()
-                .some_output_watermark()
-                .some_source_state()
+                .some_new_data_with_offset(0, 9)
+                .some_new_checkpoint()
+                .some_new_watermark()
+                .some_new_source_state()
                 .build()
                 .into(),
             CommitOpts {
@@ -196,7 +196,6 @@ async fn metadata_chain_append_event() {
         .unwrap();
     let create_result = dataset_repo
         .create_dataset_from_snapshot(
-            None,
             MetadataFactory::dataset_snapshot()
                 .name("foo")
                 .kind(DatasetKind::Root)
@@ -293,7 +292,6 @@ async fn metadata_update_readme_new() {
         .unwrap();
     let create_result = dataset_repo
         .create_dataset_from_snapshot(
-            None,
             MetadataFactory::dataset_snapshot()
                 .name("foo")
                 .kind(DatasetKind::Root)

--- a/src/adapter/graphql/tests/tests/test_gql_search.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_search.rs
@@ -35,7 +35,6 @@ async fn query() {
     let dataset_repo = cat.get_one::<dyn DatasetRepository>().unwrap();
     dataset_repo
         .create_dataset_from_snapshot(
-            None,
             MetadataFactory::dataset_snapshot()
                 .name("foo")
                 .kind(DatasetKind::Root)

--- a/src/adapter/http/src/smart_protocol/messages.rs
+++ b/src/adapter/http/src/smart_protocol/messages.rs
@@ -200,7 +200,7 @@ pub struct TransferSizeEstimate {
 pub struct ObjectFileReference {
     pub object_type: ObjectType,
     pub physical_hash: Multihash,
-    pub size: i64,
+    pub size: u64,
 }
 
 // Object type enumeration

--- a/src/adapter/http/tests/harness/common_harness.rs
+++ b/src/adapter/http/tests/harness/common_harness.rs
@@ -64,10 +64,10 @@ pub(crate) async fn create_random_data(dataset_layout: &DatasetLayout) -> AddDat
     let (d_hash, d_size) = create_random_file(&dataset_layout.data_dir).await;
     let (c_hash, c_size) = create_random_file(&dataset_layout.checkpoints_dir).await;
     MetadataFactory::add_data()
-        .data_physical_hash(d_hash)
-        .data_size(d_size as i64)
-        .checkpoint_physical_hash(c_hash)
-        .checkpoint_size(c_size as i64)
+        .new_data_physical_hash(d_hash)
+        .new_data_size(d_size as u64)
+        .new_checkpoint_physical_hash(c_hash)
+        .new_checkpoint_size(c_size as u64)
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/tests/test_data.rs
+++ b/src/adapter/http/tests/tests/test_data.rs
@@ -49,49 +49,49 @@ async fn test_data_push_ingest_handler() {
 
     let create_result = server_harness
         .cli_dataset_repository()
-        .create_dataset_from_snapshot(
-            server_harness.operating_account_name(),
-            DatasetSnapshot {
-                name: "population".try_into().unwrap(),
-                kind: DatasetKind::Root,
-                metadata: vec![
-                    AddPushSource {
-                        source_name: None, // Default source
-                        read: ReadStepNdJson {
-                            schema: Some(vec![
-                                "event_time TIMESTAMP".to_owned(),
-                                "city STRING".to_owned(),
-                                "population BIGINT".to_owned(),
-                            ]),
-                            ..Default::default()
-                        }
-                        .into(),
-                        preprocess: None,
-                        merge: MergeStrategy::Ledger(MergeStrategyLedger {
-                            primary_key: vec!["event_time".to_owned(), "city".to_owned()],
-                        }),
+        .create_dataset_from_snapshot(DatasetSnapshot {
+            name: DatasetAlias::new(
+                server_harness.operating_account_name(),
+                DatasetName::new_unchecked("population"),
+            ),
+            kind: DatasetKind::Root,
+            metadata: vec![
+                AddPushSource {
+                    source_name: None, // Default source
+                    read: ReadStepNdJson {
+                        schema: Some(vec![
+                            "event_time TIMESTAMP".to_owned(),
+                            "city STRING".to_owned(),
+                            "population BIGINT".to_owned(),
+                        ]),
+                        ..Default::default()
                     }
                     .into(),
-                    AddPushSource {
-                        source_name: Some("device1".to_string()),
-                        read: ReadStepNdJson {
-                            schema: Some(vec![
-                                "event_time TIMESTAMP".to_owned(),
-                                "city STRING".to_owned(),
-                                "population BIGINT".to_owned(),
-                            ]),
-                            ..Default::default()
-                        }
-                        .into(),
-                        preprocess: None,
-                        merge: MergeStrategy::Ledger(MergeStrategyLedger {
-                            primary_key: vec!["event_time".to_owned(), "city".to_owned()],
-                        }),
+                    preprocess: None,
+                    merge: MergeStrategy::Ledger(MergeStrategyLedger {
+                        primary_key: vec!["event_time".to_owned(), "city".to_owned()],
+                    }),
+                }
+                .into(),
+                AddPushSource {
+                    source_name: Some("device1".to_string()),
+                    read: ReadStepNdJson {
+                        schema: Some(vec![
+                            "event_time TIMESTAMP".to_owned(),
+                            "city STRING".to_owned(),
+                            "population BIGINT".to_owned(),
+                        ]),
+                        ..Default::default()
                     }
                     .into(),
-                ],
-            },
-        )
+                    preprocess: None,
+                    merge: MergeStrategy::Ledger(MergeStrategyLedger {
+                        primary_key: vec!["event_time".to_owned(), "city".to_owned()],
+                    }),
+                }
+                .into(),
+            ],
+        })
         .await
         .unwrap();
 

--- a/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
+++ b/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
@@ -463,7 +463,6 @@ async fn create_test_case(server_harness: &dyn ServerSideHarness) -> TestCase {
 
     let create_result = server_repo
         .create_dataset_from_snapshot(
-            None,
             MetadataFactory::dataset_snapshot()
                 .name("foo")
                 .kind(DatasetKind::Root)

--- a/src/adapter/http/tests/tests/test_routing.rs
+++ b/src/adapter/http/tests/tests/test_routing.rs
@@ -54,7 +54,6 @@ async fn setup_repo() -> RepoFixture {
 
     let created_dataset = dataset_repo
         .create_dataset_from_snapshot(
-            None,
             MetadataFactory::dataset_snapshot()
                 .name("foo")
                 .kind(DatasetKind::Root)

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_aborted_read_of_existing_evolved_dataset_reread_succeeds.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_aborted_read_of_existing_evolved_dataset_reread_succeeds.rs
@@ -48,9 +48,11 @@ impl<TServerHarness: ServerSideHarness>
         let server_repo = server_harness.cli_dataset_repository();
         let server_create_result = server_repo
             .create_dataset_from_snapshot(
-                server_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        server_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_aborted_read_of_new_reread_succeeds.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_aborted_read_of_new_reread_succeeds.rs
@@ -45,9 +45,11 @@ impl<TServerHarness: ServerSideHarness>
         let server_repo = server_harness.cli_dataset_repository();
         let server_create_result = server_repo
             .create_dataset_from_snapshot(
-                server_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        server_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_advanced_dataset_fails.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_advanced_dataset_fails.rs
@@ -40,9 +40,11 @@ impl<TServerHarness: ServerSideHarness>
         let server_repo = server_harness.cli_dataset_repository();
         let server_create_result = server_repo
             .create_dataset_from_snapshot(
-                server_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        server_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_evolved_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_evolved_dataset.rs
@@ -43,9 +43,11 @@ impl<TServerHarness: ServerSideHarness> SmartPullExistingEvolvedDatasetScenario<
         let server_repo = server_harness.cli_dataset_repository();
         let server_create_result = server_repo
             .create_dataset_from_snapshot(
-                server_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        server_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_up_to_date_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_up_to_date_dataset.rs
@@ -40,9 +40,11 @@ impl<TServerHarness: ServerSideHarness> SmartPullExistingUpToDateDatasetScenario
         let server_repo = server_harness.cli_dataset_repository();
         let server_create_result = server_repo
             .create_dataset_from_snapshot(
-                server_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        server_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_new_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_new_dataset.rs
@@ -40,9 +40,11 @@ impl<TServerHarness: ServerSideHarness> SmartPullNewDatasetScenario<TServerHarne
         let server_repo = server_harness.cli_dataset_repository();
         let server_create_result = server_repo
             .create_dataset_from_snapshot(
-                server_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        server_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_aborted_write_of_new_rewrite_succeeds.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_aborted_write_of_new_rewrite_succeeds.rs
@@ -45,9 +45,11 @@ impl<TServerHarness: ServerSideHarness> SmartPushAbortedWriteOfNewWriteSucceeds<
 
         let client_create_result = client_repo
             .create_dataset_from_snapshot(
-                client_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        client_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_aborted_write_of_updated_rewrite_succeeds.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_aborted_write_of_updated_rewrite_succeeds.rs
@@ -49,9 +49,11 @@ impl<TServerHarness: ServerSideHarness>
 
         let client_create_result = client_repo
             .create_dataset_from_snapshot(
-                client_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        client_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_dataset_fails_as_server_advanced.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_dataset_fails_as_server_advanced.rs
@@ -45,9 +45,11 @@ impl<TServerHarness: ServerSideHarness>
 
         let client_create_result = client_repo
             .create_dataset_from_snapshot(
-                client_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        client_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_evolved_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_evolved_dataset.rs
@@ -46,9 +46,11 @@ impl<TServerHarness: ServerSideHarness> SmartPushExistingEvolvedDatasetScenario<
 
         let client_create_result = client_repo
             .create_dataset_from_snapshot(
-                client_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        client_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_up_to_date_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_up_to_date_dataset.rs
@@ -43,9 +43,11 @@ impl<TServerHarness: ServerSideHarness> SmartPushExistingUpToDateDatasetScenario
 
         let client_create_result = client_repo
             .create_dataset_from_snapshot(
-                client_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        client_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_new_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_new_dataset.rs
@@ -44,9 +44,11 @@ impl<TServerHarness: ServerSideHarness> SmartPushNewDatasetScenario<TServerHarne
 
         let client_create_result = client_repo
             .create_dataset_from_snapshot(
-                client_account_name.clone(),
                 MetadataFactory::dataset_snapshot()
-                    .name("foo")
+                    .name(DatasetAlias::new(
+                        client_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .push_event(MetadataFactory::set_data_schema().build())

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -20,24 +20,17 @@ pub fn get_command(
     arg_matches: clap::ArgMatches,
 ) -> Result<Box<dyn Command>, CLIError> {
     let command: Box<dyn Command> = match arg_matches.subcommand() {
-        Some(("add", submatches)) => {
-            let workspace_svc = cli_catalog.get_one::<WorkspaceService>()?;
-            Box::new(AddCommand::new(
-                cli_catalog.get_one()?,
-                cli_catalog.get_one()?,
-                accounts::AccountService::current_account_indication(
-                    &arg_matches,
-                    workspace_svc.is_multi_tenant_workspace(),
-                ),
-                submatches
-                    .get_many("manifest")
-                    .unwrap_or_default()
-                    .map(String::as_str),
-                submatches.get_flag("recursive"),
-                submatches.get_flag("replace"),
-                submatches.get_flag("stdin"),
-            ))
-        }
+        Some(("add", submatches)) => Box::new(AddCommand::new(
+            cli_catalog.get_one()?,
+            cli_catalog.get_one()?,
+            submatches
+                .get_many("manifest")
+                .unwrap_or_default()
+                .map(String::as_str),
+            submatches.get_flag("recursive"),
+            submatches.get_flag("replace"),
+            submatches.get_flag("stdin"),
+        )),
         Some(("complete", submatches)) => {
             let workspace_svc = cli_catalog.get_one::<WorkspaceService>()?;
             let in_workspace =

--- a/src/app/cli/src/commands/add_command.rs
+++ b/src/app/cli/src/commands/add_command.rs
@@ -13,12 +13,10 @@ use kamu::domain::*;
 use opendatafabric::*;
 
 use super::{common, BatchError, CLIError, Command};
-use crate::accounts;
 
 pub struct AddCommand {
     resource_loader: Arc<dyn ResourceLoader>,
     dataset_repo: Arc<dyn DatasetRepository>,
-    current_account: accounts::CurrentAccountIndication,
     snapshot_refs: Vec<String>,
     recursive: bool,
     replace: bool,
@@ -29,7 +27,6 @@ impl AddCommand {
     pub fn new<'s, I>(
         resource_loader: Arc<dyn ResourceLoader>,
         dataset_repo: Arc<dyn DatasetRepository>,
-        current_account: accounts::CurrentAccountIndication,
         snapshot_refs_iter: I,
         recursive: bool,
         replace: bool,
@@ -41,7 +38,6 @@ impl AddCommand {
         Self {
             resource_loader,
             dataset_repo,
-            current_account,
             snapshot_refs: snapshot_refs_iter.map(|s| s.to_owned()).collect(),
             recursive,
             replace,
@@ -203,14 +199,7 @@ impl Command for AddCommand {
 
         let mut add_results = self
             .dataset_repo
-            .create_datasets_from_snapshots(
-                if self.current_account.is_explicit() {
-                    Some(self.current_account.account_name.clone())
-                } else {
-                    None
-                },
-                snapshots,
-            )
+            .create_datasets_from_snapshots(snapshots)
             .await;
 
         add_results.sort_by(|(id_a, _), (id_b, _)| id_a.cmp(&id_b));

--- a/src/app/cli/src/commands/inspect_query_command.rs
+++ b/src/app/cli/src/commands/inspect_query_command.rs
@@ -115,8 +115,8 @@ impl InspectQueryCommand {
             writeln!(
                 output,
                 "  {}  {}",
-                style(&input.name).bold(),
-                style(input.id.as_ref().unwrap()).dim(),
+                style(input.alias.as_ref().unwrap()).bold(),
+                style(&input.dataset_ref).dim(),
             )?;
         }
 

--- a/src/app/cli/src/commands/list_command.rs
+++ b/src/app/cli/src/commands/list_command.rs
@@ -264,7 +264,7 @@ impl Command for ListCommand {
                         num_blocks = b.sequence_number as u64 + 1;
                     }
                     if let Some(b) = b.as_data_stream_block() {
-                        last_watermark = b.event.output_watermark.cloned();
+                        last_watermark = b.event.new_watermark.cloned();
                         break;
                     }
                 }

--- a/src/app/cli/tests/tests/test_workspace_svc.rs
+++ b/src/app/cli/tests/tests/test_workspace_svc.rs
@@ -64,10 +64,11 @@ async fn init_v0_workspace(workspace_path: &Path) {
     dataset
         .commit_add_data(
             AddDataParams {
-                input_checkpoint: None,
-                output_data: Some(OffsetInterval { start: 0, end: 10 }),
-                output_watermark: None,
-                source_state: None,
+                prev_checkpoint: None,
+                prev_offset: None,
+                new_offset_interval: Some(OffsetInterval { start: 0, end: 10 }),
+                new_watermark: None,
+                new_source_state: None,
             },
             Some(OwnedFile::new(data_path)),
             Some(OwnedFile::new(checkpoint_path)),

--- a/src/app/cli/tests/utils/kamu.rs
+++ b/src/app/cli/tests/utils/kamu.rs
@@ -89,7 +89,7 @@ impl Kamu {
             .as_metadata_chain()
             .iter_blocks()
             .filter_data_stream_blocks()
-            .filter_map_ok(|(_, b)| b.event.output_data)
+            .filter_map_ok(|(_, b)| b.event.new_data)
             .try_first()
             .await
             .unwrap()

--- a/src/domain/core/src/entities/dataset.rs
+++ b/src/domain/core/src/entities/dataset.rs
@@ -172,10 +172,24 @@ pub enum CommitError {
 /// Replicates [AddData] event prior to hashing of data and checkpoint
 #[derive(Debug, Clone)]
 pub struct AddDataParams {
-    pub input_checkpoint: Option<Multihash>,
-    pub output_data: Option<OffsetInterval>,
-    pub output_watermark: Option<DateTime<Utc>>,
-    pub source_state: Option<SourceState>,
+    /// Hash of the checkpoint file used to restore ingestion state, if any.
+    pub prev_checkpoint: Option<Multihash>,
+    /// Last offset of the previous data slice, if any. Must be equal to the
+    /// last non-empty `newData.offsetInterval.end`.
+    pub prev_offset: Option<u64>,
+    /// Offset interval of the output data written during this transaction, if
+    /// any.
+    pub new_offset_interval: Option<OffsetInterval>,
+    /// Last watermark of the output data stream, if any. Initial blocks may not
+    /// have watermarks, but once watermark is set - all subsequent blocks
+    /// should either carry the same watermark or specify a new (greater) one.
+    /// Thus, watermarks are monotonically non-decreasing.
+    pub new_watermark: Option<DateTime<Utc>>,
+    /// The state of the source the data was added from to allow fast resuming.
+    /// If the state did not change but is still relevant for subsequent runs it
+    /// should be carried, i.e. only the last state per source is considered
+    /// when resuming.
+    pub new_source_state: Option<SourceState>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -183,8 +197,21 @@ pub struct AddDataParams {
 /// Replicates [ExecuteQuery] event prior to hashing of data and checkpoint
 #[derive(Debug, Clone)]
 pub struct ExecuteQueryParams {
-    pub input_slices: Vec<InputSlice>,
-    pub input_checkpoint: Option<Multihash>,
-    pub output_data: Option<OffsetInterval>,
-    pub output_watermark: Option<DateTime<Utc>>,
+    /// Defines inputs used in this transaction. Slices corresponding to every
+    /// input dataset must be present.
+    pub query_inputs: Vec<ExecuteQueryInput>,
+    /// Hash of the checkpoint file used to restore transformation state, if
+    /// any.
+    pub prev_checkpoint: Option<Multihash>,
+    /// Last offset of the previous data slice, if any. Must be equal to the
+    /// last non-empty `newData.offsetInterval.end`.
+    pub prev_offset: Option<u64>,
+    /// Offset interval of the output data written during this transaction, if
+    /// any.
+    pub new_offset_interval: Option<OffsetInterval>,
+    /// Last watermark of the output data stream, if any. Initial blocks may not
+    /// have watermarks, but once watermark is set - all subsequent blocks
+    /// should either carry the same watermark or specify a new (greater) one.
+    /// Thus, watermarks are monotonically non-decreasing.
+    pub new_watermark: Option<DateTime<Utc>>,
 }

--- a/src/domain/core/src/entities/dataset_summary.rs
+++ b/src/domain/core/src/entities/dataset_summary.rs
@@ -9,7 +9,7 @@
 
 use chrono::{DateTime, Utc};
 use opendatafabric::serde::yaml::*;
-use opendatafabric::{DatasetID, DatasetKind, Multihash, TransformInput};
+use opendatafabric::{DatasetID, DatasetKind, Multihash};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
 
@@ -24,8 +24,7 @@ pub struct DatasetSummary {
     #[serde_as(as = "DatasetKindDef")]
     pub kind: DatasetKind,
     pub last_block_hash: Multihash,
-    #[serde_as(as = "Vec<TransformInputDef>")]
-    pub dependencies: Vec<TransformInput>,
+    pub dependencies: Vec<DatasetID>,
     #[serde(default, with = "datetime_rfc3339_opt")]
     pub last_pulled: Option<DateTime<Utc>>,
     pub num_records: u64,

--- a/src/domain/core/src/entities/metadata_chain.rs
+++ b/src/domain/core/src/entities/metadata_chain.rs
@@ -525,8 +525,8 @@ impl NoOpEventError {
 #[derive(Error, PartialEq, Eq, Debug)]
 pub struct SequenceIntegrityError {
     pub prev_block_hash: Option<Multihash>,
-    pub prev_block_sequence_number: Option<i32>,
-    pub next_block_sequence_number: i32,
+    pub prev_block_sequence_number: Option<u64>,
+    pub next_block_sequence_number: u64,
 }
 
 impl Display for SequenceIntegrityError {
@@ -554,14 +554,14 @@ impl Display for SequenceIntegrityError {
 
 #[derive(Error, PartialEq, Eq, Debug)]
 pub struct OffsetsNotSequentialError {
-    pub last_offset: i64,
-    pub new_offset: i64,
+    pub expected_offset: u64,
+    pub new_offset: u64,
 }
 
 impl OffsetsNotSequentialError {
-    pub fn new(last_offset: i64, new_offset: i64) -> Self {
+    pub fn new(expected_offset: u64, new_offset: u64) -> Self {
         Self {
-            last_offset,
+            expected_offset,
             new_offset,
         }
     }
@@ -572,8 +572,7 @@ impl Display for OffsetsNotSequentialError {
         write!(
             f,
             "Expected offset interval to start at {} but got {}",
-            self.last_offset + 1,
-            self.new_offset,
+            self.expected_offset, self.new_offset,
         )
     }
 }

--- a/src/domain/core/src/utils/metadata_chain_comparator.rs
+++ b/src/domain/core/src/utils/metadata_chain_comparator.rs
@@ -197,13 +197,18 @@ impl MetadataChainComparator {
         rhs_sequence_number: u64,
         last_common_sequence_number: Option<u64>,
     ) -> CompareChainsResult {
-        CompareChainsResult::Divergence {
-            uncommon_blocks_in_lhs: (lhs_sequence_number + 1
-                - last_common_sequence_number.unwrap_or(0))
-                as usize,
-            uncommon_blocks_in_rhs: (rhs_sequence_number + 1
-                - last_common_sequence_number.unwrap_or(0))
-                as usize,
+        if let Some(last_common_sequence_number) = last_common_sequence_number {
+            CompareChainsResult::Divergence {
+                uncommon_blocks_in_lhs: (lhs_sequence_number - last_common_sequence_number)
+                    as usize,
+                uncommon_blocks_in_rhs: (rhs_sequence_number - last_common_sequence_number)
+                    as usize,
+            }
+        } else {
+            CompareChainsResult::Divergence {
+                uncommon_blocks_in_lhs: (lhs_sequence_number + 1) as usize,
+                uncommon_blocks_in_rhs: (rhs_sequence_number + 1) as usize,
+            }
         }
     }
 

--- a/src/domain/opendatafabric/schemas/odf.fbs
+++ b/src/domain/opendatafabric/schemas/odf.fbs
@@ -440,7 +440,7 @@ table SetVocab {
 ////////////////////////////////////////////////////////////////////////////////
 
 table SetWatermark {
-  output_watermark: Timestamp;
+  new_watermark: Timestamp;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -586,7 +586,7 @@ table ExecuteQueryResponseProgress {
 }
 
 table ExecuteQueryResponseSuccess {
-  offset_interval: OffsetInterval;
+  new_offset_interval: OffsetInterval;
   new_watermark: Timestamp;
 }
 

--- a/src/domain/opendatafabric/schemas/odf.fbs
+++ b/src/domain/opendatafabric/schemas/odf.fbs
@@ -16,8 +16,8 @@ struct Timestamp {
 ////////////////////////////////////////////////////////////////////////////////
 
 table OffsetInterval {
-  start: int64;
-  end: int64;
+  start: uint64;
+  end: uint64;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -28,8 +28,8 @@ table OffsetInterval {
 table DataSlice {
   logical_hash: [ubyte];
   physical_hash: [ubyte];
-  interval: OffsetInterval;
-  size: int64;
+  offset_interval: OffsetInterval;
+  size: uint64;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -39,7 +39,7 @@ table DataSlice {
 
 table Checkpoint {
   physical_hash: [ubyte];
-  size: int64;
+  size: uint64;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -48,8 +48,8 @@ table Checkpoint {
 ////////////////////////////////////////////////////////////////////////////////
 
 table SourceState {
+  source_name: string;
   kind: string;
-  source: string;
   value: string;
 }
 
@@ -59,11 +59,12 @@ table SourceState {
 ////////////////////////////////////////////////////////////////////////////////
 
 table AddData {
-  input_checkpoint: [ubyte];
-  output_data: DataSlice;
-  output_checkpoint: Checkpoint;
-  output_watermark: Timestamp;
-  source_state: SourceState;
+  prev_checkpoint: [ubyte];
+  prev_offset: uint64 = null;
+  new_data: DataSlice;
+  new_checkpoint: Checkpoint;
+  new_watermark: Timestamp;
+  new_source_state: SourceState;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,28 +78,10 @@ table ReadStepCsv {
   encoding: string;
   quote: string;
   escape: string;
-  comment: string;
   header: bool = null;
-  enforce_schema: bool = null;
   infer_schema: bool = null;
-  ignore_leading_white_space: bool = null;
-  ignore_trailing_white_space: bool = null;
   null_value: string;
-  empty_value: string;
-  nan_value: string;
-  positive_inf: string;
-  negative_inf: string;
   date_format: string;
-  timestamp_format: string;
-  multi_line: bool = null;
-}
-
-table ReadStepJsonLines {
-  schema: [string];
-  date_format: string;
-  encoding: string;
-  multi_line: bool = null;
-  primitives_as_string: bool = null;
   timestamp_format: string;
 }
 
@@ -136,7 +119,6 @@ table ReadStepNdGeoJson {
 
 union ReadStep {
   ReadStepCsv,
-  ReadStepJsonLines,
   ReadStepGeoJson,
   ReadStepEsriShapefile,
   ReadStepParquet,
@@ -245,16 +227,6 @@ union Attachments {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// BlockInterval
-// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#blockinterval-schema
-////////////////////////////////////////////////////////////////////////////////
-
-table BlockInterval {
-  start: [ubyte];
-  end: [ubyte];
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // DatasetKind
 // https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#datasetkind-schema
 ////////////////////////////////////////////////////////////////////////////////
@@ -265,14 +237,16 @@ enum DatasetKind: int32 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// InputSlice
-// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#inputslice-schema
+// ExecuteQueryInput
+// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#executequeryinput-schema
 ////////////////////////////////////////////////////////////////////////////////
 
-table InputSlice {
+table ExecuteQueryInput {
   dataset_id: [ubyte];
-  block_interval: BlockInterval;
-  data_interval: OffsetInterval;
+  prev_block_hash: [ubyte];
+  new_block_hash: [ubyte];
+  prev_offset: uint64 = null;
+  new_offset: uint64 = null;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -281,11 +255,12 @@ table InputSlice {
 ////////////////////////////////////////////////////////////////////////////////
 
 table ExecuteQuery {
-  input_slices: [InputSlice];
-  input_checkpoint: [ubyte];
-  output_data: DataSlice;
-  output_checkpoint: Checkpoint;
-  output_watermark: Timestamp;
+  query_inputs: [ExecuteQueryInput];
+  prev_checkpoint: [ubyte];
+  prev_offset: uint64 = null;
+  new_data: DataSlice;
+  new_checkpoint: Checkpoint;
+  new_watermark: Timestamp;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -434,9 +409,8 @@ table SetPollingSource {
 ////////////////////////////////////////////////////////////////////////////////
 
 table TransformInput {
-  id: [ubyte];
-  name: string;
   dataset_ref: string;
+  alias: string;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -570,15 +544,16 @@ table Watermark {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// ExecuteQueryInput
-// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#executequeryinput-schema
+// ExecuteQueryRequestInput
+// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#executequeryrequestinput-schema
 ////////////////////////////////////////////////////////////////////////////////
 
-table ExecuteQueryInput {
+table ExecuteQueryRequestInput {
   dataset_id: [ubyte];
-  dataset_name: string;
+  dataset_alias: string;
+  query_alias: string;
   vocab: DatasetVocabulary;
-  data_interval: OffsetInterval;
+  offset_interval: OffsetInterval;
   data_paths: [string];
   schema_file: string;
   explicit_watermarks: [Watermark];
@@ -591,15 +566,15 @@ table ExecuteQueryInput {
 
 table ExecuteQueryRequest {
   dataset_id: [ubyte];
-  dataset_name: string;
+  dataset_alias: string;
   system_time: Timestamp;
-  offset: int64;
   vocab: DatasetVocabulary;
   transform: Transform;
-  inputs: [ExecuteQueryInput];
+  query_inputs: [ExecuteQueryRequestInput];
+  next_offset: uint64;
   prev_checkpoint_path: string;
   new_checkpoint_path: string;
-  out_data_path: string;
+  new_data_path: string;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -611,8 +586,8 @@ table ExecuteQueryResponseProgress {
 }
 
 table ExecuteQueryResponseSuccess {
-  data_interval: OffsetInterval;
-  output_watermark: Timestamp;
+  offset_interval: OffsetInterval;
+  new_watermark: Timestamp;
 }
 
 table ExecuteQueryResponseInvalidQuery {
@@ -654,7 +629,7 @@ table Manifest {
 table MetadataBlock {
   system_time: Timestamp;
   prev_block_hash: [ubyte];
-  sequence_number: int32;
+  sequence_number: uint64;
   event: MetadataEvent;
 }
 

--- a/src/domain/opendatafabric/src/dtos/constants.rs
+++ b/src/domain/opendatafabric/src/dtos/constants.rs
@@ -25,5 +25,4 @@ impl MergeStrategySnapshot {
 impl SourceState {
     pub const KIND_ETAG: &'static str = "odf/etag";
     pub const KIND_LAST_MODIFIED: &'static str = "odf/last-modified";
-    pub const SOURCE_POLLING: &'static str = "odf/polling";
 }

--- a/src/domain/opendatafabric/src/dtos/dtos_extra.rs
+++ b/src/domain/opendatafabric/src/dtos/dtos_extra.rs
@@ -13,6 +13,54 @@ use std::fmt::Display;
 use crate::*;
 
 ////////////////////////////////////////////////////////////////////////////////
+// AddData
+////////////////////////////////////////////////////////////////////////////////
+
+impl AddData {
+    /// Helper for determining the last record offset in the dataset
+    pub fn last_offset(&self) -> Option<u64> {
+        self.new_data
+            .as_ref()
+            .map(|d| d.offset_interval.end)
+            .or(self.prev_offset)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ExecuteQuery
+////////////////////////////////////////////////////////////////////////////////
+
+impl ExecuteQuery {
+    /// Helper for determining the last record offset in the dataset
+    pub fn last_offset(&self) -> Option<u64> {
+        self.new_data
+            .as_ref()
+            .map(|d| d.offset_interval.end)
+            .or(self.prev_offset)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ExecuteQueryInput
+////////////////////////////////////////////////////////////////////////////////
+
+impl ExecuteQueryInput {
+    /// Helper for determining the input's last block hash included in the
+    /// transaction
+    pub fn last_block_hash(&self) -> Option<&Multihash> {
+        self.new_block_hash
+            .as_ref()
+            .or(self.prev_block_hash.as_ref())
+    }
+
+    /// Helper for determining the input's last record offset included in the
+    /// transaction
+    pub fn last_offset(&self) -> Option<u64> {
+        self.new_offset.or(self.prev_offset)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // DatasetVocabulary
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -194,7 +242,6 @@ impl ReadStep {
         match self {
             ReadStep::Csv(v) => v.schema.as_ref(),
             ReadStep::Json(v) => v.schema.as_ref(),
-            ReadStep::JsonLines(v) => v.schema.as_ref(),
             ReadStep::NdJson(v) => v.schema.as_ref(),
             ReadStep::GeoJson(v) => v.schema.as_ref(),
             ReadStep::NdGeoJson(v) => v.schema.as_ref(),
@@ -216,36 +263,10 @@ impl Default for ReadStepCsv {
             encoding: None,
             quote: None,
             escape: None,
-            comment: None,
             header: None,
-            enforce_schema: None,
             infer_schema: None,
-            ignore_leading_white_space: None,
-            ignore_trailing_white_space: None,
             null_value: None,
-            empty_value: None,
-            nan_value: None,
-            positive_inf: None,
-            negative_inf: None,
             date_format: None,
-            timestamp_format: None,
-            multi_line: None,
-        }
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// ReadStepJsonLines
-////////////////////////////////////////////////////////////////////////////////
-
-impl Default for ReadStepJsonLines {
-    fn default() -> Self {
-        Self {
-            schema: None,
-            date_format: None,
-            encoding: None,
-            multi_line: None,
-            primitives_as_string: None,
             timestamp_format: None,
         }
     }

--- a/src/domain/opendatafabric/src/dtos/dtos_extra.rs
+++ b/src/domain/opendatafabric/src/dtos/dtos_extra.rs
@@ -58,6 +58,20 @@ impl ExecuteQueryInput {
     pub fn last_offset(&self) -> Option<u64> {
         self.new_offset.or(self.prev_offset)
     }
+
+    /// Helper for determining the number of records included in the transaction
+    /// from this input
+    pub fn num_records(&self) -> u64 {
+        if let Some(new_offset) = self.new_offset {
+            if let Some(prev_offset) = self.prev_offset {
+                new_offset - prev_offset
+            } else {
+                new_offset + 1
+            }
+        } else {
+            0
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/opendatafabric/src/dtos/dtos_generated.rs
+++ b/src/domain/opendatafabric/src/dtos/dtos_generated.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use enum_variants::*;
 
 use crate::formats::Multihash;
-use crate::identity::{DatasetAlias, DatasetID, DatasetName, DatasetRefAny};
+use crate::identity::*;
 
 ////////////////////////////////////////////////////////////////////////////////
 // AddData
@@ -160,7 +160,7 @@ pub enum DatasetKind {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DatasetSnapshot {
     /// Alias of the dataset.
-    pub name: DatasetName,
+    pub name: DatasetAlias,
     /// Type of the dataset.
     pub kind: DatasetKind,
     /// An array of metadata events that will be used to populate the chain.
@@ -406,7 +406,7 @@ impl_enum_variant!(ExecuteQueryResponse::Progress(ExecuteQueryResponseProgress))
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ExecuteQueryResponseSuccess {
     /// Data slice produced by the transaction, if any.
-    pub offset_interval: Option<OffsetInterval>,
+    pub new_offset_interval: Option<OffsetInterval>,
     /// Watermark advanced by the transaction, if any.
     pub new_watermark: Option<DateTime<Utc>>,
 }
@@ -1024,7 +1024,7 @@ pub struct SetVocab {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SetWatermark {
     /// Last watermark of the output data stream.
-    pub output_watermark: DateTime<Utc>,
+    pub new_watermark: DateTime<Utc>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1140,7 +1140,7 @@ pub struct TransformInput {
     /// A local or remote dataset reference. When block is accepted this MUST be
     /// in the form of a DatasetId to guarantee reproducibility, as aliases can
     /// change over time.
-    pub dataset_ref: DatasetRefAny,
+    pub dataset_ref: DatasetRef,
     /// An alias under which this input will be available in queries. Will be
     /// populated from `datasetRef` if not provided before resolving it to
     /// DatasetId.

--- a/src/domain/opendatafabric/src/metadata/metadata_block_types.rs
+++ b/src/domain/opendatafabric/src/metadata/metadata_block_types.rs
@@ -161,7 +161,7 @@ impl IntoDataStreamEvent for MetadataEvent {
                 e.new_checkpoint,
                 e.new_watermark,
             ),
-            MetadataEvent::SetWatermark(e) => (None, None, None, None, Some(e.output_watermark)),
+            MetadataEvent::SetWatermark(e) => (None, None, None, None, Some(e.new_watermark)),
             MetadataEvent::Seed(_)
             | MetadataEvent::SetAttachments(_)
             | MetadataEvent::SetInfo(_)
@@ -199,7 +199,7 @@ impl IntoDataStreamEvent for MetadataEvent {
                 e.new_checkpoint.as_ref(),
                 e.new_watermark.as_ref(),
             ),
-            MetadataEvent::SetWatermark(e) => (None, None, None, None, Some(&e.output_watermark)),
+            MetadataEvent::SetWatermark(e) => (None, None, None, None, Some(&e.new_watermark)),
             MetadataEvent::Seed(_)
             | MetadataEvent::SetAttachments(_)
             | MetadataEvent::SetInfo(_)

--- a/src/domain/opendatafabric/src/serde/flatbuffers/convertors_generated.rs
+++ b/src/domain/opendatafabric/src/serde/flatbuffers/convertors_generated.rs
@@ -883,9 +883,9 @@ impl<'fb> FlatbuffersSerializable<'fb> for odf::ExecuteQueryResponseSuccess {
     type OffsetT = WIPOffset<fb::ExecuteQueryResponseSuccess<'fb>>;
 
     fn serialize(&self, fb: &mut FlatBufferBuilder<'fb>) -> Self::OffsetT {
-        let offset_interval_offset = self.offset_interval.as_ref().map(|v| v.serialize(fb));
+        let new_offset_interval_offset = self.new_offset_interval.as_ref().map(|v| v.serialize(fb));
         let mut builder = fb::ExecuteQueryResponseSuccessBuilder::new(fb);
-        offset_interval_offset.map(|off| builder.add_offset_interval(off));
+        new_offset_interval_offset.map(|off| builder.add_new_offset_interval(off));
         self.new_watermark
             .map(|v| builder.add_new_watermark(&datetime_to_fb(&v)));
         builder.finish()
@@ -897,8 +897,8 @@ impl<'fb> FlatbuffersDeserializable<fb::ExecuteQueryResponseSuccess<'fb>>
 {
     fn deserialize(proxy: fb::ExecuteQueryResponseSuccess<'fb>) -> Self {
         odf::ExecuteQueryResponseSuccess {
-            offset_interval: proxy
-                .offset_interval()
+            new_offset_interval: proxy
+                .new_offset_interval()
                 .map(|v| odf::OffsetInterval::deserialize(v)),
             new_watermark: proxy.new_watermark().map(|v| fb_to_datetime(v)),
         }
@@ -2232,7 +2232,7 @@ impl<'fb> FlatbuffersSerializable<'fb> for odf::SetWatermark {
 
     fn serialize(&self, fb: &mut FlatBufferBuilder<'fb>) -> Self::OffsetT {
         let mut builder = fb::SetWatermarkBuilder::new(fb);
-        builder.add_output_watermark(&datetime_to_fb(&self.output_watermark));
+        builder.add_new_watermark(&datetime_to_fb(&self.new_watermark));
         builder.finish()
     }
 }
@@ -2240,7 +2240,7 @@ impl<'fb> FlatbuffersSerializable<'fb> for odf::SetWatermark {
 impl<'fb> FlatbuffersDeserializable<fb::SetWatermark<'fb>> for odf::SetWatermark {
     fn deserialize(proxy: fb::SetWatermark<'fb>) -> Self {
         odf::SetWatermark {
-            output_watermark: proxy.output_watermark().map(|v| fb_to_datetime(v)).unwrap(),
+            new_watermark: proxy.new_watermark().map(|v| fb_to_datetime(v)).unwrap(),
         }
     }
 }
@@ -2486,7 +2486,7 @@ impl<'fb> FlatbuffersDeserializable<fb::TransformInput<'fb>> for odf::TransformI
         odf::TransformInput {
             dataset_ref: proxy
                 .dataset_ref()
-                .map(|v| odf::DatasetRefAny::try_from(v).unwrap())
+                .map(|v| odf::DatasetRef::try_from(v).unwrap())
                 .unwrap(),
             alias: proxy.alias().map(|v| v.to_owned()),
         }

--- a/src/domain/opendatafabric/src/serde/flatbuffers/proxies_generated.rs
+++ b/src/domain/opendatafabric/src/serde/flatbuffers/proxies_generated.rs
@@ -9410,7 +9410,7 @@ impl<'a> flatbuffers::Follow<'a> for SetWatermark<'a> {
 }
 
 impl<'a> SetWatermark<'a> {
-    pub const VT_OUTPUT_WATERMARK: flatbuffers::VOffsetT = 4;
+    pub const VT_NEW_WATERMARK: flatbuffers::VOffsetT = 4;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -9422,20 +9422,20 @@ impl<'a> SetWatermark<'a> {
         args: &'args SetWatermarkArgs<'args>,
     ) -> flatbuffers::WIPOffset<SetWatermark<'bldr>> {
         let mut builder = SetWatermarkBuilder::new(_fbb);
-        if let Some(x) = args.output_watermark {
-            builder.add_output_watermark(x);
+        if let Some(x) = args.new_watermark {
+            builder.add_new_watermark(x);
         }
         builder.finish()
     }
 
     #[inline]
-    pub fn output_watermark(&self) -> Option<&'a Timestamp> {
+    pub fn new_watermark(&self) -> Option<&'a Timestamp> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<Timestamp>(SetWatermark::VT_OUTPUT_WATERMARK, None)
+                .get::<Timestamp>(SetWatermark::VT_NEW_WATERMARK, None)
         }
     }
 }
@@ -9448,19 +9448,19 @@ impl flatbuffers::Verifiable for SetWatermark<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<Timestamp>("output_watermark", Self::VT_OUTPUT_WATERMARK, false)?
+            .visit_field::<Timestamp>("new_watermark", Self::VT_NEW_WATERMARK, false)?
             .finish();
         Ok(())
     }
 }
 pub struct SetWatermarkArgs<'a> {
-    pub output_watermark: Option<&'a Timestamp>,
+    pub new_watermark: Option<&'a Timestamp>,
 }
 impl<'a> Default for SetWatermarkArgs<'a> {
     #[inline]
     fn default() -> Self {
         SetWatermarkArgs {
-            output_watermark: None,
+            new_watermark: None,
         }
     }
 }
@@ -9471,9 +9471,9 @@ pub struct SetWatermarkBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> SetWatermarkBuilder<'a, 'b> {
     #[inline]
-    pub fn add_output_watermark(&mut self, output_watermark: &Timestamp) {
+    pub fn add_new_watermark(&mut self, new_watermark: &Timestamp) {
         self.fbb_
-            .push_slot_always::<&Timestamp>(SetWatermark::VT_OUTPUT_WATERMARK, output_watermark);
+            .push_slot_always::<&Timestamp>(SetWatermark::VT_NEW_WATERMARK, new_watermark);
     }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> SetWatermarkBuilder<'a, 'b> {
@@ -9493,7 +9493,7 @@ impl<'a: 'b, 'b> SetWatermarkBuilder<'a, 'b> {
 impl core::fmt::Debug for SetWatermark<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("SetWatermark");
-        ds.field("output_watermark", &self.output_watermark());
+        ds.field("new_watermark", &self.new_watermark());
         ds.finish()
     }
 }
@@ -11535,7 +11535,7 @@ impl<'a> flatbuffers::Follow<'a> for ExecuteQueryResponseSuccess<'a> {
 }
 
 impl<'a> ExecuteQueryResponseSuccess<'a> {
-    pub const VT_OFFSET_INTERVAL: flatbuffers::VOffsetT = 4;
+    pub const VT_NEW_OFFSET_INTERVAL: flatbuffers::VOffsetT = 4;
     pub const VT_NEW_WATERMARK: flatbuffers::VOffsetT = 6;
 
     #[inline]
@@ -11551,21 +11551,21 @@ impl<'a> ExecuteQueryResponseSuccess<'a> {
         if let Some(x) = args.new_watermark {
             builder.add_new_watermark(x);
         }
-        if let Some(x) = args.offset_interval {
-            builder.add_offset_interval(x);
+        if let Some(x) = args.new_offset_interval {
+            builder.add_new_offset_interval(x);
         }
         builder.finish()
     }
 
     #[inline]
-    pub fn offset_interval(&self) -> Option<OffsetInterval<'a>> {
+    pub fn new_offset_interval(&self) -> Option<OffsetInterval<'a>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                    ExecuteQueryResponseSuccess::VT_OFFSET_INTERVAL,
+                    ExecuteQueryResponseSuccess::VT_NEW_OFFSET_INTERVAL,
                     None,
                 )
         }
@@ -11591,8 +11591,8 @@ impl flatbuffers::Verifiable for ExecuteQueryResponseSuccess<'_> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
             .visit_field::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                "offset_interval",
-                Self::VT_OFFSET_INTERVAL,
+                "new_offset_interval",
+                Self::VT_NEW_OFFSET_INTERVAL,
                 false,
             )?
             .visit_field::<Timestamp>("new_watermark", Self::VT_NEW_WATERMARK, false)?
@@ -11601,14 +11601,14 @@ impl flatbuffers::Verifiable for ExecuteQueryResponseSuccess<'_> {
     }
 }
 pub struct ExecuteQueryResponseSuccessArgs<'a> {
-    pub offset_interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
+    pub new_offset_interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
     pub new_watermark: Option<&'a Timestamp>,
 }
 impl<'a> Default for ExecuteQueryResponseSuccessArgs<'a> {
     #[inline]
     fn default() -> Self {
         ExecuteQueryResponseSuccessArgs {
-            offset_interval: None,
+            new_offset_interval: None,
             new_watermark: None,
         }
     }
@@ -11620,14 +11620,14 @@ pub struct ExecuteQueryResponseSuccessBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> ExecuteQueryResponseSuccessBuilder<'a, 'b> {
     #[inline]
-    pub fn add_offset_interval(
+    pub fn add_new_offset_interval(
         &mut self,
-        offset_interval: flatbuffers::WIPOffset<OffsetInterval<'b>>,
+        new_offset_interval: flatbuffers::WIPOffset<OffsetInterval<'b>>,
     ) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<OffsetInterval>>(
-                ExecuteQueryResponseSuccess::VT_OFFSET_INTERVAL,
-                offset_interval,
+                ExecuteQueryResponseSuccess::VT_NEW_OFFSET_INTERVAL,
+                new_offset_interval,
             );
     }
     #[inline]
@@ -11657,7 +11657,7 @@ impl<'a: 'b, 'b> ExecuteQueryResponseSuccessBuilder<'a, 'b> {
 impl core::fmt::Debug for ExecuteQueryResponseSuccess<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("ExecuteQueryResponseSuccess");
-        ds.field("offset_interval", &self.offset_interval());
+        ds.field("new_offset_interval", &self.new_offset_interval());
         ds.field("new_watermark", &self.new_watermark());
         ds.finish()
     }

--- a/src/domain/opendatafabric/src/serde/flatbuffers/proxies_generated.rs
+++ b/src/domain/opendatafabric/src/serde/flatbuffers/proxies_generated.rs
@@ -26,16 +26,15 @@ pub const ENUM_MIN_READ_STEP: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_READ_STEP: u8 = 8;
+pub const ENUM_MAX_READ_STEP: u8 = 7;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_READ_STEP: [ReadStep; 9] = [
+pub const ENUM_VALUES_READ_STEP: [ReadStep; 8] = [
     ReadStep::NONE,
     ReadStep::ReadStepCsv,
-    ReadStep::ReadStepJsonLines,
     ReadStep::ReadStepGeoJson,
     ReadStep::ReadStepEsriShapefile,
     ReadStep::ReadStepParquet,
@@ -51,20 +50,18 @@ pub struct ReadStep(pub u8);
 impl ReadStep {
     pub const NONE: Self = Self(0);
     pub const ReadStepCsv: Self = Self(1);
-    pub const ReadStepJsonLines: Self = Self(2);
-    pub const ReadStepGeoJson: Self = Self(3);
-    pub const ReadStepEsriShapefile: Self = Self(4);
-    pub const ReadStepParquet: Self = Self(5);
-    pub const ReadStepJson: Self = Self(6);
-    pub const ReadStepNdJson: Self = Self(7);
-    pub const ReadStepNdGeoJson: Self = Self(8);
+    pub const ReadStepGeoJson: Self = Self(2);
+    pub const ReadStepEsriShapefile: Self = Self(3);
+    pub const ReadStepParquet: Self = Self(4);
+    pub const ReadStepJson: Self = Self(5);
+    pub const ReadStepNdJson: Self = Self(6);
+    pub const ReadStepNdGeoJson: Self = Self(7);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 8;
+    pub const ENUM_MAX: u8 = 7;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ReadStepCsv,
-        Self::ReadStepJsonLines,
         Self::ReadStepGeoJson,
         Self::ReadStepEsriShapefile,
         Self::ReadStepParquet,
@@ -77,7 +74,6 @@ impl ReadStep {
         match self {
             Self::NONE => Some("NONE"),
             Self::ReadStepCsv => Some("ReadStepCsv"),
-            Self::ReadStepJsonLines => Some("ReadStepJsonLines"),
             Self::ReadStepGeoJson => Some("ReadStepGeoJson"),
             Self::ReadStepEsriShapefile => Some("ReadStepEsriShapefile"),
             Self::ReadStepParquet => Some("ReadStepParquet"),
@@ -1583,24 +1579,24 @@ impl<'a> OffsetInterval<'a> {
     }
 
     #[inline]
-    pub fn start(&self) -> i64 {
+    pub fn start(&self) -> u64 {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<i64>(OffsetInterval::VT_START, Some(0))
+                .get::<u64>(OffsetInterval::VT_START, Some(0))
                 .unwrap()
         }
     }
     #[inline]
-    pub fn end(&self) -> i64 {
+    pub fn end(&self) -> u64 {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<i64>(OffsetInterval::VT_END, Some(0))
+                .get::<u64>(OffsetInterval::VT_END, Some(0))
                 .unwrap()
         }
     }
@@ -1614,15 +1610,15 @@ impl flatbuffers::Verifiable for OffsetInterval<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<i64>("start", Self::VT_START, false)?
-            .visit_field::<i64>("end", Self::VT_END, false)?
+            .visit_field::<u64>("start", Self::VT_START, false)?
+            .visit_field::<u64>("end", Self::VT_END, false)?
             .finish();
         Ok(())
     }
 }
 pub struct OffsetIntervalArgs {
-    pub start: i64,
-    pub end: i64,
+    pub start: u64,
+    pub end: u64,
 }
 impl<'a> Default for OffsetIntervalArgs {
     #[inline]
@@ -1637,13 +1633,13 @@ pub struct OffsetIntervalBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> OffsetIntervalBuilder<'a, 'b> {
     #[inline]
-    pub fn add_start(&mut self, start: i64) {
+    pub fn add_start(&mut self, start: u64) {
         self.fbb_
-            .push_slot::<i64>(OffsetInterval::VT_START, start, 0);
+            .push_slot::<u64>(OffsetInterval::VT_START, start, 0);
     }
     #[inline]
-    pub fn add_end(&mut self, end: i64) {
-        self.fbb_.push_slot::<i64>(OffsetInterval::VT_END, end, 0);
+    pub fn add_end(&mut self, end: u64) {
+        self.fbb_.push_slot::<u64>(OffsetInterval::VT_END, end, 0);
     }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> OffsetIntervalBuilder<'a, 'b> {
@@ -1689,7 +1685,7 @@ impl<'a> flatbuffers::Follow<'a> for DataSlice<'a> {
 impl<'a> DataSlice<'a> {
     pub const VT_LOGICAL_HASH: flatbuffers::VOffsetT = 4;
     pub const VT_PHYSICAL_HASH: flatbuffers::VOffsetT = 6;
-    pub const VT_INTERVAL: flatbuffers::VOffsetT = 8;
+    pub const VT_OFFSET_INTERVAL: flatbuffers::VOffsetT = 8;
     pub const VT_SIZE_: flatbuffers::VOffsetT = 10;
 
     #[inline]
@@ -1703,8 +1699,8 @@ impl<'a> DataSlice<'a> {
     ) -> flatbuffers::WIPOffset<DataSlice<'bldr>> {
         let mut builder = DataSliceBuilder::new(_fbb);
         builder.add_size_(args.size_);
-        if let Some(x) = args.interval {
-            builder.add_interval(x);
+        if let Some(x) = args.offset_interval {
+            builder.add_offset_interval(x);
         }
         if let Some(x) = args.physical_hash {
             builder.add_physical_hash(x);
@@ -1742,21 +1738,24 @@ impl<'a> DataSlice<'a> {
         }
     }
     #[inline]
-    pub fn interval(&self) -> Option<OffsetInterval<'a>> {
+    pub fn offset_interval(&self) -> Option<OffsetInterval<'a>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<OffsetInterval>>(DataSlice::VT_INTERVAL, None)
+                .get::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
+                    DataSlice::VT_OFFSET_INTERVAL,
+                    None,
+                )
         }
     }
     #[inline]
-    pub fn size_(&self) -> i64 {
+    pub fn size_(&self) -> u64 {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
-        unsafe { self._tab.get::<i64>(DataSlice::VT_SIZE_, Some(0)).unwrap() }
+        unsafe { self._tab.get::<u64>(DataSlice::VT_SIZE_, Some(0)).unwrap() }
     }
 }
 
@@ -1779,11 +1778,11 @@ impl flatbuffers::Verifiable for DataSlice<'_> {
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                "interval",
-                Self::VT_INTERVAL,
+                "offset_interval",
+                Self::VT_OFFSET_INTERVAL,
                 false,
             )?
-            .visit_field::<i64>("size_", Self::VT_SIZE_, false)?
+            .visit_field::<u64>("size_", Self::VT_SIZE_, false)?
             .finish();
         Ok(())
     }
@@ -1791,8 +1790,8 @@ impl flatbuffers::Verifiable for DataSlice<'_> {
 pub struct DataSliceArgs<'a> {
     pub logical_hash: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
     pub physical_hash: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
-    pub size_: i64,
+    pub offset_interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
+    pub size_: u64,
 }
 impl<'a> Default for DataSliceArgs<'a> {
     #[inline]
@@ -1800,7 +1799,7 @@ impl<'a> Default for DataSliceArgs<'a> {
         DataSliceArgs {
             logical_hash: None,
             physical_hash: None,
-            interval: None,
+            offset_interval: None,
             size_: 0,
         }
     }
@@ -1832,16 +1831,19 @@ impl<'a: 'b, 'b> DataSliceBuilder<'a, 'b> {
         );
     }
     #[inline]
-    pub fn add_interval(&mut self, interval: flatbuffers::WIPOffset<OffsetInterval<'b>>) {
+    pub fn add_offset_interval(
+        &mut self,
+        offset_interval: flatbuffers::WIPOffset<OffsetInterval<'b>>,
+    ) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<OffsetInterval>>(
-                DataSlice::VT_INTERVAL,
-                interval,
+                DataSlice::VT_OFFSET_INTERVAL,
+                offset_interval,
             );
     }
     #[inline]
-    pub fn add_size_(&mut self, size_: i64) {
-        self.fbb_.push_slot::<i64>(DataSlice::VT_SIZE_, size_, 0);
+    pub fn add_size_(&mut self, size_: u64) {
+        self.fbb_.push_slot::<u64>(DataSlice::VT_SIZE_, size_, 0);
     }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> DataSliceBuilder<'a, 'b> {
@@ -1863,7 +1865,7 @@ impl core::fmt::Debug for DataSlice<'_> {
         let mut ds = f.debug_struct("DataSlice");
         ds.field("logical_hash", &self.logical_hash());
         ds.field("physical_hash", &self.physical_hash());
-        ds.field("interval", &self.interval());
+        ds.field("offset_interval", &self.offset_interval());
         ds.field("size_", &self.size_());
         ds.finish()
     }
@@ -1921,11 +1923,11 @@ impl<'a> Checkpoint<'a> {
         }
     }
     #[inline]
-    pub fn size_(&self) -> i64 {
+    pub fn size_(&self) -> u64 {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
-        unsafe { self._tab.get::<i64>(Checkpoint::VT_SIZE_, Some(0)).unwrap() }
+        unsafe { self._tab.get::<u64>(Checkpoint::VT_SIZE_, Some(0)).unwrap() }
     }
 }
 
@@ -1942,14 +1944,14 @@ impl flatbuffers::Verifiable for Checkpoint<'_> {
                 Self::VT_PHYSICAL_HASH,
                 false,
             )?
-            .visit_field::<i64>("size_", Self::VT_SIZE_, false)?
+            .visit_field::<u64>("size_", Self::VT_SIZE_, false)?
             .finish();
         Ok(())
     }
 }
 pub struct CheckpointArgs<'a> {
     pub physical_hash: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub size_: i64,
+    pub size_: u64,
 }
 impl<'a> Default for CheckpointArgs<'a> {
     #[inline]
@@ -1977,8 +1979,8 @@ impl<'a: 'b, 'b> CheckpointBuilder<'a, 'b> {
         );
     }
     #[inline]
-    pub fn add_size_(&mut self, size_: i64) {
-        self.fbb_.push_slot::<i64>(Checkpoint::VT_SIZE_, size_, 0);
+    pub fn add_size_(&mut self, size_: u64) {
+        self.fbb_.push_slot::<u64>(Checkpoint::VT_SIZE_, size_, 0);
     }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> CheckpointBuilder<'a, 'b> {
@@ -2022,8 +2024,8 @@ impl<'a> flatbuffers::Follow<'a> for SourceState<'a> {
 }
 
 impl<'a> SourceState<'a> {
-    pub const VT_KIND: flatbuffers::VOffsetT = 4;
-    pub const VT_SOURCE: flatbuffers::VOffsetT = 6;
+    pub const VT_SOURCE_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_KIND: flatbuffers::VOffsetT = 6;
     pub const VT_VALUE: flatbuffers::VOffsetT = 8;
 
     #[inline]
@@ -2039,15 +2041,25 @@ impl<'a> SourceState<'a> {
         if let Some(x) = args.value {
             builder.add_value(x);
         }
-        if let Some(x) = args.source {
-            builder.add_source(x);
-        }
         if let Some(x) = args.kind {
             builder.add_kind(x);
+        }
+        if let Some(x) = args.source_name {
+            builder.add_source_name(x);
         }
         builder.finish()
     }
 
+    #[inline]
+    pub fn source_name(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(SourceState::VT_SOURCE_NAME, None)
+        }
+    }
     #[inline]
     pub fn kind(&self) -> Option<&'a str> {
         // Safety:
@@ -2056,16 +2068,6 @@ impl<'a> SourceState<'a> {
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<&str>>(SourceState::VT_KIND, None)
-        }
-    }
-    #[inline]
-    pub fn source(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(SourceState::VT_SOURCE, None)
         }
     }
     #[inline]
@@ -2088,24 +2090,28 @@ impl flatbuffers::Verifiable for SourceState<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "source_name",
+                Self::VT_SOURCE_NAME,
+                false,
+            )?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>("kind", Self::VT_KIND, false)?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("source", Self::VT_SOURCE, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>("value", Self::VT_VALUE, false)?
             .finish();
         Ok(())
     }
 }
 pub struct SourceStateArgs<'a> {
+    pub source_name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub kind: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub source: Option<flatbuffers::WIPOffset<&'a str>>,
     pub value: Option<flatbuffers::WIPOffset<&'a str>>,
 }
 impl<'a> Default for SourceStateArgs<'a> {
     #[inline]
     fn default() -> Self {
         SourceStateArgs {
+            source_name: None,
             kind: None,
-            source: None,
             value: None,
         }
     }
@@ -2117,14 +2123,16 @@ pub struct SourceStateBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> SourceStateBuilder<'a, 'b> {
     #[inline]
+    pub fn add_source_name(&mut self, source_name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            SourceState::VT_SOURCE_NAME,
+            source_name,
+        );
+    }
+    #[inline]
     pub fn add_kind(&mut self, kind: flatbuffers::WIPOffset<&'b str>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<_>>(SourceState::VT_KIND, kind);
-    }
-    #[inline]
-    pub fn add_source(&mut self, source: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(SourceState::VT_SOURCE, source);
     }
     #[inline]
     pub fn add_value(&mut self, value: flatbuffers::WIPOffset<&'b str>) {
@@ -2149,8 +2157,8 @@ impl<'a: 'b, 'b> SourceStateBuilder<'a, 'b> {
 impl core::fmt::Debug for SourceState<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("SourceState");
+        ds.field("source_name", &self.source_name());
         ds.field("kind", &self.kind());
-        ds.field("source", &self.source());
         ds.field("value", &self.value());
         ds.finish()
     }
@@ -2174,11 +2182,12 @@ impl<'a> flatbuffers::Follow<'a> for AddData<'a> {
 }
 
 impl<'a> AddData<'a> {
-    pub const VT_INPUT_CHECKPOINT: flatbuffers::VOffsetT = 4;
-    pub const VT_OUTPUT_DATA: flatbuffers::VOffsetT = 6;
-    pub const VT_OUTPUT_CHECKPOINT: flatbuffers::VOffsetT = 8;
-    pub const VT_OUTPUT_WATERMARK: flatbuffers::VOffsetT = 10;
-    pub const VT_SOURCE_STATE: flatbuffers::VOffsetT = 12;
+    pub const VT_PREV_CHECKPOINT: flatbuffers::VOffsetT = 4;
+    pub const VT_PREV_OFFSET: flatbuffers::VOffsetT = 6;
+    pub const VT_NEW_DATA: flatbuffers::VOffsetT = 8;
+    pub const VT_NEW_CHECKPOINT: flatbuffers::VOffsetT = 10;
+    pub const VT_NEW_WATERMARK: flatbuffers::VOffsetT = 12;
+    pub const VT_NEW_SOURCE_STATE: flatbuffers::VOffsetT = 14;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -2190,77 +2199,84 @@ impl<'a> AddData<'a> {
         args: &'args AddDataArgs<'args>,
     ) -> flatbuffers::WIPOffset<AddData<'bldr>> {
         let mut builder = AddDataBuilder::new(_fbb);
-        if let Some(x) = args.source_state {
-            builder.add_source_state(x);
+        if let Some(x) = args.prev_offset {
+            builder.add_prev_offset(x);
         }
-        if let Some(x) = args.output_watermark {
-            builder.add_output_watermark(x);
+        if let Some(x) = args.new_source_state {
+            builder.add_new_source_state(x);
         }
-        if let Some(x) = args.output_checkpoint {
-            builder.add_output_checkpoint(x);
+        if let Some(x) = args.new_watermark {
+            builder.add_new_watermark(x);
         }
-        if let Some(x) = args.output_data {
-            builder.add_output_data(x);
+        if let Some(x) = args.new_checkpoint {
+            builder.add_new_checkpoint(x);
         }
-        if let Some(x) = args.input_checkpoint {
-            builder.add_input_checkpoint(x);
+        if let Some(x) = args.new_data {
+            builder.add_new_data(x);
+        }
+        if let Some(x) = args.prev_checkpoint {
+            builder.add_prev_checkpoint(x);
         }
         builder.finish()
     }
 
     #[inline]
-    pub fn input_checkpoint(&self) -> Option<flatbuffers::Vector<'a, u8>> {
+    pub fn prev_checkpoint(&self) -> Option<flatbuffers::Vector<'a, u8>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    AddData::VT_INPUT_CHECKPOINT,
+                    AddData::VT_PREV_CHECKPOINT,
                     None,
                 )
         }
     }
     #[inline]
-    pub fn output_data(&self) -> Option<DataSlice<'a>> {
+    pub fn prev_offset(&self) -> Option<u64> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<u64>(AddData::VT_PREV_OFFSET, None) }
+    }
+    #[inline]
+    pub fn new_data(&self) -> Option<DataSlice<'a>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<DataSlice>>(AddData::VT_OUTPUT_DATA, None)
+                .get::<flatbuffers::ForwardsUOffset<DataSlice>>(AddData::VT_NEW_DATA, None)
         }
     }
     #[inline]
-    pub fn output_checkpoint(&self) -> Option<Checkpoint<'a>> {
+    pub fn new_checkpoint(&self) -> Option<Checkpoint<'a>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
-            self._tab.get::<flatbuffers::ForwardsUOffset<Checkpoint>>(
-                AddData::VT_OUTPUT_CHECKPOINT,
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<Checkpoint>>(AddData::VT_NEW_CHECKPOINT, None)
+        }
+    }
+    #[inline]
+    pub fn new_watermark(&self) -> Option<&'a Timestamp> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<Timestamp>(AddData::VT_NEW_WATERMARK, None) }
+    }
+    #[inline]
+    pub fn new_source_state(&self) -> Option<SourceState<'a>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab.get::<flatbuffers::ForwardsUOffset<SourceState>>(
+                AddData::VT_NEW_SOURCE_STATE,
                 None,
             )
-        }
-    }
-    #[inline]
-    pub fn output_watermark(&self) -> Option<&'a Timestamp> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<Timestamp>(AddData::VT_OUTPUT_WATERMARK, None)
-        }
-    }
-    #[inline]
-    pub fn source_state(&self) -> Option<SourceState<'a>> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<SourceState>>(AddData::VT_SOURCE_STATE, None)
         }
     }
 }
@@ -2274,24 +2290,25 @@ impl flatbuffers::Verifiable for AddData<'_> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
             .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                "input_checkpoint",
-                Self::VT_INPUT_CHECKPOINT,
+                "prev_checkpoint",
+                Self::VT_PREV_CHECKPOINT,
                 false,
             )?
+            .visit_field::<u64>("prev_offset", Self::VT_PREV_OFFSET, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<DataSlice>>(
-                "output_data",
-                Self::VT_OUTPUT_DATA,
+                "new_data",
+                Self::VT_NEW_DATA,
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<Checkpoint>>(
-                "output_checkpoint",
-                Self::VT_OUTPUT_CHECKPOINT,
+                "new_checkpoint",
+                Self::VT_NEW_CHECKPOINT,
                 false,
             )?
-            .visit_field::<Timestamp>("output_watermark", Self::VT_OUTPUT_WATERMARK, false)?
+            .visit_field::<Timestamp>("new_watermark", Self::VT_NEW_WATERMARK, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<SourceState>>(
-                "source_state",
-                Self::VT_SOURCE_STATE,
+                "new_source_state",
+                Self::VT_NEW_SOURCE_STATE,
                 false,
             )?
             .finish();
@@ -2299,21 +2316,23 @@ impl flatbuffers::Verifiable for AddData<'_> {
     }
 }
 pub struct AddDataArgs<'a> {
-    pub input_checkpoint: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub output_data: Option<flatbuffers::WIPOffset<DataSlice<'a>>>,
-    pub output_checkpoint: Option<flatbuffers::WIPOffset<Checkpoint<'a>>>,
-    pub output_watermark: Option<&'a Timestamp>,
-    pub source_state: Option<flatbuffers::WIPOffset<SourceState<'a>>>,
+    pub prev_checkpoint: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub prev_offset: Option<u64>,
+    pub new_data: Option<flatbuffers::WIPOffset<DataSlice<'a>>>,
+    pub new_checkpoint: Option<flatbuffers::WIPOffset<Checkpoint<'a>>>,
+    pub new_watermark: Option<&'a Timestamp>,
+    pub new_source_state: Option<flatbuffers::WIPOffset<SourceState<'a>>>,
 }
 impl<'a> Default for AddDataArgs<'a> {
     #[inline]
     fn default() -> Self {
         AddDataArgs {
-            input_checkpoint: None,
-            output_data: None,
-            output_checkpoint: None,
-            output_watermark: None,
-            source_state: None,
+            prev_checkpoint: None,
+            prev_offset: None,
+            new_data: None,
+            new_checkpoint: None,
+            new_watermark: None,
+            new_source_state: None,
         }
     }
 }
@@ -2324,45 +2343,47 @@ pub struct AddDataBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> AddDataBuilder<'a, 'b> {
     #[inline]
-    pub fn add_input_checkpoint(
+    pub fn add_prev_checkpoint(
         &mut self,
-        input_checkpoint: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
+        prev_checkpoint: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
     ) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            AddData::VT_INPUT_CHECKPOINT,
-            input_checkpoint,
+            AddData::VT_PREV_CHECKPOINT,
+            prev_checkpoint,
         );
     }
     #[inline]
-    pub fn add_output_data(&mut self, output_data: flatbuffers::WIPOffset<DataSlice<'b>>) {
+    pub fn add_prev_offset(&mut self, prev_offset: u64) {
         self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<DataSlice>>(
-                AddData::VT_OUTPUT_DATA,
-                output_data,
-            );
+            .push_slot_always::<u64>(AddData::VT_PREV_OFFSET, prev_offset);
     }
     #[inline]
-    pub fn add_output_checkpoint(
-        &mut self,
-        output_checkpoint: flatbuffers::WIPOffset<Checkpoint<'b>>,
-    ) {
+    pub fn add_new_data(&mut self, new_data: flatbuffers::WIPOffset<DataSlice<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<DataSlice>>(AddData::VT_NEW_DATA, new_data);
+    }
+    #[inline]
+    pub fn add_new_checkpoint(&mut self, new_checkpoint: flatbuffers::WIPOffset<Checkpoint<'b>>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<Checkpoint>>(
-                AddData::VT_OUTPUT_CHECKPOINT,
-                output_checkpoint,
+                AddData::VT_NEW_CHECKPOINT,
+                new_checkpoint,
             );
     }
     #[inline]
-    pub fn add_output_watermark(&mut self, output_watermark: &Timestamp) {
+    pub fn add_new_watermark(&mut self, new_watermark: &Timestamp) {
         self.fbb_
-            .push_slot_always::<&Timestamp>(AddData::VT_OUTPUT_WATERMARK, output_watermark);
+            .push_slot_always::<&Timestamp>(AddData::VT_NEW_WATERMARK, new_watermark);
     }
     #[inline]
-    pub fn add_source_state(&mut self, source_state: flatbuffers::WIPOffset<SourceState<'b>>) {
+    pub fn add_new_source_state(
+        &mut self,
+        new_source_state: flatbuffers::WIPOffset<SourceState<'b>>,
+    ) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<SourceState>>(
-                AddData::VT_SOURCE_STATE,
-                source_state,
+                AddData::VT_NEW_SOURCE_STATE,
+                new_source_state,
             );
     }
     #[inline]
@@ -2383,11 +2404,12 @@ impl<'a: 'b, 'b> AddDataBuilder<'a, 'b> {
 impl core::fmt::Debug for AddData<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("AddData");
-        ds.field("input_checkpoint", &self.input_checkpoint());
-        ds.field("output_data", &self.output_data());
-        ds.field("output_checkpoint", &self.output_checkpoint());
-        ds.field("output_watermark", &self.output_watermark());
-        ds.field("source_state", &self.source_state());
+        ds.field("prev_checkpoint", &self.prev_checkpoint());
+        ds.field("prev_offset", &self.prev_offset());
+        ds.field("new_data", &self.new_data());
+        ds.field("new_checkpoint", &self.new_checkpoint());
+        ds.field("new_watermark", &self.new_watermark());
+        ds.field("new_source_state", &self.new_source_state());
         ds.finish()
     }
 }
@@ -2415,20 +2437,11 @@ impl<'a> ReadStepCsv<'a> {
     pub const VT_ENCODING: flatbuffers::VOffsetT = 8;
     pub const VT_QUOTE: flatbuffers::VOffsetT = 10;
     pub const VT_ESCAPE: flatbuffers::VOffsetT = 12;
-    pub const VT_COMMENT: flatbuffers::VOffsetT = 14;
-    pub const VT_HEADER: flatbuffers::VOffsetT = 16;
-    pub const VT_ENFORCE_SCHEMA: flatbuffers::VOffsetT = 18;
-    pub const VT_INFER_SCHEMA: flatbuffers::VOffsetT = 20;
-    pub const VT_IGNORE_LEADING_WHITE_SPACE: flatbuffers::VOffsetT = 22;
-    pub const VT_IGNORE_TRAILING_WHITE_SPACE: flatbuffers::VOffsetT = 24;
-    pub const VT_NULL_VALUE: flatbuffers::VOffsetT = 26;
-    pub const VT_EMPTY_VALUE: flatbuffers::VOffsetT = 28;
-    pub const VT_NAN_VALUE: flatbuffers::VOffsetT = 30;
-    pub const VT_POSITIVE_INF: flatbuffers::VOffsetT = 32;
-    pub const VT_NEGATIVE_INF: flatbuffers::VOffsetT = 34;
-    pub const VT_DATE_FORMAT: flatbuffers::VOffsetT = 36;
-    pub const VT_TIMESTAMP_FORMAT: flatbuffers::VOffsetT = 38;
-    pub const VT_MULTI_LINE: flatbuffers::VOffsetT = 40;
+    pub const VT_HEADER: flatbuffers::VOffsetT = 14;
+    pub const VT_INFER_SCHEMA: flatbuffers::VOffsetT = 16;
+    pub const VT_NULL_VALUE: flatbuffers::VOffsetT = 18;
+    pub const VT_DATE_FORMAT: flatbuffers::VOffsetT = 20;
+    pub const VT_TIMESTAMP_FORMAT: flatbuffers::VOffsetT = 22;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -2446,23 +2459,8 @@ impl<'a> ReadStepCsv<'a> {
         if let Some(x) = args.date_format {
             builder.add_date_format(x);
         }
-        if let Some(x) = args.negative_inf {
-            builder.add_negative_inf(x);
-        }
-        if let Some(x) = args.positive_inf {
-            builder.add_positive_inf(x);
-        }
-        if let Some(x) = args.nan_value {
-            builder.add_nan_value(x);
-        }
-        if let Some(x) = args.empty_value {
-            builder.add_empty_value(x);
-        }
         if let Some(x) = args.null_value {
             builder.add_null_value(x);
-        }
-        if let Some(x) = args.comment {
-            builder.add_comment(x);
         }
         if let Some(x) = args.escape {
             builder.add_escape(x);
@@ -2479,20 +2477,8 @@ impl<'a> ReadStepCsv<'a> {
         if let Some(x) = args.schema {
             builder.add_schema(x);
         }
-        if let Some(x) = args.multi_line {
-            builder.add_multi_line(x);
-        }
-        if let Some(x) = args.ignore_trailing_white_space {
-            builder.add_ignore_trailing_white_space(x);
-        }
-        if let Some(x) = args.ignore_leading_white_space {
-            builder.add_ignore_leading_white_space(x);
-        }
         if let Some(x) = args.infer_schema {
             builder.add_infer_schema(x);
-        }
-        if let Some(x) = args.enforce_schema {
-            builder.add_enforce_schema(x);
         }
         if let Some(x) = args.header {
             builder.add_header(x);
@@ -2552,28 +2538,11 @@ impl<'a> ReadStepCsv<'a> {
         }
     }
     #[inline]
-    pub fn comment(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepCsv::VT_COMMENT, None)
-        }
-    }
-    #[inline]
     pub fn header(&self) -> Option<bool> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe { self._tab.get::<bool>(ReadStepCsv::VT_HEADER, None) }
-    }
-    #[inline]
-    pub fn enforce_schema(&self) -> Option<bool> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe { self._tab.get::<bool>(ReadStepCsv::VT_ENFORCE_SCHEMA, None) }
     }
     #[inline]
     pub fn infer_schema(&self) -> Option<bool> {
@@ -2583,26 +2552,6 @@ impl<'a> ReadStepCsv<'a> {
         unsafe { self._tab.get::<bool>(ReadStepCsv::VT_INFER_SCHEMA, None) }
     }
     #[inline]
-    pub fn ignore_leading_white_space(&self) -> Option<bool> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<bool>(ReadStepCsv::VT_IGNORE_LEADING_WHITE_SPACE, None)
-        }
-    }
-    #[inline]
-    pub fn ignore_trailing_white_space(&self) -> Option<bool> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<bool>(ReadStepCsv::VT_IGNORE_TRAILING_WHITE_SPACE, None)
-        }
-    }
-    #[inline]
     pub fn null_value(&self) -> Option<&'a str> {
         // Safety:
         // Created from valid Table for this object
@@ -2610,46 +2559,6 @@ impl<'a> ReadStepCsv<'a> {
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepCsv::VT_NULL_VALUE, None)
-        }
-    }
-    #[inline]
-    pub fn empty_value(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepCsv::VT_EMPTY_VALUE, None)
-        }
-    }
-    #[inline]
-    pub fn nan_value(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepCsv::VT_NAN_VALUE, None)
-        }
-    }
-    #[inline]
-    pub fn positive_inf(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepCsv::VT_POSITIVE_INF, None)
-        }
-    }
-    #[inline]
-    pub fn negative_inf(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepCsv::VT_NEGATIVE_INF, None)
         }
     }
     #[inline]
@@ -2671,13 +2580,6 @@ impl<'a> ReadStepCsv<'a> {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepCsv::VT_TIMESTAMP_FORMAT, None)
         }
-    }
-    #[inline]
-    pub fn multi_line(&self) -> Option<bool> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe { self._tab.get::<bool>(ReadStepCsv::VT_MULTI_LINE, None) }
     }
 }
 
@@ -2704,43 +2606,11 @@ impl flatbuffers::Verifiable for ReadStepCsv<'_> {
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>("quote", Self::VT_QUOTE, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>("escape", Self::VT_ESCAPE, false)?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("comment", Self::VT_COMMENT, false)?
             .visit_field::<bool>("header", Self::VT_HEADER, false)?
-            .visit_field::<bool>("enforce_schema", Self::VT_ENFORCE_SCHEMA, false)?
             .visit_field::<bool>("infer_schema", Self::VT_INFER_SCHEMA, false)?
-            .visit_field::<bool>(
-                "ignore_leading_white_space",
-                Self::VT_IGNORE_LEADING_WHITE_SPACE,
-                false,
-            )?
-            .visit_field::<bool>(
-                "ignore_trailing_white_space",
-                Self::VT_IGNORE_TRAILING_WHITE_SPACE,
-                false,
-            )?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
                 "null_value",
                 Self::VT_NULL_VALUE,
-                false,
-            )?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "empty_value",
-                Self::VT_EMPTY_VALUE,
-                false,
-            )?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "nan_value",
-                Self::VT_NAN_VALUE,
-                false,
-            )?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "positive_inf",
-                Self::VT_POSITIVE_INF,
-                false,
-            )?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "negative_inf",
-                Self::VT_NEGATIVE_INF,
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
@@ -2753,7 +2623,6 @@ impl flatbuffers::Verifiable for ReadStepCsv<'_> {
                 Self::VT_TIMESTAMP_FORMAT,
                 false,
             )?
-            .visit_field::<bool>("multi_line", Self::VT_MULTI_LINE, false)?
             .finish();
         Ok(())
     }
@@ -2766,20 +2635,11 @@ pub struct ReadStepCsvArgs<'a> {
     pub encoding: Option<flatbuffers::WIPOffset<&'a str>>,
     pub quote: Option<flatbuffers::WIPOffset<&'a str>>,
     pub escape: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub comment: Option<flatbuffers::WIPOffset<&'a str>>,
     pub header: Option<bool>,
-    pub enforce_schema: Option<bool>,
     pub infer_schema: Option<bool>,
-    pub ignore_leading_white_space: Option<bool>,
-    pub ignore_trailing_white_space: Option<bool>,
     pub null_value: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub empty_value: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub nan_value: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub positive_inf: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub negative_inf: Option<flatbuffers::WIPOffset<&'a str>>,
     pub date_format: Option<flatbuffers::WIPOffset<&'a str>>,
     pub timestamp_format: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub multi_line: Option<bool>,
 }
 impl<'a> Default for ReadStepCsvArgs<'a> {
     #[inline]
@@ -2790,20 +2650,11 @@ impl<'a> Default for ReadStepCsvArgs<'a> {
             encoding: None,
             quote: None,
             escape: None,
-            comment: None,
             header: None,
-            enforce_schema: None,
             infer_schema: None,
-            ignore_leading_white_space: None,
-            ignore_trailing_white_space: None,
             null_value: None,
-            empty_value: None,
-            nan_value: None,
-            positive_inf: None,
-            negative_inf: None,
             date_format: None,
             timestamp_format: None,
-            multi_line: None,
         }
     }
 }
@@ -2844,19 +2695,9 @@ impl<'a: 'b, 'b> ReadStepCsvBuilder<'a, 'b> {
             .push_slot_always::<flatbuffers::WIPOffset<_>>(ReadStepCsv::VT_ESCAPE, escape);
     }
     #[inline]
-    pub fn add_comment(&mut self, comment: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(ReadStepCsv::VT_COMMENT, comment);
-    }
-    #[inline]
     pub fn add_header(&mut self, header: bool) {
         self.fbb_
             .push_slot_always::<bool>(ReadStepCsv::VT_HEADER, header);
-    }
-    #[inline]
-    pub fn add_enforce_schema(&mut self, enforce_schema: bool) {
-        self.fbb_
-            .push_slot_always::<bool>(ReadStepCsv::VT_ENFORCE_SCHEMA, enforce_schema);
     }
     #[inline]
     pub fn add_infer_schema(&mut self, infer_schema: bool) {
@@ -2864,49 +2705,9 @@ impl<'a: 'b, 'b> ReadStepCsvBuilder<'a, 'b> {
             .push_slot_always::<bool>(ReadStepCsv::VT_INFER_SCHEMA, infer_schema);
     }
     #[inline]
-    pub fn add_ignore_leading_white_space(&mut self, ignore_leading_white_space: bool) {
-        self.fbb_.push_slot_always::<bool>(
-            ReadStepCsv::VT_IGNORE_LEADING_WHITE_SPACE,
-            ignore_leading_white_space,
-        );
-    }
-    #[inline]
-    pub fn add_ignore_trailing_white_space(&mut self, ignore_trailing_white_space: bool) {
-        self.fbb_.push_slot_always::<bool>(
-            ReadStepCsv::VT_IGNORE_TRAILING_WHITE_SPACE,
-            ignore_trailing_white_space,
-        );
-    }
-    #[inline]
     pub fn add_null_value(&mut self, null_value: flatbuffers::WIPOffset<&'b str>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<_>>(ReadStepCsv::VT_NULL_VALUE, null_value);
-    }
-    #[inline]
-    pub fn add_empty_value(&mut self, empty_value: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ReadStepCsv::VT_EMPTY_VALUE,
-            empty_value,
-        );
-    }
-    #[inline]
-    pub fn add_nan_value(&mut self, nan_value: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(ReadStepCsv::VT_NAN_VALUE, nan_value);
-    }
-    #[inline]
-    pub fn add_positive_inf(&mut self, positive_inf: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ReadStepCsv::VT_POSITIVE_INF,
-            positive_inf,
-        );
-    }
-    #[inline]
-    pub fn add_negative_inf(&mut self, negative_inf: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ReadStepCsv::VT_NEGATIVE_INF,
-            negative_inf,
-        );
     }
     #[inline]
     pub fn add_date_format(&mut self, date_format: flatbuffers::WIPOffset<&'b str>) {
@@ -2921,11 +2722,6 @@ impl<'a: 'b, 'b> ReadStepCsvBuilder<'a, 'b> {
             ReadStepCsv::VT_TIMESTAMP_FORMAT,
             timestamp_format,
         );
-    }
-    #[inline]
-    pub fn add_multi_line(&mut self, multi_line: bool) {
-        self.fbb_
-            .push_slot_always::<bool>(ReadStepCsv::VT_MULTI_LINE, multi_line);
     }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ReadStepCsvBuilder<'a, 'b> {
@@ -2950,279 +2746,10 @@ impl core::fmt::Debug for ReadStepCsv<'_> {
         ds.field("encoding", &self.encoding());
         ds.field("quote", &self.quote());
         ds.field("escape", &self.escape());
-        ds.field("comment", &self.comment());
         ds.field("header", &self.header());
-        ds.field("enforce_schema", &self.enforce_schema());
         ds.field("infer_schema", &self.infer_schema());
-        ds.field(
-            "ignore_leading_white_space",
-            &self.ignore_leading_white_space(),
-        );
-        ds.field(
-            "ignore_trailing_white_space",
-            &self.ignore_trailing_white_space(),
-        );
         ds.field("null_value", &self.null_value());
-        ds.field("empty_value", &self.empty_value());
-        ds.field("nan_value", &self.nan_value());
-        ds.field("positive_inf", &self.positive_inf());
-        ds.field("negative_inf", &self.negative_inf());
         ds.field("date_format", &self.date_format());
-        ds.field("timestamp_format", &self.timestamp_format());
-        ds.field("multi_line", &self.multi_line());
-        ds.finish()
-    }
-}
-pub enum ReadStepJsonLinesOffset {}
-#[derive(Copy, Clone, PartialEq)]
-
-pub struct ReadStepJsonLines<'a> {
-    pub _tab: flatbuffers::Table<'a>,
-}
-
-impl<'a> flatbuffers::Follow<'a> for ReadStepJsonLines<'a> {
-    type Inner = ReadStepJsonLines<'a>;
-    #[inline]
-    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table::new(buf, loc),
-        }
-    }
-}
-
-impl<'a> ReadStepJsonLines<'a> {
-    pub const VT_SCHEMA: flatbuffers::VOffsetT = 4;
-    pub const VT_DATE_FORMAT: flatbuffers::VOffsetT = 6;
-    pub const VT_ENCODING: flatbuffers::VOffsetT = 8;
-    pub const VT_MULTI_LINE: flatbuffers::VOffsetT = 10;
-    pub const VT_PRIMITIVES_AS_STRING: flatbuffers::VOffsetT = 12;
-    pub const VT_TIMESTAMP_FORMAT: flatbuffers::VOffsetT = 14;
-
-    #[inline]
-    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        ReadStepJsonLines { _tab: table }
-    }
-    #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args ReadStepJsonLinesArgs<'args>,
-    ) -> flatbuffers::WIPOffset<ReadStepJsonLines<'bldr>> {
-        let mut builder = ReadStepJsonLinesBuilder::new(_fbb);
-        if let Some(x) = args.timestamp_format {
-            builder.add_timestamp_format(x);
-        }
-        if let Some(x) = args.encoding {
-            builder.add_encoding(x);
-        }
-        if let Some(x) = args.date_format {
-            builder.add_date_format(x);
-        }
-        if let Some(x) = args.schema {
-            builder.add_schema(x);
-        }
-        if let Some(x) = args.primitives_as_string {
-            builder.add_primitives_as_string(x);
-        }
-        if let Some(x) = args.multi_line {
-            builder.add_multi_line(x);
-        }
-        builder.finish()
-    }
-
-    #[inline]
-    pub fn schema(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>,
-            >>(ReadStepJsonLines::VT_SCHEMA, None)
-        }
-    }
-    #[inline]
-    pub fn date_format(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepJsonLines::VT_DATE_FORMAT, None)
-        }
-    }
-    #[inline]
-    pub fn encoding(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ReadStepJsonLines::VT_ENCODING, None)
-        }
-    }
-    #[inline]
-    pub fn multi_line(&self) -> Option<bool> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<bool>(ReadStepJsonLines::VT_MULTI_LINE, None)
-        }
-    }
-    #[inline]
-    pub fn primitives_as_string(&self) -> Option<bool> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<bool>(ReadStepJsonLines::VT_PRIMITIVES_AS_STRING, None)
-        }
-    }
-    #[inline]
-    pub fn timestamp_format(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(
-                ReadStepJsonLines::VT_TIMESTAMP_FORMAT,
-                None,
-            )
-        }
-    }
-}
-
-impl flatbuffers::Verifiable for ReadStepJsonLines<'_> {
-    #[inline]
-    fn run_verifier(
-        v: &mut flatbuffers::Verifier,
-        pos: usize,
-    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-        use self::flatbuffers::Verifiable;
-        v.visit_table(pos)?
-            .visit_field::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<&'_ str>>,
-            >>("schema", Self::VT_SCHEMA, false)?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "date_format",
-                Self::VT_DATE_FORMAT,
-                false,
-            )?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "encoding",
-                Self::VT_ENCODING,
-                false,
-            )?
-            .visit_field::<bool>("multi_line", Self::VT_MULTI_LINE, false)?
-            .visit_field::<bool>("primitives_as_string", Self::VT_PRIMITIVES_AS_STRING, false)?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "timestamp_format",
-                Self::VT_TIMESTAMP_FORMAT,
-                false,
-            )?
-            .finish();
-        Ok(())
-    }
-}
-pub struct ReadStepJsonLinesArgs<'a> {
-    pub schema: Option<
-        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>>,
-    >,
-    pub date_format: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub encoding: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub multi_line: Option<bool>,
-    pub primitives_as_string: Option<bool>,
-    pub timestamp_format: Option<flatbuffers::WIPOffset<&'a str>>,
-}
-impl<'a> Default for ReadStepJsonLinesArgs<'a> {
-    #[inline]
-    fn default() -> Self {
-        ReadStepJsonLinesArgs {
-            schema: None,
-            date_format: None,
-            encoding: None,
-            multi_line: None,
-            primitives_as_string: None,
-            timestamp_format: None,
-        }
-    }
-}
-
-pub struct ReadStepJsonLinesBuilder<'a: 'b, 'b> {
-    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-}
-impl<'a: 'b, 'b> ReadStepJsonLinesBuilder<'a, 'b> {
-    #[inline]
-    pub fn add_schema(
-        &mut self,
-        schema: flatbuffers::WIPOffset<
-            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<&'b str>>,
-        >,
-    ) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(ReadStepJsonLines::VT_SCHEMA, schema);
-    }
-    #[inline]
-    pub fn add_date_format(&mut self, date_format: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ReadStepJsonLines::VT_DATE_FORMAT,
-            date_format,
-        );
-    }
-    #[inline]
-    pub fn add_encoding(&mut self, encoding: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ReadStepJsonLines::VT_ENCODING,
-            encoding,
-        );
-    }
-    #[inline]
-    pub fn add_multi_line(&mut self, multi_line: bool) {
-        self.fbb_
-            .push_slot_always::<bool>(ReadStepJsonLines::VT_MULTI_LINE, multi_line);
-    }
-    #[inline]
-    pub fn add_primitives_as_string(&mut self, primitives_as_string: bool) {
-        self.fbb_.push_slot_always::<bool>(
-            ReadStepJsonLines::VT_PRIMITIVES_AS_STRING,
-            primitives_as_string,
-        );
-    }
-    #[inline]
-    pub fn add_timestamp_format(&mut self, timestamp_format: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ReadStepJsonLines::VT_TIMESTAMP_FORMAT,
-            timestamp_format,
-        );
-    }
-    #[inline]
-    pub fn new(
-        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    ) -> ReadStepJsonLinesBuilder<'a, 'b> {
-        let start = _fbb.start_table();
-        ReadStepJsonLinesBuilder {
-            fbb_: _fbb,
-            start_: start,
-        }
-    }
-    #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<ReadStepJsonLines<'a>> {
-        let o = self.fbb_.end_table(self.start_);
-        flatbuffers::WIPOffset::new(o.value())
-    }
-}
-
-impl core::fmt::Debug for ReadStepJsonLines<'_> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut ds = f.debug_struct("ReadStepJsonLines");
-        ds.field("schema", &self.schema());
-        ds.field("date_format", &self.date_format());
-        ds.field("encoding", &self.encoding());
-        ds.field("multi_line", &self.multi_line());
-        ds.field("primitives_as_string", &self.primitives_as_string());
         ds.field("timestamp_format", &self.timestamp_format());
         ds.finish()
     }
@@ -5280,21 +4807,6 @@ impl<'a> AddPushSource<'a> {
 
     #[inline]
     #[allow(non_snake_case)]
-    pub fn read_as_read_step_json_lines(&self) -> Option<ReadStepJsonLines<'a>> {
-        if self.read_type() == ReadStep::ReadStepJsonLines {
-            self.read().map(|t| {
-                // Safety:
-                // Created from a valid Table for this object
-                // Which contains a valid union in this slot
-                unsafe { ReadStepJsonLines::init_from_table(t) }
-            })
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
     pub fn read_as_read_step_geo_json(&self) -> Option<ReadStepGeoJson<'a>> {
         if self.read_type() == ReadStep::ReadStepGeoJson {
             self.read().map(|t| {
@@ -5456,7 +4968,6 @@ impl flatbuffers::Verifiable for AddPushSource<'_> {
      .visit_union::<ReadStep, _>("read_type", Self::VT_READ_TYPE, "read", Self::VT_READ, false, |key, v, pos| {
         match key {
           ReadStep::ReadStepCsv => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepCsv>>("ReadStep::ReadStepCsv", pos),
-          ReadStep::ReadStepJsonLines => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepJsonLines>>("ReadStep::ReadStepJsonLines", pos),
           ReadStep::ReadStepGeoJson => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepGeoJson>>("ReadStep::ReadStepGeoJson", pos),
           ReadStep::ReadStepEsriShapefile => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepEsriShapefile>>("ReadStep::ReadStepEsriShapefile", pos),
           ReadStep::ReadStepParquet => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepParquet>>("ReadStep::ReadStepParquet", pos),
@@ -5584,16 +5095,6 @@ impl core::fmt::Debug for AddPushSource<'_> {
         match self.read_type() {
             ReadStep::ReadStepCsv => {
                 if let Some(x) = self.read_as_read_step_csv() {
-                    ds.field("read", &x)
-                } else {
-                    ds.field(
-                        "read",
-                        &"InvalidFlatbuffer: Union discriminant does not match value.",
-                    )
-                }
-            }
-            ReadStep::ReadStepJsonLines => {
-                if let Some(x) = self.read_as_read_step_json_lines() {
                     ds.field("read", &x)
                 } else {
                     ds.field(
@@ -5975,16 +5476,16 @@ impl core::fmt::Debug for AttachmentsEmbedded<'_> {
         ds.finish()
     }
 }
-pub enum BlockIntervalOffset {}
+pub enum ExecuteQueryInputOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 ////////////////////////////////////////////////////////////////////////////////
-pub struct BlockInterval<'a> {
+pub struct ExecuteQueryInput<'a> {
     pub _tab: flatbuffers::Table<'a>,
 }
 
-impl<'a> flatbuffers::Follow<'a> for BlockInterval<'a> {
-    type Inner = BlockInterval<'a>;
+impl<'a> flatbuffers::Follow<'a> for ExecuteQueryInput<'a> {
+    type Inner = ExecuteQueryInput<'a>;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
@@ -5993,169 +5494,34 @@ impl<'a> flatbuffers::Follow<'a> for BlockInterval<'a> {
     }
 }
 
-impl<'a> BlockInterval<'a> {
-    pub const VT_START: flatbuffers::VOffsetT = 4;
-    pub const VT_END: flatbuffers::VOffsetT = 6;
-
-    #[inline]
-    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        BlockInterval { _tab: table }
-    }
-    #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args BlockIntervalArgs<'args>,
-    ) -> flatbuffers::WIPOffset<BlockInterval<'bldr>> {
-        let mut builder = BlockIntervalBuilder::new(_fbb);
-        if let Some(x) = args.end {
-            builder.add_end(x);
-        }
-        if let Some(x) = args.start {
-            builder.add_start(x);
-        }
-        builder.finish()
-    }
-
-    #[inline]
-    pub fn start(&self) -> Option<flatbuffers::Vector<'a, u8>> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    BlockInterval::VT_START,
-                    None,
-                )
-        }
-    }
-    #[inline]
-    pub fn end(&self) -> Option<flatbuffers::Vector<'a, u8>> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    BlockInterval::VT_END,
-                    None,
-                )
-        }
-    }
-}
-
-impl flatbuffers::Verifiable for BlockInterval<'_> {
-    #[inline]
-    fn run_verifier(
-        v: &mut flatbuffers::Verifier,
-        pos: usize,
-    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-        use self::flatbuffers::Verifiable;
-        v.visit_table(pos)?
-            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                "start",
-                Self::VT_START,
-                false,
-            )?
-            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                "end",
-                Self::VT_END,
-                false,
-            )?
-            .finish();
-        Ok(())
-    }
-}
-pub struct BlockIntervalArgs<'a> {
-    pub start: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub end: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-}
-impl<'a> Default for BlockIntervalArgs<'a> {
-    #[inline]
-    fn default() -> Self {
-        BlockIntervalArgs {
-            start: None,
-            end: None,
-        }
-    }
-}
-
-pub struct BlockIntervalBuilder<'a: 'b, 'b> {
-    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-}
-impl<'a: 'b, 'b> BlockIntervalBuilder<'a, 'b> {
-    #[inline]
-    pub fn add_start(&mut self, start: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(BlockInterval::VT_START, start);
-    }
-    #[inline]
-    pub fn add_end(&mut self, end: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(BlockInterval::VT_END, end);
-    }
-    #[inline]
-    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> BlockIntervalBuilder<'a, 'b> {
-        let start = _fbb.start_table();
-        BlockIntervalBuilder {
-            fbb_: _fbb,
-            start_: start,
-        }
-    }
-    #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<BlockInterval<'a>> {
-        let o = self.fbb_.end_table(self.start_);
-        flatbuffers::WIPOffset::new(o.value())
-    }
-}
-
-impl core::fmt::Debug for BlockInterval<'_> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut ds = f.debug_struct("BlockInterval");
-        ds.field("start", &self.start());
-        ds.field("end", &self.end());
-        ds.finish()
-    }
-}
-pub enum InputSliceOffset {}
-#[derive(Copy, Clone, PartialEq)]
-
-////////////////////////////////////////////////////////////////////////////////
-pub struct InputSlice<'a> {
-    pub _tab: flatbuffers::Table<'a>,
-}
-
-impl<'a> flatbuffers::Follow<'a> for InputSlice<'a> {
-    type Inner = InputSlice<'a>;
-    #[inline]
-    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table::new(buf, loc),
-        }
-    }
-}
-
-impl<'a> InputSlice<'a> {
+impl<'a> ExecuteQueryInput<'a> {
     pub const VT_DATASET_ID: flatbuffers::VOffsetT = 4;
-    pub const VT_BLOCK_INTERVAL: flatbuffers::VOffsetT = 6;
-    pub const VT_DATA_INTERVAL: flatbuffers::VOffsetT = 8;
+    pub const VT_PREV_BLOCK_HASH: flatbuffers::VOffsetT = 6;
+    pub const VT_NEW_BLOCK_HASH: flatbuffers::VOffsetT = 8;
+    pub const VT_PREV_OFFSET: flatbuffers::VOffsetT = 10;
+    pub const VT_NEW_OFFSET: flatbuffers::VOffsetT = 12;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        InputSlice { _tab: table }
+        ExecuteQueryInput { _tab: table }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args InputSliceArgs<'args>,
-    ) -> flatbuffers::WIPOffset<InputSlice<'bldr>> {
-        let mut builder = InputSliceBuilder::new(_fbb);
-        if let Some(x) = args.data_interval {
-            builder.add_data_interval(x);
+        args: &'args ExecuteQueryInputArgs<'args>,
+    ) -> flatbuffers::WIPOffset<ExecuteQueryInput<'bldr>> {
+        let mut builder = ExecuteQueryInputBuilder::new(_fbb);
+        if let Some(x) = args.new_offset {
+            builder.add_new_offset(x);
         }
-        if let Some(x) = args.block_interval {
-            builder.add_block_interval(x);
+        if let Some(x) = args.prev_offset {
+            builder.add_prev_offset(x);
+        }
+        if let Some(x) = args.new_block_hash {
+            builder.add_new_block_hash(x);
+        }
+        if let Some(x) = args.prev_block_hash {
+            builder.add_prev_block_hash(x);
         }
         if let Some(x) = args.dataset_id {
             builder.add_dataset_id(x);
@@ -6171,40 +5537,57 @@ impl<'a> InputSlice<'a> {
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    InputSlice::VT_DATASET_ID,
+                    ExecuteQueryInput::VT_DATASET_ID,
                     None,
                 )
         }
     }
     #[inline]
-    pub fn block_interval(&self) -> Option<BlockInterval<'a>> {
+    pub fn prev_block_hash(&self) -> Option<flatbuffers::Vector<'a, u8>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<BlockInterval>>(
-                    InputSlice::VT_BLOCK_INTERVAL,
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
+                    ExecuteQueryInput::VT_PREV_BLOCK_HASH,
                     None,
                 )
         }
     }
     #[inline]
-    pub fn data_interval(&self) -> Option<OffsetInterval<'a>> {
+    pub fn new_block_hash(&self) -> Option<flatbuffers::Vector<'a, u8>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                    InputSlice::VT_DATA_INTERVAL,
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
+                    ExecuteQueryInput::VT_NEW_BLOCK_HASH,
                     None,
                 )
         }
+    }
+    #[inline]
+    pub fn prev_offset(&self) -> Option<u64> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<u64>(ExecuteQueryInput::VT_PREV_OFFSET, None)
+        }
+    }
+    #[inline]
+    pub fn new_offset(&self) -> Option<u64> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<u64>(ExecuteQueryInput::VT_NEW_OFFSET, None) }
     }
 }
 
-impl flatbuffers::Verifiable for InputSlice<'_> {
+impl flatbuffers::Verifiable for ExecuteQueryInput<'_> {
     #[inline]
     fn run_verifier(
         v: &mut flatbuffers::Verifier,
@@ -6217,89 +5600,112 @@ impl flatbuffers::Verifiable for InputSlice<'_> {
                 Self::VT_DATASET_ID,
                 false,
             )?
-            .visit_field::<flatbuffers::ForwardsUOffset<BlockInterval>>(
-                "block_interval",
-                Self::VT_BLOCK_INTERVAL,
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
+                "prev_block_hash",
+                Self::VT_PREV_BLOCK_HASH,
                 false,
             )?
-            .visit_field::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                "data_interval",
-                Self::VT_DATA_INTERVAL,
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
+                "new_block_hash",
+                Self::VT_NEW_BLOCK_HASH,
                 false,
             )?
+            .visit_field::<u64>("prev_offset", Self::VT_PREV_OFFSET, false)?
+            .visit_field::<u64>("new_offset", Self::VT_NEW_OFFSET, false)?
             .finish();
         Ok(())
     }
 }
-pub struct InputSliceArgs<'a> {
+pub struct ExecuteQueryInputArgs<'a> {
     pub dataset_id: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub block_interval: Option<flatbuffers::WIPOffset<BlockInterval<'a>>>,
-    pub data_interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
+    pub prev_block_hash: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub new_block_hash: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub prev_offset: Option<u64>,
+    pub new_offset: Option<u64>,
 }
-impl<'a> Default for InputSliceArgs<'a> {
+impl<'a> Default for ExecuteQueryInputArgs<'a> {
     #[inline]
     fn default() -> Self {
-        InputSliceArgs {
+        ExecuteQueryInputArgs {
             dataset_id: None,
-            block_interval: None,
-            data_interval: None,
+            prev_block_hash: None,
+            new_block_hash: None,
+            prev_offset: None,
+            new_offset: None,
         }
     }
 }
 
-pub struct InputSliceBuilder<'a: 'b, 'b> {
+pub struct ExecuteQueryInputBuilder<'a: 'b, 'b> {
     fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
     start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> InputSliceBuilder<'a, 'b> {
+impl<'a: 'b, 'b> ExecuteQueryInputBuilder<'a, 'b> {
     #[inline]
     pub fn add_dataset_id(
         &mut self,
         dataset_id: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
     ) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(InputSlice::VT_DATASET_ID, dataset_id);
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            ExecuteQueryInput::VT_DATASET_ID,
+            dataset_id,
+        );
     }
     #[inline]
-    pub fn add_block_interval(
+    pub fn add_prev_block_hash(
         &mut self,
-        block_interval: flatbuffers::WIPOffset<BlockInterval<'b>>,
+        prev_block_hash: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
     ) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<BlockInterval>>(
-                InputSlice::VT_BLOCK_INTERVAL,
-                block_interval,
-            );
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            ExecuteQueryInput::VT_PREV_BLOCK_HASH,
+            prev_block_hash,
+        );
     }
     #[inline]
-    pub fn add_data_interval(&mut self, data_interval: flatbuffers::WIPOffset<OffsetInterval<'b>>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<OffsetInterval>>(
-                InputSlice::VT_DATA_INTERVAL,
-                data_interval,
-            );
+    pub fn add_new_block_hash(
+        &mut self,
+        new_block_hash: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
+    ) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            ExecuteQueryInput::VT_NEW_BLOCK_HASH,
+            new_block_hash,
+        );
     }
     #[inline]
-    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InputSliceBuilder<'a, 'b> {
+    pub fn add_prev_offset(&mut self, prev_offset: u64) {
+        self.fbb_
+            .push_slot_always::<u64>(ExecuteQueryInput::VT_PREV_OFFSET, prev_offset);
+    }
+    #[inline]
+    pub fn add_new_offset(&mut self, new_offset: u64) {
+        self.fbb_
+            .push_slot_always::<u64>(ExecuteQueryInput::VT_NEW_OFFSET, new_offset);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> ExecuteQueryInputBuilder<'a, 'b> {
         let start = _fbb.start_table();
-        InputSliceBuilder {
+        ExecuteQueryInputBuilder {
             fbb_: _fbb,
             start_: start,
         }
     }
     #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<InputSlice<'a>> {
+    pub fn finish(self) -> flatbuffers::WIPOffset<ExecuteQueryInput<'a>> {
         let o = self.fbb_.end_table(self.start_);
         flatbuffers::WIPOffset::new(o.value())
     }
 }
 
-impl core::fmt::Debug for InputSlice<'_> {
+impl core::fmt::Debug for ExecuteQueryInput<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut ds = f.debug_struct("InputSlice");
+        let mut ds = f.debug_struct("ExecuteQueryInput");
         ds.field("dataset_id", &self.dataset_id());
-        ds.field("block_interval", &self.block_interval());
-        ds.field("data_interval", &self.data_interval());
+        ds.field("prev_block_hash", &self.prev_block_hash());
+        ds.field("new_block_hash", &self.new_block_hash());
+        ds.field("prev_offset", &self.prev_offset());
+        ds.field("new_offset", &self.new_offset());
         ds.finish()
     }
 }
@@ -6322,11 +5728,12 @@ impl<'a> flatbuffers::Follow<'a> for ExecuteQuery<'a> {
 }
 
 impl<'a> ExecuteQuery<'a> {
-    pub const VT_INPUT_SLICES: flatbuffers::VOffsetT = 4;
-    pub const VT_INPUT_CHECKPOINT: flatbuffers::VOffsetT = 6;
-    pub const VT_OUTPUT_DATA: flatbuffers::VOffsetT = 8;
-    pub const VT_OUTPUT_CHECKPOINT: flatbuffers::VOffsetT = 10;
-    pub const VT_OUTPUT_WATERMARK: flatbuffers::VOffsetT = 12;
+    pub const VT_QUERY_INPUTS: flatbuffers::VOffsetT = 4;
+    pub const VT_PREV_CHECKPOINT: flatbuffers::VOffsetT = 6;
+    pub const VT_PREV_OFFSET: flatbuffers::VOffsetT = 8;
+    pub const VT_NEW_DATA: flatbuffers::VOffsetT = 10;
+    pub const VT_NEW_CHECKPOINT: flatbuffers::VOffsetT = 12;
+    pub const VT_NEW_WATERMARK: flatbuffers::VOffsetT = 14;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -6338,80 +5745,90 @@ impl<'a> ExecuteQuery<'a> {
         args: &'args ExecuteQueryArgs<'args>,
     ) -> flatbuffers::WIPOffset<ExecuteQuery<'bldr>> {
         let mut builder = ExecuteQueryBuilder::new(_fbb);
-        if let Some(x) = args.output_watermark {
-            builder.add_output_watermark(x);
+        if let Some(x) = args.prev_offset {
+            builder.add_prev_offset(x);
         }
-        if let Some(x) = args.output_checkpoint {
-            builder.add_output_checkpoint(x);
+        if let Some(x) = args.new_watermark {
+            builder.add_new_watermark(x);
         }
-        if let Some(x) = args.output_data {
-            builder.add_output_data(x);
+        if let Some(x) = args.new_checkpoint {
+            builder.add_new_checkpoint(x);
         }
-        if let Some(x) = args.input_checkpoint {
-            builder.add_input_checkpoint(x);
+        if let Some(x) = args.new_data {
+            builder.add_new_data(x);
         }
-        if let Some(x) = args.input_slices {
-            builder.add_input_slices(x);
+        if let Some(x) = args.prev_checkpoint {
+            builder.add_prev_checkpoint(x);
+        }
+        if let Some(x) = args.query_inputs {
+            builder.add_query_inputs(x);
         }
         builder.finish()
     }
 
     #[inline]
-    pub fn input_slices(
+    pub fn query_inputs(
         &self,
-    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputSlice<'a>>>> {
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryInput<'a>>>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputSlice>>,
-            >>(ExecuteQuery::VT_INPUT_SLICES, None)
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryInput>>,
+            >>(ExecuteQuery::VT_QUERY_INPUTS, None)
         }
     }
     #[inline]
-    pub fn input_checkpoint(&self) -> Option<flatbuffers::Vector<'a, u8>> {
+    pub fn prev_checkpoint(&self) -> Option<flatbuffers::Vector<'a, u8>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    ExecuteQuery::VT_INPUT_CHECKPOINT,
+                    ExecuteQuery::VT_PREV_CHECKPOINT,
                     None,
                 )
         }
     }
     #[inline]
-    pub fn output_data(&self) -> Option<DataSlice<'a>> {
+    pub fn prev_offset(&self) -> Option<u64> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<u64>(ExecuteQuery::VT_PREV_OFFSET, None) }
+    }
+    #[inline]
+    pub fn new_data(&self) -> Option<DataSlice<'a>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<DataSlice>>(ExecuteQuery::VT_OUTPUT_DATA, None)
+                .get::<flatbuffers::ForwardsUOffset<DataSlice>>(ExecuteQuery::VT_NEW_DATA, None)
         }
     }
     #[inline]
-    pub fn output_checkpoint(&self) -> Option<Checkpoint<'a>> {
+    pub fn new_checkpoint(&self) -> Option<Checkpoint<'a>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab.get::<flatbuffers::ForwardsUOffset<Checkpoint>>(
-                ExecuteQuery::VT_OUTPUT_CHECKPOINT,
+                ExecuteQuery::VT_NEW_CHECKPOINT,
                 None,
             )
         }
     }
     #[inline]
-    pub fn output_watermark(&self) -> Option<&'a Timestamp> {
+    pub fn new_watermark(&self) -> Option<&'a Timestamp> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<Timestamp>(ExecuteQuery::VT_OUTPUT_WATERMARK, None)
+                .get::<Timestamp>(ExecuteQuery::VT_NEW_WATERMARK, None)
         }
     }
 }
@@ -6425,48 +5842,51 @@ impl flatbuffers::Verifiable for ExecuteQuery<'_> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
             .visit_field::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<InputSlice>>,
-            >>("input_slices", Self::VT_INPUT_SLICES, false)?
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ExecuteQueryInput>>,
+            >>("query_inputs", Self::VT_QUERY_INPUTS, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                "input_checkpoint",
-                Self::VT_INPUT_CHECKPOINT,
+                "prev_checkpoint",
+                Self::VT_PREV_CHECKPOINT,
                 false,
             )?
+            .visit_field::<u64>("prev_offset", Self::VT_PREV_OFFSET, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<DataSlice>>(
-                "output_data",
-                Self::VT_OUTPUT_DATA,
+                "new_data",
+                Self::VT_NEW_DATA,
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<Checkpoint>>(
-                "output_checkpoint",
-                Self::VT_OUTPUT_CHECKPOINT,
+                "new_checkpoint",
+                Self::VT_NEW_CHECKPOINT,
                 false,
             )?
-            .visit_field::<Timestamp>("output_watermark", Self::VT_OUTPUT_WATERMARK, false)?
+            .visit_field::<Timestamp>("new_watermark", Self::VT_NEW_WATERMARK, false)?
             .finish();
         Ok(())
     }
 }
 pub struct ExecuteQueryArgs<'a> {
-    pub input_slices: Option<
+    pub query_inputs: Option<
         flatbuffers::WIPOffset<
-            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputSlice<'a>>>,
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryInput<'a>>>,
         >,
     >,
-    pub input_checkpoint: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub output_data: Option<flatbuffers::WIPOffset<DataSlice<'a>>>,
-    pub output_checkpoint: Option<flatbuffers::WIPOffset<Checkpoint<'a>>>,
-    pub output_watermark: Option<&'a Timestamp>,
+    pub prev_checkpoint: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub prev_offset: Option<u64>,
+    pub new_data: Option<flatbuffers::WIPOffset<DataSlice<'a>>>,
+    pub new_checkpoint: Option<flatbuffers::WIPOffset<Checkpoint<'a>>>,
+    pub new_watermark: Option<&'a Timestamp>,
 }
 impl<'a> Default for ExecuteQueryArgs<'a> {
     #[inline]
     fn default() -> Self {
         ExecuteQueryArgs {
-            input_slices: None,
-            input_checkpoint: None,
-            output_data: None,
-            output_checkpoint: None,
-            output_watermark: None,
+            query_inputs: None,
+            prev_checkpoint: None,
+            prev_offset: None,
+            new_data: None,
+            new_checkpoint: None,
+            new_watermark: None,
         }
     }
 }
@@ -6477,50 +5897,52 @@ pub struct ExecuteQueryBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> ExecuteQueryBuilder<'a, 'b> {
     #[inline]
-    pub fn add_input_slices(
+    pub fn add_query_inputs(
         &mut self,
-        input_slices: flatbuffers::WIPOffset<
-            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<InputSlice<'b>>>,
+        query_inputs: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<ExecuteQueryInput<'b>>>,
         >,
     ) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQuery::VT_INPUT_SLICES,
-            input_slices,
+            ExecuteQuery::VT_QUERY_INPUTS,
+            query_inputs,
         );
     }
     #[inline]
-    pub fn add_input_checkpoint(
+    pub fn add_prev_checkpoint(
         &mut self,
-        input_checkpoint: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
+        prev_checkpoint: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
     ) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQuery::VT_INPUT_CHECKPOINT,
-            input_checkpoint,
+            ExecuteQuery::VT_PREV_CHECKPOINT,
+            prev_checkpoint,
         );
     }
     #[inline]
-    pub fn add_output_data(&mut self, output_data: flatbuffers::WIPOffset<DataSlice<'b>>) {
+    pub fn add_prev_offset(&mut self, prev_offset: u64) {
+        self.fbb_
+            .push_slot_always::<u64>(ExecuteQuery::VT_PREV_OFFSET, prev_offset);
+    }
+    #[inline]
+    pub fn add_new_data(&mut self, new_data: flatbuffers::WIPOffset<DataSlice<'b>>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<DataSlice>>(
-                ExecuteQuery::VT_OUTPUT_DATA,
-                output_data,
+                ExecuteQuery::VT_NEW_DATA,
+                new_data,
             );
     }
     #[inline]
-    pub fn add_output_checkpoint(
-        &mut self,
-        output_checkpoint: flatbuffers::WIPOffset<Checkpoint<'b>>,
-    ) {
+    pub fn add_new_checkpoint(&mut self, new_checkpoint: flatbuffers::WIPOffset<Checkpoint<'b>>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<Checkpoint>>(
-                ExecuteQuery::VT_OUTPUT_CHECKPOINT,
-                output_checkpoint,
+                ExecuteQuery::VT_NEW_CHECKPOINT,
+                new_checkpoint,
             );
     }
     #[inline]
-    pub fn add_output_watermark(&mut self, output_watermark: &Timestamp) {
+    pub fn add_new_watermark(&mut self, new_watermark: &Timestamp) {
         self.fbb_
-            .push_slot_always::<&Timestamp>(ExecuteQuery::VT_OUTPUT_WATERMARK, output_watermark);
+            .push_slot_always::<&Timestamp>(ExecuteQuery::VT_NEW_WATERMARK, new_watermark);
     }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ExecuteQueryBuilder<'a, 'b> {
@@ -6540,11 +5962,12 @@ impl<'a: 'b, 'b> ExecuteQueryBuilder<'a, 'b> {
 impl core::fmt::Debug for ExecuteQuery<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("ExecuteQuery");
-        ds.field("input_slices", &self.input_slices());
-        ds.field("input_checkpoint", &self.input_checkpoint());
-        ds.field("output_data", &self.output_data());
-        ds.field("output_checkpoint", &self.output_checkpoint());
-        ds.field("output_watermark", &self.output_watermark());
+        ds.field("query_inputs", &self.query_inputs());
+        ds.field("prev_checkpoint", &self.prev_checkpoint());
+        ds.field("prev_offset", &self.prev_offset());
+        ds.field("new_data", &self.new_data());
+        ds.field("new_checkpoint", &self.new_checkpoint());
+        ds.field("new_watermark", &self.new_watermark());
         ds.finish()
     }
 }
@@ -8958,21 +8381,6 @@ impl<'a> SetPollingSource<'a> {
 
     #[inline]
     #[allow(non_snake_case)]
-    pub fn read_as_read_step_json_lines(&self) -> Option<ReadStepJsonLines<'a>> {
-        if self.read_type() == ReadStep::ReadStepJsonLines {
-            self.read().map(|t| {
-                // Safety:
-                // Created from a valid Table for this object
-                // Which contains a valid union in this slot
-                unsafe { ReadStepJsonLines::init_from_table(t) }
-            })
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
     pub fn read_as_read_step_geo_json(&self) -> Option<ReadStepGeoJson<'a>> {
         if self.read_type() == ReadStep::ReadStepGeoJson {
             self.read().map(|t| {
@@ -9142,7 +8550,6 @@ impl flatbuffers::Verifiable for SetPollingSource<'_> {
      .visit_union::<ReadStep, _>("read_type", Self::VT_READ_TYPE, "read", Self::VT_READ, false, |key, v, pos| {
         match key {
           ReadStep::ReadStepCsv => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepCsv>>("ReadStep::ReadStepCsv", pos),
-          ReadStep::ReadStepJsonLines => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepJsonLines>>("ReadStep::ReadStepJsonLines", pos),
           ReadStep::ReadStepGeoJson => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepGeoJson>>("ReadStep::ReadStepGeoJson", pos),
           ReadStep::ReadStepEsriShapefile => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepEsriShapefile>>("ReadStep::ReadStepEsriShapefile", pos),
           ReadStep::ReadStepParquet => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReadStepParquet>>("ReadStep::ReadStepParquet", pos),
@@ -9341,16 +8748,6 @@ impl core::fmt::Debug for SetPollingSource<'_> {
                     )
                 }
             }
-            ReadStep::ReadStepJsonLines => {
-                if let Some(x) = self.read_as_read_step_json_lines() {
-                    ds.field("read", &x)
-                } else {
-                    ds.field(
-                        "read",
-                        &"InvalidFlatbuffer: Union discriminant does not match value.",
-                    )
-                }
-            }
             ReadStep::ReadStepGeoJson => {
                 if let Some(x) = self.read_as_read_step_geo_json() {
                     ds.field("read", &x)
@@ -9492,9 +8889,8 @@ impl<'a> flatbuffers::Follow<'a> for TransformInput<'a> {
 }
 
 impl<'a> TransformInput<'a> {
-    pub const VT_ID: flatbuffers::VOffsetT = 4;
-    pub const VT_NAME: flatbuffers::VOffsetT = 6;
-    pub const VT_DATASET_REF: flatbuffers::VOffsetT = 8;
+    pub const VT_DATASET_REF: flatbuffers::VOffsetT = 4;
+    pub const VT_ALIAS: flatbuffers::VOffsetT = 6;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -9506,41 +8902,15 @@ impl<'a> TransformInput<'a> {
         args: &'args TransformInputArgs<'args>,
     ) -> flatbuffers::WIPOffset<TransformInput<'bldr>> {
         let mut builder = TransformInputBuilder::new(_fbb);
+        if let Some(x) = args.alias {
+            builder.add_alias(x);
+        }
         if let Some(x) = args.dataset_ref {
             builder.add_dataset_ref(x);
-        }
-        if let Some(x) = args.name {
-            builder.add_name(x);
-        }
-        if let Some(x) = args.id {
-            builder.add_id(x);
         }
         builder.finish()
     }
 
-    #[inline]
-    pub fn id(&self) -> Option<flatbuffers::Vector<'a, u8>> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    TransformInput::VT_ID,
-                    None,
-                )
-        }
-    }
-    #[inline]
-    pub fn name(&self) -> Option<&'a str> {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(TransformInput::VT_NAME, None)
-        }
-    }
     #[inline]
     pub fn dataset_ref(&self) -> Option<&'a str> {
         // Safety:
@@ -9549,6 +8919,16 @@ impl<'a> TransformInput<'a> {
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<&str>>(TransformInput::VT_DATASET_REF, None)
+        }
+    }
+    #[inline]
+    pub fn alias(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(TransformInput::VT_ALIAS, None)
         }
     }
 }
@@ -9561,33 +8941,26 @@ impl flatbuffers::Verifiable for TransformInput<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                "id",
-                Self::VT_ID,
-                false,
-            )?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
                 "dataset_ref",
                 Self::VT_DATASET_REF,
                 false,
             )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("alias", Self::VT_ALIAS, false)?
             .finish();
         Ok(())
     }
 }
 pub struct TransformInputArgs<'a> {
-    pub id: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub dataset_ref: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub alias: Option<flatbuffers::WIPOffset<&'a str>>,
 }
 impl<'a> Default for TransformInputArgs<'a> {
     #[inline]
     fn default() -> Self {
         TransformInputArgs {
-            id: None,
-            name: None,
             dataset_ref: None,
+            alias: None,
         }
     }
 }
@@ -9598,21 +8971,16 @@ pub struct TransformInputBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> TransformInputBuilder<'a, 'b> {
     #[inline]
-    pub fn add_id(&mut self, id: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(TransformInput::VT_ID, id);
-    }
-    #[inline]
-    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
-        self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(TransformInput::VT_NAME, name);
-    }
-    #[inline]
     pub fn add_dataset_ref(&mut self, dataset_ref: flatbuffers::WIPOffset<&'b str>) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
             TransformInput::VT_DATASET_REF,
             dataset_ref,
         );
+    }
+    #[inline]
+    pub fn add_alias(&mut self, alias: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(TransformInput::VT_ALIAS, alias);
     }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TransformInputBuilder<'a, 'b> {
@@ -9632,9 +9000,8 @@ impl<'a: 'b, 'b> TransformInputBuilder<'a, 'b> {
 impl core::fmt::Debug for TransformInput<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("TransformInput");
-        ds.field("id", &self.id());
-        ds.field("name", &self.name());
         ds.field("dataset_ref", &self.dataset_ref());
+        ds.field("alias", &self.alias());
         ds.finish()
     }
 }
@@ -11243,16 +10610,16 @@ impl core::fmt::Debug for Watermark<'_> {
         ds.finish()
     }
 }
-pub enum ExecuteQueryInputOffset {}
+pub enum ExecuteQueryRequestInputOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 ////////////////////////////////////////////////////////////////////////////////
-pub struct ExecuteQueryInput<'a> {
+pub struct ExecuteQueryRequestInput<'a> {
     pub _tab: flatbuffers::Table<'a>,
 }
 
-impl<'a> flatbuffers::Follow<'a> for ExecuteQueryInput<'a> {
-    type Inner = ExecuteQueryInput<'a>;
+impl<'a> flatbuffers::Follow<'a> for ExecuteQueryRequestInput<'a> {
+    type Inner = ExecuteQueryRequestInput<'a>;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
@@ -11261,25 +10628,26 @@ impl<'a> flatbuffers::Follow<'a> for ExecuteQueryInput<'a> {
     }
 }
 
-impl<'a> ExecuteQueryInput<'a> {
+impl<'a> ExecuteQueryRequestInput<'a> {
     pub const VT_DATASET_ID: flatbuffers::VOffsetT = 4;
-    pub const VT_DATASET_NAME: flatbuffers::VOffsetT = 6;
-    pub const VT_VOCAB: flatbuffers::VOffsetT = 8;
-    pub const VT_DATA_INTERVAL: flatbuffers::VOffsetT = 10;
-    pub const VT_DATA_PATHS: flatbuffers::VOffsetT = 12;
-    pub const VT_SCHEMA_FILE: flatbuffers::VOffsetT = 14;
-    pub const VT_EXPLICIT_WATERMARKS: flatbuffers::VOffsetT = 16;
+    pub const VT_DATASET_ALIAS: flatbuffers::VOffsetT = 6;
+    pub const VT_QUERY_ALIAS: flatbuffers::VOffsetT = 8;
+    pub const VT_VOCAB: flatbuffers::VOffsetT = 10;
+    pub const VT_OFFSET_INTERVAL: flatbuffers::VOffsetT = 12;
+    pub const VT_DATA_PATHS: flatbuffers::VOffsetT = 14;
+    pub const VT_SCHEMA_FILE: flatbuffers::VOffsetT = 16;
+    pub const VT_EXPLICIT_WATERMARKS: flatbuffers::VOffsetT = 18;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        ExecuteQueryInput { _tab: table }
+        ExecuteQueryRequestInput { _tab: table }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args ExecuteQueryInputArgs<'args>,
-    ) -> flatbuffers::WIPOffset<ExecuteQueryInput<'bldr>> {
-        let mut builder = ExecuteQueryInputBuilder::new(_fbb);
+        args: &'args ExecuteQueryRequestInputArgs<'args>,
+    ) -> flatbuffers::WIPOffset<ExecuteQueryRequestInput<'bldr>> {
+        let mut builder = ExecuteQueryRequestInputBuilder::new(_fbb);
         if let Some(x) = args.explicit_watermarks {
             builder.add_explicit_watermarks(x);
         }
@@ -11289,14 +10657,17 @@ impl<'a> ExecuteQueryInput<'a> {
         if let Some(x) = args.data_paths {
             builder.add_data_paths(x);
         }
-        if let Some(x) = args.data_interval {
-            builder.add_data_interval(x);
+        if let Some(x) = args.offset_interval {
+            builder.add_offset_interval(x);
         }
         if let Some(x) = args.vocab {
             builder.add_vocab(x);
         }
-        if let Some(x) = args.dataset_name {
-            builder.add_dataset_name(x);
+        if let Some(x) = args.query_alias {
+            builder.add_query_alias(x);
+        }
+        if let Some(x) = args.dataset_alias {
+            builder.add_dataset_alias(x);
         }
         if let Some(x) = args.dataset_id {
             builder.add_dataset_id(x);
@@ -11312,19 +10683,33 @@ impl<'a> ExecuteQueryInput<'a> {
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    ExecuteQueryInput::VT_DATASET_ID,
+                    ExecuteQueryRequestInput::VT_DATASET_ID,
                     None,
                 )
         }
     }
     #[inline]
-    pub fn dataset_name(&self) -> Option<&'a str> {
+    pub fn dataset_alias(&self) -> Option<&'a str> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ExecuteQueryInput::VT_DATASET_NAME, None)
+            self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(
+                ExecuteQueryRequestInput::VT_DATASET_ALIAS,
+                None,
+            )
+        }
+    }
+    #[inline]
+    pub fn query_alias(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(
+                ExecuteQueryRequestInput::VT_QUERY_ALIAS,
+                None,
+            )
         }
     }
     #[inline]
@@ -11335,20 +10720,20 @@ impl<'a> ExecuteQueryInput<'a> {
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<DatasetVocabulary>>(
-                    ExecuteQueryInput::VT_VOCAB,
+                    ExecuteQueryRequestInput::VT_VOCAB,
                     None,
                 )
         }
     }
     #[inline]
-    pub fn data_interval(&self) -> Option<OffsetInterval<'a>> {
+    pub fn offset_interval(&self) -> Option<OffsetInterval<'a>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                    ExecuteQueryInput::VT_DATA_INTERVAL,
+                    ExecuteQueryRequestInput::VT_OFFSET_INTERVAL,
                     None,
                 )
         }
@@ -11363,7 +10748,7 @@ impl<'a> ExecuteQueryInput<'a> {
         unsafe {
             self._tab.get::<flatbuffers::ForwardsUOffset<
                 flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>,
-            >>(ExecuteQueryInput::VT_DATA_PATHS, None)
+            >>(ExecuteQueryRequestInput::VT_DATA_PATHS, None)
         }
     }
     #[inline]
@@ -11372,8 +10757,10 @@ impl<'a> ExecuteQueryInput<'a> {
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(ExecuteQueryInput::VT_SCHEMA_FILE, None)
+            self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(
+                ExecuteQueryRequestInput::VT_SCHEMA_FILE,
+                None,
+            )
         }
     }
     #[inline]
@@ -11386,12 +10773,12 @@ impl<'a> ExecuteQueryInput<'a> {
         unsafe {
             self._tab.get::<flatbuffers::ForwardsUOffset<
                 flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Watermark>>,
-            >>(ExecuteQueryInput::VT_EXPLICIT_WATERMARKS, None)
+            >>(ExecuteQueryRequestInput::VT_EXPLICIT_WATERMARKS, None)
         }
     }
 }
 
-impl flatbuffers::Verifiable for ExecuteQueryInput<'_> {
+impl flatbuffers::Verifiable for ExecuteQueryRequestInput<'_> {
     #[inline]
     fn run_verifier(
         v: &mut flatbuffers::Verifier,
@@ -11405,8 +10792,13 @@ impl flatbuffers::Verifiable for ExecuteQueryInput<'_> {
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "dataset_name",
-                Self::VT_DATASET_NAME,
+                "dataset_alias",
+                Self::VT_DATASET_ALIAS,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "query_alias",
+                Self::VT_QUERY_ALIAS,
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<DatasetVocabulary>>(
@@ -11415,8 +10807,8 @@ impl flatbuffers::Verifiable for ExecuteQueryInput<'_> {
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                "data_interval",
-                Self::VT_DATA_INTERVAL,
+                "offset_interval",
+                Self::VT_OFFSET_INTERVAL,
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<
@@ -11434,11 +10826,12 @@ impl flatbuffers::Verifiable for ExecuteQueryInput<'_> {
         Ok(())
     }
 }
-pub struct ExecuteQueryInputArgs<'a> {
+pub struct ExecuteQueryRequestInputArgs<'a> {
     pub dataset_id: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub dataset_name: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub dataset_alias: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub query_alias: Option<flatbuffers::WIPOffset<&'a str>>,
     pub vocab: Option<flatbuffers::WIPOffset<DatasetVocabulary<'a>>>,
-    pub data_interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
+    pub offset_interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
     pub data_paths: Option<
         flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>>,
     >,
@@ -11449,14 +10842,15 @@ pub struct ExecuteQueryInputArgs<'a> {
         >,
     >,
 }
-impl<'a> Default for ExecuteQueryInputArgs<'a> {
+impl<'a> Default for ExecuteQueryRequestInputArgs<'a> {
     #[inline]
     fn default() -> Self {
-        ExecuteQueryInputArgs {
+        ExecuteQueryRequestInputArgs {
             dataset_id: None,
-            dataset_name: None,
+            dataset_alias: None,
+            query_alias: None,
             vocab: None,
-            data_interval: None,
+            offset_interval: None,
             data_paths: None,
             schema_file: None,
             explicit_watermarks: None,
@@ -11464,42 +10858,52 @@ impl<'a> Default for ExecuteQueryInputArgs<'a> {
     }
 }
 
-pub struct ExecuteQueryInputBuilder<'a: 'b, 'b> {
+pub struct ExecuteQueryRequestInputBuilder<'a: 'b, 'b> {
     fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
     start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> ExecuteQueryInputBuilder<'a, 'b> {
+impl<'a: 'b, 'b> ExecuteQueryRequestInputBuilder<'a, 'b> {
     #[inline]
     pub fn add_dataset_id(
         &mut self,
         dataset_id: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
     ) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQueryInput::VT_DATASET_ID,
+            ExecuteQueryRequestInput::VT_DATASET_ID,
             dataset_id,
         );
     }
     #[inline]
-    pub fn add_dataset_name(&mut self, dataset_name: flatbuffers::WIPOffset<&'b str>) {
+    pub fn add_dataset_alias(&mut self, dataset_alias: flatbuffers::WIPOffset<&'b str>) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQueryInput::VT_DATASET_NAME,
-            dataset_name,
+            ExecuteQueryRequestInput::VT_DATASET_ALIAS,
+            dataset_alias,
+        );
+    }
+    #[inline]
+    pub fn add_query_alias(&mut self, query_alias: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            ExecuteQueryRequestInput::VT_QUERY_ALIAS,
+            query_alias,
         );
     }
     #[inline]
     pub fn add_vocab(&mut self, vocab: flatbuffers::WIPOffset<DatasetVocabulary<'b>>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<DatasetVocabulary>>(
-                ExecuteQueryInput::VT_VOCAB,
+                ExecuteQueryRequestInput::VT_VOCAB,
                 vocab,
             );
     }
     #[inline]
-    pub fn add_data_interval(&mut self, data_interval: flatbuffers::WIPOffset<OffsetInterval<'b>>) {
+    pub fn add_offset_interval(
+        &mut self,
+        offset_interval: flatbuffers::WIPOffset<OffsetInterval<'b>>,
+    ) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<OffsetInterval>>(
-                ExecuteQueryInput::VT_DATA_INTERVAL,
-                data_interval,
+                ExecuteQueryRequestInput::VT_OFFSET_INTERVAL,
+                offset_interval,
             );
     }
     #[inline]
@@ -11510,14 +10914,14 @@ impl<'a: 'b, 'b> ExecuteQueryInputBuilder<'a, 'b> {
         >,
     ) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQueryInput::VT_DATA_PATHS,
+            ExecuteQueryRequestInput::VT_DATA_PATHS,
             data_paths,
         );
     }
     #[inline]
     pub fn add_schema_file(&mut self, schema_file: flatbuffers::WIPOffset<&'b str>) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQueryInput::VT_SCHEMA_FILE,
+            ExecuteQueryRequestInput::VT_SCHEMA_FILE,
             schema_file,
         );
     }
@@ -11529,34 +10933,35 @@ impl<'a: 'b, 'b> ExecuteQueryInputBuilder<'a, 'b> {
         >,
     ) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQueryInput::VT_EXPLICIT_WATERMARKS,
+            ExecuteQueryRequestInput::VT_EXPLICIT_WATERMARKS,
             explicit_watermarks,
         );
     }
     #[inline]
     pub fn new(
         _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    ) -> ExecuteQueryInputBuilder<'a, 'b> {
+    ) -> ExecuteQueryRequestInputBuilder<'a, 'b> {
         let start = _fbb.start_table();
-        ExecuteQueryInputBuilder {
+        ExecuteQueryRequestInputBuilder {
             fbb_: _fbb,
             start_: start,
         }
     }
     #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<ExecuteQueryInput<'a>> {
+    pub fn finish(self) -> flatbuffers::WIPOffset<ExecuteQueryRequestInput<'a>> {
         let o = self.fbb_.end_table(self.start_);
         flatbuffers::WIPOffset::new(o.value())
     }
 }
 
-impl core::fmt::Debug for ExecuteQueryInput<'_> {
+impl core::fmt::Debug for ExecuteQueryRequestInput<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut ds = f.debug_struct("ExecuteQueryInput");
+        let mut ds = f.debug_struct("ExecuteQueryRequestInput");
         ds.field("dataset_id", &self.dataset_id());
-        ds.field("dataset_name", &self.dataset_name());
+        ds.field("dataset_alias", &self.dataset_alias());
+        ds.field("query_alias", &self.query_alias());
         ds.field("vocab", &self.vocab());
-        ds.field("data_interval", &self.data_interval());
+        ds.field("offset_interval", &self.offset_interval());
         ds.field("data_paths", &self.data_paths());
         ds.field("schema_file", &self.schema_file());
         ds.field("explicit_watermarks", &self.explicit_watermarks());
@@ -11583,16 +10988,16 @@ impl<'a> flatbuffers::Follow<'a> for ExecuteQueryRequest<'a> {
 
 impl<'a> ExecuteQueryRequest<'a> {
     pub const VT_DATASET_ID: flatbuffers::VOffsetT = 4;
-    pub const VT_DATASET_NAME: flatbuffers::VOffsetT = 6;
+    pub const VT_DATASET_ALIAS: flatbuffers::VOffsetT = 6;
     pub const VT_SYSTEM_TIME: flatbuffers::VOffsetT = 8;
-    pub const VT_OFFSET: flatbuffers::VOffsetT = 10;
-    pub const VT_VOCAB: flatbuffers::VOffsetT = 12;
-    pub const VT_TRANSFORM_TYPE: flatbuffers::VOffsetT = 14;
-    pub const VT_TRANSFORM: flatbuffers::VOffsetT = 16;
-    pub const VT_INPUTS: flatbuffers::VOffsetT = 18;
+    pub const VT_VOCAB: flatbuffers::VOffsetT = 10;
+    pub const VT_TRANSFORM_TYPE: flatbuffers::VOffsetT = 12;
+    pub const VT_TRANSFORM: flatbuffers::VOffsetT = 14;
+    pub const VT_QUERY_INPUTS: flatbuffers::VOffsetT = 16;
+    pub const VT_NEXT_OFFSET: flatbuffers::VOffsetT = 18;
     pub const VT_PREV_CHECKPOINT_PATH: flatbuffers::VOffsetT = 20;
     pub const VT_NEW_CHECKPOINT_PATH: flatbuffers::VOffsetT = 22;
-    pub const VT_OUT_DATA_PATH: flatbuffers::VOffsetT = 24;
+    pub const VT_NEW_DATA_PATH: flatbuffers::VOffsetT = 24;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -11604,9 +11009,9 @@ impl<'a> ExecuteQueryRequest<'a> {
         args: &'args ExecuteQueryRequestArgs<'args>,
     ) -> flatbuffers::WIPOffset<ExecuteQueryRequest<'bldr>> {
         let mut builder = ExecuteQueryRequestBuilder::new(_fbb);
-        builder.add_offset(args.offset);
-        if let Some(x) = args.out_data_path {
-            builder.add_out_data_path(x);
+        builder.add_next_offset(args.next_offset);
+        if let Some(x) = args.new_data_path {
+            builder.add_new_data_path(x);
         }
         if let Some(x) = args.new_checkpoint_path {
             builder.add_new_checkpoint_path(x);
@@ -11614,8 +11019,8 @@ impl<'a> ExecuteQueryRequest<'a> {
         if let Some(x) = args.prev_checkpoint_path {
             builder.add_prev_checkpoint_path(x);
         }
-        if let Some(x) = args.inputs {
-            builder.add_inputs(x);
+        if let Some(x) = args.query_inputs {
+            builder.add_query_inputs(x);
         }
         if let Some(x) = args.transform {
             builder.add_transform(x);
@@ -11626,8 +11031,8 @@ impl<'a> ExecuteQueryRequest<'a> {
         if let Some(x) = args.system_time {
             builder.add_system_time(x);
         }
-        if let Some(x) = args.dataset_name {
-            builder.add_dataset_name(x);
+        if let Some(x) = args.dataset_alias {
+            builder.add_dataset_alias(x);
         }
         if let Some(x) = args.dataset_id {
             builder.add_dataset_id(x);
@@ -11650,13 +11055,13 @@ impl<'a> ExecuteQueryRequest<'a> {
         }
     }
     #[inline]
-    pub fn dataset_name(&self) -> Option<&'a str> {
+    pub fn dataset_alias(&self) -> Option<&'a str> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(
-                ExecuteQueryRequest::VT_DATASET_NAME,
+                ExecuteQueryRequest::VT_DATASET_ALIAS,
                 None,
             )
         }
@@ -11669,17 +11074,6 @@ impl<'a> ExecuteQueryRequest<'a> {
         unsafe {
             self._tab
                 .get::<Timestamp>(ExecuteQueryRequest::VT_SYSTEM_TIME, None)
-        }
-    }
-    #[inline]
-    pub fn offset(&self) -> i64 {
-        // Safety:
-        // Created from valid Table for this object
-        // which contains a valid value in this slot
-        unsafe {
-            self._tab
-                .get::<i64>(ExecuteQueryRequest::VT_OFFSET, Some(0))
-                .unwrap()
         }
     }
     #[inline]
@@ -11723,16 +11117,28 @@ impl<'a> ExecuteQueryRequest<'a> {
         }
     }
     #[inline]
-    pub fn inputs(
+    pub fn query_inputs(
         &self,
-    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryInput<'a>>>> {
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryRequestInput<'a>>>>
+    {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryInput>>,
-            >>(ExecuteQueryRequest::VT_INPUTS, None)
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryRequestInput>>,
+            >>(ExecuteQueryRequest::VT_QUERY_INPUTS, None)
+        }
+    }
+    #[inline]
+    pub fn next_offset(&self) -> u64 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<u64>(ExecuteQueryRequest::VT_NEXT_OFFSET, Some(0))
+                .unwrap()
         }
     }
     #[inline]
@@ -11760,13 +11166,13 @@ impl<'a> ExecuteQueryRequest<'a> {
         }
     }
     #[inline]
-    pub fn out_data_path(&self) -> Option<&'a str> {
+    pub fn new_data_path(&self) -> Option<&'a str> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(
-                ExecuteQueryRequest::VT_OUT_DATA_PATH,
+                ExecuteQueryRequest::VT_NEW_DATA_PATH,
                 None,
             )
         }
@@ -11801,12 +11207,11 @@ impl flatbuffers::Verifiable for ExecuteQueryRequest<'_> {
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "dataset_name",
-                Self::VT_DATASET_NAME,
+                "dataset_alias",
+                Self::VT_DATASET_ALIAS,
                 false,
             )?
             .visit_field::<Timestamp>("system_time", Self::VT_SYSTEM_TIME, false)?
-            .visit_field::<i64>("offset", Self::VT_OFFSET, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<DatasetVocabulary>>(
                 "vocab",
                 Self::VT_VOCAB,
@@ -11828,8 +11233,9 @@ impl flatbuffers::Verifiable for ExecuteQueryRequest<'_> {
                 },
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ExecuteQueryInput>>,
-            >>("inputs", Self::VT_INPUTS, false)?
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ExecuteQueryRequestInput>>,
+            >>("query_inputs", Self::VT_QUERY_INPUTS, false)?
+            .visit_field::<u64>("next_offset", Self::VT_NEXT_OFFSET, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
                 "prev_checkpoint_path",
                 Self::VT_PREV_CHECKPOINT_PATH,
@@ -11841,8 +11247,8 @@ impl flatbuffers::Verifiable for ExecuteQueryRequest<'_> {
                 false,
             )?
             .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                "out_data_path",
-                Self::VT_OUT_DATA_PATH,
+                "new_data_path",
+                Self::VT_NEW_DATA_PATH,
                 false,
             )?
             .finish();
@@ -11851,36 +11257,36 @@ impl flatbuffers::Verifiable for ExecuteQueryRequest<'_> {
 }
 pub struct ExecuteQueryRequestArgs<'a> {
     pub dataset_id: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub dataset_name: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub dataset_alias: Option<flatbuffers::WIPOffset<&'a str>>,
     pub system_time: Option<&'a Timestamp>,
-    pub offset: i64,
     pub vocab: Option<flatbuffers::WIPOffset<DatasetVocabulary<'a>>>,
     pub transform_type: Transform,
     pub transform: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
-    pub inputs: Option<
+    pub query_inputs: Option<
         flatbuffers::WIPOffset<
-            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryInput<'a>>>,
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExecuteQueryRequestInput<'a>>>,
         >,
     >,
+    pub next_offset: u64,
     pub prev_checkpoint_path: Option<flatbuffers::WIPOffset<&'a str>>,
     pub new_checkpoint_path: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub out_data_path: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub new_data_path: Option<flatbuffers::WIPOffset<&'a str>>,
 }
 impl<'a> Default for ExecuteQueryRequestArgs<'a> {
     #[inline]
     fn default() -> Self {
         ExecuteQueryRequestArgs {
             dataset_id: None,
-            dataset_name: None,
+            dataset_alias: None,
             system_time: None,
-            offset: 0,
             vocab: None,
             transform_type: Transform::NONE,
             transform: None,
-            inputs: None,
+            query_inputs: None,
+            next_offset: 0,
             prev_checkpoint_path: None,
             new_checkpoint_path: None,
-            out_data_path: None,
+            new_data_path: None,
         }
     }
 }
@@ -11901,21 +11307,16 @@ impl<'a: 'b, 'b> ExecuteQueryRequestBuilder<'a, 'b> {
         );
     }
     #[inline]
-    pub fn add_dataset_name(&mut self, dataset_name: flatbuffers::WIPOffset<&'b str>) {
+    pub fn add_dataset_alias(&mut self, dataset_alias: flatbuffers::WIPOffset<&'b str>) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQueryRequest::VT_DATASET_NAME,
-            dataset_name,
+            ExecuteQueryRequest::VT_DATASET_ALIAS,
+            dataset_alias,
         );
     }
     #[inline]
     pub fn add_system_time(&mut self, system_time: &Timestamp) {
         self.fbb_
             .push_slot_always::<&Timestamp>(ExecuteQueryRequest::VT_SYSTEM_TIME, system_time);
-    }
-    #[inline]
-    pub fn add_offset(&mut self, offset: i64) {
-        self.fbb_
-            .push_slot::<i64>(ExecuteQueryRequest::VT_OFFSET, offset, 0);
     }
     #[inline]
     pub fn add_vocab(&mut self, vocab: flatbuffers::WIPOffset<DatasetVocabulary<'b>>) {
@@ -11944,14 +11345,21 @@ impl<'a: 'b, 'b> ExecuteQueryRequestBuilder<'a, 'b> {
         );
     }
     #[inline]
-    pub fn add_inputs(
+    pub fn add_query_inputs(
         &mut self,
-        inputs: flatbuffers::WIPOffset<
-            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<ExecuteQueryInput<'b>>>,
+        query_inputs: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<ExecuteQueryRequestInput<'b>>>,
         >,
     ) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            ExecuteQueryRequest::VT_QUERY_INPUTS,
+            query_inputs,
+        );
+    }
+    #[inline]
+    pub fn add_next_offset(&mut self, next_offset: u64) {
         self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(ExecuteQueryRequest::VT_INPUTS, inputs);
+            .push_slot::<u64>(ExecuteQueryRequest::VT_NEXT_OFFSET, next_offset, 0);
     }
     #[inline]
     pub fn add_prev_checkpoint_path(
@@ -11974,10 +11382,10 @@ impl<'a: 'b, 'b> ExecuteQueryRequestBuilder<'a, 'b> {
         );
     }
     #[inline]
-    pub fn add_out_data_path(&mut self, out_data_path: flatbuffers::WIPOffset<&'b str>) {
+    pub fn add_new_data_path(&mut self, new_data_path: flatbuffers::WIPOffset<&'b str>) {
         self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            ExecuteQueryRequest::VT_OUT_DATA_PATH,
-            out_data_path,
+            ExecuteQueryRequest::VT_NEW_DATA_PATH,
+            new_data_path,
         );
     }
     #[inline]
@@ -12001,9 +11409,8 @@ impl core::fmt::Debug for ExecuteQueryRequest<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("ExecuteQueryRequest");
         ds.field("dataset_id", &self.dataset_id());
-        ds.field("dataset_name", &self.dataset_name());
+        ds.field("dataset_alias", &self.dataset_alias());
         ds.field("system_time", &self.system_time());
-        ds.field("offset", &self.offset());
         ds.field("vocab", &self.vocab());
         ds.field("transform_type", &self.transform_type());
         match self.transform_type() {
@@ -12022,10 +11429,11 @@ impl core::fmt::Debug for ExecuteQueryRequest<'_> {
                 ds.field("transform", &x)
             }
         };
-        ds.field("inputs", &self.inputs());
+        ds.field("query_inputs", &self.query_inputs());
+        ds.field("next_offset", &self.next_offset());
         ds.field("prev_checkpoint_path", &self.prev_checkpoint_path());
         ds.field("new_checkpoint_path", &self.new_checkpoint_path());
-        ds.field("out_data_path", &self.out_data_path());
+        ds.field("new_data_path", &self.new_data_path());
         ds.finish()
     }
 }
@@ -12127,8 +11535,8 @@ impl<'a> flatbuffers::Follow<'a> for ExecuteQueryResponseSuccess<'a> {
 }
 
 impl<'a> ExecuteQueryResponseSuccess<'a> {
-    pub const VT_DATA_INTERVAL: flatbuffers::VOffsetT = 4;
-    pub const VT_OUTPUT_WATERMARK: flatbuffers::VOffsetT = 6;
+    pub const VT_OFFSET_INTERVAL: flatbuffers::VOffsetT = 4;
+    pub const VT_NEW_WATERMARK: flatbuffers::VOffsetT = 6;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -12140,36 +11548,36 @@ impl<'a> ExecuteQueryResponseSuccess<'a> {
         args: &'args ExecuteQueryResponseSuccessArgs<'args>,
     ) -> flatbuffers::WIPOffset<ExecuteQueryResponseSuccess<'bldr>> {
         let mut builder = ExecuteQueryResponseSuccessBuilder::new(_fbb);
-        if let Some(x) = args.output_watermark {
-            builder.add_output_watermark(x);
+        if let Some(x) = args.new_watermark {
+            builder.add_new_watermark(x);
         }
-        if let Some(x) = args.data_interval {
-            builder.add_data_interval(x);
+        if let Some(x) = args.offset_interval {
+            builder.add_offset_interval(x);
         }
         builder.finish()
     }
 
     #[inline]
-    pub fn data_interval(&self) -> Option<OffsetInterval<'a>> {
+    pub fn offset_interval(&self) -> Option<OffsetInterval<'a>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                    ExecuteQueryResponseSuccess::VT_DATA_INTERVAL,
+                    ExecuteQueryResponseSuccess::VT_OFFSET_INTERVAL,
                     None,
                 )
         }
     }
     #[inline]
-    pub fn output_watermark(&self) -> Option<&'a Timestamp> {
+    pub fn new_watermark(&self) -> Option<&'a Timestamp> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<Timestamp>(ExecuteQueryResponseSuccess::VT_OUTPUT_WATERMARK, None)
+                .get::<Timestamp>(ExecuteQueryResponseSuccess::VT_NEW_WATERMARK, None)
         }
     }
 }
@@ -12183,25 +11591,25 @@ impl flatbuffers::Verifiable for ExecuteQueryResponseSuccess<'_> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
             .visit_field::<flatbuffers::ForwardsUOffset<OffsetInterval>>(
-                "data_interval",
-                Self::VT_DATA_INTERVAL,
+                "offset_interval",
+                Self::VT_OFFSET_INTERVAL,
                 false,
             )?
-            .visit_field::<Timestamp>("output_watermark", Self::VT_OUTPUT_WATERMARK, false)?
+            .visit_field::<Timestamp>("new_watermark", Self::VT_NEW_WATERMARK, false)?
             .finish();
         Ok(())
     }
 }
 pub struct ExecuteQueryResponseSuccessArgs<'a> {
-    pub data_interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
-    pub output_watermark: Option<&'a Timestamp>,
+    pub offset_interval: Option<flatbuffers::WIPOffset<OffsetInterval<'a>>>,
+    pub new_watermark: Option<&'a Timestamp>,
 }
 impl<'a> Default for ExecuteQueryResponseSuccessArgs<'a> {
     #[inline]
     fn default() -> Self {
         ExecuteQueryResponseSuccessArgs {
-            data_interval: None,
-            output_watermark: None,
+            offset_interval: None,
+            new_watermark: None,
         }
     }
 }
@@ -12212,18 +11620,21 @@ pub struct ExecuteQueryResponseSuccessBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> ExecuteQueryResponseSuccessBuilder<'a, 'b> {
     #[inline]
-    pub fn add_data_interval(&mut self, data_interval: flatbuffers::WIPOffset<OffsetInterval<'b>>) {
+    pub fn add_offset_interval(
+        &mut self,
+        offset_interval: flatbuffers::WIPOffset<OffsetInterval<'b>>,
+    ) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<OffsetInterval>>(
-                ExecuteQueryResponseSuccess::VT_DATA_INTERVAL,
-                data_interval,
+                ExecuteQueryResponseSuccess::VT_OFFSET_INTERVAL,
+                offset_interval,
             );
     }
     #[inline]
-    pub fn add_output_watermark(&mut self, output_watermark: &Timestamp) {
+    pub fn add_new_watermark(&mut self, new_watermark: &Timestamp) {
         self.fbb_.push_slot_always::<&Timestamp>(
-            ExecuteQueryResponseSuccess::VT_OUTPUT_WATERMARK,
-            output_watermark,
+            ExecuteQueryResponseSuccess::VT_NEW_WATERMARK,
+            new_watermark,
         );
     }
     #[inline]
@@ -12246,8 +11657,8 @@ impl<'a: 'b, 'b> ExecuteQueryResponseSuccessBuilder<'a, 'b> {
 impl core::fmt::Debug for ExecuteQueryResponseSuccess<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("ExecuteQueryResponseSuccess");
-        ds.field("data_interval", &self.data_interval());
-        ds.field("output_watermark", &self.output_watermark());
+        ds.field("offset_interval", &self.offset_interval());
+        ds.field("new_watermark", &self.new_watermark());
         ds.finish()
     }
 }
@@ -12943,10 +12354,10 @@ impl<'a> MetadataBlock<'a> {
         args: &'args MetadataBlockArgs<'args>,
     ) -> flatbuffers::WIPOffset<MetadataBlock<'bldr>> {
         let mut builder = MetadataBlockBuilder::new(_fbb);
+        builder.add_sequence_number(args.sequence_number);
         if let Some(x) = args.event {
             builder.add_event(x);
         }
-        builder.add_sequence_number(args.sequence_number);
         if let Some(x) = args.prev_block_hash {
             builder.add_prev_block_hash(x);
         }
@@ -12981,13 +12392,13 @@ impl<'a> MetadataBlock<'a> {
         }
     }
     #[inline]
-    pub fn sequence_number(&self) -> i32 {
+    pub fn sequence_number(&self) -> u64 {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<i32>(MetadataBlock::VT_SEQUENCE_NUMBER, Some(0))
+                .get::<u64>(MetadataBlock::VT_SEQUENCE_NUMBER, Some(0))
                 .unwrap()
         }
     }
@@ -13240,7 +12651,7 @@ impl flatbuffers::Verifiable for MetadataBlock<'_> {
                 Self::VT_PREV_BLOCK_HASH,
                 false,
             )?
-            .visit_field::<i32>("sequence_number", Self::VT_SEQUENCE_NUMBER, false)?
+            .visit_field::<u64>("sequence_number", Self::VT_SEQUENCE_NUMBER, false)?
             .visit_union::<MetadataEvent, _>(
                 "event_type",
                 Self::VT_EVENT_TYPE,
@@ -13328,7 +12739,7 @@ impl flatbuffers::Verifiable for MetadataBlock<'_> {
 pub struct MetadataBlockArgs<'a> {
     pub system_time: Option<&'a Timestamp>,
     pub prev_block_hash: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    pub sequence_number: i32,
+    pub sequence_number: u64,
     pub event_type: MetadataEvent,
     pub event: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
 }
@@ -13366,9 +12777,9 @@ impl<'a: 'b, 'b> MetadataBlockBuilder<'a, 'b> {
         );
     }
     #[inline]
-    pub fn add_sequence_number(&mut self, sequence_number: i32) {
+    pub fn add_sequence_number(&mut self, sequence_number: u64) {
         self.fbb_
-            .push_slot::<i32>(MetadataBlock::VT_SEQUENCE_NUMBER, sequence_number, 0);
+            .push_slot::<u64>(MetadataBlock::VT_SEQUENCE_NUMBER, sequence_number, 0);
     }
     #[inline]
     pub fn add_event_type(&mut self, event_type: MetadataEvent) {

--- a/src/domain/opendatafabric/src/serde/yaml/derivations_generated.rs
+++ b/src/domain/opendatafabric/src/serde/yaml/derivations_generated.rs
@@ -213,7 +213,7 @@ implement_serde_as!(DatasetKind, DatasetKindDef, "DatasetKindDef");
 #[serde(remote = "DatasetSnapshot")]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct DatasetSnapshotDef {
-    pub name: DatasetName,
+    pub name: DatasetAlias,
     #[serde_as(as = "DatasetKindDef")]
     pub kind: DatasetKind,
     #[serde_as(as = "Vec<MetadataEventDef>")]
@@ -540,7 +540,7 @@ pub struct ExecuteQueryResponseProgressDef {}
 pub struct ExecuteQueryResponseSuccessDef {
     #[serde_as(as = "Option<OffsetIntervalDef>")]
     #[serde(default)]
-    pub offset_interval: Option<OffsetInterval>,
+    pub new_offset_interval: Option<OffsetInterval>,
     #[serde(default, with = "datetime_rfc3339_opt")]
     pub new_watermark: Option<DateTime<Utc>>,
 }
@@ -1166,7 +1166,7 @@ implement_serde_as!(SetVocab, SetVocabDef, "SetVocabDef");
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct SetWatermarkDef {
     #[serde(with = "datetime_rfc3339")]
-    pub output_watermark: DateTime<Utc>,
+    pub new_watermark: DateTime<Utc>,
 }
 
 implement_serde_as!(SetWatermark, SetWatermarkDef, "SetWatermarkDef");
@@ -1296,7 +1296,7 @@ pub struct TransformSqlDef {
 #[serde(remote = "TransformInput")]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct TransformInputDef {
-    pub dataset_ref: DatasetRefAny,
+    pub dataset_ref: DatasetRef,
     pub alias: Option<String>,
 }
 

--- a/src/domain/opendatafabric/tests/tests/test_dynamic.rs
+++ b/src/domain/opendatafabric/tests/tests/test_dynamic.rs
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use chrono::prelude::*;
 use opendatafabric::*;
@@ -26,7 +25,7 @@ fn load() -> MetadataBlock {
                     alias: Some("input1".to_string()),
                 },
                 TransformInput {
-                    dataset_ref: DatasetRefAny::try_from("kamu/input2").unwrap(),
+                    dataset_ref: DatasetRef::try_from("kamu/input2").unwrap(),
                     alias: Some("input2".to_string()),
                 },
             ],
@@ -63,14 +62,11 @@ fn test_accessors() {
         inputs,
         vec![
             TransformInput {
-                dataset_ref: DatasetRefAny::ID(None, DatasetID::new_seeded_ed25519(b"input1")),
+                dataset_ref: DatasetID::new_seeded_ed25519(b"input1").into(),
                 alias: Some("input1".to_string()),
             },
             TransformInput {
-                dataset_ref: DatasetRefAny::AmbiguousAlias(
-                    Arc::from("kamu"),
-                    DatasetName::try_from("input2").unwrap()
-                ),
+                dataset_ref: DatasetRef::try_from("kamu/input2").unwrap(),
                 alias: Some("input2".to_string()),
             },
         ]

--- a/src/domain/opendatafabric/tests/tests/test_dynamic.rs
+++ b/src/domain/opendatafabric/tests/tests/test_dynamic.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use chrono::prelude::*;
 use opendatafabric::*;
 
-const TEST_SEQUENCE_NUMBER: i32 = 132;
+const TEST_SEQUENCE_NUMBER: u64 = 132;
 
 fn load() -> MetadataBlock {
     MetadataBlock {
@@ -22,14 +22,12 @@ fn load() -> MetadataBlock {
         event: MetadataEvent::SetTransform(SetTransform {
             inputs: vec![
                 TransformInput {
-                    id: Some(DatasetID::new_seeded_ed25519(b"input1")),
-                    name: DatasetName::try_from("input1").unwrap(),
-                    dataset_ref: None,
+                    dataset_ref: DatasetID::new_seeded_ed25519(b"input1").into(),
+                    alias: Some("input1".to_string()),
                 },
                 TransformInput {
-                    id: Some(DatasetID::new_seeded_ed25519(b"input2")),
-                    name: DatasetName::try_from("input2").unwrap(),
-                    dataset_ref: Some(DatasetRefAny::try_from("kamu/input2").unwrap()),
+                    dataset_ref: DatasetRefAny::try_from("kamu/input2").unwrap(),
+                    alias: Some("input2".to_string()),
                 },
             ],
             transform: Transform::Sql(TransformSql {
@@ -65,17 +63,15 @@ fn test_accessors() {
         inputs,
         vec![
             TransformInput {
-                id: Some(DatasetID::new_seeded_ed25519(b"input1")),
-                name: DatasetName::try_from("input1").unwrap(),
-                dataset_ref: None,
+                dataset_ref: DatasetRefAny::ID(None, DatasetID::new_seeded_ed25519(b"input1")),
+                alias: Some("input1".to_string()),
             },
             TransformInput {
-                id: Some(DatasetID::new_seeded_ed25519(b"input2")),
-                name: DatasetName::try_from("input2").unwrap(),
-                dataset_ref: Some(DatasetRefAny::AmbiguousAlias(
+                dataset_ref: DatasetRefAny::AmbiguousAlias(
                     Arc::from("kamu"),
                     DatasetName::try_from("input2").unwrap()
-                )),
+                ),
+                alias: Some("input2".to_string()),
             },
         ]
     );

--- a/src/domain/opendatafabric/tests/tests/test_serde_flatbuffers.rs
+++ b/src/domain/opendatafabric/tests/tests/test_serde_flatbuffers.rs
@@ -240,7 +240,7 @@ fn serde_set_data_schema() {
 fn serde_execute_query_response() {
     let examples = [
         ExecuteQueryResponse::Success(ExecuteQueryResponseSuccess {
-            offset_interval: Some(OffsetInterval { start: 0, end: 10 }),
+            new_offset_interval: Some(OffsetInterval { start: 0, end: 10 }),
             new_watermark: Some(Utc::now()),
         }),
         ExecuteQueryResponse::InvalidQuery(ExecuteQueryResponseInvalidQuery {

--- a/src/domain/opendatafabric/tests/tests/test_serde_flatbuffers.rs
+++ b/src/domain/opendatafabric/tests/tests/test_serde_flatbuffers.rs
@@ -47,64 +47,65 @@ fn get_test_events() -> [(MetadataEvent, &'static str); 6] {
                     primary_key: vec!["a".to_owned()],
                 }),
             }),
-            "b7b9d53f84abee88393a92bde7f615c3a3cd2d33a7d9df1409c8a8ffee8aaf2c",
+            "18cc1680b3d36f63358b59d469d76dcbf71ddac3ea66a693ce4158cfc5dfb28d",
         ),
         (
             MetadataEvent::AddData(AddData {
-                input_checkpoint: None,
-                output_data: None,
-                output_checkpoint: None,
-                output_watermark: None,
-                source_state: None,
+                prev_checkpoint: None,
+                prev_offset: None,
+                new_data: None,
+                new_checkpoint: None,
+                new_watermark: None,
+                new_source_state: None,
             }),
-            "eb745e4f975c66d8794afce2f5792a888ecf3cb367e2c90bf108753a34a0690e",
+            "73e2977b8beae4aef53670067c1173b9d68e69721908d080b84286ab366d1e14",
         ),
         (
             MetadataEvent::AddData(AddData {
-                input_checkpoint: None,
-                output_data: Some(DataSlice {
+                prev_checkpoint: None,
+                prev_offset: Some(9),
+                new_data: Some(DataSlice {
                     logical_hash: Multihash::from_digest_sha3_256(b"logical"),
                     physical_hash: Multihash::from_digest_sha3_256(b"physical"),
-                    interval: OffsetInterval { start: 0, end: 100 },
+                    offset_interval: OffsetInterval { start: 10, end: 99 },
                     size: 100,
                 }),
-                output_checkpoint: None,
-                output_watermark: None,
-                source_state: None,
+                new_checkpoint: None,
+                new_watermark: None,
+                new_source_state: None,
             }),
-            "5f5736202e41d0da69ec9835bb0d15efc23e844dd98243da585135c9f772812d",
+            "39426541aa50092a19daa39fd488cf0a6eaace03b2130440922f27916ef74a88",
         ),
         (
             MetadataEvent::AddData(AddData {
-                input_checkpoint: None,
-                output_data: Some(DataSlice {
+                prev_checkpoint: Some(Multihash::from_digest_sha3_256(b"checkpoint")),
+                prev_offset: Some(9),
+                new_data: Some(DataSlice {
                     logical_hash: Multihash::from_digest_sha3_256(b"logical"),
                     physical_hash: Multihash::from_digest_sha3_256(b"physical"),
-                    interval: OffsetInterval { start: 0, end: 100 },
+                    offset_interval: OffsetInterval { start: 10, end: 99 },
                     size: 100,
                 }),
-                output_checkpoint: None,
-                output_watermark: None,
-                source_state: Some(SourceState {
-                    kind: "odf/etag".to_owned(),
-                    source: "odf/polling-source".to_owned(),
-                    value: "SOME_ETAG".to_owned(),
+                new_checkpoint: None,
+                new_watermark: None,
+                new_source_state: Some(SourceState {
+                    source_name: Some("push-source-1".to_owned()),
+                    kind: "kamu/kafka-offset".to_owned(),
+                    value: "SOME_OFFSET".to_owned(),
                 }),
             }),
-            "bb459566b5913507f6627a07e13ab60bbd16948ee4d8fb640e77fc4c3df57998",
+            "db5044313bbd596fb54bef9387ad61a18206d1e93e833db4d1159d20cd3cac58",
         ),
         (
             MetadataEvent::SetTransform(SetTransform {
                 inputs: vec![
                     TransformInput {
-                        id: Some(DatasetID::new_seeded_ed25519(b"input1")),
-                        name: DatasetName::try_from("input1").unwrap(),
-                        dataset_ref: None,
+                        dataset_ref: DatasetID::new_seeded_ed25519(b"input1").into(),
+                        alias: Some("input1".to_string()),
                     },
                     TransformInput {
-                        id: Some(DatasetID::new_seeded_ed25519(b"input2")),
-                        name: DatasetName::try_from("input2").unwrap(),
-                        dataset_ref: None,
+                        dataset_ref: DatasetName::try_from("input2").unwrap().into(),
+                        alias: Some("input2".to_string()),
                     },
                 ],
                 transform: Transform::Sql(TransformSql {
@@ -115,46 +116,45 @@ fn get_test_events() -> [(MetadataEvent, &'static str); 6] {
                     temporal_tables: None,
                 }),
             }),
-            "e634a72f9a9a314a64afb26fd0d34012a08c7d47402dfbc78afa78edac978777",
+            "dc2ab3737792021b6794d3969315bb521701780c91548104f149906d98c8da70",
         ),
         (
             MetadataEvent::ExecuteQuery(ExecuteQuery {
-                input_slices: vec![
-                    InputSlice {
+                query_inputs: vec![
+                    ExecuteQueryInput {
                         dataset_id: DatasetID::new_seeded_ed25519(b"input1"),
-                        block_interval: Some(BlockInterval {
-                            start: Multihash::from_digest_sha3_256(b"a"),
-                            end: Multihash::from_digest_sha3_256(b"b"),
-                        }),
-                        data_interval: Some(OffsetInterval { start: 10, end: 20 }),
+                        prev_block_hash: Some(Multihash::from_digest_sha3_256(b"a")),
+                        new_block_hash: Some(Multihash::from_digest_sha3_256(b"b")),
+                        prev_offset: Some(9),
+                        new_offset: Some(20),
                     },
-                    InputSlice {
+                    ExecuteQueryInput {
                         dataset_id: DatasetID::new_seeded_ed25519(b"input2"),
-                        block_interval: Some(BlockInterval {
-                            start: Multihash::from_digest_sha3_256(b"a"),
-                            end: Multihash::from_digest_sha3_256(b"b"),
-                        }),
-                        data_interval: None,
+                        prev_block_hash: Some(Multihash::from_digest_sha3_256(b"a")),
+                        new_block_hash: Some(Multihash::from_digest_sha3_256(b"b")),
+                        prev_offset: None,
+                        new_offset: None,
                     },
                 ],
-                input_checkpoint: None,
-                output_data: Some(DataSlice {
+                prev_checkpoint: Some(Multihash::from_digest_sha3_256(b"checkpoint")),
+                prev_offset: Some(9),
+                new_data: Some(DataSlice {
                     logical_hash: Multihash::from_digest_sha3_256(b"foo"),
                     physical_hash: Multihash::from_digest_sha3_256(b"bar"),
-                    interval: OffsetInterval { start: 10, end: 20 },
+                    offset_interval: OffsetInterval { start: 10, end: 19 },
                     size: 10,
                 }),
-                output_checkpoint: None,
-                output_watermark: Some(Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap()),
+                new_checkpoint: None,
+                new_watermark: Some(Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap()),
             }),
-            "6b9715492945e2c69a335a1cb292ccad9d3f856e6c202ca0e8335ca9e45dd9ca",
+            "a955281dca303056a88e39291d17e045d88ecdafca3ef9e75b09b83169633b52",
         ),
     ]
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-const TEST_SEQUENCE_NUMBER: i32 = 117;
+const TEST_SEQUENCE_NUMBER: u64 = 117;
 
 fn wrap_into_block(event: MetadataEvent) -> MetadataBlock {
     MetadataBlock {
@@ -222,7 +222,7 @@ fn serde_set_data_schema() {
     assert_eq!(expected_block, actual_block);
 
     let hash_actual = format!("{:x}", sha3::Sha3_256::digest(&buffer));
-    let hash_expected = "d2f009192573b1ce449c04a8b1a3866ad0f86bb15808f447481f735cd90d95f0";
+    let hash_expected = "cc969ae72e4b2a7bbd7c7ede4cda43104ccc8549497c9f4044fff1681bdd8237";
 
     assert_eq!(hash_actual, hash_expected);
 
@@ -240,8 +240,8 @@ fn serde_set_data_schema() {
 fn serde_execute_query_response() {
     let examples = [
         ExecuteQueryResponse::Success(ExecuteQueryResponseSuccess {
-            data_interval: Some(OffsetInterval { start: 0, end: 10 }),
-            output_watermark: Some(Utc::now()),
+            offset_interval: Some(OffsetInterval { start: 0, end: 10 }),
+            new_watermark: Some(Utc::now()),
         }),
         ExecuteQueryResponse::InvalidQuery(ExecuteQueryResponseInvalidQuery {
             message: "boop".to_owned(),

--- a/src/domain/opendatafabric/tests/tests/test_serde_yaml.rs
+++ b/src/domain/opendatafabric/tests/tests/test_serde_yaml.rs
@@ -218,7 +218,7 @@ fn serde_dataset_snapshot_root() {
     );
 
     let expected = DatasetSnapshot {
-        name: DatasetName::try_from("kamu.test").unwrap(),
+        name: DatasetAlias::try_from("kamu.test").unwrap(),
         kind: DatasetKind::Root,
         metadata: vec![MetadataEvent::SetPollingSource(SetPollingSource {
             fetch: FetchStep::Url(FetchStepUrl {
@@ -296,7 +296,7 @@ fn serde_dataset_snapshot_derivative() {
     );
 
     let expected = DatasetSnapshot {
-        name: DatasetName::try_from("com.naturalearthdata.admin0").unwrap(),
+        name: DatasetAlias::try_from("com.naturalearthdata.admin0").unwrap(),
         kind: DatasetKind::Derivative,
         metadata: vec![MetadataEvent::SetTransform(SetTransform {
             inputs: vec![
@@ -343,13 +343,13 @@ fn serde_dataset_snapshot_derivative_with_multi_tenant_ref() {
         kind: DatasetSnapshot
         version: 1
         content:
-          name: com.naturalearthdata.admin0
+          name: a/com.naturalearthdata.admin0
           kind: Derivative
           metadata:
           - kind: SetTransform
             inputs:
-            - datasetRef: kamu/com.naturalearthdata.10m.admin0
-            - datasetRef: remote-repo/kamu/com.naturalearthdata.50m.admin0
+            - datasetRef: b/com.naturalearthdata.10m.admin0
+            - datasetRef: c/com.naturalearthdata.50m.admin0
             transform:
               kind: Sql
               engine: spark
@@ -358,20 +358,16 @@ fn serde_dataset_snapshot_derivative_with_multi_tenant_ref() {
     );
 
     let expected = DatasetSnapshot {
-        name: DatasetName::try_from("com.naturalearthdata.admin0").unwrap(),
+        name: DatasetAlias::try_from("a/com.naturalearthdata.admin0").unwrap(),
         kind: DatasetKind::Derivative,
         metadata: vec![MetadataEvent::SetTransform(SetTransform {
             inputs: vec![
                 TransformInput {
-                    dataset_ref: DatasetRefAny::try_from("kamu/com.naturalearthdata.10m.admin0")
-                        .unwrap(),
+                    dataset_ref: DatasetRef::try_from("b/com.naturalearthdata.10m.admin0").unwrap(),
                     alias: None,
                 },
                 TransformInput {
-                    dataset_ref: DatasetRefAny::try_from(
-                        "remote-repo/kamu/com.naturalearthdata.50m.admin0",
-                    )
-                    .unwrap(),
+                    dataset_ref: DatasetRef::try_from("c/com.naturalearthdata.50m.admin0").unwrap(),
                     alias: None,
                 },
             ],

--- a/src/domain/opendatafabric/tests/tests/test_serde_yaml.rs
+++ b/src/domain/opendatafabric/tests/tests/test_serde_yaml.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::assert_matches::assert_matches;
 use std::convert::TryFrom;
 
 use ::serde::{Deserialize, Serialize};
@@ -14,6 +15,118 @@ use chrono::prelude::*;
 use indoc::indoc;
 use opendatafabric::serde::yaml::*;
 use opendatafabric::*;
+
+#[test]
+fn serde_enum_tagging() {
+    #[derive(Deserialize, Serialize, Debug)]
+    struct Wrapper(#[serde(with = "ReadStepDef")] ReadStep);
+
+    let value = ReadStep::NdJson(ReadStepNdJson {
+        encoding: Some("utf-8".to_string()),
+        ..Default::default()
+    });
+
+    // Check produces PascalCase tags on serialize
+    assert_eq!(
+        serde_yaml::to_string(&Wrapper(value.clone())).unwrap(),
+        indoc::indoc!(
+            "
+            kind: NdJson
+            encoding: utf-8
+            "
+        )
+    );
+
+    // Check deserialize with exact tag match
+    let de_value = serde_yaml::from_str::<Wrapper>(indoc::indoc!(
+        "
+        kind: NdJson
+        encoding: utf-8
+        "
+    ))
+    .unwrap();
+    assert_eq!(de_value.0, value);
+
+    // Check deserialize with old camelCase tag
+    let de_value = serde_yaml::from_str::<Wrapper>(indoc::indoc!(
+        "
+        kind: ndJson
+        encoding: utf-8
+        "
+    ))
+    .unwrap();
+    assert_eq!(de_value.0, value);
+
+    // Check deserialize with lowercase tag
+    let de_value = serde_yaml::from_str::<Wrapper>(indoc::indoc!(
+        "
+        kind: ndjson
+        encoding: utf-8
+        "
+    ))
+    .unwrap();
+    assert_eq!(de_value.0, value);
+
+    // Check rejects other case permutations
+    assert_matches!(
+        serde_yaml::from_str::<Wrapper>(indoc::indoc!(
+            "
+            kind: nDjson
+            encoding: utf-8
+            "
+        )),
+        Err(_)
+    );
+}
+
+#[test]
+fn serde_string_enum_names() {
+    #[derive(Deserialize, Serialize, Debug)]
+    struct Wrapper {
+        #[serde(with = "SourceOrderingDef")]
+        kind: SourceOrdering,
+    }
+
+    let value = SourceOrdering::ByEventTime;
+
+    // Check produces PascalCase values on serialize as in spec schemas
+    assert_eq!(
+        serde_yaml::to_string(&Wrapper { kind: value }).unwrap(),
+        indoc::indoc!(
+            "
+            kind: ByEventTime
+            "
+        )
+    );
+
+    // Can deserialize from camelCase
+    let de_value = serde_yaml::from_str::<Wrapper>(indoc::indoc!(
+        "
+        kind: byEventTime
+        "
+    ))
+    .unwrap();
+    assert_eq!(de_value.kind, value);
+
+    // Can deserialize from lowercase
+    let de_value = serde_yaml::from_str::<Wrapper>(indoc::indoc!(
+        "
+        kind: byeventtime
+        "
+    ))
+    .unwrap();
+    assert_eq!(de_value.kind, value);
+
+    // Check rejects other case permutations
+    assert_matches!(
+        serde_yaml::from_str::<Wrapper>(indoc::indoc!(
+            "
+            kind: bYeventtime
+            "
+        )),
+        Err(_)
+    );
+}
 
 #[cfg(feature = "arrow")]
 #[test]
@@ -47,7 +160,7 @@ fn serde_set_data_schema() {
           prevBlockHash: f16209eb949bd8ff0bb1d827f11809aebc6bd0d5955c7f368469a913c70d196620272
           sequenceNumber: 123
           event:
-            kind: setDataSchema
+            kind: SetDataSchema
             schema: DAAAAAgACAAAAAQACAAAAAQAAAACAAAAQAAAAAQAAADY////GAAAAAwAAAAAAAAGEAAAAAAAAAAEAAQABAAAAAEAAABiAAAAEAAUABAAAAAPAAQAAAAIABAAAAAYAAAAIAAAAAAAAAIcAAAACAAMAAQACwAIAAAAQAAAAAAAAAEAAAAAAQAAAGEAAAA=
         "#
     );
@@ -78,27 +191,27 @@ fn serde_dataset_snapshot_root() {
         version: 1
         content:
           name: kamu.test
-          kind: root
+          kind: Root
           metadata:
-          - kind: setPollingSource
+          - kind: SetPollingSource
             fetch:
-              kind: url
+              kind: Url
               url: ftp://kamu.dev/test.zip
               cache:
-                kind: forever
+                kind: Forever
             prepare:
-            - kind: decompress
-              format: zip
+            - kind: Decompress
+              format: Zip
               subPath: data_*.csv
             read:
-              kind: csv
+              kind: Csv
               header: true
             preprocess:
-              kind: sql
+              kind: Sql
               engine: spark
               query: SELECT * FROM input
             merge:
-              kind: snapshot
+              kind: Snapshot
               primaryKey:
               - id
         "#
@@ -124,20 +237,11 @@ fn serde_dataset_snapshot_root() {
                 encoding: None,
                 quote: None,
                 escape: None,
-                comment: None,
                 header: Some(true),
-                enforce_schema: None,
                 infer_schema: None,
-                ignore_leading_white_space: None,
-                ignore_trailing_white_space: None,
                 null_value: None,
-                empty_value: None,
-                nan_value: None,
-                positive_inf: None,
-                negative_inf: None,
                 date_format: None,
                 timestamp_format: None,
-                multi_line: None,
             }),
             preprocess: Some(Transform::Sql(TransformSql {
                 engine: "spark".to_owned(),
@@ -178,14 +282,14 @@ fn serde_dataset_snapshot_derivative() {
         version: 1
         content:
           name: com.naturalearthdata.admin0
-          kind: derivative
+          kind: Derivative
           metadata:
-          - kind: setTransform
+          - kind: SetTransform
             inputs:
-            - name: com.naturalearthdata.10m.admin0
-            - name: com.naturalearthdata.50m.admin0
+            - datasetRef: com.naturalearthdata.10m.admin0
+            - datasetRef: com.naturalearthdata.50m.admin0
             transform:
-              kind: sql
+              kind: Sql
               engine: spark
               query: SOME_SQL
         "#
@@ -197,14 +301,16 @@ fn serde_dataset_snapshot_derivative() {
         metadata: vec![MetadataEvent::SetTransform(SetTransform {
             inputs: vec![
                 TransformInput {
-                    id: None,
-                    name: DatasetName::try_from("com.naturalearthdata.10m.admin0").unwrap(),
-                    dataset_ref: None,
+                    dataset_ref: DatasetName::try_from("com.naturalearthdata.10m.admin0")
+                        .unwrap()
+                        .into(),
+                    alias: None,
                 },
                 TransformInput {
-                    id: None,
-                    name: DatasetName::try_from("com.naturalearthdata.50m.admin0").unwrap(),
-                    dataset_ref: None,
+                    dataset_ref: DatasetName::try_from("com.naturalearthdata.50m.admin0")
+                        .unwrap()
+                        .into(),
+                    alias: None,
                 },
             ],
             transform: Transform::Sql(TransformSql {
@@ -238,16 +344,14 @@ fn serde_dataset_snapshot_derivative_with_multi_tenant_ref() {
         version: 1
         content:
           name: com.naturalearthdata.admin0
-          kind: derivative
+          kind: Derivative
           metadata:
-          - kind: setTransform
+          - kind: SetTransform
             inputs:
-            - name: com.naturalearthdata.10m.admin0
-              datasetRef: kamu/com.naturalearthdata.10m.admin0
-            - name: com.naturalearthdata.50m.admin0
-              datasetRef: remote-repo/kamu/com.naturalearthdata.50m.admin0
+            - datasetRef: kamu/com.naturalearthdata.10m.admin0
+            - datasetRef: remote-repo/kamu/com.naturalearthdata.50m.admin0
             transform:
-              kind: sql
+              kind: Sql
               engine: spark
               query: SOME_SQL
         "#
@@ -259,19 +363,16 @@ fn serde_dataset_snapshot_derivative_with_multi_tenant_ref() {
         metadata: vec![MetadataEvent::SetTransform(SetTransform {
             inputs: vec![
                 TransformInput {
-                    id: None,
-                    name: DatasetName::try_from("com.naturalearthdata.10m.admin0").unwrap(),
-                    dataset_ref: Some(
-                        DatasetRefAny::try_from("kamu/com.naturalearthdata.10m.admin0").unwrap(),
-                    ),
+                    dataset_ref: DatasetRefAny::try_from("kamu/com.naturalearthdata.10m.admin0")
+                        .unwrap(),
+                    alias: None,
                 },
                 TransformInput {
-                    id: None,
-                    name: DatasetName::try_from("com.naturalearthdata.50m.admin0").unwrap(),
-                    dataset_ref: Some(
-                        DatasetRefAny::try_from("remote-repo/kamu/com.naturalearthdata.50m.admin0")
-                            .unwrap(),
-                    ),
+                    dataset_ref: DatasetRefAny::try_from(
+                        "remote-repo/kamu/com.naturalearthdata.50m.admin0",
+                    )
+                    .unwrap(),
+                    alias: None,
                 },
             ],
             transform: Transform::Sql(TransformSql {
@@ -299,7 +400,41 @@ fn serde_dataset_snapshot_derivative_with_multi_tenant_ref() {
 
 #[test]
 fn serde_metadata_block() {
-    let data = indoc!(
+    let block = MetadataBlock {
+        prev_block_hash: Some(Multihash::from_digest_sha3_256(b"prev")),
+        system_time: Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap(),
+        event: MetadataEvent::ExecuteQuery(ExecuteQuery {
+            query_inputs: vec![
+                ExecuteQueryInput {
+                    dataset_id: DatasetID::new_seeded_ed25519(b"input1"),
+                    prev_block_hash: Some(Multihash::from_digest_sha3_256(b"a")),
+                    new_block_hash: Some(Multihash::from_digest_sha3_256(b"b")),
+                    prev_offset: Some(9),
+                    new_offset: Some(20),
+                },
+                ExecuteQueryInput {
+                    dataset_id: DatasetID::new_seeded_ed25519(b"input2"),
+                    prev_block_hash: Some(Multihash::from_digest_sha3_256(b"a")),
+                    new_block_hash: Some(Multihash::from_digest_sha3_256(b"b")),
+                    prev_offset: None,
+                    new_offset: None,
+                },
+            ],
+            prev_checkpoint: Some(Multihash::from_digest_sha3_256(b"checkpoint")),
+            prev_offset: Some(9),
+            new_data: Some(DataSlice {
+                logical_hash: Multihash::from_digest_sha3_256(b"foo"),
+                physical_hash: Multihash::from_digest_sha3_256(b"bar"),
+                offset_interval: OffsetInterval { start: 10, end: 19 },
+                size: 10,
+            }),
+            new_checkpoint: None,
+            new_watermark: Some(Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap()),
+        }),
+        sequence_number: 127,
+    };
+
+    let expected = indoc!(
         "
         kind: MetadataBlock
         version: 2
@@ -308,109 +443,75 @@ fn serde_metadata_block() {
           prevBlockHash: f16209eb949bd8ff0bb1d827f11809aebc6bd0d5955c7f368469a913c70d196620272
           sequenceNumber: 127
           event:
-            kind: executeQuery
-            inputSlices:
-            - datasetID: \
+            kind: ExecuteQuery
+            queryInputs:
+            - datasetId: \
          did:odf:fed01816ef0a9abe93aba816ef0a9abe93aba90e6065747170300c0d3d30c2cd8d7a4
-              blockInterval:
-                start: f162080084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b
-                end: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
-              dataInterval:
-                start: 10
-                end: 20
-            - datasetID: \
+              prevBlockHash: f162080084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b
+              newBlockHash: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
+              prevOffset: 9
+              newOffset: 20
+            - datasetId: \
          did:odf:fed01826ef0a9abea3a3a826ef0a9abea3a3a90e6065747270300c1d3b30a2cd9d724
-              blockInterval:
-                start: f162080084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b
-                end: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
-            outputData:
+              prevBlockHash: f162080084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b
+              newBlockHash: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
+            prevCheckpoint: f1620894b355f91b194f31c1116dcec200b68d5cfd90a3df19032829fa643bc711fcb
+            prevOffset: 9
+            newData:
               logicalHash: f162076d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01
               physicalHash: f1620cceefd7e0545bcf8b6d19f3b5750c8a3ee8350418877bc6fb12e32de28137355
-              interval:
+              offsetInterval:
                 start: 10
-                end: 20
+                end: 19
               size: 10
-            outputWatermark: 2020-01-01T12:00:00Z
+            newWatermark: 2020-01-01T12:00:00Z
         "
     );
 
-    let expected = MetadataBlock {
-        prev_block_hash: Some(Multihash::from_digest_sha3_256(b"prev")),
-        system_time: Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap(),
-        event: MetadataEvent::ExecuteQuery(ExecuteQuery {
-            input_slices: vec![
-                InputSlice {
-                    dataset_id: DatasetID::new_seeded_ed25519(b"input1"),
-                    block_interval: Some(BlockInterval {
-                        start: Multihash::from_digest_sha3_256(b"a"),
-                        end: Multihash::from_digest_sha3_256(b"b"),
-                    }),
-                    data_interval: Some(OffsetInterval { start: 10, end: 20 }),
-                },
-                InputSlice {
-                    dataset_id: DatasetID::new_seeded_ed25519(b"input2"),
-                    block_interval: Some(BlockInterval {
-                        start: Multihash::from_digest_sha3_256(b"a"),
-                        end: Multihash::from_digest_sha3_256(b"b"),
-                    }),
-                    data_interval: None,
-                },
-            ],
-            input_checkpoint: None,
-            output_data: Some(DataSlice {
-                logical_hash: Multihash::from_digest_sha3_256(b"foo"),
-                physical_hash: Multihash::from_digest_sha3_256(b"bar"),
-                interval: OffsetInterval { start: 10, end: 20 },
-                size: 10,
-            }),
-            output_checkpoint: None,
-            output_watermark: Some(Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap()),
-        }),
-        sequence_number: 127,
-    };
+    let actual = YamlMetadataBlockSerializer.write_manifest(&block).unwrap();
 
-    let actual = YamlMetadataBlockDeserializer
-        .read_manifest(data.as_bytes())
+    assert_eq!(expected, std::str::from_utf8(&actual).unwrap());
+
+    let de_block = YamlMetadataBlockDeserializer
+        .read_manifest(expected.as_bytes())
         .unwrap();
 
-    assert_eq!(expected, actual);
-
-    let data2 = YamlMetadataBlockSerializer.write_manifest(&actual).unwrap();
-
-    assert_eq!(data, std::str::from_utf8(&data2).unwrap());
+    assert_eq!(block, de_block);
 }
 
 #[test]
 fn serde_metadata_block_obsolete_version() {
     let data = indoc!(
         "
-    kind: MetadataBlock
-    version: 1
-    content:
-      systemTime: 2020-01-01T12:00:00Z
-      prevBlockHash: zW1k8aWxnH37Xc62cSJGQASfCTHAtpEH3HdaGB1gv6NSj7P
-      event:
-        kind: executeQuery
-        inputSlices:
-        - datasetID: did:odf:z4k88e8oT6CUiFQSbmHPViLQGHoX8x5Fquj9WvvPdSCvzTRWGfJ
-          blockInterval:
-            start: zW1i4mki3rvFyZZ3DyKnT8WbqwykmSNj2adNfjZtGKrodD4
-            end: zW1mJtUjH235JZ4BBpJBousTNHaDXer4r4QzSdsqTfKENrr
-          dataInterval:
-            start: 10
-            end: 20
-        - datasetID: did:odf:z4k88e8kjvUAfcpgRSvrTL7XmEmrQfvHaYqo11wtT1JewT16nSc
-          blockInterval:
-            start: zW1i4mki3rvFyZZ3DyKnT8WbqwykmSNj2adNfjZtGKrodD4
-            end: zW1mJtUjH235JZ4BBpJBousTNHaDXer4r4QzSdsqTfKENrr
-        outputData:
-          logicalHash: zW1hSqbjSkaj1wY6EEWY7h1M1rRMo5uCLPSc5EHD4rjFxcg
-          physicalHash: zW1oExmNvSZ5wSiv7q4LmiRFDNe9U7WerQsbP5EUvyKmypG
-          interval:
-            start: 10
-            end: 20
-          size: 10
-        outputWatermark: 2020-01-01T12:00:00Z
+        kind: MetadataBlock
+        version: 1
+        content:
+          systemTime: 2020-01-01T12:00:00Z
+          prevBlockHash: f16209eb949bd8ff0bb1d827f11809aebc6bd0d5955c7f368469a913c70d196620272
+          sequenceNumber: 127
+          event:
+            kind: ExecuteQuery
+            queryInputs:
+            - datasetId: \
+         did:odf:fed01816ef0a9abe93aba816ef0a9abe93aba90e6065747170300c0d3d30c2cd8d7a4
+              prevBlockHash: f162080084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b
+              newBlockHash: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
+              prevOffset: 9
+              newOffset: 20
+            - datasetId: \
+         did:odf:fed01826ef0a9abea3a3a826ef0a9abea3a3a90e6065747270300c1d3b30a2cd9d724
+              prevBlockHash: f162080084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b
+              newBlockHash: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
+            prevCheckpoint: f1620894b355f91b194f31c1116dcec200b68d5cfd90a3df19032829fa643bc711fcb
+            prevOffset: 9
+            newData:
+              logicalHash: f162076d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01
+              physicalHash: f1620cceefd7e0545bcf8b6d19f3b5750c8a3ee8350418877bc6fb12e32de28137355
+              offsetInterval:
+                start: 10
+                end: 19
+              size: 10
+            newWatermark: 2020-01-01T12:00:00Z
         "
     );
 
@@ -430,11 +531,12 @@ fn serde_metadata_block_obsolete_version() {
 fn serde_fetch_step_files_glob() {
     let data = indoc!(
         "
-        kind: filesGlob
+        kind: FilesGlob
         path: /opt/x/*.txt
         cache:
-          kind: forever
-        order: byName"
+          kind: Forever
+        order: ByName
+        "
     );
 
     #[derive(Serialize, Deserialize)]
@@ -451,34 +553,23 @@ fn serde_fetch_step_files_glob() {
 
     assert_eq!(expected, actual);
 
-    assert_eq!(
-        serde_yaml::to_string(&Helper(actual)).unwrap(),
-        indoc!(
-            "
-            kind: filesGlob
-            path: /opt/x/*.txt
-            cache:
-              kind: forever
-            order: byName
-            "
-        )
-    );
+    assert_eq!(serde_yaml::to_string(&Helper(actual)).unwrap(), data);
 }
 
 #[test]
 fn serde_transform() {
     let data = indoc!(
         "
-        kind: sql
+        kind: Sql
         engine: flink
+        queries:
+        - alias: bar
+          query: SELECT * FROM foo
         temporalTables:
         - name: foo
           primaryKey:
           - id
-        queries:
-        - alias: bar
-          query: >
-            SELECT * FROM foo"
+        "
     );
 
     #[derive(Serialize, Deserialize)]
@@ -502,20 +593,5 @@ fn serde_transform() {
 
     assert_eq!(expected, actual);
 
-    assert_eq!(
-        serde_yaml::to_string(&Helper(actual)).unwrap(),
-        indoc!(
-            "
-            kind: sql
-            engine: flink
-            queries:
-            - alias: bar
-              query: SELECT * FROM foo
-            temporalTables:
-            - name: foo
-              primaryKey:
-              - id
-            "
-        )
-    );
+    assert_eq!(serde_yaml::to_string(&Helper(actual)).unwrap(), data);
 }

--- a/src/infra/core/src/dependency_graph_repository_inmem.rs
+++ b/src/infra/core/src/dependency_graph_repository_inmem.rs
@@ -45,12 +45,9 @@ impl DependencyGraphRepository for DependencyGraphRepositoryInMemory {
                     .await
                     .int_err()?;
 
-                for transform_input in summary.dependencies {
-                    if let Some(input_id) = transform_input.id {
-                        yield (dataset_handle.id.clone(), input_id);
-                    }
+                for input_id in summary.dependencies {
+                    yield (dataset_handle.id.clone(), input_id);
                 }
-
             }
         })
     }

--- a/src/infra/core/src/ingest/data_format_registry_impl.rs
+++ b/src/infra/core/src/ingest/data_format_registry_impl.rs
@@ -75,7 +75,6 @@ impl DataFormatRegistry for DataFormatRegistryImpl {
             ReadStep::Csv(_) => Self::FMT_CSV,
             ReadStep::Json(_) => Self::FMT_JSON,
             ReadStep::NdJson(_) => Self::FMT_NDJSON,
-            ReadStep::JsonLines(_) => Self::FMT_NDJSON,
             ReadStep::GeoJson(_) => Self::FMT_GEOJSON,
             ReadStep::NdGeoJson(_) => Self::FMT_NDGEOJSON,
             ReadStep::Parquet(_) => Self::FMT_PARQUET,
@@ -93,7 +92,6 @@ impl DataFormatRegistry for DataFormatRegistryImpl {
             ReadStep::Csv(conf) => Arc::new(ReaderCsv::new(ctx, conf).await?),
             ReadStep::Json(conf) => Arc::new(ReaderJson::new(ctx, conf, temp_path).await?),
             ReadStep::NdJson(conf) => Arc::new(ReaderNdJson::new(ctx, conf).await?),
-            ReadStep::JsonLines(conf) => Arc::new(ReaderNdJson::new_compat(ctx, conf).await?),
             ReadStep::GeoJson(conf) => Arc::new(ReaderGeoJson::new(ctx, conf, temp_path).await?),
             ReadStep::NdGeoJson(conf) => {
                 Arc::new(ReaderNdGeoJson::new(ctx, conf, temp_path).await?)

--- a/src/infra/core/src/ingest/polling_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/polling_ingest_service_impl.rs
@@ -231,8 +231,8 @@ impl PollingIngestServiceImpl {
         args.listener
             .on_stage_progress(PollingIngestStage::CheckCache, 0, TotalSteps::Exact(1));
 
-        let uncacheable = args.data_writer.last_offset().is_some()
-            && args.data_writer.last_source_state().is_none();
+        let uncacheable = args.data_writer.prev_offset().is_some()
+            && args.data_writer.prev_source_state().is_none();
 
         if uncacheable && !args.options.fetch_uncacheable {
             tracing::info!("Skipping fetch of uncacheable source");
@@ -340,7 +340,7 @@ impl PollingIngestServiceImpl {
         let fetch_step = &args.polling_source.fetch;
         let prev_source_state = args
             .data_writer
-            .last_source_state()
+            .prev_source_state()
             .and_then(|ss| PollingSourceState::try_from_source_state(&ss));
 
         let savepoint_path = self.get_savepoint_path(fetch_step, prev_source_state.as_ref())?;
@@ -668,15 +668,15 @@ impl PollingIngestServiceImpl {
             input_data_path: PathBuf::new(), // TODO: Will be filled out by IngestTask
             prev_data_slices: state.data_slices,
             schema: state.schema,
-            next_offset: state.last_offset.map(|off| off + 1).unwrap_or(0),
+            prev_offset: state.prev_offset,
             vocab: DatasetVocabulary {
                 offset_column: Some(state.vocab.offset_column.into_owned()),
                 system_time_column: Some(state.vocab.system_time_column.into_owned()),
                 event_time_column: Some(state.vocab.event_time_column.into_owned()),
             },
-            prev_checkpoint: state.last_checkpoint,
-            prev_watermark: state.last_watermark,
-            prev_source_state: state.last_source_state,
+            prev_checkpoint: state.prev_checkpoint,
+            prev_watermark: state.prev_watermark,
+            prev_source_state: state.prev_source_state,
         })
     }
 }

--- a/src/infra/core/src/ingest/polling_source_state.rs
+++ b/src/infra/core/src/ingest/polling_source_state.rs
@@ -26,19 +26,15 @@ pub enum PollingSourceState {
 
 impl PollingSourceState {
     pub fn from_source_state(source_state: &SourceState) -> Result<Option<Self>, InternalError> {
-        if source_state.source == SourceState::SOURCE_POLLING {
-            if source_state.kind == SourceState::KIND_ETAG {
-                Ok(Some(Self::ETag(source_state.value.clone())))
-            } else if source_state.kind == SourceState::KIND_LAST_MODIFIED {
-                let dt = DateTime::parse_from_rfc3339(&source_state.value)
-                    .map(|dt| dt.into())
-                    .int_err()?;
-                Ok(Some(Self::LastModified(dt)))
-            } else {
-                tracing::debug!(kind = %source_state.kind, "Ignoring unsupported source state kind");
-                Ok(None)
-            }
+        if source_state.kind == SourceState::KIND_ETAG {
+            Ok(Some(Self::ETag(source_state.value.clone())))
+        } else if source_state.kind == SourceState::KIND_LAST_MODIFIED {
+            let dt = DateTime::parse_from_rfc3339(&source_state.value)
+                .map(|dt| dt.into())
+                .int_err()?;
+            Ok(Some(Self::LastModified(dt)))
         } else {
+            tracing::debug!(kind = %source_state.kind, "Ignoring unsupported source state kind");
             Ok(None)
         }
     }
@@ -66,8 +62,8 @@ impl PollingSourceState {
             ),
         };
         SourceState {
+            source_name: None,
             kind,
-            source: SourceState::SOURCE_POLLING.to_owned(),
             value,
         }
     }

--- a/src/infra/core/src/provenance_service_impl.rs
+++ b/src/infra/core/src/provenance_service_impl.rs
@@ -56,20 +56,17 @@ impl ProvenanceServiceImpl {
                 .await
                 .int_err()?;
 
-            // Resolving by ID because name of the input
-            // can be different than the dataset name in the workspace
             let mut resolved_inputs = Vec::new();
-            for input in &summary.dependencies {
-                let input_id = input.id.as_ref().unwrap();
-
+            for input_id in &summary.dependencies {
                 let handle = self
                     .dataset_repo
                     .resolve_dataset_ref(&input_id.as_local_ref())
                     .await?;
 
                 resolved_inputs.push(ResolvedTransformInput {
+                    // TODO: This likely needs to be changed into query alias
+                    name: handle.alias.dataset_name.clone(),
                     handle,
-                    name: input.name.clone(),
                 })
             }
 

--- a/src/infra/core/src/query_service_impl.rs
+++ b/src/infra/core/src/query_service_impl.rs
@@ -90,11 +90,12 @@ impl QueryServiceImpl {
             .get_dataset(&dataset_handle.as_local_ref())
             .await?;
 
+        // TODO: Update to use SetDataSchema event
         let last_data_slice_opt = dataset
             .as_metadata_chain()
             .iter_blocks()
             .filter_data_stream_blocks()
-            .filter_map_ok(|(_, b)| b.event.output_data)
+            .filter_map_ok(|(_, b)| b.event.new_data)
             .try_first()
             .await
             .map_err(|e| {
@@ -413,12 +414,12 @@ impl KamuSchema {
             .as_metadata_chain()
             .iter_blocks()
             .filter_data_stream_blocks()
-            .filter_map_ok(|(_, b)| b.event.output_data);
+            .filter_map_ok(|(_, b)| b.event.new_data);
 
         while let Some(slice) = slices.try_next().await.int_err()? {
             files.push(slice.physical_hash);
 
-            num_records += slice.interval.end - slice.interval.start + 1;
+            num_records += slice.offset_interval.end - slice.offset_interval.start + 1;
 
             if last_records_to_consider.is_some()
                 && last_records_to_consider.unwrap() <= num_records as u64

--- a/src/infra/core/src/repos/dataset_repository_local_fs.rs
+++ b/src/infra/core/src/repos/dataset_repository_local_fs.rs
@@ -289,11 +289,9 @@ impl DatasetRepository for DatasetRepositoryLocalFs {
 
     async fn create_dataset_from_snapshot(
         &self,
-        account_name: Option<AccountName>,
         snapshot: DatasetSnapshot,
     ) -> Result<CreateDatasetResult, CreateDatasetFromSnapshotError> {
-        create_dataset_from_snapshot_impl(self, self.event_bus.as_ref(), account_name, snapshot)
-            .await
+        create_dataset_from_snapshot_impl(self, self.event_bus.as_ref(), snapshot).await
     }
 
     async fn rename_dataset(

--- a/src/infra/core/src/repos/dataset_repository_s3.rs
+++ b/src/infra/core/src/repos/dataset_repository_s3.rs
@@ -326,11 +326,9 @@ impl DatasetRepository for DatasetRepositoryS3 {
 
     async fn create_dataset_from_snapshot(
         &self,
-        account_name: Option<AccountName>,
         snapshot: DatasetSnapshot,
     ) -> Result<CreateDatasetResult, CreateDatasetFromSnapshotError> {
-        create_dataset_from_snapshot_impl(self, self.event_bus.as_ref(), account_name, snapshot)
-            .await
+        create_dataset_from_snapshot_impl(self, self.event_bus.as_ref(), snapshot).await
     }
 
     async fn rename_dataset(

--- a/src/infra/core/src/testing/dataset_data_helper.rs
+++ b/src/infra/core/src/testing/dataset_data_helper.rs
@@ -70,7 +70,7 @@ impl DatasetDataHelper {
         kamu_data_utils::data::local_url::into_local_path(
             self.dataset
                 .as_data_repo()
-                .get_internal_url(&block.event.output_data.unwrap().physical_hash)
+                .get_internal_url(&block.event.new_data.unwrap().physical_hash)
                 .await,
         )
         .unwrap()

--- a/src/infra/core/src/utils/simple_transfer_protocol.rs
+++ b/src/infra/core/src/utils/simple_transfer_protocol.rs
@@ -229,13 +229,13 @@ impl SimpleTransferProtocol {
         // Update stats estimates based on metadata
         stats.dst_estimated.metadata_blocks_writen += blocks.len();
         for block in blocks.iter().filter_map(|(_, b)| b.as_data_stream_block()) {
-            if let Some(data_slice) = block.event.output_data {
+            if let Some(data_slice) = block.event.new_data {
                 stats.src_estimated.data_slices_read += 1;
                 stats.src_estimated.bytes_read += data_slice.size as usize;
                 stats.dst_estimated.data_slices_written += 1;
                 stats.dst_estimated.bytes_written += data_slice.size as usize;
             }
-            if let Some(checkpoint) = block.event.output_checkpoint {
+            if let Some(checkpoint) = block.event.new_checkpoint {
                 stats.src_estimated.checkpoints_read += 1;
                 stats.src_estimated.bytes_read += checkpoint.size as usize;
                 stats.dst_estimated.checkpoints_written += 1;
@@ -253,7 +253,7 @@ impl SimpleTransferProtocol {
             .filter_map(|(_, b)| b.as_data_stream_block())
         {
             // Data
-            if let Some(data_slice) = block.event.output_data {
+            if let Some(data_slice) = block.event.new_data {
                 tracing::info!(hash = ?data_slice.physical_hash, "Transfering data file");
 
                 let stream = match src
@@ -311,7 +311,7 @@ impl SimpleTransferProtocol {
             }
 
             // Checkpoint
-            if let Some(checkpoint) = block.event.output_checkpoint {
+            if let Some(checkpoint) = block.event.new_checkpoint {
                 tracing::info!(hash = ?checkpoint.physical_hash, "Transfering checkpoint file");
 
                 let stream = match src

--- a/src/infra/core/src/verification_service_impl.rs
+++ b/src/infra/core/src/verification_service_impl.rs
@@ -80,7 +80,7 @@ impl VerificationServiceImpl {
                 VerificationPhase::DataIntegrity,
             );
 
-            if let Some(output_slice) = &block.event.output_data {
+            if let Some(output_slice) = &block.event.new_data {
                 // Check size first
                 let size_actual = dataset
                     .as_data_repo()
@@ -138,7 +138,7 @@ impl VerificationServiceImpl {
                     }
                 }
 
-                if let Some(checkpoint) = block.event.output_checkpoint {
+                if let Some(checkpoint) = block.event.new_checkpoint {
                     // Check size
                     let size_actual = dataset
                         .as_checkpoint_repo()

--- a/src/infra/core/tests/tests/engine/test_engine_io.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_io.rs
@@ -107,10 +107,10 @@ async fn test_engine_io_common(
         )
         .build();
 
-    let root_alias = DatasetAlias::new(None, root_snapshot.name.clone());
+    let root_alias = root_snapshot.name.clone();
 
     dataset_repo
-        .create_dataset_from_snapshot(None, root_snapshot)
+        .create_dataset_from_snapshot(root_snapshot)
         .await
         .unwrap();
 
@@ -131,16 +131,17 @@ async fn test_engine_io_common(
         .name("deriv")
         .kind(DatasetKind::Derivative)
         .push_event(
-            MetadataFactory::set_transform([&root_alias.dataset_name])
+            MetadataFactory::set_transform()
+                .inputs_from_refs([&root_alias.dataset_name])
                 .transform(transform)
                 .build(),
         )
         .build();
 
-    let deriv_alias = DatasetAlias::new(None, deriv_snapshot.name.clone());
+    let deriv_alias = deriv_snapshot.name.clone();
 
     let dataset_deriv = dataset_repo
-        .create_dataset_from_snapshot(None, deriv_snapshot)
+        .create_dataset_from_snapshot(deriv_snapshot)
         .await
         .unwrap()
         .dataset;
@@ -163,7 +164,7 @@ async fn test_engine_io_common(
         .unwrap();
 
     assert_eq!(
-        block.event.output_data.unwrap().interval,
+        block.event.new_data.unwrap().offset_interval,
         OffsetInterval { start: 0, end: 2 }
     );
 
@@ -213,7 +214,7 @@ async fn test_engine_io_common(
         .unwrap();
 
     assert_eq!(
-        block.event.output_data.unwrap().interval,
+        block.event.new_data.unwrap().offset_interval,
         OffsetInterval { start: 3, end: 4 }
     );
 

--- a/src/infra/core/tests/tests/ingest/test_push_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_push_ingest.rs
@@ -54,11 +54,11 @@ async fn test_ingest_push_url_stream() {
         })
         .build();
 
-    let dataset_name = dataset_snapshot.name.clone();
-    let dataset_ref = DatasetAlias::new(None, dataset_name.clone()).as_local_ref();
+    let dataset_alias = dataset_snapshot.name.clone();
+    let dataset_ref = dataset_alias.as_local_ref();
 
     harness.create_dataset(dataset_snapshot).await;
-    let data_helper = harness.dataset_data_helper(&dataset_name).await;
+    let data_helper = harness.dataset_data_helper(&dataset_alias).await;
 
     // Round 1: Push from URL
     let src_path = harness.temp_dir.path().join("data.csv");
@@ -119,7 +119,7 @@ async fn test_ingest_push_url_stream() {
             .get_last_data_block()
             .await
             .event
-            .output_watermark
+            .new_watermark
             .map(|dt| dt.to_rfc3339()),
         Some("2020-01-01T00:00:00+00:00".to_string())
     );
@@ -157,7 +157,7 @@ async fn test_ingest_push_url_stream() {
             .get_last_data_block()
             .await
             .event
-            .output_watermark
+            .new_watermark
             .map(|dt| dt.to_rfc3339()),
         Some("2021-01-01T00:00:00+00:00".to_string())
     );
@@ -196,11 +196,11 @@ async fn test_ingest_push_media_type_override() {
         })
         .build();
 
-    let dataset_name = dataset_snapshot.name.clone();
-    let dataset_ref = DatasetAlias::new(None, dataset_name.clone()).as_local_ref();
+    let dataset_alias = dataset_snapshot.name.clone();
+    let dataset_ref = dataset_alias.as_local_ref();
 
     harness.create_dataset(dataset_snapshot).await;
-    let data_helper = harness.dataset_data_helper(&dataset_name).await;
+    let data_helper = harness.dataset_data_helper(&dataset_alias).await;
 
     // Push CSV conversion
     let src_path = harness.temp_dir.path().join("data.csv");
@@ -415,15 +415,15 @@ impl IngestTestHarness {
 
     async fn create_dataset(&self, dataset_snapshot: DatasetSnapshot) {
         self.dataset_repo
-            .create_dataset_from_snapshot(None, dataset_snapshot)
+            .create_dataset_from_snapshot(dataset_snapshot)
             .await
             .unwrap();
     }
 
-    async fn dataset_data_helper(&self, dataset_name: &DatasetName) -> DatasetDataHelper {
+    async fn dataset_data_helper(&self, dataset_alias: &DatasetAlias) -> DatasetDataHelper {
         let dataset = self
             .dataset_repo
-            .get_dataset(&dataset_name.as_local_ref())
+            .get_dataset(&dataset_alias.as_local_ref())
             .await
             .unwrap();
 

--- a/src/infra/core/tests/tests/ingest/test_writer.rs
+++ b/src/infra/core/tests/tests/ingest/test_writer.rs
@@ -99,7 +99,7 @@ async fn test_data_writer_happy_path() {
     .await;
 
     assert_eq!(
-        res.new_block.event.output_watermark.as_ref(),
+        res.new_block.event.new_watermark.as_ref(),
         Some(&harness.source_event_time)
     );
 
@@ -168,7 +168,7 @@ async fn test_data_writer_happy_path() {
     .await;
 
     assert_eq!(
-        res.new_block.event.output_watermark.as_ref(),
+        res.new_block.event.new_watermark.as_ref(),
         Some(&harness.source_event_time)
     );
 
@@ -176,7 +176,7 @@ async fn test_data_writer_happy_path() {
     assert_eq!(schema_block_hash, harness.get_last_schema_block().await.0);
 
     // Round 3 (nothing to commit)
-    let prev_watermark = res.new_block.event.output_watermark.unwrap();
+    let prev_watermark = res.new_block.event.new_watermark.unwrap();
     harness.set_system_time(Utc.with_ymd_and_hms(2010, 1, 3, 12, 0, 0).unwrap());
     harness.set_source_event_time(Utc.with_ymd_and_hms(2000, 1, 3, 12, 0, 0).unwrap());
 
@@ -199,8 +199,8 @@ async fn test_data_writer_happy_path() {
 
     // Round 4 (nothing but source state changed)
     let source_state = odf::SourceState {
+        source_name: None,
         kind: "odf/etag".to_string(),
-        source: "odf/poll".to_string(),
         value: "123".to_string(),
     };
 
@@ -224,11 +224,11 @@ async fn test_data_writer_happy_path() {
         .await
         .unwrap();
 
-    assert_eq!(res.new_block.event.output_data, None);
+    assert_eq!(res.new_block.event.new_data, None);
     // Watermark is carried
-    assert_eq!(res.new_block.event.output_watermark, Some(prev_watermark));
+    assert_eq!(res.new_block.event.new_watermark, Some(prev_watermark));
     // Source state updated
-    assert_eq!(res.new_block.event.source_state, Some(source_state));
+    assert_eq!(res.new_block.event.new_source_state, Some(source_state));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -478,7 +478,7 @@ async fn test_data_writer_orders_by_event_time() {
     assert_eq!(
         res.new_block
             .event
-            .output_watermark
+            .new_watermark
             .as_ref()
             .map(|dt| dt.to_rfc3339()),
         Some("2023-01-01T00:00:00+00:00".to_string())
@@ -647,10 +647,10 @@ async fn test_data_writer_builder_scan_no_source() {
             merge_strategy: odf::MergeStrategy::Append(_),
             vocab,
             data_slices: _,
-            last_offset: None,
-            last_checkpoint: None,
-            last_watermark: None,
-            last_source_state: None,
+            prev_offset: None,
+            prev_checkpoint: None,
+            prev_watermark: None,
+            prev_source_state: None,
         } if *h == head && vocab.event_time_column == "foo"
 
     );
@@ -682,10 +682,10 @@ async fn test_data_writer_builder_scan_polling_source() {
             merge_strategy: odf::MergeStrategy::Ledger(_),
             vocab,
             data_slices: _,
-            last_offset: None,
-            last_checkpoint: None,
-            last_watermark: None,
-            last_source_state: None,
+            prev_offset: None,
+            prev_checkpoint: None,
+            prev_watermark: None,
+            prev_source_state: None,
         } if *vocab == odf::DatasetVocabularyResolvedOwned::default()
     );
 }
@@ -724,10 +724,10 @@ async fn test_data_writer_builder_scan_push_source() {
             merge_strategy: odf::MergeStrategy::Ledger(_),
             vocab,
             data_slices: _,
-            last_offset: None,
-            last_checkpoint: None,
-            last_watermark: None,
-            last_source_state: None,
+            prev_offset: None,
+            prev_checkpoint: None,
+            prev_watermark: None,
+            prev_source_state: None,
         } if *vocab == odf::DatasetVocabularyResolvedOwned::default()
     );
 }
@@ -908,7 +908,7 @@ impl Harness {
         kamu_data_utils::data::local_url::into_local_path(
             self.dataset
                 .as_data_repo()
-                .get_internal_url(&block.event.output_data.unwrap().physical_hash)
+                .get_internal_url(&block.event.new_data.unwrap().physical_hash)
                 .await,
         )
         .unwrap()

--- a/src/infra/core/tests/tests/repos/test_dataset_impl.rs
+++ b/src/infra/core/tests/tests/repos/test_dataset_impl.rs
@@ -70,9 +70,9 @@ async fn test_summary_updates() {
     // ---
     let block_3 = MetadataFactory::metadata_block(
         MetadataFactory::add_data()
-            .interval(0, 9)
-            .data_size(16)
-            .checkpoint_size(10)
+            .new_offset_interval(0, 9)
+            .new_data_size(16)
+            .new_checkpoint_size(10)
             .build(),
     )
     .prev(&hash_2, block_2.sequence_number)

--- a/src/infra/core/tests/tests/repos/test_metadata_chain_impl.rs
+++ b/src/infra/core/tests/tests/repos/test_metadata_chain_impl.rs
@@ -209,18 +209,25 @@ async fn test_append_prev_block_sequence_integrity_broken() {
 
     let hash = chain
         .append(
-            MetadataFactory::metadata_block(MetadataFactory::add_data().interval(0, 9).build())
-                .prev(&hash, 1)
-                .build(),
+            MetadataFactory::metadata_block(
+                MetadataFactory::add_data()
+                    .new_offset_interval(0, 9)
+                    .build(),
+            )
+            .prev(&hash, 1)
+            .build(),
             AppendOpts::default(),
         )
         .await
         .unwrap();
 
-    let block_too_low =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(10, 19).build())
-            .prev(&hash, 1 /* should be 2 */)
-            .build();
+    let block_too_low = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(10, 19)
+            .build(),
+    )
+    .prev(&hash, 1 /* should be 2 */)
+    .build();
 
     assert_matches!(
         chain.append(block_too_low, AppendOpts::default()).await,
@@ -234,10 +241,13 @@ async fn test_append_prev_block_sequence_integrity_broken() {
         if prev_block_hash.as_ref() == Some(&hash) && prev_block_sequence_number == Some(2) && next_block_sequence_number == 2
     );
 
-    let block_too_high =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(10, 19).build())
-            .prev(&hash, 3 /* should be 2 */)
-            .build();
+    let block_too_high = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(10, 19)
+            .build(),
+    )
+    .prev(&hash, 3 /* should be 2 */)
+    .build();
 
     assert_matches!(
         chain.append(block_too_high, AppendOpts::default()).await,
@@ -251,10 +261,13 @@ async fn test_append_prev_block_sequence_integrity_broken() {
         if prev_block_hash.as_ref() == Some(&hash) && prev_block_sequence_number == Some(2) && next_block_sequence_number == 4
     );
 
-    let block_just_right =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(10, 19).build())
-            .prev(&hash, 2)
-            .build();
+    let block_just_right = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(10, 19)
+            .build(),
+    )
+    .prev(&hash, 2)
+    .build();
 
     let hash_just_right = chain
         .append(block_just_right, AppendOpts::default())
@@ -390,8 +403,8 @@ async fn test_append_watermark_non_monotonic() {
     // output_watermart = None
     let block = MetadataFactory::metadata_block(
         MetadataFactory::add_data()
-            .some_output_data()
-            .interval(0, 9)
+            .some_new_data()
+            .new_offset_interval(0, 9)
             .build(),
     )
     .prev(&hash, 1)
@@ -402,9 +415,9 @@ async fn test_append_watermark_non_monotonic() {
     // output_watermart = Some(2000-01-01)
     let block = MetadataFactory::metadata_block(
         MetadataFactory::add_data()
-            .some_output_data()
-            .interval(10, 19)
-            .watermark(Utc.with_ymd_and_hms(2000, 1, 1, 12, 0, 0).unwrap())
+            .some_new_data()
+            .new_offset_interval(10, 19)
+            .new_watermark(Some(Utc.with_ymd_and_hms(2000, 1, 1, 12, 0, 0).unwrap()))
             .build(),
     )
     .prev(&hash, 2)
@@ -415,8 +428,8 @@ async fn test_append_watermark_non_monotonic() {
     // output_watermart = None
     let block = MetadataFactory::metadata_block(
         MetadataFactory::add_data()
-            .some_output_data()
-            .interval(20, 29)
+            .some_new_data()
+            .new_offset_interval(20, 29)
             .build(),
     )
     .prev(&hash, 3)
@@ -432,9 +445,9 @@ async fn test_append_watermark_non_monotonic() {
     // output_watermart = Some(1988-01-01)
     let block = MetadataFactory::metadata_block(
         MetadataFactory::add_data()
-            .some_output_data()
-            .interval(20, 29)
-            .watermark(Utc.with_ymd_and_hms(1988, 1, 1, 12, 0, 0).unwrap())
+            .some_new_data()
+            .new_offset_interval(20, 29)
+            .new_watermark(Some(Utc.with_ymd_and_hms(1988, 1, 1, 12, 0, 0).unwrap()))
             .build(),
     )
     .prev(&hash, 3)
@@ -450,9 +463,9 @@ async fn test_append_watermark_non_monotonic() {
     // output_watermart = Some(2020-01-01)
     let block = MetadataFactory::metadata_block(
         MetadataFactory::add_data()
-            .some_output_data()
-            .interval(20, 29)
-            .watermark(Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap())
+            .some_new_data()
+            .new_offset_interval(20, 29)
+            .new_watermark(Some(Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap()))
             .build(),
     )
     .prev(&hash, 3)
@@ -486,9 +499,9 @@ async fn test_append_add_data_empty_commit() {
         .unwrap();
 
     let add_data = AddDataBuilder::empty()
-        .some_output_data()
-        .some_output_checkpoint()
-        .some_output_watermark()
+        .some_new_data()
+        .some_new_checkpoint()
+        .some_new_watermark()
         .build();
     let block = MetadataFactory::metadata_block(add_data.clone())
         .prev(&hash, 1)
@@ -499,9 +512,9 @@ async fn test_append_add_data_empty_commit() {
     // No data, same checkpoint, watermark, and source state
     let block = MetadataFactory::metadata_block(
         AddDataBuilder::empty()
-            .output_checkpoint(add_data.output_checkpoint)
-            .output_watermark(add_data.output_watermark)
-            .source_state(add_data.source_state)
+            .new_checkpoint(add_data.new_checkpoint)
+            .new_watermark(add_data.new_watermark)
+            .new_source_state(add_data.new_source_state)
             .build(),
     )
     .prev(&hash, 2)
@@ -540,9 +553,9 @@ async fn test_append_execute_query_empty_commit() {
         .unwrap();
 
     let execute_query = MetadataFactory::execute_query()
-        .some_output_data()
-        .some_output_checkpoint()
-        .some_output_watermark()
+        .some_new_data()
+        .some_new_checkpoint()
+        .some_new_watermark()
         .build();
     let block = MetadataFactory::metadata_block(execute_query.clone())
         .prev(&hash, 1)
@@ -553,8 +566,8 @@ async fn test_append_execute_query_empty_commit() {
     // No data, same checkpoint and watermark
     let block = MetadataFactory::metadata_block(
         MetadataFactory::execute_query()
-            .output_checkpoint(execute_query.output_checkpoint)
-            .output_watermark(execute_query.output_watermark)
+            .new_checkpoint(execute_query.new_checkpoint)
+            .new_watermark(execute_query.new_watermark)
             .build(),
     )
     .prev(&hash, 2)
@@ -634,7 +647,7 @@ async fn test_append_add_data_must_be_preceeded_by_schema() {
     let hash = chain
         .append(
             MetadataFactory::metadata_block(
-                MetadataFactory::add_data().some_source_state().build(),
+                MetadataFactory::add_data().some_new_source_state().build(),
             )
             .prev(&hash, 0)
             .build(),
@@ -643,28 +656,31 @@ async fn test_append_add_data_must_be_preceeded_by_schema() {
         .await
         .unwrap();
 
-    // TODO: Should rejects one with data when schema is not set yet
-    // https://github.com/kamu-data/kamu-cli/issues/314
-    let hash = chain
-        .append(
-            MetadataFactory::metadata_block(
-                MetadataFactory::add_data()
-                    .some_output_data_with_offset(0, 9)
-                    .some_source_state()
-                    .build(),
+    // Rejects one with data when schema is not set yet
+    assert_matches!(
+        chain
+            .append(
+                MetadataFactory::metadata_block(
+                    MetadataFactory::add_data()
+                        .some_new_data_with_offset(0, 9)
+                        .some_new_source_state()
+                        .build(),
+                )
+                .prev(&hash, 1)
+                .build(),
+                AppendOpts::default(),
             )
-            .prev(&hash, 1)
-            .build(),
-            AppendOpts::default(),
-        )
-        .await
-        .unwrap();
+            .await,
+        Err(AppendError::InvalidBlock(
+            AppendValidationError::InvalidEvent(..)
+        ))
+    );
 
     // Schema is now set
     let hash = chain
         .append(
             MetadataFactory::metadata_block(MetadataFactory::set_data_schema().build())
-                .prev(&hash, 2)
+                .prev(&hash, 1)
                 .build(),
             AppendOpts::default(),
         )
@@ -676,11 +692,11 @@ async fn test_append_add_data_must_be_preceeded_by_schema() {
         .append(
             MetadataFactory::metadata_block(
                 MetadataFactory::add_data()
-                    .some_output_data_with_offset(10, 19)
-                    .some_source_state()
+                    .some_new_data_with_offset(0, 9)
+                    .some_new_source_state()
                     .build(),
             )
-            .prev(&hash, 3)
+            .prev(&hash, 2)
             .build(),
             AppendOpts::default(),
         )
@@ -709,7 +725,7 @@ async fn test_append_execute_query_must_be_preceeded_by_schema() {
         .append(
             MetadataFactory::metadata_block(
                 MetadataFactory::execute_query()
-                    .output_checkpoint(Some(Checkpoint {
+                    .new_checkpoint(Some(Checkpoint {
                         physical_hash: Multihash::from_digest_sha3_256(b"foo"),
                         size: 1,
                     }))
@@ -722,32 +738,35 @@ async fn test_append_execute_query_must_be_preceeded_by_schema() {
         .await
         .unwrap();
 
-    // TODO: Should rejects one with data when schema is not set yet
-    // https://github.com/kamu-data/kamu-cli/issues/314
-    let hash = chain
-        .append(
-            MetadataFactory::metadata_block(
-                MetadataFactory::execute_query()
-                    .input_checkpoint(Some(Multihash::from_digest_sha3_256(b"foo")))
-                    .output_checkpoint(Some(Checkpoint {
-                        physical_hash: Multihash::from_digest_sha3_256(b"bar"),
-                        size: 1,
-                    }))
-                    .some_output_data_with_offset(0, 9)
-                    .build(),
+    // Rejects one with data when schema is not set yet
+    assert_matches!(
+        chain
+            .append(
+                MetadataFactory::metadata_block(
+                    MetadataFactory::execute_query()
+                        .prev_checkpoint(Some(Multihash::from_digest_sha3_256(b"foo")))
+                        .new_checkpoint(Some(Checkpoint {
+                            physical_hash: Multihash::from_digest_sha3_256(b"bar"),
+                            size: 1,
+                        }))
+                        .some_new_data_with_offset(0, 9)
+                        .build(),
+                )
+                .prev(&hash, 1)
+                .build(),
+                AppendOpts::default(),
             )
-            .prev(&hash, 1)
-            .build(),
-            AppendOpts::default(),
-        )
-        .await
-        .unwrap();
+            .await,
+        Err(AppendError::InvalidBlock(
+            AppendValidationError::InvalidEvent(..)
+        ))
+    );
 
     // Schema is now set
     let hash = chain
         .append(
             MetadataFactory::metadata_block(MetadataFactory::set_data_schema().build())
-                .prev(&hash, 2)
+                .prev(&hash, 1)
                 .build(),
             AppendOpts::default(),
         )
@@ -759,12 +778,15 @@ async fn test_append_execute_query_must_be_preceeded_by_schema() {
         .append(
             MetadataFactory::metadata_block(
                 MetadataFactory::execute_query()
-                    .input_checkpoint(Some(Multihash::from_digest_sha3_256(b"bar")))
-                    .some_output_checkpoint()
-                    .some_output_data_with_offset(10, 19)
+                    .prev_checkpoint(Some(Multihash::from_digest_sha3_256(b"foo")))
+                    .new_checkpoint(Some(Checkpoint {
+                        physical_hash: Multihash::from_digest_sha3_256(b"bar"),
+                        size: 1,
+                    }))
+                    .some_new_data_with_offset(0, 9)
                     .build(),
             )
-            .prev(&hash, 3)
+            .prev(&hash, 2)
             .build(),
             AppendOpts::default(),
         )
@@ -794,19 +816,25 @@ async fn test_iter_blocks() {
         .await
         .unwrap();
 
-    let block_3 =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(0, 9).build())
-            .prev(&hash_2, block_2.sequence_number)
-            .build();
+    let block_3 = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(0, 9)
+            .build(),
+    )
+    .prev(&hash_2, block_2.sequence_number)
+    .build();
     let hash_3 = chain
         .append(block_3.clone(), AppendOpts::default())
         .await
         .unwrap();
 
-    let block_4 =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(10, 19).build())
-            .prev(&hash_3, block_3.sequence_number)
-            .build();
+    let block_4 = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(10, 19)
+            .build(),
+    )
+    .prev(&hash_3, block_3.sequence_number)
+    .build();
     let hash_4 = chain
         .append(block_4.clone(), AppendOpts::default())
         .await

--- a/src/infra/core/tests/tests/test_dependency_graph_inmem.rs
+++ b/src/infra/core/tests/tests/test_dependency_graph_inmem.rs
@@ -543,9 +543,11 @@ impl DependencyGraphHarness {
     async fn create_root_dataset(&self, account_name: Option<AccountName>, dataset_name: &str) {
         self.dataset_repo
             .create_dataset_from_snapshot(
-                account_name,
                 MetadataFactory::dataset_snapshot()
-                    .name(DatasetName::new_unchecked(dataset_name))
+                    .name(DatasetAlias::new(
+                        account_name,
+                        DatasetName::new_unchecked(dataset_name),
+                    ))
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .build(),
@@ -562,11 +564,17 @@ impl DependencyGraphHarness {
     ) {
         self.dataset_repo
             .create_dataset_from_snapshot(
-                account_name,
                 MetadataFactory::dataset_snapshot()
-                    .name(DatasetName::new_unchecked(dataset_name))
+                    .name(DatasetAlias::new(
+                        account_name,
+                        DatasetName::new_unchecked(dataset_name),
+                    ))
                     .kind(DatasetKind::Derivative)
-                    .push_event(MetadataFactory::set_transform_aliases(input_aliases).build())
+                    .push_event(
+                        MetadataFactory::set_transform()
+                            .inputs_from_refs(input_aliases)
+                            .build(),
+                    )
                     .build(),
             )
             .await
@@ -588,20 +596,20 @@ impl DependencyGraphHarness {
             .await
             .unwrap();
 
-        let mut id_map = HashMap::new();
-        for input_alias in &input_aliases {
-            id_map.insert(
-                input_alias.dataset_name.clone(),
+        let mut id_aliases = Vec::new();
+        for input_alias in input_aliases {
+            id_aliases.push((
                 self.dataset_id_by_name(input_alias.dataset_name.as_str())
                     .await,
-            );
+                input_alias.to_string(),
+            ));
         }
 
         dataset
             .commit_event(
                 MetadataEvent::SetTransform(
-                    MetadataFactory::set_transform_aliases(input_aliases)
-                        .set_dataset_ids(id_map)
+                    MetadataFactory::set_transform()
+                        .inputs_from_refs_and_aliases(id_aliases)
                         .build(),
                 ),
                 Default::default(),

--- a/src/infra/core/tests/tests/test_metadata_chain_comparator.rs
+++ b/src/infra/core/tests/tests/test_metadata_chain_comparator.rs
@@ -125,18 +125,24 @@ async fn test_equal_multiple_blocks() {
     let schema_hash = push_block(&lhs_chain, block_schema.clone()).await;
     push_block(&rhs_chain, block_schema).await;
 
-    let block_data_1 =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(0, 9).build())
-            .prev(&schema_hash, 1)
-            .build();
+    let block_data_1 = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(0, 9)
+            .build(),
+    )
+    .prev(&schema_hash, 1)
+    .build();
 
     let data_1_hash = push_block(&lhs_chain, block_data_1.clone()).await;
     push_block(&rhs_chain, block_data_1).await;
 
-    let block_data_2 =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(10, 19).build())
-            .prev(&data_1_hash, 2)
-            .build();
+    let block_data_2 = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(10, 19)
+            .build(),
+    )
+    .prev(&data_1_hash, 2)
+    .build();
     push_block(&lhs_chain, block_data_2.clone()).await;
     push_block(&rhs_chain, block_data_2).await;
 
@@ -168,16 +174,22 @@ async fn test_one_ahead_another() {
 
     // Push data blocks only to RHS
 
-    let block_data_1 =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(0, 9).build())
-            .prev(&schema_hash, 1)
-            .build();
+    let block_data_1 = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(0, 9)
+            .build(),
+    )
+    .prev(&schema_hash, 1)
+    .build();
     let data_1_hash = push_block(&rhs_chain, block_data_1).await;
 
-    let block_data_2 =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(10, 19).build())
-            .prev(&data_1_hash, 2)
-            .build();
+    let block_data_2 = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(10, 19)
+            .build(),
+    )
+    .prev(&data_1_hash, 2)
+    .build();
     push_block(&rhs_chain, block_data_2).await;
 
     assert_matches!(
@@ -215,16 +227,22 @@ async fn test_equal_length_divergence() {
 
     // Push two different data blocks after the same head
 
-    let block1_data =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(0, 9).build())
-            .prev(&schema_hash, 1)
-            .build();
+    let block1_data = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(0, 9)
+            .build(),
+    )
+    .prev(&schema_hash, 1)
+    .build();
     push_block(&lhs_chain, block1_data).await;
 
-    let block2_data =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(0, 9).build())
-            .prev(&schema_hash, 1)
-            .build();
+    let block2_data = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(0, 9)
+            .build(),
+    )
+    .prev(&schema_hash, 1)
+    .build();
     push_block(&rhs_chain, block2_data).await;
 
     assert_matches!(
@@ -263,21 +281,30 @@ async fn test_different_length_divergence() {
     // Push two data blocks to LHS and one unrelated block to RHS after the same
     // head
 
-    let block1_data1 =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(0, 9).build())
-            .prev(&schema_hash, 1)
-            .build();
+    let block1_data1 = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(0, 9)
+            .build(),
+    )
+    .prev(&schema_hash, 1)
+    .build();
     let block1_data1_hash = push_block(&lhs_chain, block1_data1).await;
-    let block1_data2 =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(10, 19).build())
-            .prev(&block1_data1_hash, 2)
-            .build();
+    let block1_data2 = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(10, 19)
+            .build(),
+    )
+    .prev(&block1_data1_hash, 2)
+    .build();
     push_block(&lhs_chain, block1_data2).await;
 
-    let block2_data =
-        MetadataFactory::metadata_block(MetadataFactory::add_data().interval(0, 9).build())
-            .prev(&schema_hash, 1)
-            .build();
+    let block2_data = MetadataFactory::metadata_block(
+        MetadataFactory::add_data()
+            .new_offset_interval(0, 9)
+            .build(),
+    )
+    .prev(&schema_hash, 1)
+    .build();
     push_block(&rhs_chain, block2_data).await;
 
     assert_matches!(

--- a/src/infra/core/tests/tests/test_search_service_impl.rs
+++ b/src/infra/core/tests/tests/test_search_service_impl.rs
@@ -61,9 +61,8 @@ async fn do_test_search(tmp_workspace_dir: &Path, repo_url: Url) {
     // Add and sync dataset
     dataset_repo
         .create_dataset_from_snapshot(
-            None,
             MetadataFactory::dataset_snapshot()
-                .name(&dataset_local_alias.dataset_name)
+                .name(dataset_local_alias.clone())
                 .kind(DatasetKind::Root)
                 .push_event(MetadataFactory::set_polling_source().build())
                 .build(),

--- a/src/infra/core/tests/tests/test_serde_yaml.rs
+++ b/src/infra/core/tests/tests/test_serde_yaml.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::convert::TryFrom;
-
 use chrono::prelude::*;
 use indoc::indoc;
 use kamu::domain::DatasetSummary;
@@ -19,75 +17,20 @@ use opendatafabric::*;
 fn serde_dataset_summary() {
     let data = indoc!(
         "
-    kind: DatasetSummary
-    version: 1
-    content:
-      id: did:odf:fed01626f6f21b8373800626f6f21b837380020f6f606070000008d6edc2eb877e8cc
-      kind: root
-      lastBlockHash: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
-      dependencies:
-      - name: foo
-      - name: bar
-      lastPulled: 2020-01-01T12:00:00Z
-      numRecords: 100
-      dataSize: 1024
-      checkpointsSize: 64\n"
-    );
-
-    let actual: Manifest<DatasetSummary> = serde_yaml::from_str(data).unwrap();
-
-    let expected = Manifest {
-        kind: "DatasetSummary".to_owned(),
-        version: 1,
-        content: DatasetSummary {
-            id: DatasetID::new_seeded_ed25519(b"boop"),
-            kind: DatasetKind::Root,
-            last_block_hash: Multihash::from_multibase(
-                "zW1mJtUjH235JZ4BBpJBousTNHaDXer4r4QzSdsqTfKENrr",
-            )
-            .unwrap(),
-            dependencies: vec![
-                TransformInput {
-                    id: None,
-                    name: DatasetName::try_from("foo").unwrap(),
-                    dataset_ref: None,
-                },
-                TransformInput {
-                    id: None,
-                    name: DatasetName::try_from("bar").unwrap(),
-                    dataset_ref: None,
-                },
-            ],
-            last_pulled: Some(Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap()),
-            num_records: 100,
-            data_size: 1024,
-            checkpoints_size: 64,
-        },
-    };
-
-    assert_eq!(expected.content, actual.content);
-    assert_eq!(serde_yaml::to_string(&actual).unwrap(), data);
-}
-
-#[test]
-fn serde_dataset_summary_with_refs() {
-    let data = indoc!(
+        kind: DatasetSummary
+        version: 1
+        content:
+          id: did:odf:fed01626f6f21b8373800626f6f21b837380020f6f606070000008d6edc2eb877e8cc
+          kind: Root
+          lastBlockHash: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
+          dependencies:
+          - did:odf:fed01666f6fb3b7370000666f6fb3b737000060f6f60600000000895cddbcb7f7b8cc
+          - did:odf:fed01626172b130390000626172b1303900002016260700000000508ebebd3079f00e
+          lastPulled: 2020-01-01T12:00:00Z
+          numRecords: 100
+          dataSize: 1024
+          checkpointsSize: 64
         "
-    kind: DatasetSummary
-    version: 1
-    content:
-      id: did:odf:fed01626f6f21b8373800626f6f21b837380020f6f606070000008d6edc2eb877e8cc
-      kind: root
-      lastBlockHash: f1620b039179a8a4ce2c252aa6f2f25798251c19b75fc1508d9d511a191e0487d64a7
-      dependencies:
-      - name: foo
-        datasetRef: me/foo
-      - name: bar
-        datasetRef: remote-repo/her/bar
-      lastPulled: 2020-01-01T12:00:00Z
-      numRecords: 100
-      dataSize: 1024
-      checkpointsSize: 64\n"
     );
 
     let actual: Manifest<DatasetSummary> = serde_yaml::from_str(data).unwrap();
@@ -103,16 +46,8 @@ fn serde_dataset_summary_with_refs() {
             )
             .unwrap(),
             dependencies: vec![
-                TransformInput {
-                    id: None,
-                    name: DatasetName::try_from("foo").unwrap(),
-                    dataset_ref: Some(DatasetRefAny::try_from("me/foo").unwrap()),
-                },
-                TransformInput {
-                    id: None,
-                    name: DatasetName::try_from("bar").unwrap(),
-                    dataset_ref: Some(DatasetRefAny::try_from("remote-repo/her/bar").unwrap()),
-                },
+                DatasetID::new_seeded_ed25519(b"foo"),
+                DatasetID::new_seeded_ed25519(b"bar"),
             ],
             last_pulled: Some(Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap()),
             num_records: 100,

--- a/src/infra/core/tests/utils/mock_engine_provisioner.rs
+++ b/src/infra/core/tests/utils/mock_engine_provisioner.rs
@@ -64,10 +64,10 @@ impl Engine for EngineStub {
     ) -> Result<TransformResponse, EngineError> {
         // Note: At least 1 output field must be present, watermark is easy to mimic
         Ok(TransformResponse {
-            data_interval: None,
-            output_watermark: Some(Utc::now()),
-            out_checkpoint: None,
-            out_data: None,
+            new_offset_interval: None,
+            new_watermark: Some(Utc::now()),
+            new_checkpoint: None,
+            new_data: None,
         })
     }
 }

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_configuration_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_configuration_service_inmem.rs
@@ -421,9 +421,8 @@ impl FlowConfigurationHarness {
         let result = self
             .dataset_repo
             .create_dataset_from_snapshot(
-                None,
                 MetadataFactory::dataset_snapshot()
-                    .name(DatasetName::new_unchecked(dataset_name))
+                    .name(dataset_name)
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .build(),

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -1014,9 +1014,8 @@ impl FlowHarness {
         let result = self
             .dataset_repo
             .create_dataset_from_snapshot(
-                None,
                 MetadataFactory::dataset_snapshot()
-                    .name(DatasetName::new_unchecked(dataset_name))
+                    .name(dataset_name)
                     .kind(DatasetKind::Root)
                     .push_event(MetadataFactory::set_polling_source().build())
                     .build(),
@@ -1032,24 +1031,17 @@ impl FlowHarness {
         dataset_name: &str,
         input_ids: Vec<DatasetID>,
     ) -> DatasetID {
-        let mut input_aliases = Vec::new();
-        for input_id in input_ids {
-            let input_hdl = self
-                .dataset_repo
-                .resolve_dataset_ref(&input_id.as_local_ref())
-                .await
-                .unwrap();
-            input_aliases.push(input_hdl.alias);
-        }
-
         let create_result = self
             .dataset_repo
             .create_dataset_from_snapshot(
-                None,
                 MetadataFactory::dataset_snapshot()
-                    .name(DatasetName::new_unchecked(dataset_name))
+                    .name(dataset_name)
                     .kind(DatasetKind::Derivative)
-                    .push_event(MetadataFactory::set_transform_aliases(input_aliases).build())
+                    .push_event(
+                        MetadataFactory::set_transform()
+                            .inputs_from_refs(input_ids)
+                            .build(),
+                    )
                     .build(),
             )
             .await

--- a/src/infra/ingest-datafusion/src/readers/csv.rs
+++ b/src/infra/ingest-datafusion/src/readers/csv.rs
@@ -89,47 +89,9 @@ impl Reader for ReaderCsv {
             None | Some("utf8") => Ok(()),
             Some(v) => Err(unsupported!("Unsupported Csv.encoding: {}", v)),
         }?;
-        match self.conf.comment.as_ref().map(|s| s.as_str()) {
-            None => Ok(()),
-            Some(v) => Err(unsupported!("Unsupported Csv.comment: {}", v)),
-        }?;
-        match self.conf.enforce_schema {
-            None | Some(true) => Ok(()),
-            Some(v) => Err(unsupported!("Unsupported Csv.enforceSchema: {}", v)),
-        }?;
-        match self.conf.ignore_leading_white_space {
-            None | Some(false) => Ok(()),
-            Some(v) => Err(unsupported!(
-                "Unsupported Csv.ignoreLeadingWhiteSpace: {}",
-                v
-            )),
-        }?;
-        match self.conf.ignore_trailing_white_space {
-            None | Some(false) => Ok(()),
-            Some(v) => Err(unsupported!(
-                "Unsupported Csv.ignoreTrailingWhiteSpace: {}",
-                v
-            )),
-        }?;
         match self.conf.null_value.as_ref().map(|s| s.as_str()) {
             None | Some("") => Ok(()),
             Some(v) => Err(unsupported!("Unsupported Csv.nullValue: {}", v)),
-        }?;
-        match self.conf.empty_value.as_ref().map(|s| s.as_str()) {
-            None => Ok(()),
-            Some(v) => Err(unsupported!("Unsupported Csv.emptyValue: {}", v)),
-        }?;
-        match self.conf.nan_value.as_ref().map(|s| s.as_str()) {
-            None => Ok(()),
-            Some(v) => Err(unsupported!("Unsupported Csv.nanValue: {}", v)),
-        }?;
-        match self.conf.positive_inf.as_ref().map(|s| s.as_str()) {
-            None => Ok(()),
-            Some(v) => Err(unsupported!("Unsupported Csv.positiveInf: {}", v)),
-        }?;
-        match self.conf.negative_inf.as_ref().map(|s| s.as_str()) {
-            None => Ok(()),
-            Some(v) => Err(unsupported!("Unsupported Csv.negativeInf: {}", v)),
         }?;
         match self.conf.date_format.as_ref().map(|s| s.as_str()) {
             None | Some("rfc3339") => Ok(()),
@@ -138,10 +100,6 @@ impl Reader for ReaderCsv {
         match self.conf.timestamp_format.as_ref().map(|s| s.as_str()) {
             None | Some("rfc3339") => Ok(()),
             Some(v) => Err(unsupported!("Unsupported Csv.timestampFormat: {}", v)),
-        }?;
-        match self.conf.multi_line {
-            None | Some(false) => Ok(()),
-            Some(v) => Err(unsupported!("Unsupported Csv.multiLine: {}", v)),
         }?;
 
         let options = CsvReadOptions {

--- a/src/infra/ingest-datafusion/src/readers/ndjson.rs
+++ b/src/infra/ingest-datafusion/src/readers/ndjson.rs
@@ -36,22 +36,6 @@ impl ReaderNdJson {
             conf,
         })
     }
-
-    pub async fn new_compat(
-        ctx: SessionContext,
-        conf: ReadStepJsonLines,
-    ) -> Result<Self, ReadError> {
-        Self::new(
-            ctx,
-            ReadStepNdJson {
-                schema: conf.schema,
-                date_format: conf.date_format,
-                encoding: conf.encoding,
-                timestamp_format: conf.timestamp_format,
-            },
-        )
-        .await
-    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/infra/ingest-datafusion/src/writer.rs
+++ b/src/infra/ingest-datafusion/src/writer.rs
@@ -291,7 +291,7 @@ impl DataWriterDataFusion {
             .with_column(
                 &self.meta.vocab.offset_column,
                 cast(
-                    col(&self.meta.vocab.offset_column as &str) + lit(start_offset - 1),
+                    col(&self.meta.vocab.offset_column as &str) + lit(start_offset as i64 - 1),
                     DataType::Int64,
                 ),
             )

--- a/src/infra/ingest-datafusion/src/writer.rs
+++ b/src/infra/ingest-datafusion/src/writer.rs
@@ -43,10 +43,10 @@ pub struct DataWriterMetadataState {
     pub merge_strategy: odf::MergeStrategy,
     pub vocab: odf::DatasetVocabularyResolvedOwned,
     pub data_slices: Vec<odf::Multihash>,
-    pub last_offset: Option<i64>,
-    pub last_checkpoint: Option<odf::Multihash>,
-    pub last_watermark: Option<DateTime<Utc>>,
-    pub last_source_state: Option<odf::SourceState>,
+    pub prev_offset: Option<u64>,
+    pub prev_checkpoint: Option<odf::Multihash>,
+    pub prev_watermark: Option<DateTime<Utc>>,
+    pub prev_source_state: Option<odf::SourceState>,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -73,12 +73,12 @@ impl DataWriterDataFusion {
         }
     }
 
-    pub fn last_offset(&self) -> Option<i64> {
-        self.meta.last_offset
+    pub fn prev_offset(&self) -> Option<u64> {
+        self.meta.prev_offset
     }
 
-    pub fn last_source_state(&self) -> Option<&odf::SourceState> {
-        self.meta.last_source_state.as_ref()
+    pub fn prev_source_state(&self) -> Option<&odf::SourceState> {
+        self.meta.prev_source_state.as_ref()
     }
 
     pub fn vocab(&self) -> &odf::DatasetVocabularyResolvedOwned {
@@ -217,7 +217,7 @@ impl DataWriterDataFusion {
         df: DataFrame,
         system_time: DateTime<Utc>,
         fallback_event_time: DateTime<Utc>,
-        start_offset: i64,
+        start_offset: u64,
     ) -> Result<DataFrame, InternalError> {
         use datafusion::arrow::datatypes::DataType;
         use datafusion::logical_expr as expr;
@@ -447,8 +447,8 @@ impl DataWriterDataFusion {
             .value(0);
 
         let offset_interval = odf::OffsetInterval {
-            start: offset_min,
-            end: offset_max,
+            start: offset_min as u64,
+            end: offset_max as u64,
         };
 
         // Event time is either Date or Timestamp(Millisecond, UTC)
@@ -530,7 +530,7 @@ impl DataWriter for DataWriterDataFusion {
                     df,
                     opts.system_time,
                     opts.source_event_time,
-                    self.meta.last_offset.map(|e| e + 1).unwrap_or(0),
+                    self.meta.prev_offset.map(|e| e + 1).unwrap_or(0),
                 )
                 .await?;
 
@@ -544,24 +544,26 @@ impl DataWriter for DataWriterDataFusion {
             let data_file = self.write_output(opts.data_staging_path, df).await?;
 
             // Prepare commit info
-            let input_checkpoint = self.meta.last_checkpoint.clone();
-            let source_state = opts.source_state.clone();
-            let prev_watermark = self.meta.last_watermark.clone();
+            let prev_offset = self.meta.prev_offset;
+            let prev_checkpoint = self.meta.prev_checkpoint.clone();
+            let new_source_state = opts.source_state;
+            let prev_watermark = self.meta.prev_watermark.clone();
 
             if data_file.is_none() {
                 // Empty result - carry watermark and propagate source state
                 (
                     AddDataParams {
-                        input_checkpoint,
-                        output_data: None,
-                        output_watermark: prev_watermark,
-                        source_state,
+                        prev_checkpoint,
+                        prev_offset,
+                        new_offset_interval: None,
+                        new_watermark: prev_watermark,
+                        new_source_state,
                     },
                     Some(output_schema),
                     None,
                 )
             } else {
-                let (offset_interval, output_watermark) = self
+                let (new_offset_interval, new_watermark) = self
                     .compute_offset_and_watermark(
                         data_file.as_ref().unwrap().as_path(),
                         prev_watermark,
@@ -570,10 +572,11 @@ impl DataWriter for DataWriterDataFusion {
 
                 (
                     AddDataParams {
-                        input_checkpoint,
-                        output_data: Some(offset_interval),
-                        output_watermark,
-                        source_state,
+                        prev_checkpoint,
+                        prev_offset,
+                        new_offset_interval: Some(new_offset_interval),
+                        new_watermark,
+                        new_source_state,
                     },
                     Some(output_schema),
                     data_file,
@@ -582,19 +585,20 @@ impl DataWriter for DataWriterDataFusion {
         } else {
             // TODO: Should watermark be advanced by the source event time?
             let add_data = AddDataParams {
-                input_checkpoint: self.meta.last_checkpoint.clone(),
-                output_data: None,
-                output_watermark: self.meta.last_watermark.clone(),
-                source_state: opts.source_state.clone(),
+                prev_checkpoint: self.meta.prev_checkpoint.clone(),
+                prev_offset: self.meta.prev_offset,
+                new_offset_interval: None,
+                new_watermark: self.meta.prev_watermark.clone(),
+                new_source_state: opts.source_state,
             };
 
             (add_data, None, None)
         };
 
         // Do we have anything to commit?
-        if add_data.output_data.is_none()
-            && add_data.output_watermark == self.meta.last_watermark
-            && opts.source_state == self.meta.last_source_state
+        if add_data.new_offset_interval.is_none()
+            && add_data.new_watermark == self.meta.prev_watermark
+            && add_data.new_source_state == self.meta.prev_source_state
         {
             Err(EmptyCommitError {}.into())
         } else {
@@ -661,21 +665,19 @@ impl DataWriter for DataWriterDataFusion {
 
         self.meta.head = commit_data_result.new_head.clone();
 
-        if let Some(output_data) = &new_block.event.output_data {
-            self.meta.last_offset = Some(output_data.interval.end);
-            self.meta
-                .data_slices
-                .push(output_data.physical_hash.clone());
+        if let Some(new_data) = &new_block.event.new_data {
+            self.meta.prev_offset = Some(new_data.offset_interval.end);
+            self.meta.data_slices.push(new_data.physical_hash.clone());
         }
 
-        self.meta.last_checkpoint = new_block
+        self.meta.prev_checkpoint = new_block
             .event
-            .output_checkpoint
+            .new_checkpoint
             .as_ref()
             .map(|c| c.physical_hash.clone());
 
-        self.meta.last_watermark = new_block.event.output_watermark;
-        self.meta.last_source_state = new_block.event.source_state.clone();
+        self.meta.prev_watermark = new_block.event.new_watermark;
+        self.meta.prev_source_state = new_block.event.new_source_state.clone();
 
         Ok(WriteDataResult {
             old_head,
@@ -743,12 +745,12 @@ impl DataWriterDataFusionBuilder {
 
         let mut schema = None;
         let mut source_event: Option<odf::MetadataEvent> = None;
-        let mut data_slices = Vec::new();
-        let mut last_checkpoint = None;
-        let mut last_watermark = None;
-        let mut last_source_state = None;
         let mut vocab: Option<odf::DatasetVocabulary> = None;
-        let mut last_offset = None;
+        let mut data_slices = Vec::new();
+        let mut prev_checkpoint = None;
+        let mut prev_watermark = None;
+        let mut prev_source_state = None;
+        let mut prev_offset = None;
 
         {
             use futures::stream::TryStreamExt;
@@ -765,27 +767,33 @@ impl DataWriterDataFusionBuilder {
                         }
                     }
                     odf::MetadataEvent::AddData(e) => {
-                        if let Some(output_data) = &e.output_data {
+                        if let Some(output_data) = &e.new_data {
                             data_slices.push(output_data.physical_hash.clone());
-
-                            if last_offset.is_none() {
-                                last_offset = Some(output_data.interval.end);
+                        }
+                        if prev_offset.is_none() {
+                            prev_offset = Some(e.last_offset());
+                        }
+                        if prev_checkpoint.is_none() {
+                            prev_checkpoint = Some(e.new_checkpoint.map(|cp| cp.physical_hash));
+                        }
+                        if prev_watermark.is_none() {
+                            prev_watermark = Some(e.new_watermark);
+                        }
+                        if prev_source_state.is_none() {
+                            if let Some(ss) = &e.new_source_state {
+                                if ss.source_name.as_deref() != source_name {
+                                    unimplemented!(
+                                        "Differentiating between the state of multiple sources is \
+                                         not yet supported"
+                                    );
+                                }
                             }
-                        }
-                        if last_checkpoint.is_none() {
-                            last_checkpoint = Some(e.output_checkpoint.map(|cp| cp.physical_hash));
-                        }
-                        if last_watermark.is_none() {
-                            last_watermark = Some(e.output_watermark);
-                        }
-                        // TODO: Consider multiple sources situation
-                        if last_source_state.is_none() {
-                            last_source_state = Some(e.source_state);
+                            prev_source_state = Some(e.new_source_state);
                         }
                     }
                     odf::MetadataEvent::SetWatermark(e) => {
-                        if last_watermark.is_none() {
-                            last_watermark = Some(Some(e.output_watermark));
+                        if prev_watermark.is_none() {
+                            prev_watermark = Some(Some(e.new_watermark));
                         }
                     }
                     odf::MetadataEvent::SetPollingSource(e) => {
@@ -851,10 +859,10 @@ impl DataWriterDataFusionBuilder {
             merge_strategy,
             vocab: vocab.unwrap_or_default().into(),
             data_slices,
-            last_offset,
-            last_checkpoint: last_checkpoint.unwrap_or_default(),
-            last_watermark: last_watermark.unwrap_or_default(),
-            last_source_state: last_source_state.unwrap_or_default(),
+            prev_offset: prev_offset.unwrap_or_default(),
+            prev_checkpoint: prev_checkpoint.unwrap_or_default(),
+            prev_watermark: prev_watermark.unwrap_or_default(),
+            prev_source_state: prev_source_state.unwrap_or_default(),
         }))
     }
 


### PR DESCRIPTION
This PR reflects changes proposed in open-data-fabric/open-data-fabric#71, most notably:
- New enum tagging scheme in YAML per ODF RFC-013
- New offset and block range propagation scheme per ODF RFC-014
  - This significantly simplified logic in some places!
- A much simpler structure of `TransformInput` containing `dataset_ref` (ID) and an `alias` (string for queries only)
- Some other renaming and format changes
  - Most notably a switch to `u64` sequence numbers