### PR TITLE
Flows: API to pause/resume dataset flows quickly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - New type `DatasetRefPattern` which allows CLI command to accept global pattern
+- New GraphQL APIs for quick pausing/resuming of dataset flow configs preserving the scheduling rules
 ### Changed
 - `kamu deleted` and `kamu verify` now accepts global pattern expression
 

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -337,6 +337,8 @@ type DatasetFlowConfigs {
 type DatasetFlowConfigsMut {
 	setConfigSchedule(datasetFlowType: DatasetFlowType!, paused: Boolean!, schedule: ScheduleInput!): SetFlowConfigResult!
 	setConfigBatching(datasetFlowType: DatasetFlowType!, paused: Boolean!, throttlingPeriod: TimeDeltaInput, minimalDataBatch: Int): SetFlowConfigResult!
+	pauseFlows(datasetFlowType: DatasetFlowType): Boolean!
+	resumeFlows(datasetFlowType: DatasetFlowType): Boolean!
 }
 
 type DatasetFlowRuns {

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -124,6 +124,40 @@ impl DatasetFlowConfigsMut {
             config: res.into(),
         }))
     }
+
+    #[graphql(guard = "LoggedInGuard::new()")]
+    async fn pause_flows(
+        &self,
+        ctx: &Context<'_>,
+        dataset_flow_type: Option<DatasetFlowType>,
+    ) -> Result<bool> {
+        ensure_scheduling_permission(ctx, &self.dataset_handle).await?;
+
+        let flow_config_service = from_catalog::<dyn FlowConfigurationService>(ctx).unwrap();
+
+        flow_config_service
+            .pause_dataset_flows(&self.dataset_handle.id, dataset_flow_type.map(Into::into))
+            .await?;
+
+        Ok(true)
+    }
+
+    #[graphql(guard = "LoggedInGuard::new()")]
+    async fn resume_flows(
+        &self,
+        ctx: &Context<'_>,
+        dataset_flow_type: Option<DatasetFlowType>,
+    ) -> Result<bool> {
+        ensure_scheduling_permission(ctx, &self.dataset_handle).await?;
+
+        let flow_config_service = from_catalog::<dyn FlowConfigurationService>(ctx).unwrap();
+
+        flow_config_service
+            .resume_dataset_flows(&self.dataset_handle.id, dataset_flow_type.map(Into::into))
+            .await?;
+
+        Ok(true)
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/aggregates/flow_configuration/flow_configuration.rs
+++ b/src/domain/flow-system/src/aggregates/flow_configuration/flow_configuration.rs
@@ -62,13 +62,17 @@ impl FlowConfiguration {
         &mut self,
         now: DateTime<Utc>,
     ) -> Result<(), ProjectionError<FlowConfigurationState>> {
-        let event = FlowConfigurationEventModified {
-            event_time: now,
-            flow_key: self.flow_key.clone(),
-            paused: true,
-            rule: self.rule.clone(),
-        };
-        self.apply(event)
+        if self.is_active() {
+            let event = FlowConfigurationEventModified {
+                event_time: now,
+                flow_key: self.flow_key.clone(),
+                paused: true,
+                rule: self.rule.clone(),
+            };
+            self.apply(event)
+        } else {
+            Ok(())
+        }
     }
 
     /// Resume configuration
@@ -76,13 +80,17 @@ impl FlowConfiguration {
         &mut self,
         now: DateTime<Utc>,
     ) -> Result<(), ProjectionError<FlowConfigurationState>> {
-        let event = FlowConfigurationEventModified {
-            event_time: now,
-            flow_key: self.flow_key.clone(),
-            paused: false,
-            rule: self.rule.clone(),
-        };
-        self.apply(event)
+        if self.is_active() {
+            Ok(())
+        } else {
+            let event = FlowConfigurationEventModified {
+                event_time: now,
+                flow_key: self.flow_key.clone(),
+                paused: false,
+                rule: self.rule.clone(),
+            };
+            self.apply(event)
+        }
     }
 
     /// Handle dataset removal

--- a/src/domain/flow-system/src/aggregates/flow_configuration/flow_configuration.rs
+++ b/src/domain/flow-system/src/aggregates/flow_configuration/flow_configuration.rs
@@ -57,6 +57,34 @@ impl FlowConfiguration {
         self.apply(event)
     }
 
+    /// Pause configuration
+    pub fn pause(
+        &mut self,
+        now: DateTime<Utc>,
+    ) -> Result<(), ProjectionError<FlowConfigurationState>> {
+        let event = FlowConfigurationEventModified {
+            event_time: now,
+            flow_key: self.flow_key.clone(),
+            paused: true,
+            rule: self.rule.clone(),
+        };
+        self.apply(event)
+    }
+
+    /// Resume configuration
+    pub fn resume(
+        &mut self,
+        now: DateTime<Utc>,
+    ) -> Result<(), ProjectionError<FlowConfigurationState>> {
+        let event = FlowConfigurationEventModified {
+            event_time: now,
+            flow_key: self.flow_key.clone(),
+            paused: false,
+            rule: self.rule.clone(),
+        };
+        self.apply(event)
+    }
+
     /// Handle dataset removal
     pub fn notify_dataset_removed(
         &mut self,

--- a/src/domain/flow-system/src/services/flow_configuration/flow_configuration_service.rs
+++ b/src/domain/flow-system/src/services/flow_configuration/flow_configuration_service.rs
@@ -13,7 +13,13 @@ use internal_error::{ErrorIntoInternal, InternalError};
 use opendatafabric::DatasetID;
 use tokio_stream::Stream;
 
-use crate::{DatasetFlowType, FlowConfigurationRule, FlowConfigurationState, FlowKey, SystemFlowType};
+use crate::{
+    DatasetFlowType,
+    FlowConfigurationRule,
+    FlowConfigurationState,
+    FlowKey,
+    SystemFlowType,
+};
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -46,7 +52,7 @@ pub trait FlowConfigurationService: Sync + Send {
     ) -> Result<(), InternalError>;
 
     /// Pauses system flows of given type.
-    /// If type is omitted, all possible system flow types are paused    
+    /// If type is omitted, all possible system flow types are paused
     async fn pause_system_flows(
         &self,
         maybe_system_flow_type: Option<SystemFlowType>,
@@ -61,11 +67,12 @@ pub trait FlowConfigurationService: Sync + Send {
     ) -> Result<(), InternalError>;
 
     /// Resumes system flows of given type.
-    /// If type is omitted, all possible system flow types are resumed (where configured)
+    /// If type is omitted, all possible system flow types are resumed (where
+    /// configured)
     async fn resume_system_flows(
         &self,
         maybe_system_flow_type: Option<SystemFlowType>,
-    ) -> Result<(), InternalError>;    
+    ) -> Result<(), InternalError>;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/services/flow_configuration/flow_configuration_service.rs
+++ b/src/domain/flow-system/src/services/flow_configuration/flow_configuration_service.rs
@@ -10,9 +10,10 @@
 use chrono::{DateTime, Utc};
 use event_sourcing::TryLoadError;
 use internal_error::{ErrorIntoInternal, InternalError};
+use opendatafabric::DatasetID;
 use tokio_stream::Stream;
 
-use crate::{FlowConfigurationRule, FlowConfigurationState, FlowKey};
+use crate::{DatasetFlowType, FlowConfigurationRule, FlowConfigurationState, FlowKey, SystemFlowType};
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -35,6 +36,36 @@ pub trait FlowConfigurationService: Sync + Send {
 
     /// Lists all flow configurations, which are currently enabled
     fn list_enabled_configurations(&self) -> FlowConfigurationStateStream;
+
+    /// Pauses dataset flows of given type for given dataset.
+    /// If type is omitted, all possible dataset flow types are paused
+    async fn pause_dataset_flows(
+        &self,
+        dataset_id: &DatasetID,
+        maybe_dataset_flow_type: Option<DatasetFlowType>,
+    ) -> Result<(), InternalError>;
+
+    /// Pauses system flows of given type.
+    /// If type is omitted, all possible system flow types are paused    
+    async fn pause_system_flows(
+        &self,
+        maybe_system_flow_type: Option<SystemFlowType>,
+    ) -> Result<(), InternalError>;
+
+    /// Resumes dataset flows of given type for given dataset.
+    /// If type is omitted, all possible types are resumed (where configured)
+    async fn resume_dataset_flows(
+        &self,
+        dataset_id: &DatasetID,
+        maybe_dataset_flow_type: Option<DatasetFlowType>,
+    ) -> Result<(), InternalError>;
+
+    /// Resumes system flows of given type.
+    /// If type is omitted, all possible system flow types are resumed (where configured)
+    async fn resume_system_flows(
+        &self,
+        maybe_system_flow_type: Option<SystemFlowType>,
+    ) -> Result<(), InternalError>;    
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/flow-system-inmem/src/services/flow_configuration/flow_configuration_service_inmem.rs
+++ b/src/infra/flow-system-inmem/src/services/flow_configuration/flow_configuration_service_inmem.rs
@@ -59,33 +59,53 @@ impl FlowConfigurationServiceInMemory {
         self.event_bus.dispatch_event(event).await
     }
 
-    fn get_dataset_flow_keys(dataset_id: &DatasetID, maybe_dataset_flow_type: Option<DatasetFlowType>) -> Vec<FlowKey> {
+    fn get_dataset_flow_keys(
+        dataset_id: &DatasetID,
+        maybe_dataset_flow_type: Option<DatasetFlowType>,
+    ) -> Vec<FlowKey> {
         if let Some(dataset_flow_type) = maybe_dataset_flow_type {
-            vec![FlowKey::Dataset(FlowKeyDataset { dataset_id: dataset_id.clone(), flow_type: dataset_flow_type })]
+            vec![FlowKey::Dataset(FlowKeyDataset {
+                dataset_id: dataset_id.clone(),
+                flow_type: dataset_flow_type,
+            })]
         } else {
-            DatasetFlowType::all().iter()
-                .map(|dft| FlowKey::Dataset(FlowKeyDataset { dataset_id: dataset_id.clone(), flow_type: *dft}))
+            DatasetFlowType::all()
+                .iter()
+                .map(|dft| {
+                    FlowKey::Dataset(FlowKeyDataset {
+                        dataset_id: dataset_id.clone(),
+                        flow_type: *dft,
+                    })
+                })
                 .collect()
         }
     }
 
     fn get_system_flow_keys(maybe_system_flow_type: Option<SystemFlowType>) -> Vec<FlowKey> {
         if let Some(system_flow_type) = maybe_system_flow_type {
-            vec![FlowKey::System(FlowKeySystem { flow_type: system_flow_type })]
+            vec![FlowKey::System(FlowKeySystem {
+                flow_type: system_flow_type,
+            })]
         } else {
-            SystemFlowType::all().iter()
-                .map(|sft| FlowKey::System(FlowKeySystem { flow_type: *sft}))
+            SystemFlowType::all()
+                .iter()
+                .map(|sft| FlowKey::System(FlowKeySystem { flow_type: *sft }))
                 .collect()
         }
     }
 
     async fn pause_flow_configuration(&self, flow_key: FlowKey) -> Result<(), InternalError> {
         let maybe_flow_configuration =
-            FlowConfiguration::try_load(flow_key.clone(), self.event_store.as_ref()).await.int_err()?;
+            FlowConfiguration::try_load(flow_key.clone(), self.event_store.as_ref())
+                .await
+                .int_err()?;
 
         if let Some(mut flow_configuration) = maybe_flow_configuration {
             flow_configuration.pause(self.time_source.now()).int_err()?;
-            flow_configuration.save(self.event_store.as_ref()).await.int_err()?;
+            flow_configuration
+                .save(self.event_store.as_ref())
+                .await
+                .int_err()?;
         }
 
         Ok(())
@@ -93,15 +113,22 @@ impl FlowConfigurationServiceInMemory {
 
     async fn resume_flow_configuration(&self, flow_key: FlowKey) -> Result<(), InternalError> {
         let maybe_flow_configuration =
-            FlowConfiguration::try_load(flow_key.clone(), self.event_store.as_ref()).await.int_err()?;
+            FlowConfiguration::try_load(flow_key.clone(), self.event_store.as_ref())
+                .await
+                .int_err()?;
 
         if let Some(mut flow_configuration) = maybe_flow_configuration {
-            flow_configuration.resume(self.time_source.now()).int_err()?;
-            flow_configuration.save(self.event_store.as_ref()).await.int_err()?;
+            flow_configuration
+                .resume(self.time_source.now())
+                .int_err()?;
+            flow_configuration
+                .save(self.event_store.as_ref())
+                .await
+                .int_err()?;
         }
 
         Ok(())
-    }    
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -197,7 +224,7 @@ impl FlowConfigurationService for FlowConfigurationServiceInMemory {
     }
 
     /// Pauses system flows of given type.
-    /// If type is omitted, all possible system flow types are paused    
+    /// If type is omitted, all possible system flow types are paused
     async fn pause_system_flows(
         &self,
         maybe_system_flow_type: Option<SystemFlowType>,
@@ -219,7 +246,7 @@ impl FlowConfigurationService for FlowConfigurationServiceInMemory {
         maybe_dataset_flow_type: Option<DatasetFlowType>,
     ) -> Result<(), InternalError> {
         let flow_keys = Self::get_dataset_flow_keys(dataset_id, maybe_dataset_flow_type);
-        
+
         for flow_key in flow_keys {
             self.resume_flow_configuration(flow_key).await.int_err()?;
         }
@@ -228,7 +255,8 @@ impl FlowConfigurationService for FlowConfigurationServiceInMemory {
     }
 
     /// Resumes system flows of given type.
-    /// If type is omitted, all possible system flow types are resumed (where configured)
+    /// If type is omitted, all possible system flow types are resumed (where
+    /// configured)
     async fn resume_system_flows(
         &self,
         maybe_system_flow_type: Option<SystemFlowType>,
@@ -240,7 +268,7 @@ impl FlowConfigurationService for FlowConfigurationServiceInMemory {
         }
 
         Ok(())
-    }    
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Closes: #474 

New flow config APIs to pause/resume all dataset flows or flows of given type preserving the scheduling rule.

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration - not needed
- [x] Documentation update PR: N/A
- [x] Dataset pipelines update scheduled if needed - not needed
