### PR TITLE
DataFusion-based SQL console #228:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Datafusion-based interactive SQL shell
+### Changed
+- Datafusion is now the default engine for `kamu sql` command
+
 ## [0.154.2] - 2024-01-25
 ### Changed
 - Use artificial control over time in `FlowService` tests to stabilize their behavior

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,34 +164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
-name = "apache-avro"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
-dependencies = [
- "bzip2",
- "crc32fast",
- "digest",
- "lazy_static",
- "libflate 2.0.0",
- "log",
- "num-bigint",
- "quad-rand",
- "rand",
- "regex-lite",
- "serde",
- "serde_json",
- "snap",
- "strum",
- "strum_macros 0.25.3",
- "thiserror",
- "typed-builder",
- "uuid",
- "xz2",
- "zstd 0.12.4",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,17 +608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,55 +615,25 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
-dependencies = [
- "aws-credential-types 0.55.3",
- "aws-http 0.55.3",
- "aws-sdk-sso 0.28.0",
- "aws-sdk-sts 0.28.0",
- "aws-smithy-async 0.55.3",
- "aws-smithy-client",
- "aws-smithy-http 0.55.3",
- "aws-smithy-http-tower",
- "aws-smithy-json 0.55.3",
- "aws-smithy-types 0.55.3",
- "aws-types 0.55.3",
- "bytes",
- "fastrand 1.9.0",
- "hex",
- "http",
- "hyper",
- "ring 0.16.20",
- "time",
- "tokio",
- "tower",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-config"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bf00cb9416daab4ce4927c54ebe63c08b9caf4d7b9314b6d7a4a2c5a1afb09"
 dependencies = [
- "aws-credential-types 0.57.2",
- "aws-http 0.57.2",
+ "aws-credential-types",
+ "aws-http",
  "aws-runtime",
- "aws-sdk-sso 0.36.0",
+ "aws-sdk-sso",
  "aws-sdk-ssooidc",
- "aws-sdk-sts 0.36.0",
- "aws-smithy-async 0.57.2",
- "aws-smithy-http 0.57.2",
- "aws-smithy-json 0.57.2",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
- "aws-types 0.57.2",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand",
  "hex",
  "http",
  "hyper",
@@ -715,61 +646,14 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
-dependencies = [
- "aws-smithy-async 0.55.3",
- "aws-smithy-types 0.55.3",
- "fastrand 1.9.0",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-credential-types"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9073c88dbf12f68ce7d0e149f989627a1d1ae3d2b680459f04ccc29d1cbd0f"
 dependencies = [
- "aws-smithy-async 0.57.2",
+ "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
+ "aws-smithy-types",
  "zeroize",
-]
-
-[[package]]
-name = "aws-endpoint"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
-dependencies = [
- "aws-smithy-http 0.55.3",
- "aws-smithy-types 0.55.3",
- "aws-types 0.55.3",
- "http",
- "regex",
- "tracing",
-]
-
-[[package]]
-name = "aws-http"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
-dependencies = [
- "aws-credential-types 0.55.3",
- "aws-smithy-http 0.55.3",
- "aws-smithy-types 0.55.3",
- "aws-types 0.55.3",
- "bytes",
- "http",
- "http-body",
- "lazy_static",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
 ]
 
 [[package]]
@@ -778,10 +662,10 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24067106d09620cf02d088166cdaedeaca7146d4d499c41b37accecbea11b246"
 dependencies = [
- "aws-smithy-http 0.57.2",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
- "aws-types 0.57.2",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
  "http",
  "http-body",
@@ -795,16 +679,16 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6ee0152c06d073602236a4e94a8c52a327d310c1ecd596570ce795af8777ff"
 dependencies = [
- "aws-credential-types 0.57.2",
- "aws-http 0.57.2",
- "aws-sigv4 0.57.2",
- "aws-smithy-async 0.57.2",
+ "aws-credential-types",
+ "aws-http",
+ "aws-sigv4",
+ "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.57.2",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
- "aws-types 0.57.2",
- "fastrand 2.0.1",
+ "aws-smithy-types",
+ "aws-types",
+ "fastrand",
  "http",
  "percent-encoding",
  "tracing",
@@ -817,20 +701,20 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84022763485483ea17d417f9832d5da198bc36829b59f086c0d35ecd2ce59991"
 dependencies = [
- "aws-credential-types 0.57.2",
- "aws-http 0.57.2",
+ "aws-credential-types",
+ "aws-http",
  "aws-runtime",
- "aws-sigv4 0.57.2",
- "aws-smithy-async 0.57.2",
+ "aws-sigv4",
+ "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.57.2",
- "aws-smithy-json 0.57.2",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
- "aws-smithy-xml 0.57.2",
- "aws-types 0.57.2",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
  "bytes",
  "http",
  "http-body",
@@ -843,45 +727,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b812340d86d4a766b2ca73f740dfd47a97c2dff0c06c8517a16d88241957e4"
-dependencies = [
- "aws-credential-types 0.55.3",
- "aws-endpoint",
- "aws-http 0.55.3",
- "aws-sig-auth",
- "aws-smithy-async 0.55.3",
- "aws-smithy-client",
- "aws-smithy-http 0.55.3",
- "aws-smithy-http-tower",
- "aws-smithy-json 0.55.3",
- "aws-smithy-types 0.55.3",
- "aws-types 0.55.3",
- "bytes",
- "http",
- "regex",
- "tokio-stream",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sso"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb8158015232b4596ccef74a205600398e152d704b40b7ec9f486092474d7fa"
 dependencies = [
- "aws-credential-types 0.57.2",
- "aws-http 0.57.2",
+ "aws-credential-types",
+ "aws-http",
  "aws-runtime",
- "aws-smithy-async 0.57.2",
- "aws-smithy-http 0.57.2",
- "aws-smithy-json 0.57.2",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
- "aws-types 0.57.2",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
  "http",
  "regex",
@@ -894,45 +753,19 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36a1493e1c57f173e53621935bfb5b6217376168dbdb4cd459aebcf645924a48"
 dependencies = [
- "aws-credential-types 0.57.2",
- "aws-http 0.57.2",
+ "aws-credential-types",
+ "aws-http",
  "aws-runtime",
- "aws-smithy-async 0.57.2",
- "aws-smithy-http 0.57.2",
- "aws-smithy-json 0.57.2",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
- "aws-types 0.57.2",
+ "aws-smithy-types",
+ "aws-types",
  "bytes",
  "http",
  "regex",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
-dependencies = [
- "aws-credential-types 0.55.3",
- "aws-endpoint",
- "aws-http 0.55.3",
- "aws-sig-auth",
- "aws-smithy-async 0.55.3",
- "aws-smithy-client",
- "aws-smithy-http 0.55.3",
- "aws-smithy-http-tower",
- "aws-smithy-json 0.55.3",
- "aws-smithy-query 0.55.3",
- "aws-smithy-types 0.55.3",
- "aws-smithy-xml 0.55.3",
- "aws-types 0.55.3",
- "bytes",
- "http",
- "regex",
- "tower",
  "tracing",
 ]
 
@@ -942,53 +775,20 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e032b77f5cd1dd3669d777a38ac08cbf8ec68e29460d4ef5d3e50cffa74ec75a"
 dependencies = [
- "aws-credential-types 0.57.2",
- "aws-http 0.57.2",
+ "aws-credential-types",
+ "aws-http",
  "aws-runtime",
- "aws-smithy-async 0.57.2",
- "aws-smithy-http 0.57.2",
- "aws-smithy-json 0.57.2",
- "aws-smithy-query 0.57.2",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
- "aws-smithy-xml 0.57.2",
- "aws-types 0.57.2",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
  "http",
  "regex",
- "tracing",
-]
-
-[[package]]
-name = "aws-sig-auth"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
-dependencies = [
- "aws-credential-types 0.55.3",
- "aws-sigv4 0.55.3",
- "aws-smithy-http 0.55.3",
- "aws-types 0.55.3",
- "http",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
-dependencies = [
- "aws-smithy-http 0.55.3",
- "form_urlencoded",
- "hex",
- "hmac",
- "http",
- "once_cell",
- "percent-encoding",
- "regex",
- "sha2",
- "time",
  "tracing",
 ]
 
@@ -998,9 +798,9 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64f81a6abc4daab06b53cabf27c54189928893283093e37164ca53aa47488a5b"
 dependencies = [
- "aws-credential-types 0.57.2",
+ "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.57.2",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
  "bytes",
  "form_urlencoded",
@@ -1021,18 +821,6 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bda3996044c202d75b91afeb11a9afae9db9a721c6a7a427410018e286b880"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "aws-smithy-async"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe53fccd3b10414b9cae63767a15a2789b34e6c6727b6e32b33e8c7998a3e80"
@@ -1048,8 +836,8 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb5701fbfb40600cc0fa547f318552dfd4e632b2099bd75d95fb0faae70675d"
 dependencies = [
- "aws-smithy-http 0.57.2",
- "aws-smithy-types 0.57.2",
+ "aws-smithy-http",
+ "aws-smithy-types",
  "bytes",
  "crc32c",
  "crc32fast",
@@ -1064,58 +852,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-client"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
-dependencies = [
- "aws-smithy-async 0.55.3",
- "aws-smithy-http 0.55.3",
- "aws-smithy-http-tower",
- "aws-smithy-types 0.55.3",
- "bytes",
- "fastrand 1.9.0",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls 0.23.2",
- "lazy_static",
- "pin-project-lite",
- "rustls 0.20.9",
- "tokio",
- "tower",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-eventstream"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b33fa99f928a5815b94ee07e1377901bcf51aa749034a2c802dc38f9dcfacf5"
 dependencies = [
- "aws-smithy-types 0.57.2",
+ "aws-smithy-types",
  "bytes",
  "crc32fast",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
-dependencies = [
- "aws-smithy-types 0.55.3",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http",
- "http-body",
- "hyper",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
 ]
 
 [[package]]
@@ -1126,7 +870,7 @@ checksum = "f7972373213d1d6e619c0edc9dda2d6634154e4ed75c5e0b2bf065cd5ec9f0d1"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
+ "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -1140,47 +884,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http-tower"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
-dependencies = [
- "aws-smithy-http 0.55.3",
- "aws-smithy-types 0.55.3",
- "bytes",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
-dependencies = [
- "aws-smithy-types 0.55.3",
-]
-
-[[package]]
 name = "aws-smithy-json"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d64d5af16dd585de9ff6c606423c1aaad47c6baa38de41c2beb32ef21c6645"
 dependencies = [
- "aws-smithy-types 0.57.2",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
-dependencies = [
- "aws-smithy-types 0.55.3",
- "urlencoding",
+ "aws-smithy-types",
 ]
 
 [[package]]
@@ -1189,7 +898,7 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7527bf5335154ba1b285479c50b630e44e93d1b4a759eaceb8d0bf9fbc82caa5"
 dependencies = [
- "aws-smithy-types 0.57.2",
+ "aws-smithy-types",
  "urlencoding",
 ]
 
@@ -1199,20 +908,20 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "839b363adf3b2bdab2742a1f540fec23039ea8bc9ec0f9f61df48470cfe5527b"
 dependencies = [
- "aws-smithy-async 0.57.2",
- "aws-smithy-http 0.57.2",
+ "aws-smithy-async",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
+ "aws-smithy-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand",
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.24.2",
+ "hyper-rustls",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.10",
+ "rustls",
  "tokio",
  "tracing",
 ]
@@ -1223,27 +932,14 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24ecc446e62c3924539e7c18dec8038dba4fdf8718d5c2de62f9d2fecca8ba9"
 dependencies = [
- "aws-smithy-async 0.57.2",
- "aws-smithy-types 0.57.2",
+ "aws-smithy-async",
+ "aws-smithy-types",
  "bytes",
  "http",
  "pin-project-lite",
  "tokio",
  "tracing",
  "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
-dependencies = [
- "base64-simd",
- "itoa",
- "num-integer",
- "ryu",
- "time",
 ]
 
 [[package]]
@@ -1271,15 +967,6 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-smithy-xml"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb1e3ac22c652662096c8e37a6f9af80c6f3520cab5610b2fe76c725bce18eac"
@@ -1289,30 +976,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "0.55.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
-dependencies = [
- "aws-credential-types 0.55.3",
- "aws-smithy-async 0.55.3",
- "aws-smithy-client",
- "aws-smithy-http 0.55.3",
- "aws-smithy-types 0.55.3",
- "http",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
-name = "aws-types"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048bbf1c24cdf4eb1efcdc243388a93a90ebf63979e25fc1c7b8cbd9cb6beb38"
 dependencies = [
- "aws-credential-types 0.57.2",
- "aws-smithy-async 0.57.2",
+ "aws-credential-types",
+ "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-types 0.57.2",
+ "aws-smithy-types",
  "http",
  "rustc_version",
  "tracing",
@@ -1729,6 +1400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1739,7 +1411,7 @@ checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
+ "clap_lex",
  "strsim",
 ]
 
@@ -1749,29 +1421,19 @@ version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df631ae429f6613fcd3a7c1adbdb65f637271e561b03680adaa6573015dfb106"
 dependencies = [
- "clap 4.4.14",
+ "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1876,7 +1538,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "libc",
  "rand",
  "regex",
@@ -1906,15 +1568,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1952,7 +1605,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.14",
+ "clap",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -2204,12 +1857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dary_heap"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,7 +1882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "676796427e638d85e9eadf13765705212be60b34f8fc5d3934d95184c63ca1b4"
 dependencies = [
  "ahash",
- "apache-avro",
  "arrow",
  "arrow-array",
  "arrow-schema",
@@ -2260,7 +1906,6 @@ dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
  "log",
- "num-traits",
  "num_cpus",
  "object_store",
  "parking_lot",
@@ -2278,36 +1923,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-cli"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d09ed6f01e41a983cf720228b4f0811d755b3f52776dd5170c744bd5d626e"
-dependencies = [
- "arrow",
- "async-trait",
- "aws-config 0.55.3",
- "aws-credential-types 0.55.3",
- "clap 3.2.25",
- "datafusion",
- "dirs 4.0.0",
- "env_logger 0.9.3",
- "mimalloc",
- "object_store",
- "parking_lot",
- "regex",
- "rustyline",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "datafusion-common"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e23b3d21a6531259d291bd20ce59282ea794bda1018b0a1e278c13cd52e50c"
 dependencies = [
  "ahash",
- "apache-avro",
  "arrow",
  "arrow-array",
  "arrow-buffer",
@@ -2541,20 +2162,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2565,17 +2177,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -2782,7 +2383,7 @@ version = "0.154.2"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "futures",
  "internal-error",
  "test-group",
@@ -2823,15 +2424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
 dependencies = [
  "ascii_utils",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -3162,15 +2754,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -3331,21 +2914,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
-dependencies = [
- "http",
- "hyper",
- "log",
- "rustls 0.20.9",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls 0.23.4",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
@@ -3354,10 +2922,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.10",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3440,7 +3008,7 @@ checksum = "c2e11569346406931d20276cc460215ee2826e7cad43aa986999cb244dd7adb0"
 dependencies = [
  "include-flate-codegen-exports",
  "lazy_static",
- "libflate 1.4.0",
+ "libflate",
 ]
 
 [[package]]
@@ -3449,7 +3017,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7d6e1419fa3129eb0802b4c99603c0d425c79fb5d76191d5a20d0ab0d664e8"
 dependencies = [
- "libflate 1.4.0",
+ "libflate",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -3569,7 +3137,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -3660,11 +3228,11 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
- "aws-config 0.57.2",
- "aws-credential-types 0.57.2",
+ "aws-config",
+ "aws-credential-types",
  "aws-sdk-s3",
- "aws-smithy-http 0.57.2",
- "aws-smithy-types 0.57.2",
+ "aws-smithy-http",
+ "aws-smithy-types",
  "axum",
  "bytes",
  "cfg-if",
@@ -3677,7 +3245,7 @@ dependencies = [
  "datafusion",
  "digest",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "event-bus",
  "filetime",
  "flatbuffers",
@@ -3736,7 +3304,7 @@ version = "0.154.2"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "event-bus",
  "kamu",
  "kamu-core",
@@ -3760,7 +3328,7 @@ dependencies = [
  "base64 0.21.7",
  "dashmap",
  "datafusion",
- "env_logger 0.10.1",
+ "env_logger",
  "futures",
  "indoc 2.0.4",
  "kamu-data-utils",
@@ -3786,7 +3354,7 @@ dependencies = [
  "cron",
  "datafusion",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "event-bus",
  "event-sourcing",
  "futures",
@@ -3824,7 +3392,7 @@ dependencies = [
  "chrono",
  "container-runtime",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "event-bus",
  "flate2",
  "fs_extra",
@@ -3863,7 +3431,7 @@ version = "0.154.2"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "http",
  "kamu",
  "kamu-core",
@@ -3893,17 +3461,16 @@ dependencies = [
  "cfg-if",
  "chrono",
  "chrono-humanize",
- "clap 4.4.14",
+ "clap",
  "clap_complete",
  "console",
  "container-runtime",
  "ctrlc",
  "datafusion",
- "datafusion-cli",
  "dill",
- "dirs 5.0.1",
+ "dirs",
  "duration-string",
- "env_logger 0.10.1",
+ "env_logger",
  "event-bus",
  "fs_extra",
  "futures",
@@ -3922,6 +3489,7 @@ dependencies = [
  "kamu-adapter-http",
  "kamu-adapter-oauth",
  "kamu-data-utils",
+ "kamu-datafusion-cli",
  "kamu-flow-system-inmem",
  "kamu-task-system-inmem",
  "libc",
@@ -4001,7 +3569,7 @@ dependencies = [
  "async-trait",
  "datafusion",
  "digest",
- "env_logger 0.10.1",
+ "env_logger",
  "opendatafabric",
  "pretty_assertions",
  "sha3",
@@ -4010,6 +3578,26 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "kamu-datafusion-cli"
+version = "0.154.2"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "clap",
+ "datafusion",
+ "futures",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "regex",
+ "rustyline",
+ "tokio",
  "url",
 ]
 
@@ -4044,7 +3632,7 @@ dependencies = [
  "chrono",
  "cron",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "event-bus",
  "futures",
  "kamu",
@@ -4075,7 +3663,7 @@ dependencies = [
  "criterion",
  "datafusion",
  "digest",
- "env_logger 0.10.1",
+ "env_logger",
  "futures",
  "geo-types",
  "geojson",
@@ -4109,7 +3697,7 @@ name = "kamu-repo-tools"
 version = "0.154.2"
 dependencies = [
  "chrono",
- "clap 4.4.14",
+ "clap",
  "glob",
  "indoc 2.0.4",
  "regex",
@@ -4145,7 +3733,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dill",
- "env_logger 0.10.1",
+ "env_logger",
  "event-bus",
  "futures",
  "kamu-core",
@@ -4284,20 +3872,7 @@ checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
 dependencies = [
  "adler32",
  "crc32fast",
- "libflate_lz77 1.2.0",
-]
-
-[[package]]
-name = "libflate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77 2.0.0",
+ "libflate_lz77",
 ]
 
 [[package]]
@@ -4310,31 +3885,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libflate_lz77"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524"
-dependencies = [
- "core2",
- "hashbrown 0.13.2",
- "rle-decode-fast",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "libmimalloc-sys"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "libredox"
@@ -4494,15 +4048,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4803,7 +4348,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4955,12 +4500,6 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "oso"
@@ -5488,12 +5027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quad-rand"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5643,12 +5176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5676,7 +5203,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.24.2",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -5684,14 +5211,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -5830,18 +5357,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "log",
- "ring 0.16.20",
- "sct",
- "webpki",
 ]
 
 [[package]]
@@ -6170,7 +5685,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
 ]
 
 [[package]]
@@ -6501,7 +6016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
+ "fastrand",
  "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
@@ -6552,7 +6067,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
 dependencies = [
- "env_logger 0.10.1",
+ "env_logger",
  "test-log-macros",
  "tracing-subscriber",
 ]
@@ -6725,22 +6240,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls",
  "tokio",
 ]
 
@@ -7000,7 +6504,7 @@ dependencies = [
 name = "tracing-perfetto"
 version = "0.154.2"
 dependencies = [
- "env_logger 0.10.1",
+ "env_logger",
  "serde",
  "serde_json",
  "test-group",
@@ -7107,26 +6611,6 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "static_assertions",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -7250,7 +6734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
- "serde",
 ]
 
 [[package]]
@@ -7421,16 +6904,6 @@ dependencies = [
  "raw-window-handle",
  "url",
  "web-sys",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.7",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -7801,15 +7274,6 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
@@ -7822,16 +7286,6 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "apache-avro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
+dependencies = [
+ "bzip2",
+ "crc32fast",
+ "digest",
+ "lazy_static",
+ "libflate 2.0.0",
+ "log",
+ "num-bigint",
+ "quad-rand",
+ "rand",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "snap",
+ "strum",
+ "strum_macros 0.25.3",
+ "thiserror",
+ "typed-builder",
+ "uuid",
+ "xz2",
+ "zstd 0.12.4",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +636,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,25 +654,55 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sdk-sso 0.28.0",
+ "aws-sdk-sts 0.28.0",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "fastrand 1.9.0",
+ "hex",
+ "http",
+ "hyper",
+ "ring 0.16.20",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-config"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bf00cb9416daab4ce4927c54ebe63c08b9caf4d7b9314b6d7a4a2c5a1afb09"
 dependencies = [
- "aws-credential-types",
- "aws-http",
+ "aws-credential-types 0.57.2",
+ "aws-http 0.57.2",
  "aws-runtime",
- "aws-sdk-sso",
+ "aws-sdk-sso 0.36.0",
  "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-sdk-sts 0.36.0",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
- "fastrand",
+ "fastrand 2.0.1",
  "hex",
  "http",
  "hyper",
@@ -646,14 +715,61 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
+dependencies = [
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "fastrand 1.9.0",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9073c88dbf12f68ce7d0e149f989627a1d1ae3d2b680459f04ccc29d1cbd0f"
 dependencies = [
- "aws-smithy-async",
+ "aws-smithy-async 0.57.2",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
  "zeroize",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
+dependencies = [
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "http",
+ "http-body",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -662,10 +778,10 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24067106d09620cf02d088166cdaedeaca7146d4d499c41b37accecbea11b246"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.57.2",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "http",
  "http-body",
@@ -679,16 +795,16 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6ee0152c06d073602236a4e94a8c52a327d310c1ecd596570ce795af8777ff"
 dependencies = [
- "aws-credential-types",
- "aws-http",
- "aws-sigv4",
- "aws-smithy-async",
+ "aws-credential-types 0.57.2",
+ "aws-http 0.57.2",
+ "aws-sigv4 0.57.2",
+ "aws-smithy-async 0.57.2",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.57.2",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "fastrand",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
+ "fastrand 2.0.1",
  "http",
  "percent-encoding",
  "tracing",
@@ -701,20 +817,20 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84022763485483ea17d417f9832d5da198bc36829b59f086c0d35ecd2ce59991"
 dependencies = [
- "aws-credential-types",
- "aws-http",
+ "aws-credential-types 0.57.2",
+ "aws-http 0.57.2",
  "aws-runtime",
- "aws-sigv4",
- "aws-smithy-async",
+ "aws-sigv4 0.57.2",
+ "aws-smithy-async 0.57.2",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-smithy-types 0.57.2",
+ "aws-smithy-xml 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "http",
  "http-body",
@@ -727,20 +843,45 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b812340d86d4a766b2ca73f740dfd47a97c2dff0c06c8517a16d88241957e4"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-endpoint",
+ "aws-http 0.55.3",
+ "aws-sig-auth",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "http",
+ "regex",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb8158015232b4596ccef74a205600398e152d704b40b7ec9f486092474d7fa"
 dependencies = [
- "aws-credential-types",
- "aws-http",
+ "aws-credential-types 0.57.2",
+ "aws-http 0.57.2",
  "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "http",
  "regex",
@@ -753,19 +894,45 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36a1493e1c57f173e53621935bfb5b6217376168dbdb4cd459aebcf645924a48"
 dependencies = [
- "aws-credential-types",
- "aws-http",
+ "aws-credential-types 0.57.2",
+ "aws-http 0.57.2",
  "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "http",
  "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-endpoint",
+ "aws-http 0.55.3",
+ "aws-sig-auth",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-query 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "http",
+ "regex",
+ "tower",
  "tracing",
 ]
 
@@ -775,20 +942,53 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e032b77f5cd1dd3669d777a38ac08cbf8ec68e29460d4ef5d3e50cffa74ec75a"
 dependencies = [
- "aws-credential-types",
- "aws-http",
+ "aws-credential-types 0.57.2",
+ "aws-http 0.57.2",
  "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-query",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
+ "aws-smithy-query 0.57.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-smithy-types 0.57.2",
+ "aws-smithy-xml 0.57.2",
+ "aws-types 0.57.2",
  "http",
  "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-sigv4 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-types 0.55.3",
+ "http",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
+dependencies = [
+ "aws-smithy-http 0.55.3",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2",
+ "time",
  "tracing",
 ]
 
@@ -798,9 +998,9 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64f81a6abc4daab06b53cabf27c54189928893283093e37164ca53aa47488a5b"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.57.2",
  "aws-smithy-runtime-api",
  "bytes",
  "form_urlencoded",
@@ -821,6 +1021,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bda3996044c202d75b91afeb11a9afae9db9a721c6a7a427410018e286b880"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "aws-smithy-async"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe53fccd3b10414b9cae63767a15a2789b34e6c6727b6e32b33e8c7998a3e80"
@@ -836,8 +1048,8 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb5701fbfb40600cc0fa547f318552dfd4e632b2099bd75d95fb0faae70675d"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-types 0.57.2",
  "bytes",
  "crc32c",
  "crc32fast",
@@ -852,14 +1064,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-client"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
+dependencies = [
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "fastrand 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.23.2",
+ "lazy_static",
+ "pin-project-lite",
+ "rustls 0.20.9",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-eventstream"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b33fa99f928a5815b94ee07e1377901bcf51aa749034a2c802dc38f9dcfacf5"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
  "bytes",
  "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
+dependencies = [
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
 ]
 
 [[package]]
@@ -870,7 +1126,7 @@ checksum = "f7972373213d1d6e619c0edc9dda2d6634154e4ed75c5e0b2bf065cd5ec9f0d1"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -884,12 +1140,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http-tower"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
+dependencies = [
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
+dependencies = [
+ "aws-smithy-types 0.55.3",
+]
+
+[[package]]
 name = "aws-smithy-json"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d64d5af16dd585de9ff6c606423c1aaad47c6baa38de41c2beb32ef21c6645"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
+dependencies = [
+ "aws-smithy-types 0.55.3",
+ "urlencoding",
 ]
 
 [[package]]
@@ -898,7 +1189,7 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7527bf5335154ba1b285479c50b630e44e93d1b4a759eaceb8d0bf9fbc82caa5"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
  "urlencoding",
 ]
 
@@ -908,20 +1199,20 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "839b363adf3b2bdab2742a1f540fec23039ea8bc9ec0f9f61df48470cfe5527b"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
  "bytes",
- "fastrand",
+ "fastrand 2.0.1",
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
  "tracing",
 ]
@@ -932,14 +1223,27 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24ecc446e62c3924539e7c18dec8038dba4fdf8718d5c2de62f9d2fecca8ba9"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-types 0.57.2",
  "bytes",
  "http",
  "pin-project-lite",
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time",
 ]
 
 [[package]]
@@ -967,6 +1271,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-smithy-xml"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb1e3ac22c652662096c8e37a6f9af80c6f3520cab5610b2fe76c725bce18eac"
@@ -976,14 +1289,30 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "http",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
+name = "aws-types"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048bbf1c24cdf4eb1efcdc243388a93a90ebf63979e25fc1c7b8cbd9cb6beb38"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
+ "aws-credential-types 0.57.2",
+ "aws-smithy-async 0.57.2",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
  "http",
  "rustc_version",
  "tracing",
@@ -1410,7 +1739,7 @@ checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.6.0",
  "strsim",
 ]
 
@@ -1420,7 +1749,29 @@ version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df631ae429f6613fcd3a7c1adbdb65f637271e561b03680adaa6573015dfb106"
 dependencies = [
- "clap",
+ "clap 4.4.14",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1428,6 +1779,17 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1514,7 +1876,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "libc",
  "rand",
  "regex",
@@ -1544,6 +1906,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1581,7 +1952,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap",
+ "clap 4.4.14",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1735,7 +2106,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
- "nix",
+ "nix 0.27.1",
  "windows-sys 0.52.0",
 ]
 
@@ -1833,6 +2204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +2235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "676796427e638d85e9eadf13765705212be60b34f8fc5d3934d95184c63ca1b4"
 dependencies = [
  "ahash",
+ "apache-avro",
  "arrow",
  "arrow-array",
  "arrow-schema",
@@ -1882,6 +2260,7 @@ dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
  "log",
+ "num-traits",
  "num_cpus",
  "object_store",
  "parking_lot",
@@ -1899,12 +2278,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-cli"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d09ed6f01e41a983cf720228b4f0811d755b3f52776dd5170c744bd5d626e"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "aws-config 0.55.3",
+ "aws-credential-types 0.55.3",
+ "clap 3.2.25",
+ "datafusion",
+ "dirs 4.0.0",
+ "env_logger 0.9.3",
+ "mimalloc",
+ "object_store",
+ "parking_lot",
+ "regex",
+ "rustyline",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "datafusion-common"
 version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e23b3d21a6531259d291bd20ce59282ea794bda1018b0a1e278c13cd52e50c"
 dependencies = [
  "ahash",
+ "apache-avro",
  "arrow",
  "arrow-array",
  "arrow-buffer",
@@ -2138,11 +2541,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -2153,6 +2565,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2293,6 +2716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,12 +2767,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "event-bus"
 version = "0.154.2"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "futures",
  "internal-error",
  "test-group",
@@ -2388,9 +2827,29 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ff"
@@ -2703,6 +3162,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -2863,6 +3331,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.20.9",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
@@ -2871,10 +3354,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.21.10",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2957,7 +3440,7 @@ checksum = "c2e11569346406931d20276cc460215ee2826e7cad43aa986999cb244dd7adb0"
 dependencies = [
  "include-flate-codegen-exports",
  "lazy_static",
- "libflate",
+ "libflate 1.4.0",
 ]
 
 [[package]]
@@ -2966,7 +3449,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7d6e1419fa3129eb0802b4c99603c0d425c79fb5d76191d5a20d0ab0d664e8"
 dependencies = [
- "libflate",
+ "libflate 1.4.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -3086,7 +3569,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -3177,11 +3660,11 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
- "aws-config",
- "aws-credential-types",
+ "aws-config 0.57.2",
+ "aws-credential-types 0.57.2",
  "aws-sdk-s3",
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-types 0.57.2",
  "axum",
  "bytes",
  "cfg-if",
@@ -3194,7 +3677,7 @@ dependencies = [
  "datafusion",
  "digest",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "event-bus",
  "filetime",
  "flatbuffers",
@@ -3253,7 +3736,7 @@ version = "0.154.2"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "event-bus",
  "kamu",
  "kamu-core",
@@ -3277,7 +3760,7 @@ dependencies = [
  "base64 0.21.7",
  "dashmap",
  "datafusion",
- "env_logger",
+ "env_logger 0.10.1",
  "futures",
  "indoc 2.0.4",
  "kamu-data-utils",
@@ -3303,7 +3786,7 @@ dependencies = [
  "cron",
  "datafusion",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "event-bus",
  "event-sourcing",
  "futures",
@@ -3341,7 +3824,7 @@ dependencies = [
  "chrono",
  "container-runtime",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "event-bus",
  "flate2",
  "fs_extra",
@@ -3380,7 +3863,7 @@ version = "0.154.2"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "http",
  "kamu",
  "kamu-core",
@@ -3410,16 +3893,17 @@ dependencies = [
  "cfg-if",
  "chrono",
  "chrono-humanize",
- "clap",
+ "clap 4.4.14",
  "clap_complete",
  "console",
  "container-runtime",
  "ctrlc",
  "datafusion",
+ "datafusion-cli",
  "dill",
- "dirs",
+ "dirs 5.0.1",
  "duration-string",
- "env_logger",
+ "env_logger 0.10.1",
  "event-bus",
  "fs_extra",
  "futures",
@@ -3517,7 +4001,7 @@ dependencies = [
  "async-trait",
  "datafusion",
  "digest",
- "env_logger",
+ "env_logger 0.10.1",
  "opendatafabric",
  "pretty_assertions",
  "sha3",
@@ -3560,7 +4044,7 @@ dependencies = [
  "chrono",
  "cron",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "event-bus",
  "futures",
  "kamu",
@@ -3591,7 +4075,7 @@ dependencies = [
  "criterion",
  "datafusion",
  "digest",
- "env_logger",
+ "env_logger 0.10.1",
  "futures",
  "geo-types",
  "geojson",
@@ -3625,7 +4109,7 @@ name = "kamu-repo-tools"
 version = "0.154.2"
 dependencies = [
  "chrono",
- "clap",
+ "clap 4.4.14",
  "glob",
  "indoc 2.0.4",
  "regex",
@@ -3661,7 +4145,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dill",
- "env_logger",
+ "env_logger 0.10.1",
  "event-bus",
  "futures",
  "kamu-core",
@@ -3800,7 +4284,20 @@ checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
 dependencies = [
  "adler32",
  "crc32fast",
- "libflate_lz77",
+ "libflate_lz77 1.2.0",
+]
+
+[[package]]
+name = "libflate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77 2.0.0",
 ]
 
 [[package]]
@@ -3813,10 +4310,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "libflate_lz77"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524"
+dependencies = [
+ "core2",
+ "hashbrown 0.13.2",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "libredox"
@@ -3979,6 +4497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,6 +4654,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,7 +4803,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
@@ -4313,6 +4860,7 @@ dependencies = [
  "rand",
  "reqwest",
  "ring 0.16.20",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "snafu",
@@ -4407,6 +4955,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "oso"
@@ -4934,6 +5488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quad-rand"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,6 +5516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -5073,6 +5643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5100,7 +5676,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -5108,14 +5684,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.10",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -5258,6 +5834,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
 version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
@@ -5304,6 +5892,29 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rustyline"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "clipboard-win",
+ "dirs-next",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.26.4",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -5559,7 +6170,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
- "dirs",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -5758,6 +6369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5884,7 +6501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.1",
  "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
@@ -5935,7 +6552,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
 dependencies = [
- "env_logger",
+ "env_logger 0.10.1",
  "test-log-macros",
  "tracing-subscriber",
 ]
@@ -6108,11 +6725,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.9",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
  "tokio",
 ]
 
@@ -6372,7 +7000,7 @@ dependencies = [
 name = "tracing-perfetto"
 version = "0.154.2"
 dependencies = [
- "env_logger",
+ "env_logger 0.10.1",
  "serde",
  "serde_json",
  "test-group",
@@ -6479,6 +7107,26 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "static_assertions",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6602,6 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -6772,6 +7421,16 @@ dependencies = [
  "raw-window-handle",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -7142,6 +7801,15 @@ dependencies = [
 
 [[package]]
 name = "zstd"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+dependencies = [
+ "zstd-safe 6.0.6",
+]
+
+[[package]]
+name = "zstd"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
@@ -7154,6 +7822,16 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     # Utils
     "src/utils/container-runtime",
     "src/utils/data-utils",
+    "src/utils/datafusion-cli",
     "src/utils/enum-variants",
     "src/utils/event-bus",
     "src/utils/event-sourcing",
@@ -43,6 +44,7 @@ event-sourcing-macros = { version = "0.154.2", path = "src/utils/event-sourcing-
 internal-error = { version = "0.154.2", path = "src/utils/internal-error", default-features = false }
 multiformats = { version = "0.154.2", path = "src/utils/multiformats", default-features = false }
 kamu-data-utils = { version = "0.154.2", path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { version = "0.154.2", path = "src/utils/datafusion-cli", default-features = false }
 tracing-perfetto = { version = "0.154.2", path = "src/utils/tracing-perfetto", default-features = false }
 # Domain
 opendatafabric = { version = "0.154.2", path = "src/domain/opendatafabric", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -28,7 +28,10 @@ deny = [
     # This is a temporary approach until we deny by default with some exceptions
     { name = "arrow", deny-multiple-versions = true },
     { name = "axum", deny-multiple-versions = true },
+    { name = "aws-config", deny-multiple-versions = true },
+    { name = "clap", deny-multiple-versions = true },
     { name = "datafusion", deny-multiple-versions = true },
+    { name = "object_store", deny-multiple-versions = true },
     { name = "prost", deny-multiple-versions = true },
     # { name = "rustls", deny-multiple-versions = true },
     { name = "tokio", deny-multiple-versions = true },

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,7 @@ allow = [
     "0BSD",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "ISC",
     "MIT",
     "MPL-2.0",

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -104,6 +104,7 @@ async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1"  # Conditional compilation
 datafusion = "33"
+datafusion-cli = "33"
 dill = "0.8"
 dirs = "5"
 fs_extra = "1.3"

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -50,6 +50,7 @@ kamu-adapter-flight-sql = { workspace = true }
 kamu-adapter-graphql = { workspace = true }
 kamu-adapter-http = { workspace = true }
 kamu-adapter-oauth = { workspace = true }
+kamu-datafusion-cli = { workspace = true }
 
 # CLI
 chrono-humanize = "0.2"  # Human readable durations
@@ -104,7 +105,6 @@ async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1"  # Conditional compilation
 datafusion = "33"
-datafusion-cli = "33"
 dill = "0.8"
 dirs = "5"
 fs_extra = "1.3"

--- a/src/app/cli/src/commands/sql_shell_command.rs
+++ b/src/app/cli/src/commands/sql_shell_command.rs
@@ -11,12 +11,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use container_runtime::ContainerRuntime;
-use datafusion_cli::exec;
-use datafusion_cli::print_format::PrintFormat;
-use datafusion_cli::print_options::{MaxRows, PrintOptions};
 use internal_error::*;
 use kamu::domain::{QueryOptions, QueryService};
 use kamu::*;
+use kamu_datafusion_cli::exec;
+use kamu_datafusion_cli::print_format::PrintFormat;
+use kamu_datafusion_cli::print_options::{MaxRows, PrintOptions};
 
 use super::common::PullImageProgress;
 use super::{CLIError, Command};
@@ -138,6 +138,11 @@ impl SqlShellCommand {
         };
 
         let mut ctx = self.query_svc.create_session().await.unwrap();
+
+        eprintln!(
+            "{}",
+            console::style("Kamu + DataFusion SQL shell. Type \\? for help.").dim()
+        );
 
         exec::exec_from_repl(&mut ctx, &mut print_options)
             .await

--- a/src/utils/datafusion-cli/Cargo.toml
+++ b/src/utils/datafusion-cli/Cargo.toml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "kamu-datafusion-cli"
+description = "Command Line Client for DataFusion query engine."
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+
+[dependencies]
+arrow = "48.0.0"
+async-trait = "0.1"
+aws-config = "0.57"
+aws-credential-types = "0.57"
+clap = { version = "4", features = ["derive"] }
+datafusion = { version = "33", features = ["crypto_expressions", "encoding_expressions", "parquet", "regex_expressions", "unicode_expressions", "compression"] }
+futures = "0.3"
+object_store = { version = "0.7", features = ["aws", "gcp"] }
+parking_lot = { version = "0.12" }
+parquet = { version = "48.0.0", default-features = false }
+regex = "1"
+rustyline = "11"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot", "signal"] }
+url = "2.2"
+

--- a/src/utils/datafusion-cli/LICENSE.txt
+++ b/src/utils/datafusion-cli/LICENSE.txt
@@ -1,0 +1,212 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+This project includes code from Apache Aurora.
+
+* dev/release/{release,changelog,release-candidate} are based on the scripts from
+  Apache Aurora
+
+Copyright: 2016 The Apache Software Foundation.
+Home page: https://aurora.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0

--- a/src/utils/datafusion-cli/README.md
+++ b/src/utils/datafusion-cli/README.md
@@ -1,0 +1,31 @@
+# datafusion-cli
+
+This crate is heavily based on `datafusion-cli` in the https://github.com/apache/arrow-datafusion/ repository and therefore is licensed under the same `Apache 2.0` license.
+
+We decided to copy the code instead of using the existing `datafusion-cli` crate because:
+- It was hard to align the dependency versions between our and `arrow-datafusion` repo
+- The crate comes with more dependencies than we actually need / want
+- Maintaining optional features in the upstream repo would introduce too much overhead
+- Maintaining a fork was problematic due to `datafusion-cli` sharing the repo with all other `datafusion` crates, not only due to slow clone speed, but also due to `cargo` also switching to use `datafusion` crates from that repo instead of using published artifacts from `crates.io`.
+
+
+## Upgrade procedure
+1. Clone or sync the upstream repo:
+  
+  `git clone https://github.com/apache/arrow-datafusion.git`
+
+2. Checkout the appropriate release tag:
+    
+  `git checkout MAJOR.MINOR.PATCH`
+
+3. Replace source files (except `main.rs`):
+
+  ```
+  rm -rf src/utils/datafusion-cli/src
+  cp ../arrow-datafusion/datafusion-cli/src src/utils/datafusion-cli/
+  rm src/utils/datafusion-cli/src/main.rs
+  ```
+
+4. Compare `Cargo.toml` files:
+
+  `diff ../arrow-datafusion/datafusion-cli/Cargo.toml src/utils/datafusion-cli/Cargo.toml`

--- a/src/utils/datafusion-cli/src/catalog.rs
+++ b/src/utils/datafusion-cli/src/catalog.rs
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::any::Any;
+use std::sync::{Arc, Weak};
+
+use async_trait::async_trait;
+use datafusion::catalog::schema::SchemaProvider;
+use datafusion::catalog::{CatalogList, CatalogProvider};
+use datafusion::datasource::listing::{ListingTable, ListingTableConfig, ListingTableUrl};
+use datafusion::datasource::TableProvider;
+use datafusion::error::Result;
+use datafusion::execution::context::SessionState;
+use parking_lot::RwLock;
+
+/// Wraps another catalog, automatically creating table providers
+/// for local files if needed
+pub struct DynamicFileCatalog {
+    inner: Arc<dyn CatalogList>,
+    state: Weak<RwLock<SessionState>>,
+}
+
+impl DynamicFileCatalog {
+    pub fn new(inner: Arc<dyn CatalogList>, state: Weak<RwLock<SessionState>>) -> Self {
+        Self { inner, state }
+    }
+}
+
+impl CatalogList for DynamicFileCatalog {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn register_catalog(
+        &self,
+        name: String,
+        catalog: Arc<dyn CatalogProvider>,
+    ) -> Option<Arc<dyn CatalogProvider>> {
+        self.inner.register_catalog(name, catalog)
+    }
+
+    fn catalog_names(&self) -> Vec<String> {
+        self.inner.catalog_names()
+    }
+
+    fn catalog(&self, name: &str) -> Option<Arc<dyn CatalogProvider>> {
+        let state = self.state.clone();
+        self.inner
+            .catalog(name)
+            .map(|catalog| Arc::new(DynamicFileCatalogProvider::new(catalog, state)) as _)
+    }
+}
+
+/// Wraps another catalog provider
+struct DynamicFileCatalogProvider {
+    inner: Arc<dyn CatalogProvider>,
+    state: Weak<RwLock<SessionState>>,
+}
+
+impl DynamicFileCatalogProvider {
+    pub fn new(inner: Arc<dyn CatalogProvider>, state: Weak<RwLock<SessionState>>) -> Self {
+        Self { inner, state }
+    }
+}
+
+impl CatalogProvider for DynamicFileCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        self.inner.schema_names()
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        let state = self.state.clone();
+        self.inner
+            .schema(name)
+            .map(|schema| Arc::new(DynamicFileSchemaProvider::new(schema, state)) as _)
+    }
+
+    fn register_schema(
+        &self,
+        name: &str,
+        schema: Arc<dyn SchemaProvider>,
+    ) -> Result<Option<Arc<dyn SchemaProvider>>> {
+        self.inner.register_schema(name, schema)
+    }
+}
+
+/// Wraps another schema provider
+struct DynamicFileSchemaProvider {
+    inner: Arc<dyn SchemaProvider>,
+    state: Weak<RwLock<SessionState>>,
+}
+
+impl DynamicFileSchemaProvider {
+    pub fn new(inner: Arc<dyn SchemaProvider>, state: Weak<RwLock<SessionState>>) -> Self {
+        Self { inner, state }
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for DynamicFileSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        self.inner.table_names()
+    }
+
+    fn register_table(
+        &self,
+        name: String,
+        table: Arc<dyn TableProvider>,
+    ) -> Result<Option<Arc<dyn TableProvider>>> {
+        self.inner.register_table(name, table)
+    }
+
+    async fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        let inner_table = self.inner.table(name).await;
+        if inner_table.is_some() {
+            return inner_table;
+        }
+
+        // if the inner schema provider didn't have a table by
+        // that name, try to treat it as a listing table
+        let state = self.state.upgrade()?.read().clone();
+        let config = ListingTableConfig::new(ListingTableUrl::parse(name).ok()?)
+            .infer(&state)
+            .await
+            .ok()?;
+        Some(Arc::new(ListingTable::try_new(config).ok()?))
+    }
+
+    fn deregister_table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+        self.inner.deregister_table(name)
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.inner.table_exist(name)
+    }
+}

--- a/src/utils/datafusion-cli/src/command.rs
+++ b/src/utils/datafusion-cli/src/command.rs
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Command within CLI
+
+use std::fs::File;
+use std::io::BufReader;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Instant;
+
+use clap::ValueEnum;
+use datafusion::arrow::array::{ArrayRef, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::exec_err;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::prelude::SessionContext;
+
+use crate::exec::exec_from_lines;
+use crate::functions::{display_all_functions, Function};
+use crate::print_format::PrintFormat;
+use crate::print_options::PrintOptions;
+
+/// Command
+#[derive(Debug)]
+pub enum Command {
+    Quit,
+    Help,
+    ListTables,
+    DescribeTableStmt(String),
+    ListFunctions,
+    Include(Option<String>),
+    SearchFunctions(String),
+    QuietMode(Option<bool>),
+    OutputFormat(Option<String>),
+}
+
+pub enum OutputFormat {
+    ChangeFormat(String),
+}
+
+impl Command {
+    pub async fn execute(
+        &self,
+        ctx: &mut SessionContext,
+        print_options: &mut PrintOptions,
+    ) -> Result<()> {
+        let now = Instant::now();
+        match self {
+            Self::Help => print_options.print_batches(&[all_commands_info()], now),
+            Self::ListTables => {
+                let df = ctx.sql("SHOW TABLES").await?;
+                let batches = df.collect().await?;
+                print_options.print_batches(&batches, now)
+            }
+            Self::DescribeTableStmt(name) => {
+                let df = ctx.sql(&format!("SHOW COLUMNS FROM {}", name)).await?;
+                let batches = df.collect().await?;
+                print_options.print_batches(&batches, now)
+            }
+            Self::Include(filename) => {
+                if let Some(filename) = filename {
+                    let file = File::open(filename).map_err(|e| {
+                        DataFusionError::Execution(format!("Error opening {:?} {}", filename, e))
+                    })?;
+                    exec_from_lines(ctx, &mut BufReader::new(file), print_options).await;
+                    Ok(())
+                } else {
+                    exec_err!("Required filename argument is missing")
+                }
+            }
+            Self::QuietMode(quiet) => {
+                if let Some(quiet) = quiet {
+                    print_options.quiet = *quiet;
+                    println!(
+                        "Quiet mode set to {}",
+                        if print_options.quiet { "true" } else { "false" }
+                    );
+                } else {
+                    println!(
+                        "Quiet mode is {}",
+                        if print_options.quiet { "true" } else { "false" }
+                    );
+                }
+                Ok(())
+            }
+            Self::Quit => exec_err!("Unexpected quit, this should be handled outside"),
+            Self::ListFunctions => display_all_functions(),
+            Self::SearchFunctions(function) => {
+                if let Ok(func) = function.parse::<Function>() {
+                    let details = func.function_details()?;
+                    println!("{}", details);
+                    Ok(())
+                } else {
+                    exec_err!("{function} is not a supported function")
+                }
+            }
+            Self::OutputFormat(_) => {
+                exec_err!("Unexpected change output format, this should be handled outside")
+            }
+        }
+    }
+
+    fn get_name_and_description(&self) -> (&'static str, &'static str) {
+        match self {
+            Self::Quit => ("\\q", "quit datafusion-cli"),
+            Self::ListTables => ("\\d", "list tables"),
+            Self::DescribeTableStmt(_) => ("\\d name", "describe table"),
+            Self::Help => ("\\?", "help"),
+            Self::Include(_) => ("\\i filename", "reads input from the specified filename"),
+            Self::ListFunctions => ("\\h", "function list"),
+            Self::SearchFunctions(_) => ("\\h function", "search function"),
+            Self::QuietMode(_) => ("\\quiet (true|false)?", "print or set quiet mode"),
+            Self::OutputFormat(_) => ("\\pset [NAME [VALUE]]", "set table output option\n(format)"),
+        }
+    }
+}
+
+const ALL_COMMANDS: [Command; 9] = [
+    Command::ListTables,
+    Command::DescribeTableStmt(String::new()),
+    Command::Quit,
+    Command::Help,
+    Command::Include(Some(String::new())),
+    Command::ListFunctions,
+    Command::SearchFunctions(String::new()),
+    Command::QuietMode(None),
+    Command::OutputFormat(None),
+];
+
+fn all_commands_info() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("Command", DataType::Utf8, false),
+        Field::new("Description", DataType::Utf8, false),
+    ]));
+    let (names, description): (Vec<&str>, Vec<&str>) = ALL_COMMANDS
+        .into_iter()
+        .map(|c| c.get_name_and_description())
+        .unzip();
+    RecordBatch::try_new(
+        schema,
+        [names, description]
+            .into_iter()
+            .map(|i| Arc::new(StringArray::from(i)) as ArrayRef)
+            .collect::<Vec<_>>(),
+    )
+    .expect("This should not fail")
+}
+
+impl FromStr for Command {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (c, arg) = if let Some((a, b)) = s.split_once(' ') {
+            (a, Some(b))
+        } else {
+            (s, None)
+        };
+        Ok(match (c, arg) {
+            ("q", None) => Self::Quit,
+            ("d", None) => Self::ListTables,
+            ("d", Some(name)) => Self::DescribeTableStmt(name.into()),
+            ("?", None) => Self::Help,
+            ("h", None) => Self::ListFunctions,
+            ("h", Some(function)) => Self::SearchFunctions(function.into()),
+            ("i", None) => Self::Include(None),
+            ("i", Some(filename)) => Self::Include(Some(filename.to_owned())),
+            ("quiet", Some("true" | "t" | "yes" | "y" | "on")) => Self::QuietMode(Some(true)),
+            ("quiet", Some("false" | "f" | "no" | "n" | "off")) => Self::QuietMode(Some(false)),
+            ("quiet", None) => Self::QuietMode(None),
+            ("pset", Some(subcommand)) => Self::OutputFormat(Some(subcommand.to_string())),
+            ("pset", None) => Self::OutputFormat(None),
+            _ => return Err(()),
+        })
+    }
+}
+
+impl FromStr for OutputFormat {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (c, arg) = if let Some((a, b)) = s.split_once(' ') {
+            (a, Some(b))
+        } else {
+            (s, None)
+        };
+        Ok(match (c, arg) {
+            ("format", Some(format)) => Self::ChangeFormat(format.to_string()),
+            _ => return Err(()),
+        })
+    }
+}
+
+impl OutputFormat {
+    pub async fn execute(&self, print_options: &mut PrintOptions) -> Result<()> {
+        match self {
+            Self::ChangeFormat(format) => {
+                if let Ok(format) = format.parse::<PrintFormat>() {
+                    print_options.format = format;
+                    println!("Output format is {:?}.", print_options.format);
+                    Ok(())
+                } else {
+                    exec_err!(
+                        "{:?} is not a valid format type [possible values: {:?}]",
+                        format,
+                        PrintFormat::value_variants()
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/utils/datafusion-cli/src/exec.rs
+++ b/src/utils/datafusion-cli/src/exec.rs
@@ -1,0 +1,412 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Execution functions
+
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::sync::Arc;
+use std::time::Instant;
+
+use datafusion::common::plan_datafusion_err;
+use datafusion::datasource::listing::ListingTableUrl;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::{CreateExternalTable, DdlStatement, LogicalPlan};
+use datafusion::prelude::SessionContext;
+use datafusion::sql::parser::DFParser;
+use datafusion::sql::sqlparser::dialect::dialect_from_str;
+use object_store::ObjectStore;
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
+use url::Url;
+
+use crate::command::{Command, OutputFormat};
+use crate::helper::{unescape_input, CliHelper};
+use crate::object_storage::{
+    get_gcs_object_store_builder,
+    get_oss_object_store_builder,
+    get_s3_object_store_builder,
+};
+use crate::print_options::{MaxRows, PrintOptions};
+
+/// run and execute SQL statements and commands, against a context with the
+/// given print options
+pub async fn exec_from_commands(
+    ctx: &mut SessionContext,
+    print_options: &PrintOptions,
+    commands: Vec<String>,
+) {
+    for sql in commands {
+        match exec_and_print(ctx, print_options, sql).await {
+            Ok(_) => {}
+            Err(err) => println!("{err}"),
+        }
+    }
+}
+
+/// run and execute SQL statements and commands from a file, against a context
+/// with the given print options
+pub async fn exec_from_lines(
+    ctx: &mut SessionContext,
+    reader: &mut BufReader<File>,
+    print_options: &PrintOptions,
+) {
+    let mut query = "".to_owned();
+
+    for line in reader.lines() {
+        match line {
+            Ok(line) if line.starts_with("--") => {
+                continue;
+            }
+            Ok(line) => {
+                let line = line.trim_end();
+                query.push_str(line);
+                if line.ends_with(';') {
+                    match exec_and_print(ctx, print_options, query).await {
+                        Ok(_) => {}
+                        Err(err) => eprintln!("{err}"),
+                    }
+                    query = "".to_owned();
+                } else {
+                    query.push('\n');
+                }
+            }
+            _ => {
+                break;
+            }
+        }
+    }
+
+    // run the left over query if the last statement doesn't contain ‘;’
+    // ignore if it only consists of '\n'
+    if query.contains(|c| c != '\n') {
+        match exec_and_print(ctx, print_options, query).await {
+            Ok(_) => {}
+            Err(err) => println!("{err}"),
+        }
+    }
+}
+
+pub async fn exec_from_files(
+    files: Vec<String>,
+    ctx: &mut SessionContext,
+    print_options: &PrintOptions,
+) {
+    let files = files
+        .into_iter()
+        .map(|file_path| File::open(file_path).unwrap())
+        .collect::<Vec<_>>();
+    for file in files {
+        let mut reader = BufReader::new(file);
+        exec_from_lines(ctx, &mut reader, print_options).await;
+    }
+}
+
+/// run and execute SQL statements and commands against a context with the given
+/// print options
+pub async fn exec_from_repl(
+    ctx: &mut SessionContext,
+    print_options: &mut PrintOptions,
+) -> rustyline::Result<()> {
+    let mut rl = Editor::new()?;
+    rl.set_helper(Some(CliHelper::new(
+        &ctx.task_ctx().session_config().options().sql_parser.dialect,
+    )));
+    rl.load_history(".history").ok();
+
+    let mut print_options = print_options.clone();
+
+    loop {
+        match rl.readline("❯ ") {
+            Ok(line) if line.starts_with('\\') => {
+                rl.add_history_entry(line.trim_end())?;
+                let command = line.split_whitespace().collect::<Vec<_>>().join(" ");
+                if let Ok(cmd) = &command[1..].parse::<Command>() {
+                    match cmd {
+                        Command::Quit => break,
+                        Command::OutputFormat(subcommand) => {
+                            if let Some(subcommand) = subcommand {
+                                if let Ok(command) = subcommand.parse::<OutputFormat>() {
+                                    if let Err(e) = command.execute(&mut print_options).await {
+                                        eprintln!("{e}")
+                                    }
+                                } else {
+                                    eprintln!("'\\{}' is not a valid command", &line[1..]);
+                                }
+                            } else {
+                                println!("Output format is {:?}.", print_options.format);
+                            }
+                        }
+                        _ => {
+                            if let Err(e) = cmd.execute(ctx, &mut print_options).await {
+                                eprintln!("{e}")
+                            }
+                        }
+                    }
+                } else {
+                    eprintln!("'\\{}' is not a valid command", &line[1..]);
+                }
+            }
+            Ok(line) => {
+                rl.add_history_entry(line.trim_end())?;
+                match exec_and_print(ctx, &print_options, line).await {
+                    Ok(_) => {}
+                    Err(err) => eprintln!("{err}"),
+                }
+                // dialect might have changed
+                rl.helper_mut()
+                    .unwrap()
+                    .set_dialect(&ctx.task_ctx().session_config().options().sql_parser.dialect);
+            }
+            Err(ReadlineError::Interrupted) => {
+                println!("^C");
+                continue;
+            }
+            Err(ReadlineError::Eof) => {
+                println!("\\q");
+                break;
+            }
+            Err(err) => {
+                eprintln!("Unknown error happened {:?}", err);
+                break;
+            }
+        }
+    }
+
+    rl.save_history(".history")
+}
+
+async fn exec_and_print(
+    ctx: &mut SessionContext,
+    print_options: &PrintOptions,
+    sql: String,
+) -> Result<()> {
+    let now = Instant::now();
+
+    let sql = unescape_input(&sql)?;
+    let task_ctx = ctx.task_ctx();
+    let dialect = &task_ctx.session_config().options().sql_parser.dialect;
+    let dialect = dialect_from_str(dialect).ok_or_else(|| {
+        plan_datafusion_err!(
+            "Unsupported SQL dialect: {dialect}. Available dialects: Generic, MySQL, PostgreSQL, \
+             Hive, SQLite, Snowflake, Redshift, MsSQL, ClickHouse, BigQuery, Ansi."
+        )
+    })?;
+    let statements = DFParser::parse_sql_with_dialect(&sql, dialect.as_ref())?;
+    for statement in statements {
+        let plan = ctx.state().statement_to_plan(statement).await?;
+
+        // For plans like `Explain` ignore `MaxRows` option and always display all rows
+        let should_ignore_maxrows = matches!(
+            plan,
+            LogicalPlan::Explain(_) | LogicalPlan::DescribeTable(_) | LogicalPlan::Analyze(_)
+        );
+
+        let df = match &plan {
+            LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) => {
+                create_external_table(ctx, cmd).await?;
+                ctx.execute_logical_plan(plan).await?
+            }
+            _ => ctx.execute_logical_plan(plan).await?,
+        };
+
+        let results = df.collect().await?;
+
+        let print_options = if should_ignore_maxrows {
+            PrintOptions {
+                maxrows: MaxRows::Unlimited,
+                ..print_options.clone()
+            }
+        } else {
+            print_options.clone()
+        };
+        print_options.print_batches(&results, now)?;
+    }
+
+    Ok(())
+}
+
+async fn create_external_table(ctx: &SessionContext, cmd: &CreateExternalTable) -> Result<()> {
+    let table_path = ListingTableUrl::parse(&cmd.location)?;
+    let scheme = table_path.scheme();
+    let url: &Url = table_path.as_ref();
+
+    // registering the cloud object store dynamically using cmd.options
+    let store = match scheme {
+        "s3" => {
+            let builder = get_s3_object_store_builder(url, cmd).await?;
+            Arc::new(builder.build()?) as Arc<dyn ObjectStore>
+        }
+        "oss" => {
+            let builder = get_oss_object_store_builder(url, cmd)?;
+            Arc::new(builder.build()?) as Arc<dyn ObjectStore>
+        }
+        "gs" | "gcs" => {
+            let builder = get_gcs_object_store_builder(url, cmd)?;
+            Arc::new(builder.build()?) as Arc<dyn ObjectStore>
+        }
+        _ => {
+            // for other types, try to get from the object_store_registry
+            ctx.runtime_env()
+                .object_store_registry
+                .get_store(url)
+                .map_err(|_| {
+                    DataFusionError::Execution(format!(
+                        "Unsupported object store scheme: {}",
+                        scheme
+                    ))
+                })?
+        }
+    };
+
+    ctx.runtime_env().register_object_store(url, store);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::common::plan_err;
+
+    use super::*;
+
+    async fn create_external_table_test(location: &str, sql: &str) -> Result<()> {
+        let ctx = SessionContext::new();
+        let plan = ctx.state().create_logical_plan(sql).await?;
+
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &plan {
+            create_external_table(&ctx, cmd).await?;
+        } else {
+            return plan_err!("LogicalPlan is not a CreateExternalTable");
+        }
+
+        ctx.runtime_env()
+            .object_store(ListingTableUrl::parse(location)?)?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_object_store_table_s3() -> Result<()> {
+        let access_key_id = "fake_access_key_id";
+        let secret_access_key = "fake_secret_access_key";
+        let region = "fake_us-east-2";
+        let session_token = "fake_session_token";
+        let location = "s3://bucket/path/file.parquet";
+
+        // Missing region
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET
+            OPTIONS('access_key_id' '{access_key_id}', 'secret_access_key' '{secret_access_key}') \
+             LOCATION '{location}'"
+        );
+        let err = create_external_table_test(location, &sql)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Missing region"));
+
+        // Should be OK
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET
+            OPTIONS('access_key_id' '{access_key_id}', 'secret_access_key' '{secret_access_key}', \
+             'region' '{region}', 'session_token' '{session_token}') LOCATION '{location}'"
+        );
+        create_external_table_test(location, &sql).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_object_store_table_oss() -> Result<()> {
+        let access_key_id = "fake_access_key_id";
+        let secret_access_key = "fake_secret_access_key";
+        let endpoint = "fake_endpoint";
+        let location = "oss://bucket/path/file.parquet";
+
+        // Should be OK
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET
+            OPTIONS('access_key_id' '{access_key_id}', 'secret_access_key' '{secret_access_key}', \
+             'endpoint' '{endpoint}') LOCATION '{location}'"
+        );
+        create_external_table_test(location, &sql).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_object_store_table_gcs() -> Result<()> {
+        let service_account_path = "fake_service_account_path";
+        let service_account_key =
+            "{\"private_key\": \"fake_private_key.pem\",\"client_email\":\"fake_client_email\"}";
+        let application_credentials_path = "fake_application_credentials_path";
+        let location = "gcs://bucket/path/file.parquet";
+
+        // for service_account_path
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET
+            OPTIONS('service_account_path' '{service_account_path}') LOCATION '{location}'"
+        );
+        let err = create_external_table_test(location, &sql)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("os error 2"));
+
+        // for service_account_key
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET OPTIONS('service_account_key' \
+             '{service_account_key}') LOCATION '{location}'"
+        );
+        let err = create_external_table_test(location, &sql)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("No RSA key found in pem file"));
+
+        // for application_credentials_path
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET
+            OPTIONS('application_credentials_path' '{application_credentials_path}') LOCATION \
+             '{location}'"
+        );
+        let err = create_external_table_test(location, &sql)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("os error 2"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_external_table_local_file() -> Result<()> {
+        let location = "path/to/file.parquet";
+
+        // Ensure that local files are also registered
+        let sql = format!("CREATE EXTERNAL TABLE test STORED AS PARQUET LOCATION '{location}'");
+        let err = create_external_table_test(location, &sql)
+            .await
+            .unwrap_err();
+
+        if let DataFusionError::IoError(e) = err {
+            assert_eq!(e.kind(), std::io::ErrorKind::NotFound);
+        } else {
+            return Err(err);
+        }
+
+        Ok(())
+    }
+}

--- a/src/utils/datafusion-cli/src/functions.rs
+++ b/src/utils/datafusion-cli/src/functions.rs
@@ -1,0 +1,199 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Functions that are query-able and searchable via the `\h` command
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use arrow::array::StringArray;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use arrow::util::pretty::pretty_format_batches;
+use datafusion::error::Result;
+
+#[derive(Debug)]
+pub enum Function {
+    Select,
+    Explain,
+    Show,
+    CreateTable,
+    CreateTableAs,
+    Insert,
+    DropTable,
+}
+
+const ALL_FUNCTIONS: [Function; 7] = [
+    Function::CreateTable,
+    Function::CreateTableAs,
+    Function::DropTable,
+    Function::Explain,
+    Function::Insert,
+    Function::Select,
+    Function::Show,
+];
+
+impl Function {
+    pub fn function_details(&self) -> Result<&str> {
+        let details = match self {
+            Function::Select => {
+                r#"
+Command:     SELECT
+Description: retrieve rows from a table or view
+Syntax:
+SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ]
+    [ * | expression [ [ AS ] output_name ] [, ...] ]
+    [ FROM from_item [, ...] ]
+    [ WHERE condition ]
+    [ GROUP BY [ ALL | DISTINCT ] grouping_element [, ...] ]
+    [ HAVING condition ]
+    [ WINDOW window_name AS ( window_definition ) [, ...] ]
+    [ { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] select ]
+    [ ORDER BY expression [ ASC | DESC | USING operator ] [ NULLS { FIRST | LAST } ] [, ...] ]
+    [ LIMIT { count | ALL } ]
+    [ OFFSET start [ ROW | ROWS ] ]
+
+where from_item can be one of:
+
+    [ ONLY ] table_name [ * ] [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+                [ TABLESAMPLE sampling_method ( argument [, ...] ) [ REPEATABLE ( seed ) ] ]
+    [ LATERAL ] ( select ) [ AS ] alias [ ( column_alias [, ...] ) ]
+    with_query_name [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+    [ LATERAL ] function_name ( [ argument [, ...] ] )
+                [ WITH ORDINALITY ] [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+    [ LATERAL ] function_name ( [ argument [, ...] ] ) [ AS ] alias ( column_definition [, ...] )
+    [ LATERAL ] function_name ( [ argument [, ...] ] ) AS ( column_definition [, ...] )
+    [ LATERAL ] ROWS FROM( function_name ( [ argument [, ...] ] ) [ AS ( column_definition [, ...] ) ] [, ...] )
+                [ WITH ORDINALITY ] [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+    from_item [ NATURAL ] join_type from_item [ ON join_condition | USING ( join_column [, ...] ) [ AS join_using_alias ] ]
+
+and grouping_element can be one of:
+
+    ( )
+    expression
+    ( expression [, ...] )
+
+and with_query is:
+
+    with_query_name [ ( column_name [, ...] ) ] AS [ [ NOT ] MATERIALIZED ] ( select | values | insert | update | delete )
+
+TABLE [ ONLY ] table_name [ * ]"#
+            }
+            Function::Explain => {
+                r#"
+Command:     EXPLAIN
+Description: show the execution plan of a statement
+Syntax:
+EXPLAIN [ ANALYZE ] statement
+"#
+            }
+            Function::Show => {
+                r#"
+Command:     SHOW
+Description: show the value of a run-time parameter
+Syntax:
+SHOW name
+"#
+            }
+            Function::CreateTable => {
+                r#"
+Command:     CREATE TABLE
+Description: define a new table
+Syntax:
+CREATE [ EXTERNAL ]  TABLE table_name ( [
+  { column_name data_type }
+    [, ... ]
+] )
+"#
+            }
+            Function::CreateTableAs => {
+                r#"
+Command:     CREATE TABLE AS
+Description: define a new table from the results of a query
+Syntax:
+CREATE TABLE table_name
+    [ (column_name [, ...] ) ]
+    AS query
+    [ WITH [ NO ] DATA ]
+"#
+            }
+            Function::Insert => {
+                r#"
+Command:     INSERT
+Description: create new rows in a table
+Syntax:
+INSERT INTO table_name [ ( column_name [, ...] ) ]
+    { VALUES ( { expression } [, ...] ) [, ...] }
+"#
+            }
+            Function::DropTable => {
+                r#"
+Command:     DROP TABLE
+Description: remove a table
+Syntax:
+DROP TABLE [ IF EXISTS ] name [, ...]
+"#
+            }
+        };
+        Ok(details)
+    }
+}
+
+impl FromStr for Function {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.trim().to_uppercase().as_str() {
+            "SELECT" => Self::Select,
+            "EXPLAIN" => Self::Explain,
+            "SHOW" => Self::Show,
+            "CREATE TABLE" => Self::CreateTable,
+            "CREATE TABLE AS" => Self::CreateTableAs,
+            "INSERT" => Self::Insert,
+            "DROP TABLE" => Self::DropTable,
+            _ => return Err(()),
+        })
+    }
+}
+
+impl fmt::Display for Function {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Function::Select => write!(f, "SELECT"),
+            Function::Explain => write!(f, "EXPLAIN"),
+            Function::Show => write!(f, "SHOW"),
+            Function::CreateTable => write!(f, "CREATE TABLE"),
+            Function::CreateTableAs => write!(f, "CREATE TABLE AS"),
+            Function::Insert => write!(f, "INSERT"),
+            Function::DropTable => write!(f, "DROP TABLE"),
+        }
+    }
+}
+
+pub fn display_all_functions() -> Result<()> {
+    println!("Available help:");
+    let array = StringArray::from(
+        ALL_FUNCTIONS
+            .iter()
+            .map(|f| format!("{}", f))
+            .collect::<Vec<String>>(),
+    );
+    let schema = Schema::new(vec![Field::new("Function", DataType::Utf8, false)]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])?;
+    println!("{}", pretty_format_batches(&[batch]).unwrap());
+    Ok(())
+}

--- a/src/utils/datafusion-cli/src/helper.rs
+++ b/src/utils/datafusion-cli/src/helper.rs
@@ -1,0 +1,294 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Helper that helps with interactive editing, including multi-line parsing and
+//! validation, and auto-completion for file name during creating external
+//! table.
+
+use datafusion::common::sql_err;
+use datafusion::error::DataFusionError;
+use datafusion::sql::parser::{DFParser, Statement};
+use datafusion::sql::sqlparser::dialect::dialect_from_str;
+use datafusion::sql::sqlparser::parser::ParserError;
+use rustyline::completion::{Completer, FilenameCompleter, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
+use rustyline::{Context, Helper, Result};
+
+pub struct CliHelper {
+    completer: FilenameCompleter,
+    dialect: String,
+}
+
+impl CliHelper {
+    pub fn new(dialect: &str) -> Self {
+        Self {
+            completer: FilenameCompleter::new(),
+            dialect: dialect.into(),
+        }
+    }
+
+    pub fn set_dialect(&mut self, dialect: &str) {
+        if dialect != self.dialect {
+            self.dialect = dialect.to_string();
+        }
+    }
+
+    fn validate_input(&self, input: &str) -> Result<ValidationResult> {
+        if let Some(sql) = input.strip_suffix(';') {
+            let sql = match unescape_input(sql) {
+                Ok(sql) => sql,
+                Err(err) => {
+                    return Ok(ValidationResult::Invalid(Some(format!(
+                        "  🤔 Invalid statement: {err}",
+                    ))))
+                }
+            };
+
+            let dialect = match dialect_from_str(&self.dialect) {
+                Some(dialect) => dialect,
+                None => {
+                    return Ok(ValidationResult::Invalid(Some(format!(
+                        "  🤔 Invalid dialect: {}",
+                        self.dialect
+                    ))))
+                }
+            };
+
+            match DFParser::parse_sql_with_dialect(&sql, dialect.as_ref()) {
+                Ok(statements) if statements.is_empty() => Ok(ValidationResult::Invalid(Some(
+                    "  🤔 You entered an empty statement".to_string(),
+                ))),
+                Ok(_statements) => Ok(ValidationResult::Valid(None)),
+                Err(err) => Ok(ValidationResult::Invalid(Some(format!(
+                    "  🤔 Invalid statement: {err}",
+                )))),
+            }
+        } else if input.starts_with('\\') {
+            // command
+            Ok(ValidationResult::Valid(None))
+        } else {
+            Ok(ValidationResult::Incomplete)
+        }
+    }
+}
+
+impl Default for CliHelper {
+    fn default() -> Self {
+        Self::new("generic")
+    }
+}
+
+impl Highlighter for CliHelper {}
+
+impl Hinter for CliHelper {
+    type Hint = String;
+}
+
+/// returns true if the current position is after the open quote for
+/// creating an external table.
+fn is_open_quote_for_location(line: &str, pos: usize) -> bool {
+    let mut sql = line[..pos].to_string();
+    sql.push('\'');
+    if let Ok(stmts) = DFParser::parse_sql(&sql) {
+        if let Some(Statement::CreateExternalTable(_)) = stmts.back() {
+            return true;
+        }
+    }
+    false
+}
+
+impl Completer for CliHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        ctx: &Context<'_>,
+    ) -> std::result::Result<(usize, Vec<Pair>), ReadlineError> {
+        if is_open_quote_for_location(line, pos) {
+            self.completer.complete(line, pos, ctx)
+        } else {
+            Ok((0, Vec::with_capacity(0)))
+        }
+    }
+}
+
+impl Validator for CliHelper {
+    fn validate(&self, ctx: &mut ValidationContext<'_>) -> Result<ValidationResult> {
+        let input = ctx.input().trim_end();
+        self.validate_input(input)
+    }
+}
+
+impl Helper for CliHelper {}
+
+/// Unescape input string from readline.
+///
+/// The data read from stdio will be escaped, so we need to unescape the input
+/// before executing the input
+pub fn unescape_input(input: &str) -> datafusion::error::Result<String> {
+    let mut chars = input.chars();
+
+    let mut result = String::with_capacity(input.len());
+    while let Some(char) = chars.next() {
+        if char == '\\' {
+            if let Some(next_char) = chars.next() {
+                // https://static.rust-lang.org/doc/master/reference.html#literals
+                result.push(match next_char {
+                    '0' => '\0',
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    '\\' => '\\',
+                    _ => {
+                        return sql_err!(ParserError::TokenizerError(format!(
+                            "unsupported escape char: '\\{}'",
+                            next_char
+                        ),))
+                    }
+                });
+            }
+        } else {
+            result.push(char);
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufRead, Cursor};
+
+    use super::*;
+
+    fn readline_direct(
+        mut reader: impl BufRead,
+        validator: &CliHelper,
+    ) -> Result<ValidationResult> {
+        let mut input = String::new();
+
+        if reader.read_line(&mut input)? == 0 {
+            return Err(ReadlineError::Eof);
+        }
+
+        validator.validate_input(&input)
+    }
+
+    #[test]
+    fn unescape_readline_input() -> Result<()> {
+        let validator = CliHelper::default();
+
+        // shoule be valid
+        let result = readline_direct(
+            Cursor::new(
+                r"create external table test stored as csv location 'data.csv' delimiter ',';"
+                    .as_bytes(),
+            ),
+            &validator,
+        )?;
+        assert!(matches!(result, ValidationResult::Valid(None)));
+
+        let result = readline_direct(
+            Cursor::new(
+                r"create external table test stored as csv location 'data.csv' delimiter '\0';"
+                    .as_bytes(),
+            ),
+            &validator,
+        )?;
+        assert!(matches!(result, ValidationResult::Valid(None)));
+
+        let result = readline_direct(
+            Cursor::new(
+                r"create external table test stored as csv location 'data.csv' delimiter '\n';"
+                    .as_bytes(),
+            ),
+            &validator,
+        )?;
+        assert!(matches!(result, ValidationResult::Valid(None)));
+
+        let result = readline_direct(
+            Cursor::new(
+                r"create external table test stored as csv location 'data.csv' delimiter '\r';"
+                    .as_bytes(),
+            ),
+            &validator,
+        )?;
+        assert!(matches!(result, ValidationResult::Valid(None)));
+
+        let result = readline_direct(
+            Cursor::new(
+                r"create external table test stored as csv location 'data.csv' delimiter '\t';"
+                    .as_bytes(),
+            ),
+            &validator,
+        )?;
+        assert!(matches!(result, ValidationResult::Valid(None)));
+
+        let result = readline_direct(
+            Cursor::new(
+                r"create external table test stored as csv location 'data.csv' delimiter '\\';"
+                    .as_bytes(),
+            ),
+            &validator,
+        )?;
+        assert!(matches!(result, ValidationResult::Valid(None)));
+
+        // should be invalid
+        let result = readline_direct(
+            Cursor::new(
+                r"create external table test stored as csv location 'data.csv' delimiter ',,';"
+                    .as_bytes(),
+            ),
+            &validator,
+        )?;
+        assert!(matches!(result, ValidationResult::Invalid(Some(_))));
+
+        let result = readline_direct(
+            Cursor::new(
+                r"create external table test stored as csv location 'data.csv' delimiter '\u{07}';"
+                    .as_bytes(),
+            ),
+            &validator,
+        )?;
+        assert!(matches!(result, ValidationResult::Invalid(Some(_))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn sql_dialect() -> Result<()> {
+        let mut validator = CliHelper::default();
+
+        // shoule be invalid in generic dialect
+        let result = readline_direct(Cursor::new(r"select 1 # 2;".as_bytes()), &validator)?;
+        assert!(
+            matches!(result, ValidationResult::Invalid(Some(e)) if e.contains("Invalid statement"))
+        );
+
+        // valid in postgresql dialect
+        validator.set_dialect("postgresql");
+        let result = readline_direct(Cursor::new(r"select 1 # 2;".as_bytes()), &validator)?;
+        assert!(matches!(result, ValidationResult::Valid(None)));
+
+        Ok(())
+    }
+}

--- a/src/utils/datafusion-cli/src/lib.rs
+++ b/src/utils/datafusion-cli/src/lib.rs
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![doc = include_str!("../README.md")]
+pub const DATAFUSION_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub mod catalog;
+pub mod command;
+pub mod exec;
+pub mod functions;
+pub mod helper;
+pub mod object_storage;
+pub mod print_format;
+pub mod print_options;

--- a/src/utils/datafusion-cli/src/object_storage.rs
+++ b/src/utils/datafusion-cli/src/object_storage.rs
@@ -1,0 +1,278 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use aws_credential_types::provider::ProvideCredentials;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::CreateExternalTable;
+use object_store::aws::{AmazonS3Builder, AwsCredential};
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::CredentialProvider;
+use url::Url;
+
+pub async fn get_s3_object_store_builder(
+    url: &Url,
+    cmd: &CreateExternalTable,
+) -> Result<AmazonS3Builder> {
+    let bucket_name = get_bucket_name(url)?;
+    let mut builder = AmazonS3Builder::from_env().with_bucket_name(bucket_name);
+
+    if let (Some(access_key_id), Some(secret_access_key)) = (
+        cmd.options.get("access_key_id"),
+        cmd.options.get("secret_access_key"),
+    ) {
+        builder = builder
+            .with_access_key_id(access_key_id)
+            .with_secret_access_key(secret_access_key);
+
+        if let Some(session_token) = cmd.options.get("session_token") {
+            builder = builder.with_token(session_token);
+        }
+    } else {
+        let config = aws_config::from_env().load().await;
+        if let Some(region) = config.region() {
+            builder = builder.with_region(region.to_string());
+        }
+
+        let credentials = config
+            .credentials_provider()
+            .ok_or_else(|| {
+                DataFusionError::ObjectStore(object_store::Error::Generic {
+                    store: "S3",
+                    source: "Failed to get S3 credentials from environment".into(),
+                })
+            })?
+            .clone();
+
+        let credentials = Arc::new(S3CredentialProvider { credentials });
+        builder = builder.with_credentials(credentials);
+    }
+
+    if let Some(region) = cmd.options.get("region") {
+        builder = builder.with_region(region);
+    }
+
+    Ok(builder)
+}
+
+#[derive(Debug)]
+struct S3CredentialProvider {
+    credentials: aws_credential_types::provider::SharedCredentialsProvider,
+}
+
+#[async_trait]
+impl CredentialProvider for S3CredentialProvider {
+    type Credential = AwsCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<Self::Credential>> {
+        let creds = self.credentials.provide_credentials().await.map_err(|e| {
+            object_store::Error::Generic {
+                store: "S3",
+                source: Box::new(e),
+            }
+        })?;
+        Ok(Arc::new(AwsCredential {
+            key_id: creds.access_key_id().to_string(),
+            secret_key: creds.secret_access_key().to_string(),
+            token: creds.session_token().map(ToString::to_string),
+        }))
+    }
+}
+
+pub fn get_oss_object_store_builder(
+    url: &Url,
+    cmd: &CreateExternalTable,
+) -> Result<AmazonS3Builder> {
+    let bucket_name = get_bucket_name(url)?;
+    let mut builder = AmazonS3Builder::from_env()
+        .with_virtual_hosted_style_request(true)
+        .with_bucket_name(bucket_name)
+        // oss don't care about the "region" field
+        .with_region("do_not_care");
+
+    if let (Some(access_key_id), Some(secret_access_key)) = (
+        cmd.options.get("access_key_id"),
+        cmd.options.get("secret_access_key"),
+    ) {
+        builder = builder
+            .with_access_key_id(access_key_id)
+            .with_secret_access_key(secret_access_key);
+    }
+
+    if let Some(endpoint) = cmd.options.get("endpoint") {
+        builder = builder.with_endpoint(endpoint);
+    }
+
+    Ok(builder)
+}
+
+pub fn get_gcs_object_store_builder(
+    url: &Url,
+    cmd: &CreateExternalTable,
+) -> Result<GoogleCloudStorageBuilder> {
+    let bucket_name = get_bucket_name(url)?;
+    let mut builder = GoogleCloudStorageBuilder::from_env().with_bucket_name(bucket_name);
+
+    if let Some(service_account_path) = cmd.options.get("service_account_path") {
+        builder = builder.with_service_account_path(service_account_path);
+    }
+
+    if let Some(service_account_key) = cmd.options.get("service_account_key") {
+        builder = builder.with_service_account_key(service_account_key);
+    }
+
+    if let Some(application_credentials_path) = cmd.options.get("application_credentials_path") {
+        builder = builder.with_application_credentials(application_credentials_path);
+    }
+
+    Ok(builder)
+}
+
+fn get_bucket_name(url: &Url) -> Result<&str> {
+    url.host_str().ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "Not able to parse bucket name from url: {}",
+            url.as_str()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::common::plan_err;
+    use datafusion::datasource::listing::ListingTableUrl;
+    use datafusion::logical_expr::{DdlStatement, LogicalPlan};
+    use datafusion::prelude::SessionContext;
+    use object_store::aws::AmazonS3ConfigKey;
+    use object_store::gcp::GoogleConfigKey;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn s3_object_store_builder() -> Result<()> {
+        let access_key_id = "fake_access_key_id";
+        let secret_access_key = "fake_secret_access_key";
+        let region = "fake_us-east-2";
+        let session_token = "fake_session_token";
+        let location = "s3://bucket/path/file.parquet";
+
+        let table_url = ListingTableUrl::parse(location)?;
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET OPTIONS('access_key_id' \
+             '{access_key_id}', 'secret_access_key' '{secret_access_key}', 'region' '{region}', \
+             'session_token' {session_token}) LOCATION '{location}'"
+        );
+
+        let ctx = SessionContext::new();
+        let plan = ctx.state().create_logical_plan(&sql).await?;
+
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &plan {
+            let builder = get_s3_object_store_builder(table_url.as_ref(), cmd).await?;
+            // get the actual configuration information, then assert_eq!
+            let config = [
+                (AmazonS3ConfigKey::AccessKeyId, access_key_id),
+                (AmazonS3ConfigKey::SecretAccessKey, secret_access_key),
+                (AmazonS3ConfigKey::Region, region),
+                (AmazonS3ConfigKey::Token, session_token),
+            ];
+            for (key, value) in config {
+                assert_eq!(value, builder.get_config_value(&key).unwrap());
+            }
+        } else {
+            return plan_err!("LogicalPlan is not a CreateExternalTable");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn oss_object_store_builder() -> Result<()> {
+        let access_key_id = "fake_access_key_id";
+        let secret_access_key = "fake_secret_access_key";
+        let endpoint = "fake_endpoint";
+        let location = "oss://bucket/path/file.parquet";
+
+        let table_url = ListingTableUrl::parse(location)?;
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET OPTIONS('access_key_id' \
+             '{access_key_id}', 'secret_access_key' '{secret_access_key}', 'endpoint' \
+             '{endpoint}') LOCATION '{location}'"
+        );
+
+        let ctx = SessionContext::new();
+        let plan = ctx.state().create_logical_plan(&sql).await?;
+
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &plan {
+            let builder = get_oss_object_store_builder(table_url.as_ref(), cmd)?;
+            // get the actual configuration information, then assert_eq!
+            let config = [
+                (AmazonS3ConfigKey::AccessKeyId, access_key_id),
+                (AmazonS3ConfigKey::SecretAccessKey, secret_access_key),
+                (AmazonS3ConfigKey::Endpoint, endpoint),
+            ];
+            for (key, value) in config {
+                assert_eq!(value, builder.get_config_value(&key).unwrap());
+            }
+        } else {
+            return plan_err!("LogicalPlan is not a CreateExternalTable");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn gcs_object_store_builder() -> Result<()> {
+        let service_account_path = "fake_service_account_path";
+        let service_account_key =
+            "{\"private_key\": \"fake_private_key.pem\",\"client_email\":\"fake_client_email\"}";
+        let application_credentials_path = "fake_application_credentials_path";
+        let location = "gcs://bucket/path/file.parquet";
+
+        let table_url = ListingTableUrl::parse(location)?;
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET OPTIONS('service_account_path' \
+             '{service_account_path}', 'service_account_key' '{service_account_key}', \
+             'application_credentials_path' '{application_credentials_path}') LOCATION \
+             '{location}'"
+        );
+
+        let ctx = SessionContext::new();
+        let plan = ctx.state().create_logical_plan(&sql).await?;
+
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &plan {
+            let builder = get_gcs_object_store_builder(table_url.as_ref(), cmd)?;
+            // get the actual configuration information, then assert_eq!
+            let config = [
+                (GoogleConfigKey::ServiceAccount, service_account_path),
+                (GoogleConfigKey::ServiceAccountKey, service_account_key),
+                (
+                    GoogleConfigKey::ApplicationCredentials,
+                    application_credentials_path,
+                ),
+            ];
+            for (key, value) in config {
+                assert_eq!(value, builder.get_config_value(&key).unwrap());
+            }
+        } else {
+            return plan_err!("LogicalPlan is not a CreateExternalTable");
+        }
+
+        Ok(())
+    }
+}

--- a/src/utils/datafusion-cli/src/print_format.rs
+++ b/src/utils/datafusion-cli/src/print_format.rs
@@ -1,0 +1,303 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Print format variants
+use std::str::FromStr;
+
+use arrow::csv::writer::WriterBuilder;
+use arrow::json::{ArrayWriter, LineDelimitedWriter};
+use arrow::util::pretty::pretty_format_batches_with_options;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::format::DEFAULT_FORMAT_OPTIONS;
+use datafusion::error::{DataFusionError, Result};
+
+use crate::print_options::MaxRows;
+
+/// Allow records to be printed in different formats
+#[derive(Debug, PartialEq, Eq, clap::ValueEnum, Clone)]
+pub enum PrintFormat {
+    Csv,
+    Tsv,
+    Table,
+    Json,
+    NdJson,
+}
+
+impl FromStr for PrintFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        clap::ValueEnum::from_str(s, true)
+    }
+}
+
+macro_rules! batches_to_json {
+    ($WRITER: ident, $batches: expr) => {{
+        let mut bytes = vec![];
+        {
+            let mut writer = $WRITER::new(&mut bytes);
+            $batches.iter().try_for_each(|batch| writer.write(batch))?;
+            writer.finish()?;
+        }
+        String::from_utf8(bytes).map_err(|e| DataFusionError::External(Box::new(e)))?
+    }};
+}
+
+fn print_batches_with_sep(batches: &[RecordBatch], delimiter: u8) -> Result<String> {
+    let mut bytes = vec![];
+    {
+        let builder = WriterBuilder::new()
+            .with_header(true)
+            .with_delimiter(delimiter);
+        let mut writer = builder.build(&mut bytes);
+        for batch in batches {
+            writer.write(batch)?;
+        }
+    }
+    let formatted = String::from_utf8(bytes).map_err(|e| DataFusionError::External(Box::new(e)))?;
+    Ok(formatted)
+}
+
+fn keep_only_maxrows(s: &str, maxrows: usize) -> String {
+    let lines: Vec<String> = s.lines().map(String::from).collect();
+
+    assert!(lines.len() >= maxrows + 4); // 4 lines for top and bottom border
+
+    let last_line = &lines[lines.len() - 1]; // bottom border line
+
+    let spaces = last_line.len().saturating_sub(4);
+    let dotted_line = format!("| .{:<spaces$}|", "", spaces = spaces);
+
+    let mut result = lines[0..(maxrows + 3)].to_vec(); // Keep top border and `maxrows` lines
+    result.extend(vec![dotted_line; 3]); // Append ... lines
+    result.push(last_line.clone());
+
+    result.join("\n")
+}
+
+fn format_batches_with_maxrows(batches: &[RecordBatch], maxrows: MaxRows) -> Result<String> {
+    match maxrows {
+        MaxRows::Limited(maxrows) => {
+            // Only format enough batches for maxrows
+            let mut filtered_batches = Vec::new();
+            let mut batches = batches;
+            let row_count: usize = batches.iter().map(|b| b.num_rows()).sum();
+            if row_count > maxrows {
+                let mut accumulated_rows = 0;
+
+                for batch in batches {
+                    filtered_batches.push(batch.clone());
+                    if accumulated_rows + batch.num_rows() > maxrows {
+                        break;
+                    }
+                    accumulated_rows += batch.num_rows();
+                }
+
+                batches = &filtered_batches;
+            }
+
+            let mut formatted = format!(
+                "{}",
+                pretty_format_batches_with_options(batches, &DEFAULT_FORMAT_OPTIONS)?,
+            );
+
+            if row_count > maxrows {
+                formatted = keep_only_maxrows(&formatted, maxrows);
+            }
+
+            Ok(formatted)
+        }
+        MaxRows::Unlimited => {
+            // maxrows not specified, print all rows
+            Ok(format!(
+                "{}",
+                pretty_format_batches_with_options(batches, &DEFAULT_FORMAT_OPTIONS)?,
+            ))
+        }
+    }
+}
+
+impl PrintFormat {
+    /// print the batches to stdout using the specified format
+    /// `maxrows` option is only used for `Table` format:
+    ///     If `maxrows` is Some(n), then at most n rows will be displayed
+    ///     If `maxrows` is None, then every row will be displayed
+    pub fn print_batches(&self, batches: &[RecordBatch], maxrows: MaxRows) -> Result<()> {
+        if batches.is_empty() {
+            return Ok(());
+        }
+
+        match self {
+            Self::Csv => println!("{}", print_batches_with_sep(batches, b',')?),
+            Self::Tsv => println!("{}", print_batches_with_sep(batches, b'\t')?),
+            Self::Table => {
+                if maxrows == MaxRows::Limited(0) {
+                    return Ok(());
+                }
+                println!("{}", format_batches_with_maxrows(batches, maxrows)?,)
+            }
+            Self::Json => println!("{}", batches_to_json!(ArrayWriter, batches)),
+            Self::NdJson => {
+                println!("{}", batches_to_json!(LineDelimitedWriter, batches))
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    use super::*;
+
+    #[test]
+    fn test_print_batches_with_sep() {
+        let batches = vec![];
+        assert_eq!("", print_batches_with_sep(&batches, b',').unwrap());
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+        let r = print_batches_with_sep(&batches, b',').unwrap();
+        assert_eq!("a,b,c\n1,4,7\n2,5,8\n3,6,9\n", r);
+    }
+
+    #[test]
+    fn test_print_batches_to_json_empty() -> Result<()> {
+        let batches = vec![];
+        let r = batches_to_json!(ArrayWriter, &batches);
+        assert_eq!("", r);
+
+        let r = batches_to_json!(LineDelimitedWriter, &batches);
+        assert_eq!("", r);
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+        let r = batches_to_json!(ArrayWriter, &batches);
+        assert_eq!(
+            "[{\"a\":1,\"b\":4,\"c\":7},{\"a\":2,\"b\":5,\"c\":8},{\"a\":3,\"b\":6,\"c\":9}]",
+            r
+        );
+
+        let r = batches_to_json!(LineDelimitedWriter, &batches);
+        assert_eq!(
+            "{\"a\":1,\"b\":4,\"c\":7}\n{\"a\":2,\"b\":5,\"c\":8}\n{\"a\":3,\"b\":6,\"c\":9}\n",
+            r
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_batches_with_maxrows() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))]).unwrap();
+
+        #[rustfmt::skip]
+        let all_rows_expected = [
+            "+---+",
+            "| a |",
+            "+---+",
+            "| 1 |",
+            "| 2 |",
+            "| 3 |",
+            "+---+",
+        ].join("\n");
+
+        #[rustfmt::skip]
+        let one_row_expected = [
+            "+---+",
+            "| a |",
+            "+---+",
+            "| 1 |",
+            "| . |",
+            "| . |",
+            "| . |",
+            "+---+",
+        ].join("\n");
+
+        #[rustfmt::skip]
+        let multi_batches_expected = [
+            "+---+",
+            "| a |",
+            "+---+",
+            "| 1 |",
+            "| 2 |",
+            "| 3 |",
+            "| 1 |",
+            "| 2 |",
+            "| . |",
+            "| . |",
+            "| . |",
+            "+---+",
+        ].join("\n");
+
+        let no_limit = format_batches_with_maxrows(&[batch.clone()], MaxRows::Unlimited)?;
+        assert_eq!(all_rows_expected, no_limit);
+
+        let maxrows_less_than_actual =
+            format_batches_with_maxrows(&[batch.clone()], MaxRows::Limited(1))?;
+        assert_eq!(one_row_expected, maxrows_less_than_actual);
+        let maxrows_more_than_actual =
+            format_batches_with_maxrows(&[batch.clone()], MaxRows::Limited(5))?;
+        assert_eq!(all_rows_expected, maxrows_more_than_actual);
+        let maxrows_equals_actual =
+            format_batches_with_maxrows(&[batch.clone()], MaxRows::Limited(3))?;
+        assert_eq!(all_rows_expected, maxrows_equals_actual);
+        let multi_batches = format_batches_with_maxrows(
+            &[batch.clone(), batch.clone(), batch.clone()],
+            MaxRows::Limited(5),
+        )?;
+        assert_eq!(multi_batches_expected, multi_batches);
+
+        Ok(())
+    }
+}

--- a/src/utils/datafusion-cli/src/print_options.rs
+++ b/src/utils/datafusion-cli/src/print_options.rs
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+use std::time::Instant;
+
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::error::Result;
+
+use crate::print_format::PrintFormat;
+
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub enum MaxRows {
+    /// show all rows in the output
+    Unlimited,
+    /// Only show n rows
+    Limited(usize),
+}
+
+impl FromStr for MaxRows {
+    type Err = String;
+
+    fn from_str(maxrows: &str) -> Result<Self, Self::Err> {
+        if maxrows.to_lowercase() == "inf"
+            || maxrows.to_lowercase() == "infinite"
+            || maxrows.to_lowercase() == "none"
+        {
+            Ok(Self::Unlimited)
+        } else {
+            match maxrows.parse::<usize>() {
+                Ok(nrows) => Ok(Self::Limited(nrows)),
+                _ => Err(format!(
+                    "Invalid maxrows {}. Valid inputs are natural numbers or \'none\', \'inf\', \
+                     or \'infinite\' for no limit.",
+                    maxrows
+                )),
+            }
+        }
+    }
+}
+
+impl Display for MaxRows {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unlimited => write!(f, "unlimited"),
+            Self::Limited(max_rows) => write!(f, "at most {max_rows}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrintOptions {
+    pub format: PrintFormat,
+    pub quiet: bool,
+    pub maxrows: MaxRows,
+}
+
+fn get_timing_info_str(row_count: usize, maxrows: MaxRows, query_start_time: Instant) -> String {
+    let row_word = if row_count == 1 { "row" } else { "rows" };
+    let nrows_shown_msg = match maxrows {
+        MaxRows::Limited(nrows) if nrows < row_count => format!(" ({} shown)", nrows),
+        _ => String::new(),
+    };
+
+    format!(
+        "{} {} in set{}. Query took {:.3} seconds.\n",
+        row_count,
+        row_word,
+        nrows_shown_msg,
+        query_start_time.elapsed().as_secs_f64()
+    )
+}
+
+impl PrintOptions {
+    /// print the batches to stdout using the specified format
+    pub fn print_batches(&self, batches: &[RecordBatch], query_start_time: Instant) -> Result<()> {
+        let row_count: usize = batches.iter().map(|b| b.num_rows()).sum();
+        // Elapsed time should not count time for printing batches
+        let timing_info = get_timing_info_str(row_count, self.maxrows, query_start_time);
+
+        self.format.print_batches(batches, self.maxrows)?;
+
+        if !self.quiet {
+            println!("{timing_info}");
+        }
+
+        Ok(())
+    }
+}

--- a/src/utils/repo-tools/tests/lints/license_header.rs
+++ b/src/utils/repo-tools/tests/lints/license_header.rs
@@ -9,6 +9,8 @@
 
 use std::path::PathBuf;
 
+const IGNORE_CRATES: &[&str] = &["src/utils/datafusion-cli"];
+
 fn get_repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../../")
@@ -31,6 +33,7 @@ fn get_all_crates() -> Vec<PathBuf> {
         .unwrap()
         .iter()
         .map(|v| v.as_str().unwrap())
+        .filter(|s| !IGNORE_CRATES.contains(s))
         .map(|s| repo_root.join(s))
         .collect()
 }


### PR DESCRIPTION
## Description

Closes: [<#issue>](https://github.com/kamu-data/kamu-cli/issues/228) DataFusion-based SQL console #228

Job done:
1. Linked datafusion-cli as a dependency of kamu-cli.
2. Allowed launching datafusion-cli via kamu sql, made datafusion the default engine for kamu sql command.
3. added BSL-1.0 to licenses after running cargo deny check.

## Testing:

1. kamu sql => datafusion-cli:
<img width="1343" alt="image" src="https://github.com/kamu-data/kamu-cli/assets/3535553/97ed9330-d5d1-4bea-8c77-053e3b4f83a8">

2. kamu --sql --command "select 1": datafusion engine:

<img width="1442" alt="image" src="https://github.com/kamu-data/kamu-cli/assets/3535553/5a70d7e3-b35a-43b8-859d-860165f34bfd">

**NB! Testing will be added in next PR.**

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
