### PR TITLE
API for CRON expressions is using struct with explciit CRON part fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `kamu login` and `kamu logout` commands accept server URL as a positional argument, not as `-s` switch
 - Improved output reporting of `kamu logout` command
+- API for CRON expressions is using struct with explicit CRON part fields instead of raw string
 ### Fixed
 - `kamu login` and `kamu logout` commands properly handle plaform URLs without an explicit schema (`https://` attached by default)
 - Flow configuration API no longer crashes on specific input combinations when interval expressed in smaller time units 

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -164,7 +164,19 @@ type CreateDatasetResultSuccess implements CreateDatasetResult & CreateDatasetFr
 }
 
 type CronExpression {
-	cronExpression: String!
+	min: String!
+	hour: String!
+	dayOfMonth: String!
+	month: String!
+	dayOfWeek: String!
+}
+
+input CronExpressionInput {
+	min: String!
+	hour: String!
+	dayOfMonth: String!
+	month: String!
+	dayOfWeek: String!
 }
 
 type DataBatch {
@@ -1139,7 +1151,7 @@ type RequestHeader {
 
 input ScheduleInput @oneOf {
 	timeDelta: TimeDeltaInput
-	cronExpression: String
+	cronExpression: CronExpressionInput
 }
 
 type Search {

--- a/src/adapter/graphql/src/scalars/flow_configuration.rs
+++ b/src/adapter/graphql/src/scalars/flow_configuration.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use cron::Schedule as CronSchedule;
 use kamu_flow_system::{FlowConfigurationRule, Schedule};
 
 use crate::prelude::*;
@@ -65,13 +64,21 @@ pub struct FlowConfigurationBatching {
 
 #[derive(SimpleObject, Clone, PartialEq, Eq)]
 pub struct CronExpression {
-    pub cron_expression: String,
+    pub min: String,
+    pub hour: String,
+    pub day_of_month: String,
+    pub month: String,
+    pub day_of_week: String,
 }
 
-impl From<CronSchedule> for CronExpression {
-    fn from(value: CronSchedule) -> Self {
+impl From<kamu_flow_system::ScheduleCronExpression> for CronExpression {
+    fn from(value: kamu_flow_system::ScheduleCronExpression) -> Self {
         Self {
-            cron_expression: value.to_string(),
+            min: value.source.min,
+            hour: value.source.hour,
+            day_of_month: value.source.day_of_month,
+            month: value.source.month,
+            day_of_week: value.source.day_of_week,
         }
     }
 }

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_configs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_configs.rs
@@ -317,7 +317,7 @@ async fn test_crud_cron_root_dataset() {
             hour: "*/2",
             dayOfMonth: "*",
             month: "*",
-            dayOfWeek: "*" 
+            dayOfWeek: "*"
         }"#,
     );
 
@@ -348,7 +348,7 @@ async fn test_crud_cron_root_dataset() {
                                         "hour": "*/2",
                                         "dayOfMonth": "*",
                                         "month": "*",
-                                        "dayOfWeek": "*" 
+                                        "dayOfWeek": "*"
                                     },
                                     "batching": null
                                 }
@@ -369,8 +369,8 @@ async fn test_crud_cron_root_dataset() {
             hour: "*/1",
             dayOfMonth: "*",
             month: "*",
-            dayOfWeek: "*" 
-        }"#,        
+            dayOfWeek: "*"
+        }"#,
     );
 
     let res = schema
@@ -400,7 +400,7 @@ async fn test_crud_cron_root_dataset() {
                                         "hour": "*/1",
                                         "dayOfMonth": "*",
                                         "month": "*",
-                                        "dayOfWeek": "*" 
+                                        "dayOfWeek": "*"
                                     },
                                     "batching": null
                                 }
@@ -417,14 +417,14 @@ async fn test_crud_cron_root_dataset() {
         &create_result.dataset_handle.id,
         "INGEST",
         true,
-         // invalid day of week
+        // invalid day of week
         r#"{
             min: "0",
             hour: "*/1",
             dayOfMonth: "*",
             month: "*",
-            dayOfWeek: "PIATNICA"  
-        }"#,    
+            dayOfWeek: "PIATNICA"
+        }"#,
     );
 
     let res = schema
@@ -438,7 +438,6 @@ async fn test_crud_cron_root_dataset() {
         res.errors[0].message,
         format!("Cron expression 0 */1 * * PIATNICA is invalid")
     );
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -611,8 +610,8 @@ async fn test_incorrect_dataset_kinds_for_flow_type() {
             hour: "*/2",
             dayOfMonth: "*",
             month: "*",
-            dayOfWeek: "*" 
-        }"#
+            dayOfWeek: "*"
+        }"#,
     );
 
     let res = schema
@@ -704,7 +703,7 @@ async fn test_anonymous_setters_fail() {
                 hour: "*/2",
                 dayOfMonth: "*",
                 month: "*",
-                dayOfWeek: "*" 
+                dayOfWeek: "*"
             }"#,
         ),
         FlowConfigHarness::set_config_batching_mutation(

--- a/src/domain/flow-system/src/entities/shared/schedule.rs
+++ b/src/domain/flow-system/src/entities/shared/schedule.rs
@@ -46,6 +46,15 @@ pub struct CronExpressionSource {
     pub day_of_week: String,
 }
 
+impl CronExpressionSource {
+    pub fn as_cron_expression_string_with_sec(&self) -> String {
+        format!(
+            "0 {} {} {} {} {}",
+            self.min, self.hour, self.day_of_month, self.month, self.day_of_week
+        )
+    }
+}
+
 impl Default for CronExpressionSource {
     fn default() -> Self {
         // Means run every 1 minute
@@ -96,10 +105,7 @@ pub struct CronExpressionIterationError {
 
 impl Schedule {
     pub fn new_cron_schedule(source: CronExpressionSource) -> Result<Schedule, ScheduleError> {
-        let cron_as_string_with_dummy_seconds = format!(
-            "0 {} {} {} {} {}",
-            source.min, source.hour, source.day_of_month, source.month, source.day_of_week
-        );
+        let cron_as_string_with_dummy_seconds = source.as_cron_expression_string_with_sec();
 
         let schedule = match CronSchedule::from_str(&cron_as_string_with_dummy_seconds) {
             Err(_) => {


### PR DESCRIPTION
## Description

Closes: #459 

Replacing string-based CRON expressions with a data structure with explicit CRON fields.

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [ ] API changes are backwards-compatible - NOT COMPATIBLE, but no consumer yet
- [x] Workspace layout changes include a migration - not needed
- [x] Documentation update PR: not needed
- [x] Dataset pipelines update scheduled if needed - not needed
