### PR TITLE
tests::ingest::test_fetch::*: fix race condition during parallel execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fixed race condition during tests parallel execution (`tests::ingest::test_fetch::*` test group)
+
 ## [0.150.0] - 2023-12-27
 ### Changed
 - Changed logic in `SimpleTransferProtocol` now block data and checkpoint downloading/uploading

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,6 +3186,7 @@ dependencies = [
  "kamu-ingest-datafusion",
  "libc",
  "mockall",
+ "nanoid",
  "object_store",
  "opendatafabric",
  "petgraph",
@@ -4046,6 +4047,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1a5d38b9b352dbd913288736af36af41c48d61b1a8cd34bcecd727561b7d511"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -117,6 +117,7 @@ tokio = { version = "1", default-features = false, features=["rt", "macros"] }
 test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+nanoid = "0.4.0"
 
 [[bench]]
 name = "parallel_simple_transfer_protocol"

--- a/src/infra/core/tests/tests/ingest/test_fetch.rs
+++ b/src/infra/core/tests/tests/ingest/test_fetch.rs
@@ -46,7 +46,14 @@ async fn test_fetch_url_file() {
     // No file to fetch
     assert_matches!(
         fetch_svc
-            .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+            .fetch(
+                &generate_unique_operation_id(),
+                &fetch_step,
+                None,
+                &target_path,
+                &Utc::now(),
+                None
+            )
             .await,
         Err(PollingIngestError::NotFound { .. })
     );
@@ -56,7 +63,14 @@ async fn test_fetch_url_file() {
 
     // Normal fetch
     let res = fetch_svc
-        .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+        .fetch(
+            &generate_unique_operation_id(),
+            &fetch_step,
+            None,
+            &target_path,
+            &Utc::now(),
+            None,
+        )
         .await
         .unwrap();
     let FetchResult::Updated(update) = res else {
@@ -68,7 +82,7 @@ async fn test_fetch_url_file() {
     // No modifications
     let res2 = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update.source_state.as_ref(),
             &target_path,
@@ -83,7 +97,7 @@ async fn test_fetch_url_file() {
     filetime::set_file_mtime(&src_path, filetime::FileTime::from_unix_time(0, 0)).unwrap();
     let res3 = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update.source_state.as_ref(),
             &target_path,
@@ -118,7 +132,14 @@ async fn test_fetch_url_http_unreachable() {
 
     assert_matches!(
         fetch_svc
-            .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+            .fetch(
+                &generate_unique_operation_id(),
+                &fetch_step,
+                None,
+                &target_path,
+                &Utc::now(),
+                None
+            )
             .await,
         Err(PollingIngestError::Unreachable { .. })
     );
@@ -147,7 +168,14 @@ async fn test_fetch_url_http_not_found() {
 
     assert_matches!(
         fetch_svc
-            .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+            .fetch(
+                &generate_unique_operation_id(),
+                &fetch_step,
+                None,
+                &target_path,
+                &Utc::now(),
+                None
+            )
             .await,
         Err(PollingIngestError::NotFound { .. })
     );
@@ -183,7 +211,7 @@ async fn test_fetch_url_http_ok() {
 
     let res = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             None,
             &target_path,
@@ -215,7 +243,7 @@ async fn test_fetch_url_http_ok() {
 
     let res_repeat = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update.source_state.as_ref(),
             &target_path,
@@ -231,7 +259,7 @@ async fn test_fetch_url_http_ok() {
     filetime::set_file_mtime(&src_path, filetime::FileTime::from_unix_time(0, 0)).unwrap();
     let res_touch = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update.source_state.as_ref(),
             &target_path,
@@ -248,7 +276,7 @@ async fn test_fetch_url_http_ok() {
     assert_matches!(
         fetch_svc
             .fetch(
-                "1",
+                &generate_unique_operation_id(),
                 &fetch_step,
                 update.source_state.as_ref(),
                 &target_path,
@@ -295,7 +323,7 @@ async fn test_fetch_url_http_env_interpolation() {
     assert_matches!(
         fetch_svc
             .fetch(
-                "1",
+                &generate_unique_operation_id(),
                 &fetch_step,
                 None,
                 &target_path,
@@ -310,7 +338,7 @@ async fn test_fetch_url_http_env_interpolation() {
 
     let res = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             None,
             &target_path,
@@ -369,7 +397,7 @@ async fn test_fetch_url_ftp_ok() {
 
     let res = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             None,
             &target_path,
@@ -428,7 +456,14 @@ async fn test_fetch_files_glob() {
     // No file to fetch
     assert_matches!(
         fetch_svc
-            .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+            .fetch(
+                &generate_unique_operation_id(),
+                &fetch_step,
+                None,
+                &target_path,
+                &Utc::now(),
+                None
+            )
             .await,
         Err(PollingIngestError::NotFound { .. })
     );
@@ -438,7 +473,14 @@ async fn test_fetch_files_glob() {
 
     // Normal fetch
     let res = fetch_svc
-        .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+        .fetch(
+            &generate_unique_operation_id(),
+            &fetch_step,
+            None,
+            &target_path,
+            &Utc::now(),
+            None,
+        )
         .await
         .unwrap();
     let FetchResult::Updated(update) = res else {
@@ -458,7 +500,7 @@ async fn test_fetch_files_glob() {
     // No modifications
     let res2 = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update.source_state.as_ref(),
             &target_path,
@@ -473,7 +515,7 @@ async fn test_fetch_files_glob() {
     filetime::set_file_mtime(&src_path_1, filetime::FileTime::from_unix_time(0, 0)).unwrap();
     let res3 = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update.source_state.as_ref(),
             &target_path,
@@ -491,7 +533,7 @@ async fn test_fetch_files_glob() {
 
     let res4 = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update.source_state.as_ref(),
             &target_path,
@@ -529,7 +571,7 @@ async fn test_fetch_files_glob() {
 
     let res5 = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update.source_state.as_ref(),
             &target_path,
@@ -555,7 +597,7 @@ async fn test_fetch_files_glob() {
 
     let res6 = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             update5.source_state.as_ref(),
             &target_path,
@@ -606,7 +648,7 @@ async fn test_fetch_container_ok() {
 
     let res = fetch_svc
         .fetch(
-            "1",
+            &generate_unique_operation_id(),
             &fetch_step,
             None,
             &target_path,
@@ -652,7 +694,14 @@ async fn test_fetch_container_batch_size_default() {
     });
 
     let res = fetch_svc
-        .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+        .fetch(
+            &generate_unique_operation_id(),
+            &fetch_step,
+            None,
+            &target_path,
+            &Utc::now(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -684,7 +733,14 @@ async fn test_fetch_container_batch_size_set() {
     });
 
     let res = fetch_svc
-        .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+        .fetch(
+            &generate_unique_operation_id(),
+            &fetch_step,
+            None,
+            &target_path,
+            &Utc::now(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -716,7 +772,14 @@ async fn test_fetch_container_batch_size_invalid_format() {
     });
 
     let res = fetch_svc
-        .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+        .fetch(
+            &generate_unique_operation_id(),
+            &fetch_step,
+            None,
+            &target_path,
+            &Utc::now(),
+            None,
+        )
         .await;
 
     assert_matches!(
@@ -745,7 +808,14 @@ async fn test_fetch_container_has_more_no_data() {
     });
 
     let res = fetch_svc
-        .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+        .fetch(
+            &generate_unique_operation_id(),
+            &fetch_step,
+            None,
+            &target_path,
+            &Utc::now(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -782,7 +852,14 @@ async fn test_fetch_container_has_more_data_is_less_than_a_batch() {
     });
 
     let res = fetch_svc
-        .fetch("1", &fetch_step, None, &target_path, &Utc::now(), None)
+        .fetch(
+            &generate_unique_operation_id(),
+            &fetch_step,
+            None,
+            &target_path,
+            &Utc::now(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -838,7 +915,14 @@ async fn test_fetch_container_has_more_data_is_more_than_a_batch() {
         });
 
         let res_1 = fetch_svc
-            .fetch("1", &fetch_step_1, None, &target_path, &Utc::now(), None)
+            .fetch(
+                &generate_unique_operation_id(),
+                &fetch_step_1,
+                None,
+                &target_path,
+                &Utc::now(),
+                None,
+            )
             .await
             .unwrap();
 
@@ -885,7 +969,7 @@ async fn test_fetch_container_has_more_data_is_more_than_a_batch() {
 
         let res_2 = fetch_svc
             .fetch(
-                "2",
+                &generate_unique_operation_id(),
                 &fetch_step_2,
                 prev_source_state.as_ref(),
                 &target_path,
@@ -937,7 +1021,7 @@ async fn test_fetch_container_has_more_data_is_more_than_a_batch() {
 
         let res_3 = fetch_svc
             .fetch(
-                "3",
+                &generate_unique_operation_id(),
                 &fetch_step_3,
                 prev_source_state.as_ref(),
                 &target_path,
@@ -985,7 +1069,7 @@ async fn test_fetch_container_has_more_data_is_more_than_a_batch() {
 
         let res_4 = fetch_svc
             .fetch(
-                "4",
+                &generate_unique_operation_id(),
                 &fetch_step_4,
                 prev_source_state.as_ref(),
                 &target_path,
@@ -1054,6 +1138,14 @@ const HAS_MORE_TESTER_SCRIPT: &str = indoc! {r#"
 
     simulate_set_new_etag "${NEW_ETAG}"
 "#};
+
+///////////////////////////////////////////////////////////////////////////////
+// Utils: helpers
+///////////////////////////////////////////////////////////////////////////////
+
+fn generate_unique_operation_id() -> String {
+    nanoid::nanoid!()
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Utils: Listener


### PR DESCRIPTION
- Context: OperationID is used for container name generation. For parallel test running, we had several failed attempts to create a container with the same name.