### PR TITLE
clippy: fix pedantic warnings (redundant_else) and disable rules (single_match_else, default_trait_access)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,10 @@ must_use_candidate = { level = "allow", priority = 1 }
 redundant_closure_for_method_calls = { level = "allow", priority = 1 }
 ignored_unit_patterns = { level = "allow", priority = 1 }
 needless_raw_string_hashes = { level = "allow", priority = 1 }
+default_trait_access = { level = "allow", priority = 1 }
+single_match_else = { level = "allow", priority = 1 }
+
+redundant_else = "warn"
 
 # clippy::cargo
 cargo = { level = "warn", priority = 0 }

--- a/src/domain/core/src/entities/metadata_stream.rs
+++ b/src/domain/core/src/entities/metadata_stream.rs
@@ -305,9 +305,9 @@ where
             if let Some(iter) = this.iter.as_mut() {
                 if let Some(next) = iter.next() {
                     break Poll::Ready(Some(Ok(next)));
-                } else {
-                    *this.iter = None;
                 }
+
+                *this.iter = None;
             }
             match this.inner.as_mut().poll_next(cx) {
                 Poll::Pending => break Poll::Pending,
@@ -361,9 +361,9 @@ where
                 Poll::Ready(None) => {
                     if let Some(v) = this.accum.take() {
                         break Poll::Ready(Ok(v));
-                    } else {
-                        panic!("Any polled after completion")
                     }
+
+                    panic!("Any polled after completion")
                 }
                 Poll::Ready(Some(Ok(v))) => {
                     let acc = (this.f)(&v) || this.accum.unwrap();
@@ -481,9 +481,9 @@ where
                 Poll::Ready(None) => {
                     if let Some(v) = this.accum.take() {
                         break Poll::Ready(Ok(v));
-                    } else {
-                        panic!("Any polled after completion")
                     }
+
+                    panic!("Any polled after completion")
                 }
                 Poll::Ready(Some(Ok(_))) => {
                     *this.accum = Some(this.accum.unwrap() + 1);

--- a/src/infra/task-system-inmem/src/task_scheduler_inmem.rs
+++ b/src/infra/task-system-inmem/src/task_scheduler_inmem.rs
@@ -116,13 +116,11 @@ impl TaskScheduler for TaskSchedulerInMemory {
     // TODO: Use signaling instead of a loop
     async fn take(&self) -> Result<TaskID, TakeTaskError> {
         loop {
-            match self.try_take().await? {
-                Some(task_id) => return Ok(task_id),
-                None => {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    continue;
-                }
+            if let Some(task_id) = self.try_take().await? {
+                return Ok(task_id);
             }
+
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 

--- a/src/utils/container-runtime/src/runtime.rs
+++ b/src/utils/container-runtime/src/runtime.rs
@@ -386,9 +386,9 @@ impl ContainerRuntime {
                 break Ok(hp);
             } else if start.elapsed() >= timeout {
                 break Err(TimeoutError::new(timeout).into());
-            } else {
-                tokio::time::sleep(Self::TICK_INTERVAL).await;
             }
+
+            tokio::time::sleep(Self::TICK_INTERVAL).await;
         }
     }
 
@@ -445,9 +445,9 @@ impl ContainerRuntime {
                 break Ok(());
             } else if start.elapsed() >= timeout {
                 break Err(TimeoutError::new(timeout).into());
-            } else {
-                tokio::time::sleep(Self::TICK_INTERVAL).await;
             }
+
+            tokio::time::sleep(Self::TICK_INTERVAL).await;
         }
     }
 


### PR DESCRIPTION
## Description

Fixed clippy warnings
- `pedantic::redundant_else`

Disabled rules
- `pedantic::single_match_else`
- `pedantic::default_trait_access`

Related issue: https://github.com/kamu-data/kamu-cli/issues/332

<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
