### PR TITLE
Fix tail command cli parser regression

### DIFF
--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -1217,14 +1217,14 @@ pub fn cli() -> Command {
                             Arg::new("num-records")
                                 .long("num-records")
                                 .short('n')
-                                .value_parser(value_parser!(usize))
+                                .value_parser(value_parser!(u64))
                                 .default_value("10")
                                 .value_name("NUM")
                                 .help("Number of records to display"),
                             Arg::new("skip-records")
                                 .long("skip-records")
                                 .short('s')
-                                .value_parser(value_parser!(usize))
+                                .value_parser(value_parser!(u64))
                                 .default_value("0")
                                 .value_name("NUM")
                                 .help("Number of initial records to skip before applying the limit"),


### PR DESCRIPTION
Fixes a regression introduced in cf1682aecf96af9ec0913b170401dbbd4828712e
```
$ kamu tail gps
thread 'main' panicked at src/app/cli/src/cli_commands.rs:467:26:
Mismatch between definition and access of `skip-records`. Could not downcast to u64, need to downcast to usize
```
Unfortunately `clap` is super sensitive to getting the exact type as the value converter produces.

Our commands are pretty complex, but we could try to migrate to `clippy derive` that avoids these kinds of issues.