### PR TITLE
CRON expressions should allow only classic 5-component syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 ### Changed
 - Use artificial control over time in `FlowService` tests to stabilize their behavior
 - CRON expressions API should allow only classic 5-component syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
 ### Changed
 - Use artificial control over time in `FlowService` tests to stabilize their behavior
+- CRON expressions API should allow only classic 5-component syntax
 
 ## [0.154.1] - 2024-01-24
 ### Fixed

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -163,8 +163,8 @@ type CreateDatasetResultSuccess implements CreateDatasetResult & CreateDatasetFr
 	message: String!
 }
 
-type CronExpression {
-	cronExpression: String!
+type Cron5ComponentExpression {
+	cron5ComponentExpression: String!
 }
 
 type DataBatch {
@@ -678,7 +678,7 @@ type FlowConfigurationBatching {
 	minimalDataBatch: Int
 }
 
-union FlowConfigurationSchedule = TimeDelta | CronExpression
+union FlowConfigurationSchedule = TimeDelta | Cron5ComponentExpression
 
 type FlowConnection {
 	"""
@@ -1139,7 +1139,7 @@ type RequestHeader {
 
 input ScheduleInput @oneOf {
 	timeDelta: TimeDeltaInput
-	cronExpression: String
+	cron5ComponentExpression: String
 }
 
 type Search {

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -61,10 +61,9 @@ impl DatasetFlowConfigsMut {
             ScheduleInput::TimeDelta(td) => {
                 Schedule::TimeDelta(ScheduleTimeDelta { every: td.into() })
             }
-            ScheduleInput::CronExpression(cron_expression) => {
-                let cron_struct = Schedule::validate_cron_expression(cron_expression)
-                    .map_err(|e| GqlError::Gql(e.into()))?;
-                Schedule::CronExpression(cron_struct)
+            ScheduleInput::Cron5ComponentExpression(cron_5component_expression) => {
+                Schedule::try_from_5component_cron_expression(&cron_5component_expression)
+                    .map_err(|e| GqlError::Gql(e.into()))?
             }
         };
 
@@ -132,7 +131,8 @@ impl DatasetFlowConfigsMut {
 #[derive(OneofObject)]
 enum ScheduleInput {
     TimeDelta(TimeDeltaInput),
-    CronExpression(String),
+    /// Supported CRON syntax: min hour dayOfMonth month dayOfWeek
+    Cron5ComponentExpression(String),
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/scalars/flow_configuration.rs
+++ b/src/adapter/graphql/src/scalars/flow_configuration.rs
@@ -7,8 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use cron::Schedule as CronSchedule;
-use kamu_flow_system::{FlowConfigurationRule, Schedule};
+use kamu_flow_system::{FlowConfigurationRule, Schedule, ScheduleCron};
 
 use crate::prelude::*;
 
@@ -38,9 +37,7 @@ impl From<kamu_flow_system::FlowConfigurationState> for FlowConfiguration {
                     Schedule::TimeDelta(time_delta) => Some(FlowConfigurationSchedule::TimeDelta(
                         time_delta.every.into(),
                     )),
-                    Schedule::CronExpression(cron) => {
-                        Some(FlowConfigurationSchedule::Cron(cron.into()))
-                    }
+                    Schedule::Cron(cron) => Some(FlowConfigurationSchedule::Cron(cron.into())),
                 }
             } else {
                 None
@@ -52,7 +49,7 @@ impl From<kamu_flow_system::FlowConfigurationState> for FlowConfiguration {
 #[derive(Union, Clone, PartialEq, Eq)]
 pub enum FlowConfigurationSchedule {
     TimeDelta(TimeDelta),
-    Cron(CronExpression),
+    Cron(Cron5ComponentExpression),
 }
 
 #[derive(SimpleObject, Clone, PartialEq, Eq)]
@@ -64,14 +61,14 @@ pub struct FlowConfigurationBatching {
 /////////////////////////////////////////////////////////////////////////////////
 
 #[derive(SimpleObject, Clone, PartialEq, Eq)]
-pub struct CronExpression {
-    pub cron_expression: String,
+pub struct Cron5ComponentExpression {
+    pub cron_5component_expression: String,
 }
 
-impl From<CronSchedule> for CronExpression {
-    fn from(value: CronSchedule) -> Self {
+impl From<ScheduleCron> for Cron5ComponentExpression {
+    fn from(value: ScheduleCron) -> Self {
         Self {
-            cron_expression: value.to_string(),
+            cron_5component_expression: value.source_5component_cron_expression,
         }
     }
 }

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_configs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_configs.rs
@@ -263,8 +263,8 @@ async fn test_crud_cron_root_dataset() {
                                 paused
                                 schedule {
                                     __typename
-                                    ... on CronExpression {
-                                        cronExpression
+                                    ... on Cron5ComponentExpression {
+                                        cron5ComponentExpression
                                     }
                                 }
                                 batching {
@@ -308,7 +308,7 @@ async fn test_crud_cron_root_dataset() {
         &create_result.dataset_handle.id,
         "INGEST",
         false,
-        "0 */2 * * * *",
+        "*/2 * * * *",
     );
 
     let res = schema
@@ -333,8 +333,8 @@ async fn test_crud_cron_root_dataset() {
                                     "__typename": "FlowConfiguration",
                                     "paused": false,
                                     "schedule": {
-                                        "__typename": "CronExpression",
-                                        "cronExpression": "0 */2 * * * *",
+                                        "__typename": "Cron5ComponentExpression",
+                                        "cron5ComponentExpression": "*/2 * * * *",
                                     },
                                     "batching": null
                                 }
@@ -350,7 +350,7 @@ async fn test_crud_cron_root_dataset() {
         &create_result.dataset_handle.id,
         "INGEST",
         true,
-        "0 0 */1 * * *",
+        "0 */1 * * *",
     );
 
     let res = schema
@@ -375,8 +375,8 @@ async fn test_crud_cron_root_dataset() {
                                     "__typename": "FlowConfiguration",
                                     "paused": true,
                                     "schedule": {
-                                        "__typename": "CronExpression",
-                                        "cronExpression": "0 0 */1 * * *",
+                                        "__typename": "Cron5ComponentExpression",
+                                        "cron5ComponentExpression": "0 */1 * * *",
                                     },
                                     "batching": null
                                 }
@@ -409,8 +409,8 @@ async fn test_crud_cron_root_dataset() {
         format!("Cron expression {invalid_cron_expression} is invalid")
     );
 
-    // Try to pass valid cron expression from past
-    let past_cron_expression = "0 0 0 1 JAN ? 2024";
+    // Try to pass valid cron expression with year (not supported)
+    let past_cron_expression = "0 0 1 JAN ? 2024";
     let mutation_code = FlowConfigHarness::set_config_cron_expression_mutation(
         &create_result.dataset_handle.id,
         "INGEST",
@@ -427,7 +427,7 @@ async fn test_crud_cron_root_dataset() {
     assert!(res.is_err(), "{res:?}");
     assert_eq!(
         res.errors[0].message,
-        format!("Cron expression {past_cron_expression} iteration has been exceeded",)
+        format!("Cron expression {past_cron_expression} is invalid",)
     );
 }
 
@@ -862,7 +862,7 @@ impl FlowConfigHarness {
                                     datasetFlowType: "<dataset_flow_type>",
                                     paused: <paused>,
                                     schedule: {
-                                        cronExpression: "<cron_expression>"
+                                        cron5ComponentExpression: "<cron_expression>"
                                     }
                                 ) {
                                     __typename,
@@ -873,8 +873,8 @@ impl FlowConfigHarness {
                                             paused
                                             schedule {
                                                 __typename
-                                                ... on CronExpression {
-                                                    cronExpression
+                                                ... on Cron5ComponentExpression {
+                                                    cron5ComponentExpression
                                                 }
                                             }
                                             batching {

--- a/src/domain/flow-system/src/entities/shared/schedule.rs
+++ b/src/domain/flow-system/src/entities/shared/schedule.rs
@@ -61,7 +61,7 @@ pub struct CronExpressionIterationError {
 }
 
 // Classic CRON expression has 5 components: min hour dayOfMonth month dayOfWeek
-const CLASSIC_CRONTAB_COMPONENTS_COUNT: i32 = 5;
+const CLASSIC_CRONTAB_COMPONENTS_COUNT: usize = 5;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -70,10 +70,7 @@ impl Schedule {
         source_5component_cron_expression: &str,
     ) -> Result<Schedule, ScheduleCronError> {
         // Ensure we obtained classic 5-component CRONTAB expression
-        let mut components_count = 0;
-        for _ in source_5component_cron_expression.split_whitespace() {
-            components_count += 1;
-        }
+        let components_count = source_5component_cron_expression.split_whitespace().count();
         if components_count != CLASSIC_CRONTAB_COMPONENTS_COUNT {
             return Err(ScheduleCronError::InvalidCronExpression(
                 InvalidCronExpressionError {

--- a/src/domain/flow-system/src/lib.rs
+++ b/src/domain/flow-system/src/lib.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![feature(assert_matches)]
+
 // Re-exports
 pub use event_sourcing::*;
 


### PR DESCRIPTION
## Description

Closes: #459

CRON expressions API should accept only classic 5-component syntax (min hour dayOfMonth month dayOfWeek). Years and seconds are forbidden.

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible - NOT COMPATIBLE, but no consumers yet
- [x] Workspace layout changes include a migration - not required
- [x] Documentation update PR -not required
- [x] Dataset pipelines update - not required
