### PR TITLE
476 flows provide api for server side filtering of flows that respects pagination as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.156.0] - 2024-02-03
 ### Added
 - New type `DatasetRefPattern` which allows CLI command to accept global pattern
 - New GraphQL APIs for quick pausing/resuming of dataset flow configs preserving the scheduling rules
+- New GraphQL APIs for server-side filtering of flow listings (by type, by status, and by initiator)
 ### Changed
 - `kamu deleted` and `kamu verify` now accepts global pattern expression
 - Error handling for pipe subprocesses with file output
+- Pagination implementation made more effecient for flows and tasks event stores
 
 ## [0.155.0] - 2024-01-25
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "anstyle-parse"
@@ -362,7 +362,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "lexical-core",
  "num",
  "serde",
@@ -503,7 +503,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "mime",
  "multer",
  "num-traits",
@@ -573,7 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323a5143f5bdd2030f45e3f2e0c821c9b1d36e79cf382129c64299c50a7f3750"
 dependencies = [
  "bytes",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "serde",
  "serde_json",
 ]
@@ -1443,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.9"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df631ae429f6613fcd3a7c1adbdb65f637271e561b03680adaa6573015dfb106"
+checksum = "abb745187d7f4d76267b37485a65e0149edd0e91a4cfcdd3f27524ad86cee9f3"
 dependencies = [
  "clap",
 ]
@@ -1559,7 +1559,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "container-runtime"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1815,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.70+curl-8.5.0"
+version = "0.4.71+curl-8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0333d8849afe78a4c8102a429a446bfdd055832af071945520e835ae2d841e"
+checksum = "c7b12a7ab780395666cb576203dc3ed6e01513754939a600b85196ccf5356bc5"
 dependencies = [
  "cc",
  "libc",
@@ -1864,9 +1864,9 @@ checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1874,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1888,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
 dependencies = [
  "darling_core",
  "quote",
@@ -1944,7 +1944,7 @@ dependencies = [
  "glob",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itertools 0.11.0",
  "log",
  "num_cpus",
@@ -2057,7 +2057,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.3",
  "hex",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itertools 0.11.0",
  "libc",
  "log",
@@ -2091,7 +2091,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itertools 0.11.0",
  "log",
  "once_cell",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.155.0"
+version = "0.156.0"
 
 [[package]]
 name = "env_logger"
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "event-bus"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -2755,7 +2755,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -3088,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3148,7 +3148,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "test-log",
  "thiserror",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-recursion",
  "async-stream",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "arrow-flight",
  "assert_cmd",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "arrow-digest",
  "async-trait",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3903,9 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libflate"
@@ -3946,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
  "libc",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "bs58",
  "digest",
@@ -4331,6 +4331,12 @@ checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-format"
@@ -4475,7 +4481,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendatafabric"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "arrow",
  "base64 0.21.7",
@@ -4510,9 +4516,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "300.2.2+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "8bbfad0063610ac26ee79f7484739e2b07555a75c42453b89263830b5c8103bc"
 dependencies = [
  "cc",
 ]
@@ -4762,7 +4768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
 ]
 
 [[package]]
@@ -5244,9 +5250,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
@@ -5271,6 +5277,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -5403,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -5580,18 +5587,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5600,9 +5607,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -5642,15 +5649,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.5.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
+checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
 dependencies = [
  "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -5659,9 +5666,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.5.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
+checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5671,11 +5678,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.30"
+version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itoa",
  "ryu",
  "serde",
@@ -6190,13 +6197,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "00b24b79b7a07f10209f19e683ca1e289d80b1e76ffa8c2b779718566a083679"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -6212,10 +6220,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -6255,9 +6264,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6343,14 +6352,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.0",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -6368,18 +6377,18 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6557,7 +6566,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.155.0"
+version = "0.156.0"
 dependencies = [
  "conv",
  "env_logger",
@@ -6933,9 +6942,9 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-streams"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6973,9 +6982,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
@@ -7233,9 +7242,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,35 +36,35 @@ resolver = "2"
 
 [workspace.dependencies]
 # Utils
-container-runtime = { version = "0.155.0", path = "src/utils/container-runtime", default-features = false }
-enum-variants = { version = "0.155.0", path = "src/utils/enum-variants", default-features = false }
-event-bus = { version = "0.155.0", path = "src/utils/event-bus", default-features = false}
-event-sourcing = { version = "0.155.0", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.155.0", path = "src/utils/event-sourcing-macros", default-features = false }
-internal-error = { version = "0.155.0", path = "src/utils/internal-error", default-features = false }
-multiformats = { version = "0.155.0", path = "src/utils/multiformats", default-features = false }
-kamu-data-utils = { version = "0.155.0", path = "src/utils/data-utils", default-features = false }
-kamu-datafusion-cli = { version = "0.155.0", path = "src/utils/datafusion-cli", default-features = false }
-tracing-perfetto = { version = "0.155.0", path = "src/utils/tracing-perfetto", default-features = false }
+container-runtime = { version = "0.156.0", path = "src/utils/container-runtime", default-features = false }
+enum-variants = { version = "0.156.0", path = "src/utils/enum-variants", default-features = false }
+event-bus = { version = "0.156.0", path = "src/utils/event-bus", default-features = false}
+event-sourcing = { version = "0.156.0", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.156.0", path = "src/utils/event-sourcing-macros", default-features = false }
+internal-error = { version = "0.156.0", path = "src/utils/internal-error", default-features = false }
+multiformats = { version = "0.156.0", path = "src/utils/multiformats", default-features = false }
+kamu-data-utils = { version = "0.156.0", path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { version = "0.156.0", path = "src/utils/datafusion-cli", default-features = false }
+tracing-perfetto = { version = "0.156.0", path = "src/utils/tracing-perfetto", default-features = false }
 # Domain
-opendatafabric = { version = "0.155.0", path = "src/domain/opendatafabric", default-features = false }
-kamu-core = { version = "0.155.0", path = "src/domain/core", default-features = false }
-kamu-task-system = { version = "0.155.0", path = "src/domain/task-system", default-features = false }
-kamu-flow-system = { version = "0.155.0", path = "src/domain/flow-system", default-features = false }
+opendatafabric = { version = "0.156.0", path = "src/domain/opendatafabric", default-features = false }
+kamu-core = { version = "0.156.0", path = "src/domain/core", default-features = false }
+kamu-task-system = { version = "0.156.0", path = "src/domain/task-system", default-features = false }
+kamu-flow-system = { version = "0.156.0", path = "src/domain/flow-system", default-features = false }
 # Infra
-kamu = { version = "0.155.0", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.155.0", path = "src/infra/ingest-datafusion", default-features = false }
-kamu-task-system-inmem = { version = "0.155.0", path = "src/infra/task-system-inmem", default-features = false }
-kamu-flow-system-inmem = { version = "0.155.0", path = "src/infra/flow-system-inmem", default-features = false }
+kamu = { version = "0.156.0", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.156.0", path = "src/infra/ingest-datafusion", default-features = false }
+kamu-task-system-inmem = { version = "0.156.0", path = "src/infra/task-system-inmem", default-features = false }
+kamu-flow-system-inmem = { version = "0.156.0", path = "src/infra/flow-system-inmem", default-features = false }
 # Adapters
-kamu-adapter-auth-oso = { version = "0.155.0", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.155.0", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.155.0", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.155.0", path = "src/adapter/http", default-features = false }
-kamu-adapter-oauth = { version = "0.155.0", path = "src/adapter/oauth", defualt-features = false }
+kamu-adapter-auth-oso = { version = "0.156.0", path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { version = "0.156.0", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.156.0", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.156.0", path = "src/adapter/http", default-features = false }
+kamu-adapter-oauth = { version = "0.156.0", path = "src/adapter/oauth", defualt-features = false }
 
 [workspace.package]
-version = "0.155.0"
+version = "0.156.0"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.155.0
+Licensed Work:             Kamu CLI Version 0.156.0
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2028-01-25
+Change Date:               2028-02-03
 
 Change License:            Apache License, Version 2.0
 

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -341,9 +341,15 @@ type DatasetFlowConfigsMut {
 	resumeFlows(datasetFlowType: DatasetFlowType): Boolean!
 }
 
+input DatasetFlowFilters {
+	byFlowType: DatasetFlowType
+	byStatus: FlowStatus
+	byInitiator: InitiatorFilterInput
+}
+
 type DatasetFlowRuns {
 	getFlow(flowId: FlowID!): GetFlowResult!
-	listFlows(page: Int, perPage: Int, filterByFlowType: DatasetFlowType, filterByStatus: FlowStatus, filterByInitiator: InitiatorFilterInput): FlowConnection!
+	listFlows(page: Int, perPage: Int, filters: DatasetFlowFilters): FlowConnection!
 }
 
 type DatasetFlowRunsMut {

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -343,7 +343,7 @@ type DatasetFlowConfigsMut {
 
 type DatasetFlowRuns {
 	getFlow(flowId: FlowID!): GetFlowResult!
-	listFlows(page: Int, perPage: Int): FlowConnection!
+	listFlows(page: Int, perPage: Int, filterByFlowType: DatasetFlowType, filterByStatus: FlowStatus, filterByInitiator: AccountName): FlowConnection!
 }
 
 type DatasetFlowRunsMut {

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -343,7 +343,7 @@ type DatasetFlowConfigsMut {
 
 type DatasetFlowRuns {
 	getFlow(flowId: FlowID!): GetFlowResult!
-	listFlows(page: Int, perPage: Int, filterByFlowType: DatasetFlowType, filterByStatus: FlowStatus, filterByInitiator: AccountName): FlowConnection!
+	listFlows(page: Int, perPage: Int, filterByFlowType: DatasetFlowType, filterByStatus: FlowStatus, filterByInitiator: InitiatorFilterInput): FlowConnection!
 }
 
 type DatasetFlowRunsMut {
@@ -861,6 +861,11 @@ type GetFlowSuccess implements GetFlowResult {
 	message: String!
 }
 
+
+input InitiatorFilterInput @oneOf {
+	system: Boolean
+	account: AccountName
+}
 
 
 type LoginResponse {

--- a/src/adapter/graphql/src/queries/datasets/dataset_flow_runs.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_flow_runs.rs
@@ -78,12 +78,19 @@ impl DatasetFlowRuns {
             .await
             .int_err()?;
 
-        let matched_flows: Vec<_> = flows_state_listing.matched_stream.try_collect().await?;
+        let matched_flows: Vec<_> = flows_state_listing
+            .matched_stream
+            .map_ok(Flow::new)
+            .try_collect()
+            .await?;
         let total_count = flows_state_listing.total_count;
 
-        let nodes = matched_flows.into_iter().map(Flow::new).collect();
-
-        Ok(FlowConnection::new(nodes, page, per_page, total_count))
+        Ok(FlowConnection::new(
+            matched_flows,
+            page,
+            per_page,
+            total_count,
+        ))
     }
 }
 

--- a/src/adapter/graphql/src/queries/datasets/dataset_flow_runs.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_flow_runs.rs
@@ -56,7 +56,7 @@ impl DatasetFlowRuns {
         per_page: Option<usize>,
         filter_by_flow_type: Option<DatasetFlowType>,
         filter_by_status: Option<FlowStatus>,
-        filter_by_initiator: Option<AccountName>, // TODO: replace on AccountID
+        filter_by_initiator: Option<InitiatorFilterInput>,
     ) -> Result<FlowConnection> {
         utils::check_dataset_read_access(ctx, &self.dataset_handle).await?;
 
@@ -114,6 +114,23 @@ struct GetFlowSuccess {
 impl GetFlowSuccess {
     pub async fn message(&self) -> String {
         "Success".to_string()
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[derive(OneofObject)]
+enum InitiatorFilterInput {
+    System(bool),
+    Account(AccountName), // TODO: replace on AccountID
+}
+
+impl From<InitiatorFilterInput> for fs::InitiatorFilter {
+    fn from(value: InitiatorFilterInput) -> Self {
+        match value {
+            InitiatorFilterInput::System(_) => Self::System,
+            InitiatorFilterInput::Account(account_name) => Self::Account(account_name.into()),
+        }
     }
 }
 

--- a/src/adapter/graphql/src/queries/datasets/dataset_flow_runs.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_flow_runs.rs
@@ -70,12 +70,16 @@ impl DatasetFlowRuns {
                     Some(filters) => filters.into(),
                     None => Default::default(),
                 },
-                fs::FlowPaginationOpts { page, per_page },
+                fs::FlowPaginationOpts {
+                    offset: page * per_page,
+                    limit: per_page,
+                },
             )
+            .await
             .int_err()?;
 
         let matched_flows: Vec<_> = flows_state_listing.matched_stream.try_collect().await?;
-        let total_count = flows_state_listing.total_count_future.await;
+        let total_count = flows_state_listing.total_count;
 
         let nodes = matched_flows.into_iter().map(Flow::new).collect();
 

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -26,6 +26,7 @@ use kamu::{
     ObjectStoreRegistryImpl,
     PollingIngestServiceImpl,
 };
+use kamu_core::auth::DEFAULT_ACCOUNT_NAME;
 use kamu_core::{
     auth,
     CreateDatasetResult,
@@ -256,6 +257,431 @@ async fn test_trigger_execute_transform_derived_dataset() {
                                     "hasNextPage": false,
                                     "currentPage": 0,
                                     "totalPages": 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_list_flows_with_filters_and_pagination() {
+    let harness = FlowRunsHarness::new();
+    let create_result = harness.create_root_dataset().await;
+
+    let ingest_mutation_code =
+        FlowRunsHarness::trigger_flow_mutation(&create_result.dataset_handle.id, "INGEST");
+    let compaction_mutation_code =
+        FlowRunsHarness::trigger_flow_mutation(&create_result.dataset_handle.id, "COMPACTION");
+
+    let schema = kamu_adapter_graphql::schema_quiet();
+
+    let response = schema
+        .execute(
+            async_graphql::Request::new(ingest_mutation_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+    assert!(response.is_ok(), "{response:?}");
+
+    let response = schema
+        .execute(
+            async_graphql::Request::new(compaction_mutation_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+    assert!(response.is_ok(), "{response:?}");
+
+    // Pure listing
+
+    let request_code = indoc!(
+        r#"
+        {
+            datasets {
+                byId (datasetId: "<id>") {
+                    flows {
+                        runs {
+                            listFlows {
+                                nodes {
+                                    flowId
+                                }
+                                pageInfo {
+                                    currentPage
+                                    totalPages
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        "#
+    )
+    .replace("<id>", &create_result.dataset_handle.id.to_string());
+
+    let response = schema
+        .execute(async_graphql::Request::new(request_code).data(harness.catalog_authorized.clone()))
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "datasets": {
+                "byId": {
+                    "flows": {
+                        "runs": {
+                            "listFlows": {
+                                "nodes": [
+                                    {
+                                        "flowId": "1",
+                                    },
+                                    {
+                                        "flowId": "0",
+                                    }
+                                ],
+                                "pageInfo": {
+                                    "currentPage": 0,
+                                    "totalPages": 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    // Split on 2 pages by 1 element
+
+    let request_code = indoc!(
+        r#"
+        {
+            datasets {
+                byId (datasetId: "<id>") {
+                    flows {
+                        runs {
+                            listFlows(perPage: 1, page: 1) {
+                                nodes {
+                                    flowId
+                                }
+                                pageInfo {
+                                    currentPage
+                                    totalPages
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        "#
+    )
+    .replace("<id>", &create_result.dataset_handle.id.to_string());
+
+    let response = schema
+        .execute(async_graphql::Request::new(request_code).data(harness.catalog_authorized.clone()))
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "datasets": {
+                "byId": {
+                    "flows": {
+                        "runs": {
+                            "listFlows": {
+                                "nodes": [
+                                    {
+                                        "flowId": "0",
+                                    }
+                                ],
+                                "pageInfo": {
+                                    "currentPage": 1,
+                                    "totalPages": 2,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    // Filter by flow type
+
+    let request_code = indoc!(
+        r#"
+        {
+            datasets {
+                byId (datasetId: "<id>") {
+                    flows {
+                        runs {
+                            listFlows(
+                                filters: {
+                                    byFlowType: "COMPACTION"
+                                }
+                            ) {
+                                nodes {
+                                    flowId
+                                }
+                                pageInfo {
+                                    currentPage
+                                    totalPages
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        "#
+    )
+    .replace("<id>", &create_result.dataset_handle.id.to_string());
+
+    let response = schema
+        .execute(async_graphql::Request::new(request_code).data(harness.catalog_authorized.clone()))
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "datasets": {
+                "byId": {
+                    "flows": {
+                        "runs": {
+                            "listFlows": {
+                                "nodes": [
+                                    {
+                                        "flowId": "1",
+                                    }
+                                ],
+                                "pageInfo": {
+                                    "currentPage": 0,
+                                    "totalPages": 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    // Filter by flow status
+
+    let request_code = indoc!(
+        r#"
+        {
+            datasets {
+                byId (datasetId: "<id>") {
+                    flows {
+                        runs {
+                            listFlows(
+                                filters: {
+                                    byStatus: "QUEUED"
+                                }
+                            ) {
+                                nodes {
+                                    flowId
+                                }
+                                pageInfo {
+                                    currentPage
+                                    totalPages
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        "#
+    )
+    .replace("<id>", &create_result.dataset_handle.id.to_string());
+
+    let response = schema
+        .execute(
+            async_graphql::Request::new(request_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "datasets": {
+                "byId": {
+                    "flows": {
+                        "runs": {
+                            "listFlows": {
+                                "nodes": [
+                                    {
+                                        "flowId": "1",
+                                    },
+                                    {
+                                        "flowId": "0",
+                                    }
+                                ],
+                                "pageInfo": {
+                                    "currentPage": 0,
+                                    "totalPages": 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    let request_code = request_code.replace("QUEUED", "SCHEDULED");
+
+    let response = schema
+        .execute(async_graphql::Request::new(request_code).data(harness.catalog_authorized.clone()))
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "datasets": {
+                "byId": {
+                    "flows": {
+                        "runs": {
+                            "listFlows": {
+                                "nodes": [],
+                                "pageInfo": {
+                                    "currentPage": 0,
+                                    "totalPages": 0,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    // Filter by initiator
+
+    let request_code = indoc!(
+        r#"
+    {
+        datasets {
+            byId (datasetId: "<id>") {
+                flows {
+                    runs {
+                        listFlows(
+                            filters: {
+                                byInitiator: { account: "<account_name>"}
+                            }
+                        ) {
+                            nodes {
+                                flowId
+                            }
+                            pageInfo {
+                                currentPage
+                                totalPages
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    "#
+    )
+    .replace("<id>", &create_result.dataset_handle.id.to_string())
+    .replace("<account_name>", DEFAULT_ACCOUNT_NAME);
+
+    let response = schema
+        .execute(async_graphql::Request::new(request_code).data(harness.catalog_authorized.clone()))
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "datasets": {
+                "byId": {
+                    "flows": {
+                        "runs": {
+                            "listFlows": {
+                                "nodes": [
+                                    {
+                                        "flowId": "1",
+                                    },
+                                    {
+                                        "flowId": "0",
+                                    }
+                                ],
+                                "pageInfo": {
+                                    "currentPage": 0,
+                                    "totalPages": 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    let request_code = indoc!(
+        r#"
+    {
+        datasets {
+            byId (datasetId: "<id>") {
+                flows {
+                    runs {
+                        listFlows(
+                            filters: {
+                                byInitiator: { system: true}
+                            }
+                        ) {
+                            nodes {
+                                flowId
+                            }
+                            pageInfo {
+                                currentPage
+                                totalPages
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    "#
+    )
+    .replace("<id>", &create_result.dataset_handle.id.to_string())
+    .replace("<account_name>", DEFAULT_ACCOUNT_NAME);
+
+    let response = schema
+        .execute(async_graphql::Request::new(request_code).data(harness.catalog_authorized.clone()))
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "datasets": {
+                "byId": {
+                    "flows": {
+                        "runs": {
+                            "listFlows": {
+                                "nodes": [],
+                                "pageInfo": {
+                                    "currentPage": 0,
+                                    "totalPages": 0,
                                 }
                             }
                         }

--- a/src/adapter/graphql/tests/tests/test_tasks.rs
+++ b/src/adapter/graphql/tests/tests/test_tasks.rs
@@ -152,7 +152,7 @@ async fn test_task_list_by_dataset() {
         .expect_list_tasks_by_dataset()
         .return_once(move |_, _| {
             Ok(TaskStateListing {
-                stream: Box::pin(futures::stream::iter([Ok(returned_task)].into_iter())),
+                stream: Box::pin(futures::stream::once(async { Ok(returned_task) })),
                 total_count: 1,
             })
         });

--- a/src/adapter/graphql/tests/tests/test_tasks.rs
+++ b/src/adapter/graphql/tests/tests/test_tasks.rs
@@ -19,7 +19,7 @@ mockall::mock! {
     #[async_trait::async_trait]
     impl TaskScheduler for TaskScheduler {
         async fn get_task(&self, task_id: TaskID) -> Result<TaskState, GetTaskError>;
-        fn list_tasks_by_dataset<'a>(&'a self, dataset_id: &DatasetID) -> Result<TaskStateStream<'a>, ListTasksByDatasetError>;
+        async fn list_tasks_by_dataset<'a>(&'a self, dataset_id: &DatasetID, pagination: TaskPaginationOpts) -> Result<TaskStateListing<'a>, ListTasksByDatasetError>;
         async fn create_task(&self, plan: LogicalPlan) -> Result<TaskState, CreateTaskError>;
         async fn cancel_task(&self, task_id: TaskID) -> Result<TaskState, CancelTaskError>;
         async fn take(&self) -> Result<TaskID, TakeTaskError>;
@@ -150,10 +150,11 @@ async fn test_task_list_by_dataset() {
     let mut task_sched_mock = MockTaskScheduler::new();
     task_sched_mock
         .expect_list_tasks_by_dataset()
-        .return_once(move |_| {
-            Ok(Box::pin(futures::stream::iter(
-                [Ok(returned_task)].into_iter(),
-            )))
+        .return_once(move |_, _| {
+            Ok(TaskStateListing {
+                stream: Box::pin(futures::stream::iter([Ok(returned_task)].into_iter())),
+                total_count: 1,
+            })
         });
 
     let cat = dill::CatalogBuilder::new()

--- a/src/domain/flow-system/src/entities/flow/flow_event.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_event.rs
@@ -136,6 +136,17 @@ impl FlowEvent {
             FlowEvent::Aborted(e) => e.event_time,
         }
     }
+
+    pub fn new_status(&self) -> Option<FlowStatus> {
+        match self {
+            FlowEvent::Initiated(_) => Some(FlowStatus::Waiting),
+            FlowEvent::StartConditionDefined(_) | FlowEvent::TriggerAdded(_) => None,
+            FlowEvent::Queued(_) => Some(FlowStatus::Queued),
+            FlowEvent::TaskScheduled(_) => Some(FlowStatus::Scheduled),
+            FlowEvent::TaskRunning(_) => Some(FlowStatus::Running),
+            FlowEvent::TaskFinished(_) | FlowEvent::Aborted(_) => Some(FlowStatus::Finished),
+        }
+    }
 }
 
 impl_enum_with_variants!(FlowEvent);

--- a/src/domain/flow-system/src/entities/flow/flow_id.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_id.rs
@@ -9,8 +9,6 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-use internal_error::InternalError;
-
 /// Uniquely identifies a flow
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FlowID(u64);
@@ -37,10 +35,6 @@ impl From<FlowID> for u64 {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-pub type FlowIDStream<'a> =
-    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<FlowID, InternalError>> + Send + 'a>>;
-
-pub type FlowIDCountFuture<'a> =
-    std::pin::Pin<Box<dyn std::future::Future<Output = usize> + Send + 'a>>;
+pub type FlowIDStream<'a> = std::pin::Pin<Box<dyn tokio_stream::Stream<Item = FlowID> + Send + 'a>>;
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/entities/flow/flow_id.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_id.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use internal_error::InternalError;
+
 /////////////////////////////////////////////////////////////////////////////////////////
 
 /// Uniquely identifies a flow
@@ -35,6 +37,7 @@ impl From<FlowID> for u64 {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-pub type FlowIDStream<'a> = std::pin::Pin<Box<dyn tokio_stream::Stream<Item = FlowID> + Send + 'a>>;
+pub type FlowIDStream<'a> =
+    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<FlowID, InternalError>> + Send + 'a>>;
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/entities/flow/flow_id.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_id.rs
@@ -40,4 +40,7 @@ impl From<FlowID> for u64 {
 pub type FlowIDStream<'a> =
     std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<FlowID, InternalError>> + Send + 'a>>;
 
+pub type FlowIDCountFuture<'a> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = usize> + Send + 'a>>;
+
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/repos/flow/flow_event_store.rs
+++ b/src/domain/flow-system/src/repos/flow/flow_event_store.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use event_sourcing::EventStore;
-use opendatafabric::DatasetID;
+use opendatafabric::{AccountName, DatasetID};
 
 use crate::*;
 
@@ -19,35 +19,49 @@ pub trait FlowEventStore: EventStore<FlowState> {
     /// Generates new unique flow identifier
     fn new_flow_id(&self) -> FlowID;
 
-    /// Returns the last dataset flow of certain type
-    fn get_last_dataset_flow_of_type(
+    /// Returns ID of the last dataset flow of certain type
+    fn get_last_dataset_flow_id_of_type(
         &self,
         dataset_id: &DatasetID,
         flow_type: DatasetFlowType,
     ) -> Option<FlowID>;
 
-    /// Returns the last system flow of certain type
-    fn get_last_system_flow_of_type(&self, flow_type: SystemFlowType) -> Option<FlowID>;
+    /// Returns ID of the last system flow of certain type
+    fn get_last_system_flow_id_of_type(&self, flow_type: SystemFlowType) -> Option<FlowID>;
 
-    /// Returns the flows of certain type associated with the specified dataset
-    /// in reverse chronological order based on creation time
-    fn get_flows_by_dataset_of_type(
+    /// Returns IDs of the flows associated with the specified
+    /// dataset in reverse chronological order based on creation time.
+    /// Applies filters, if specified
+    fn get_all_flow_ids_by_dataset(
         &self,
         dataset_id: &DatasetID,
-        flow_type: DatasetFlowType,
+        filters: DatasetFlowFilters,
     ) -> FlowIDStream;
 
-    /// Returns the flows of certain type in reverse chronological order based
-    /// on creation time
-    fn get_system_flows_of_type(&self, flow_type: SystemFlowType) -> FlowIDStream<'_>;
+    /// Returns IDs of the system flows  in reverse chronological order based on
+    /// creation time
+    /// Applies filters, if specified///
+    fn get_all_system_flow_ids(&self, filters: SystemFlowFilters) -> FlowIDStream;
 
-    /// Returns the flows of any type associated with the specified dataset
-    /// in reverse chronological order based on creation time
-    fn get_all_flows_by_dataset(&self, dataset_id: &DatasetID) -> FlowIDStream;
-
-    /// Returns the flows of any type in reverse chronological order
+    /// Returns IDs of the flows of any type in reverse chronological order
     /// based on creation time
-    fn get_all_flows(&self) -> FlowIDStream<'_>;
+    fn get_all_flow_ids(&self) -> FlowIDStream<'_>;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Default, Debug)]
+pub struct DatasetFlowFilters {
+    pub by_flow_type: Option<DatasetFlowType>,
+    pub by_flow_status: Option<FlowStatus>,
+    pub by_initiator: Option<AccountName>, // TODO: replace on AccountID
+}
+
+#[derive(Default, Debug)]
+pub struct SystemFlowFilters {
+    pub by_flow_type: Option<SystemFlowType>,
+    pub by_flow_status: Option<FlowStatus>,
+    pub by_initiator: Option<AccountName>, // TODO: replace on AccountID
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/repos/flow/flow_event_store.rs
+++ b/src/domain/flow-system/src/repos/flow/flow_event_store.rs
@@ -34,7 +34,7 @@ pub trait FlowEventStore: EventStore<FlowState> {
     /// Applies filters/pagination, if specified
     fn get_all_flow_ids_by_dataset(
         &self,
-        dataset_id: DatasetID,
+        dataset_id: &DatasetID,
         filters: DatasetFlowFilters,
         pagination: FlowPaginationOpts,
     ) -> FlowIDStream;
@@ -70,7 +70,7 @@ pub trait FlowEventStore: EventStore<FlowState> {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct FlowPaginationOpts {
     pub offset: usize,
     pub limit: usize,

--- a/src/domain/flow-system/src/repos/flow/flow_event_store.rs
+++ b/src/domain/flow-system/src/repos/flow/flow_event_store.rs
@@ -54,14 +54,20 @@ pub trait FlowEventStore: EventStore<FlowState> {
 pub struct DatasetFlowFilters {
     pub by_flow_type: Option<DatasetFlowType>,
     pub by_flow_status: Option<FlowStatus>,
-    pub by_initiator: Option<AccountName>, // TODO: replace on AccountID
+    pub by_initiator: Option<InitiatorFilter>, // TODO: replace on AccountID
 }
 
 #[derive(Default, Debug)]
 pub struct SystemFlowFilters {
     pub by_flow_type: Option<SystemFlowType>,
     pub by_flow_status: Option<FlowStatus>,
-    pub by_initiator: Option<AccountName>, // TODO: replace on AccountID
+    pub by_initiator: Option<InitiatorFilter>,
+}
+
+#[derive(Debug)]
+pub enum InitiatorFilter {
+    System,
+    Account(AccountName), // TODO: replace on AccountID
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/repos/flow/flow_event_store.rs
+++ b/src/domain/flow-system/src/repos/flow/flow_event_store.rs
@@ -24,10 +24,13 @@ pub trait FlowEventStore: EventStore<FlowState> {
         &self,
         dataset_id: &DatasetID,
         flow_type: DatasetFlowType,
-    ) -> Option<FlowID>;
+    ) -> Result<Option<FlowID>, InternalError>;
 
     /// Returns ID of the last system flow of certain type
-    fn get_last_system_flow_id_of_type(&self, flow_type: SystemFlowType) -> Option<FlowID>;
+    fn get_last_system_flow_id_of_type(
+        &self,
+        flow_type: SystemFlowType,
+    ) -> Result<Option<FlowID>, InternalError>;
 
     /// Returns IDs of the flows associated with the specified
     /// dataset in reverse chronological order based on creation time.
@@ -45,7 +48,7 @@ pub trait FlowEventStore: EventStore<FlowState> {
         &self,
         dataset_id: &DatasetID,
         filters: &DatasetFlowFilters,
-    ) -> usize;
+    ) -> Result<usize, InternalError>;
 
     /// Returns IDs of the system flows  in reverse chronological order based on
     /// creation time
@@ -57,7 +60,10 @@ pub trait FlowEventStore: EventStore<FlowState> {
     ) -> FlowIDStream;
 
     /// Returns number of system flows matching filters, if specified
-    async fn get_count_system_flows(&self, filters: &SystemFlowFilters) -> usize;
+    async fn get_count_system_flows(
+        &self,
+        filters: &SystemFlowFilters,
+    ) -> Result<usize, InternalError>;
 
     /// Returns IDs of the flows of any type in reverse chronological order
     /// based on creation time
@@ -65,7 +71,7 @@ pub trait FlowEventStore: EventStore<FlowState> {
     fn get_all_flow_ids(&self, pagination: FlowPaginationOpts) -> FlowIDStream<'_>;
 
     /// Returns number of all flows
-    async fn get_count_all_flows(&self) -> usize;
+    async fn get_count_all_flows(&self) -> Result<usize, InternalError>;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/repos/flow/flow_event_store.rs
+++ b/src/domain/flow-system/src/repos/flow/flow_event_store.rs
@@ -41,11 +41,11 @@ pub trait FlowEventStore: EventStore<FlowState> {
 
     /// Returns number of flows associated with the specified dataset and
     /// matching filters, if specified
-    fn get_count_flows_by_dataset(
+    async fn get_count_flows_by_dataset(
         &self,
-        dataset_id: DatasetID,
-        filters: DatasetFlowFilters,
-    ) -> FlowIDCountFuture;
+        dataset_id: &DatasetID,
+        filters: &DatasetFlowFilters,
+    ) -> usize;
 
     /// Returns IDs of the system flows  in reverse chronological order based on
     /// creation time
@@ -57,22 +57,23 @@ pub trait FlowEventStore: EventStore<FlowState> {
     ) -> FlowIDStream;
 
     /// Returns number of system flows matching filters, if specified
-    fn get_count_system_flows(&self, filters: SystemFlowFilters) -> FlowIDCountFuture;
+    async fn get_count_system_flows(&self, filters: &SystemFlowFilters) -> usize;
 
     /// Returns IDs of the flows of any type in reverse chronological order
     /// based on creation time
-    /// TODO: not used yet, evaluate need in filters and pagination
-    fn get_all_flow_ids(&self) -> FlowIDStream<'_>;
+    /// TODO: not used yet, evaluate need in filters
+    fn get_all_flow_ids(&self, pagination: FlowPaginationOpts) -> FlowIDStream<'_>;
 
     /// Returns number of all flows
-    fn get_count_all_flows(&self) -> FlowIDCountFuture;
+    async fn get_count_all_flows(&self) -> usize;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+#[derive(Debug)]
 pub struct FlowPaginationOpts {
-    pub page: usize,
-    pub per_page: usize,
+    pub offset: usize,
+    pub limit: usize,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/src/domain/flow-system/src/repos/flow/flow_event_store.rs
+++ b/src/domain/flow-system/src/repos/flow/flow_event_store.rs
@@ -31,40 +31,65 @@ pub trait FlowEventStore: EventStore<FlowState> {
 
     /// Returns IDs of the flows associated with the specified
     /// dataset in reverse chronological order based on creation time.
-    /// Applies filters, if specified
+    /// Applies filters/pagination, if specified
     fn get_all_flow_ids_by_dataset(
         &self,
-        dataset_id: &DatasetID,
+        dataset_id: DatasetID,
         filters: DatasetFlowFilters,
+        pagination: FlowPaginationOpts,
     ) -> FlowIDStream;
+
+    /// Returns number of flows associated with the specified dataset and
+    /// matching filters, if specified
+    fn get_count_flows_by_dataset(
+        &self,
+        dataset_id: DatasetID,
+        filters: DatasetFlowFilters,
+    ) -> FlowIDCountFuture;
 
     /// Returns IDs of the system flows  in reverse chronological order based on
     /// creation time
-    /// Applies filters, if specified///
-    fn get_all_system_flow_ids(&self, filters: SystemFlowFilters) -> FlowIDStream;
+    /// Applies filters/pagination, if specified
+    fn get_all_system_flow_ids(
+        &self,
+        filters: SystemFlowFilters,
+        pagination: FlowPaginationOpts,
+    ) -> FlowIDStream;
+
+    /// Returns number of system flows matching filters, if specified
+    fn get_count_system_flows(&self, filters: SystemFlowFilters) -> FlowIDCountFuture;
 
     /// Returns IDs of the flows of any type in reverse chronological order
     /// based on creation time
+    /// TODO: not used yet, evaluate need in filters and pagination
     fn get_all_flow_ids(&self) -> FlowIDStream<'_>;
+
+    /// Returns number of all flows
+    fn get_count_all_flows(&self) -> FlowIDCountFuture;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Default, Debug)]
+pub struct FlowPaginationOpts {
+    pub page: usize,
+    pub per_page: usize,
+}
+
+#[derive(Default, Debug, Clone)]
 pub struct DatasetFlowFilters {
     pub by_flow_type: Option<DatasetFlowType>,
     pub by_flow_status: Option<FlowStatus>,
-    pub by_initiator: Option<InitiatorFilter>, // TODO: replace on AccountID
+    pub by_initiator: Option<InitiatorFilter>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct SystemFlowFilters {
     pub by_flow_type: Option<SystemFlowType>,
     pub by_flow_status: Option<FlowStatus>,
     pub by_initiator: Option<InitiatorFilter>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum InitiatorFilter {
     System,
     Account(AccountName), // TODO: replace on AccountID

--- a/src/domain/flow-system/src/services/flow/flow_service.rs
+++ b/src/domain/flow-system/src/services/flow/flow_service.rs
@@ -13,7 +13,7 @@ use internal_error::{ErrorIntoInternal, InternalError};
 use opendatafabric::{AccountID, AccountName, DatasetID};
 use tokio_stream::Stream;
 
-use crate::{DatasetFlowType, FlowID, FlowKey, FlowState, SystemFlowType};
+use crate::{DatasetFlowFilters, DatasetFlowType, FlowID, FlowKey, FlowState, SystemFlowFilters, SystemFlowType};
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -31,31 +31,26 @@ pub trait FlowService: Sync + Send {
         initiator_account_name: AccountName,
     ) -> Result<FlowState, RequestFlowError>;
 
-    /// Returns states of flows of certain type associated with a given dataset
-    /// ordered by creation time from newest to oldest
-    fn list_flows_by_dataset_of_type(
-        &self,
-        dataset_id: &DatasetID,
-        flow_type: DatasetFlowType,
-    ) -> Result<FlowStateStream, ListFlowsByDatasetError>;
-
-    /// Returns states of system flows of certain type
-    /// ordered by creation time from newest to oldest
-    fn list_system_flows_of_type(
-        &self,
-        flow_type: SystemFlowType,
-    ) -> Result<FlowStateStream, ListSystemFlowsError>;
-
-    /// Returns states of flows of any type associated with a given dataset
-    /// ordered by creation time from newest to oldest
+    /// Returns states of flows associated with a given dataset
+    /// ordered by creation time from newest to oldest.
+    /// Applies specified filters
     fn list_all_flows_by_dataset(
         &self,
         dataset_id: &DatasetID,
+        filters: DatasetFlowFilters,
     ) -> Result<FlowStateStream, ListFlowsByDatasetError>;
+
+    /// Returns states of system flows associated with a given dataset
+    /// ordered by creation time from newest to oldest.
+    /// Applies specified filters    
+    fn list_all_system_flows(
+        &self,
+        filters: SystemFlowFilters,
+    ) -> Result<FlowStateStream, ListSystemFlowsError>;
 
     /// Returns state of all flows, whether they are system-level or
     /// dataset-bound, ordered by creation time from newest to oldest
-    fn list_all_flows(&self) -> Result<FlowStateStream, ListSystemFlowsError>;
+    fn list_all_flows(&self) -> Result<FlowStateStream, ListFlowsError>;
 
     /// Returns state of the latest flow of certain type created for the given
     /// dataset
@@ -105,6 +100,13 @@ pub enum ListSystemFlowsError {
     #[error(transparent)]
     Internal(#[from] InternalError),
 }
+
+#[derive(thiserror::Error, Debug)]
+pub enum ListFlowsError {
+    #[error(transparent)]
+    Internal(#[from] InternalError),
+}
+
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetLastDatasetFlowError {

--- a/src/domain/task-system/src/repos/task_system_event_store.rs
+++ b/src/domain/task-system/src/repos/task_system_event_store.rs
@@ -19,12 +19,26 @@ pub trait TaskSystemEventStore: EventStore<TaskState> {
     /// Generates new unique task identifier
     fn new_task_id(&self) -> TaskID;
 
-    /// Returns the tasks associated with the specified dataset in reverse
-    /// chronological order based on creation time
-    fn get_tasks_by_dataset(&self, dataset_id: &DatasetID) -> TaskIDStream;
+    /// Returns page of the tasks associated with the specified dataset in
+    /// reverse chronological order based on creation time
+    fn get_tasks_by_dataset(
+        &self,
+        dataset_id: &DatasetID,
+        pagination: TaskPaginationOpts,
+    ) -> TaskIDStream;
+
+    /// Returns total number of tasks associated  with the specified dataset
+    async fn get_count_tasks_by_dataset(&self, dataset_id: &DatasetID) -> usize;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-pub type TaskIDStream<'a> =
-    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<TaskID, InternalError>> + Send + 'a>>;
+pub type TaskIDStream<'a> = std::pin::Pin<Box<dyn tokio_stream::Stream<Item = TaskID> + Send + 'a>>;
+
+#[derive(Debug)]
+pub struct TaskPaginationOpts {
+    pub offset: usize,
+    pub limit: usize,
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/task-system/src/services/task_scheduler.rs
+++ b/src/domain/task-system/src/services/task_scheduler.rs
@@ -21,13 +21,13 @@ pub trait TaskScheduler: Sync + Send {
     /// Creates a new task from provided logical plan
     async fn create_task(&self, plan: LogicalPlan) -> Result<TaskState, CreateTaskError>;
 
-    /// Returns states of tasks associated with a given dataset ordered by
-    /// creation time from newest to oldest
-    // TODO: reconsider performance impact
-    fn list_tasks_by_dataset(
+    /// Returns page of states of tasks associated with a given dataset ordered
+    /// by creation time from newest to oldest
+    async fn list_tasks_by_dataset(
         &self,
         dataset_id: &DatasetID,
-    ) -> Result<TaskStateStream, ListTasksByDatasetError>;
+        pagination: TaskPaginationOpts,
+    ) -> Result<TaskStateListing, ListTasksByDatasetError>;
 
     /// Returns current state of a given task
     async fn get_task(&self, task_id: TaskID) -> Result<TaskState, GetTaskError>;
@@ -47,6 +47,11 @@ pub trait TaskScheduler: Sync + Send {
 
 pub type TaskStateStream<'a> =
     std::pin::Pin<Box<dyn Stream<Item = Result<TaskState, InternalError>> + Send + 'a>>;
+
+pub struct TaskStateListing<'a> {
+    pub stream: TaskStateStream<'a>,
+    pub total_count: usize,
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////
 // Errors

--- a/src/infra/flow-system-inmem/src/repos/flow/flow_event_store_inmem.rs
+++ b/src/infra/flow-system-inmem/src/repos/flow/flow_event_store_inmem.rs
@@ -292,7 +292,7 @@ impl FlowEventStore for FlowEventStoreInMem {
     #[tracing::instrument(level = "debug", skip_all, fields(%dataset_id, ?filters, ?pagination))]
     fn get_all_flow_ids_by_dataset(
         &self,
-        dataset_id: DatasetID,
+        dataset_id: &DatasetID,
         filters: DatasetFlowFilters,
         pagination: FlowPaginationOpts,
     ) -> FlowIDStream {
@@ -300,7 +300,7 @@ impl FlowEventStore for FlowEventStoreInMem {
             let state = self.inner.as_state();
             let g = state.lock().unwrap();
             g.all_flows_by_dataset
-                .get(&dataset_id)
+                .get(dataset_id)
                 .map(|dataset_flow_ids| {
                     dataset_flow_ids
                         .iter()

--- a/src/infra/flow-system-inmem/src/services/flow/flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/src/services/flow/flow_service_inmem.rs
@@ -559,12 +559,12 @@ impl FlowService for FlowServiceInMemory {
             .get_count_flows_by_dataset(dataset_id, &filters)
             .await;
 
-        let dataset_id_clone = dataset_id.clone();
+        let dataset_id = dataset_id.clone();
 
         let matched_stream = Box::pin(async_stream::try_stream! {
             let relevant_flow_ids: Vec<_> = self
                 .flow_event_store
-                .get_all_flow_ids_by_dataset(dataset_id_clone, filters, pagination)
+                .get_all_flow_ids_by_dataset(&dataset_id, filters, pagination)
                 .collect()
                 .await;
 

--- a/src/infra/flow-system-inmem/src/services/flow/flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/src/services/flow/flow_service_inmem.rs
@@ -564,7 +564,6 @@ impl FlowService for FlowServiceInMemory {
 
             for flow_id in relevant_flow_ids {
                 let flow = Flow::load(flow_id, self.flow_event_store.as_ref()).await.int_err()?;
-
                 yield flow.into();
             }
         }))
@@ -587,7 +586,6 @@ impl FlowService for FlowServiceInMemory {
 
             for flow_id in relevant_flow_ids {
                 let flow = Flow::load(flow_id, self.flow_event_store.as_ref()).await.int_err()?;
-
                 yield flow.into();
             }
         }))
@@ -606,7 +604,6 @@ impl FlowService for FlowServiceInMemory {
 
             for flow_id in all_flows {
                 let flow = Flow::load(flow_id, self.flow_event_store.as_ref()).await.int_err()?;
-
                 yield flow.into();
             }
         }))

--- a/src/infra/flow-system-inmem/tests/tests/mod.rs
+++ b/src/infra/flow-system-inmem/tests/tests/mod.rs
@@ -8,4 +8,5 @@
 // by the Apache License, Version 2.0.
 
 mod test_flow_configuration_service_inmem;
+mod test_flow_event_store_inmem;
 mod test_flow_service_inmem;

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 
 use chrono::{Duration, Utc};
-use futures::StreamExt;
+use futures::TryStreamExt;
 use kamu_flow_system::*;
 use kamu_flow_system_inmem::FlowEventStoreInMem;
 use kamu_task_system::TaskSystemEventStore;
@@ -1034,13 +1034,15 @@ async fn assert_dataset_flow_expectaitons(
 ) {
     let total_flows_count = flow_event_store
         .get_count_flows_by_dataset(&dataset_test_case.dataset_id, &filters)
-        .await;
+        .await
+        .unwrap();
     assert_eq!(expected_total_count, total_flows_count);
 
     let flow_ids: Vec<_> = flow_event_store
         .get_all_flow_ids_by_dataset(&dataset_test_case.dataset_id, filters, pagination)
-        .collect()
-        .await;
+        .try_collect()
+        .await
+        .unwrap();
     assert_eq!(flow_ids, expected_flow_ids);
 }
 
@@ -1051,13 +1053,17 @@ async fn assert_system_flow_expectaitons(
     expected_total_count: usize,
     expected_flow_ids: Vec<FlowID>,
 ) {
-    let total_flows_count = flow_event_store.get_count_system_flows(&filters).await;
+    let total_flows_count = flow_event_store
+        .get_count_system_flows(&filters)
+        .await
+        .unwrap();
     assert_eq!(expected_total_count, total_flows_count);
 
     let flow_ids: Vec<_> = flow_event_store
         .get_all_system_flow_ids(filters, pagination)
-        .collect()
-        .await;
+        .try_collect()
+        .await
+        .unwrap();
     assert_eq!(flow_ids, expected_flow_ids);
 }
 

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
@@ -30,7 +30,7 @@ async fn test_dataset_flow_empty_filters_distingush_dataset() {
     let bar_cases =
         make_dataset_test_case(flow_event_store.clone(), task_event_store.clone()).await;
 
-    assert_flow_expectaitons(
+    assert_dataset_flow_expectaitons(
         flow_event_store.clone(),
         &foo_cases,
         always_happy_filters.clone(),
@@ -54,7 +54,7 @@ async fn test_dataset_flow_empty_filters_distingush_dataset() {
     )
     .await;
 
-    assert_flow_expectaitons(
+    assert_dataset_flow_expectaitons(
         flow_event_store.clone(),
         &bar_cases,
         always_happy_filters.clone(),
@@ -142,7 +142,7 @@ async fn test_dataset_flow_filter_by_status() {
     ];
 
     for (filters, expected_flow_ids) in cases {
-        assert_flow_expectaitons(
+        assert_dataset_flow_expectaitons(
             flow_event_store.clone(),
             &foo_cases,
             filters,
@@ -203,7 +203,7 @@ async fn test_dataset_flow_filter_by_flow_type() {
     ];
 
     for (filters, expected_flow_ids) in cases {
-        assert_flow_expectaitons(
+        assert_dataset_flow_expectaitons(
             flow_event_store.clone(),
             &foo_cases,
             filters,
@@ -269,7 +269,7 @@ async fn test_dataset_flow_filter_by_initiator() {
     ];
 
     for (filters, expected_flow_ids) in cases {
-        assert_flow_expectaitons(
+        assert_dataset_flow_expectaitons(
             flow_event_store.clone(),
             &foo_cases,
             filters,
@@ -323,7 +323,7 @@ async fn test_dataset_flow_filter_combinations() {
     ];
 
     for (filters, expected_flow_ids) in cases {
-        assert_flow_expectaitons(
+        assert_dataset_flow_expectaitons(
             flow_event_store.clone(),
             &foo_cases,
             filters,
@@ -397,7 +397,7 @@ async fn test_dataset_flow_pagination() {
     ];
 
     for (pagination, expected_flow_ids) in cases {
-        assert_flow_expectaitons(
+        assert_dataset_flow_expectaitons(
             flow_event_store.clone(),
             &foo_cases,
             Default::default(),
@@ -476,9 +476,367 @@ async fn test_dataset_flow_pagination_with_filters() {
     ];
 
     for (pagination, filters, expected_total_count, expected_flow_ids) in cases {
-        assert_flow_expectaitons(
+        assert_dataset_flow_expectaitons(
             flow_event_store.clone(),
             &foo_cases,
+            filters,
+            pagination,
+            expected_total_count,
+            expected_flow_ids,
+        )
+        .await;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_unfiltered_system_flows() {
+    let (flow_event_store, task_event_store) = make_event_stores();
+
+    let system_case =
+        make_system_test_case(flow_event_store.clone(), task_event_store.clone()).await;
+
+    assert_system_flow_expectaitons(
+        flow_event_store.clone(),
+        SystemFlowFilters::default(),
+        FlowPaginationOpts {
+            offset: 0,
+            limit: 100,
+        },
+        5,
+        vec![
+            system_case.gc_flow_ids.flow_id_finished,
+            system_case.gc_flow_ids.flow_id_running,
+            system_case.gc_flow_ids.flow_id_scheduled,
+            system_case.gc_flow_ids.flow_id_queued,
+            system_case.gc_flow_ids.flow_id_waiting,
+        ],
+    )
+    .await;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_system_flows_filtered_by_flow_type() {
+    let (flow_event_store, task_event_store) = make_event_stores();
+
+    let system_case =
+        make_system_test_case(flow_event_store.clone(), task_event_store.clone()).await;
+
+    let cases = vec![(
+        SystemFlowFilters {
+            by_flow_type: Some(SystemFlowType::GC),
+            ..Default::default()
+        },
+        vec![
+            system_case.gc_flow_ids.flow_id_finished,
+            system_case.gc_flow_ids.flow_id_running,
+            system_case.gc_flow_ids.flow_id_scheduled,
+            system_case.gc_flow_ids.flow_id_queued,
+            system_case.gc_flow_ids.flow_id_waiting,
+        ],
+    )];
+
+    for (filters, expected_flow_ids) in cases {
+        assert_system_flow_expectaitons(
+            flow_event_store.clone(),
+            filters,
+            FlowPaginationOpts {
+                offset: 0,
+                limit: 100,
+            },
+            expected_flow_ids.len(),
+            expected_flow_ids,
+        )
+        .await;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_system_flows_filtered_by_flow_status() {
+    let (flow_event_store, task_event_store) = make_event_stores();
+
+    let system_case =
+        make_system_test_case(flow_event_store.clone(), task_event_store.clone()).await;
+
+    let cases = vec![
+        (
+            SystemFlowFilters {
+                by_flow_status: Some(FlowStatus::Queued),
+                ..Default::default()
+            },
+            vec![system_case.gc_flow_ids.flow_id_queued],
+        ),
+        (
+            SystemFlowFilters {
+                by_flow_status: Some(FlowStatus::Finished),
+                ..Default::default()
+            },
+            vec![system_case.gc_flow_ids.flow_id_finished],
+        ),
+    ];
+
+    for (filters, expected_flow_ids) in cases {
+        assert_system_flow_expectaitons(
+            flow_event_store.clone(),
+            filters,
+            FlowPaginationOpts {
+                offset: 0,
+                limit: 100,
+            },
+            expected_flow_ids.len(),
+            expected_flow_ids,
+        )
+        .await;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_system_flows_filtered_by_initiator() {
+    let (flow_event_store, task_event_store) = make_event_stores();
+
+    let system_case =
+        make_system_test_case(flow_event_store.clone(), task_event_store.clone()).await;
+
+    let cases = vec![
+        (
+            SystemFlowFilters {
+                by_initiator: Some(InitiatorFilter::System),
+                ..Default::default()
+            },
+            vec![
+                system_case.gc_flow_ids.flow_id_finished,
+                system_case.gc_flow_ids.flow_id_running,
+            ],
+        ),
+        (
+            SystemFlowFilters {
+                by_initiator: Some(InitiatorFilter::Account(AccountName::new_unchecked(
+                    "wasya",
+                ))),
+                ..Default::default()
+            },
+            vec![
+                system_case.gc_flow_ids.flow_id_queued,
+                system_case.gc_flow_ids.flow_id_waiting,
+            ],
+        ),
+        (
+            SystemFlowFilters {
+                by_initiator: Some(InitiatorFilter::Account(AccountName::new_unchecked(
+                    "unrelated-user",
+                ))),
+                ..Default::default()
+            },
+            vec![],
+        ),
+    ];
+
+    for (filters, expected_flow_ids) in cases {
+        assert_system_flow_expectaitons(
+            flow_event_store.clone(),
+            filters,
+            FlowPaginationOpts {
+                offset: 0,
+                limit: 100,
+            },
+            expected_flow_ids.len(),
+            expected_flow_ids,
+        )
+        .await;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_system_flows_complex_filter() {
+    let (flow_event_store, task_event_store) = make_event_stores();
+
+    let system_case =
+        make_system_test_case(flow_event_store.clone(), task_event_store.clone()).await;
+
+    let cases = vec![
+        (
+            SystemFlowFilters {
+                by_flow_status: Some(FlowStatus::Finished),
+                by_initiator: Some(InitiatorFilter::System),
+                by_flow_type: Some(SystemFlowType::GC),
+            },
+            vec![system_case.gc_flow_ids.flow_id_finished],
+        ),
+        (
+            SystemFlowFilters {
+                by_initiator: Some(InitiatorFilter::Account(AccountName::new_unchecked(
+                    "wasya",
+                ))),
+                by_flow_status: Some(FlowStatus::Waiting),
+                by_flow_type: None,
+            },
+            vec![system_case.gc_flow_ids.flow_id_waiting],
+        ),
+        (
+            SystemFlowFilters {
+                by_flow_status: Some(FlowStatus::Queued),
+                by_initiator: Some(InitiatorFilter::System),
+                by_flow_type: Some(SystemFlowType::GC),
+            },
+            vec![],
+        ),
+    ];
+
+    for (filters, expected_flow_ids) in cases {
+        assert_system_flow_expectaitons(
+            flow_event_store.clone(),
+            filters,
+            FlowPaginationOpts {
+                offset: 0,
+                limit: 100,
+            },
+            expected_flow_ids.len(),
+            expected_flow_ids,
+        )
+        .await;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_system_flow_pagination() {
+    let (flow_event_store, task_event_store) = make_event_stores();
+
+    let system_case =
+        make_system_test_case(flow_event_store.clone(), task_event_store.clone()).await;
+
+    let cases = vec![
+        (
+            FlowPaginationOpts {
+                offset: 0,
+                limit: 2,
+            },
+            vec![
+                system_case.gc_flow_ids.flow_id_finished,
+                system_case.gc_flow_ids.flow_id_running,
+            ],
+        ),
+        (
+            FlowPaginationOpts {
+                offset: 2,
+                limit: 1,
+            },
+            vec![system_case.gc_flow_ids.flow_id_scheduled],
+        ),
+        (
+            FlowPaginationOpts {
+                offset: 3,
+                limit: 2,
+            },
+            vec![
+                system_case.gc_flow_ids.flow_id_queued,
+                system_case.gc_flow_ids.flow_id_waiting,
+            ],
+        ),
+        (
+            FlowPaginationOpts {
+                offset: 4,
+                limit: 2,
+            },
+            vec![system_case.gc_flow_ids.flow_id_waiting],
+        ),
+        (
+            FlowPaginationOpts {
+                offset: 5,
+                limit: 5,
+            },
+            vec![],
+        ),
+    ];
+
+    for (pagination, expected_flow_ids) in cases {
+        assert_system_flow_expectaitons(
+            flow_event_store.clone(),
+            Default::default(),
+            pagination,
+            5,
+            expected_flow_ids,
+        )
+        .await;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_system_flow_pagination_with_filters() {
+    let (flow_event_store, task_event_store) = make_event_stores();
+
+    let system_case =
+        make_system_test_case(flow_event_store.clone(), task_event_store.clone()).await;
+
+    let cases = vec![
+        (
+            FlowPaginationOpts {
+                offset: 0,
+                limit: 2,
+            },
+            SystemFlowFilters {
+                by_flow_type: Some(SystemFlowType::GC),
+                ..Default::default()
+            },
+            5,
+            vec![
+                system_case.gc_flow_ids.flow_id_finished,
+                system_case.gc_flow_ids.flow_id_running,
+            ],
+        ),
+        (
+            FlowPaginationOpts {
+                offset: 0,
+                limit: 2,
+            },
+            SystemFlowFilters {
+                by_flow_status: Some(FlowStatus::Queued),
+                ..Default::default()
+            },
+            1,
+            vec![system_case.gc_flow_ids.flow_id_queued],
+        ),
+        (
+            FlowPaginationOpts {
+                offset: 1,
+                limit: 2,
+            },
+            SystemFlowFilters {
+                by_initiator: Some(InitiatorFilter::System),
+                ..Default::default()
+            },
+            2,
+            vec![system_case.gc_flow_ids.flow_id_running],
+        ),
+        (
+            FlowPaginationOpts {
+                offset: 1,
+                limit: 5,
+            },
+            SystemFlowFilters {
+                by_flow_status: Some(FlowStatus::Scheduled),
+                ..Default::default()
+            },
+            1,
+            vec![],
+        ),
+    ];
+
+    for (pagination, filters, expected_total_count, expected_flow_ids) in cases {
+        assert_system_flow_expectaitons(
+            flow_event_store.clone(),
             filters,
             pagination,
             expected_total_count,
@@ -503,6 +861,10 @@ struct DatasetTestCase {
     dataset_id: DatasetID,
     ingest_flow_ids: TestFlowIDs,
     compacting_flow_ids: TestFlowIDs,
+}
+
+struct SystemTestCase {
+    gc_flow_ids: TestFlowIDs,
 }
 
 struct TestFlowIDs {
@@ -535,6 +897,16 @@ async fn make_dataset_test_case(
             task_event_store,
         )
         .await,
+    }
+}
+
+async fn make_system_test_case(
+    flow_event_store: Arc<dyn FlowEventStore>,
+    task_event_store: Arc<dyn TaskSystemEventStore>,
+) -> SystemTestCase {
+    SystemTestCase {
+        gc_flow_ids: make_system_test_flows(SystemFlowType::GC, flow_event_store, task_event_store)
+            .await,
     }
 }
 
@@ -596,7 +968,63 @@ async fn make_dataset_test_flows(
     }
 }
 
-async fn assert_flow_expectaitons(
+async fn make_system_test_flows(
+    system_flow_type: SystemFlowType,
+    flow_event_store: Arc<dyn FlowEventStore>,
+    task_event_store: Arc<dyn TaskSystemEventStore>,
+) -> TestFlowIDs {
+    let flow_generator = SystemFlowGenerator::new(flow_event_store.clone(), task_event_store);
+
+    let wasya_manual_trigger = FlowTrigger::Manual(FlowTriggerManual {
+        initiator_account_id: FAKE_ACCOUNT_ID.to_string(),
+        initiator_account_name: AccountName::new_unchecked("wasya"),
+    });
+
+    let petya_manual_trigger = FlowTrigger::Manual(FlowTriggerManual {
+        initiator_account_id: FAKE_ACCOUNT_ID.to_string(),
+        initiator_account_name: AccountName::new_unchecked("petya"),
+    });
+
+    let automatic_trigger = FlowTrigger::AutoPolling(FlowTriggerAutoPolling {});
+
+    let flow_id_waiting = flow_generator
+        .make_new_flow(
+            system_flow_type,
+            FlowStatus::Waiting,
+            wasya_manual_trigger.clone(),
+        )
+        .await;
+    let flow_id_queued = flow_generator
+        .make_new_flow(system_flow_type, FlowStatus::Queued, wasya_manual_trigger)
+        .await;
+    let flow_id_scheduled = flow_generator
+        .make_new_flow(
+            system_flow_type,
+            FlowStatus::Scheduled,
+            petya_manual_trigger.clone(),
+        )
+        .await;
+    let flow_id_running = flow_generator
+        .make_new_flow(
+            system_flow_type,
+            FlowStatus::Running,
+            automatic_trigger.clone(),
+        )
+        .await;
+    let flow_id_finished = flow_generator
+        .make_new_flow(system_flow_type, FlowStatus::Finished, automatic_trigger)
+        .await;
+
+    TestFlowIDs {
+        flow_id_waiting,
+        flow_id_queued,
+        flow_id_scheduled,
+        flow_id_running,
+        flow_id_finished,
+    }
+}
+
+async fn assert_dataset_flow_expectaitons(
     flow_event_store: Arc<dyn FlowEventStore>,
     dataset_test_case: &DatasetTestCase,
     filters: DatasetFlowFilters,
@@ -611,6 +1039,23 @@ async fn assert_flow_expectaitons(
 
     let flow_ids: Vec<_> = flow_event_store
         .get_all_flow_ids_by_dataset(&dataset_test_case.dataset_id, filters, pagination)
+        .collect()
+        .await;
+    assert_eq!(flow_ids, expected_flow_ids);
+}
+
+async fn assert_system_flow_expectaitons(
+    flow_event_store: Arc<dyn FlowEventStore>,
+    filters: SystemFlowFilters,
+    pagination: FlowPaginationOpts,
+    expected_total_count: usize,
+    expected_flow_ids: Vec<FlowID>,
+) {
+    let total_flows_count = flow_event_store.get_count_system_flows(&filters).await;
+    assert_eq!(expected_total_count, total_flows_count);
+
+    let flow_ids: Vec<_> = flow_event_store
+        .get_all_system_flow_ids(filters, pagination)
         .collect()
         .await;
     assert_eq!(flow_ids, expected_flow_ids);
@@ -658,39 +1103,94 @@ impl<'a> DatasetFlowGenerator<'a> {
             initial_trigger,
         );
 
-        if expected_status != FlowStatus::Waiting {
-            flow.activate_at_time(
-                creation_moment + Duration::seconds(1),
-                creation_moment + Duration::minutes(1),
-            )
-            .unwrap();
-
-            if expected_status != FlowStatus::Queued {
-                let task_id = self.task_event_store.new_task_id();
-                flow.on_task_scheduled(creation_moment + Duration::minutes(5), task_id)
-                    .unwrap();
-
-                if expected_status != FlowStatus::Scheduled {
-                    flow.on_task_running(creation_moment + Duration::minutes(7), task_id)
-                        .unwrap();
-
-                    if expected_status == FlowStatus::Finished {
-                        flow.on_task_finished(
-                            creation_moment + Duration::minutes(10),
-                            task_id,
-                            kamu_task_system::TaskOutcome::Success,
-                        )
-                        .unwrap();
-                    } else if expected_status != FlowStatus::Running {
-                        panic!("Not expecting flow status {expected_status:?}");
-                    }
-                }
-            }
-        }
+        drive_flow_to_status(&mut flow, self.task_event_store.as_ref(), expected_status);
 
         flow.save(self.flow_event_store.as_ref()).await.unwrap();
 
         flow_id
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+struct SystemFlowGenerator {
+    flow_event_store: Arc<dyn FlowEventStore>,
+    task_event_store: Arc<dyn TaskSystemEventStore>,
+}
+
+impl SystemFlowGenerator {
+    fn new(
+        flow_event_store: Arc<dyn FlowEventStore>,
+        task_event_store: Arc<dyn TaskSystemEventStore>,
+    ) -> Self {
+        Self {
+            flow_event_store,
+            task_event_store,
+        }
+    }
+
+    async fn make_new_flow(
+        &self,
+        flow_type: SystemFlowType,
+        expected_status: FlowStatus,
+        initial_trigger: FlowTrigger,
+    ) -> FlowID {
+        let flow_id = self.flow_event_store.new_flow_id();
+
+        let creation_moment = Utc::now();
+
+        let mut flow = Flow::new(
+            creation_moment,
+            flow_id,
+            FlowKey::System(FlowKeySystem { flow_type }),
+            initial_trigger,
+        );
+
+        drive_flow_to_status(&mut flow, self.task_event_store.as_ref(), expected_status);
+
+        flow.save(self.flow_event_store.as_ref()).await.unwrap();
+
+        flow_id
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+fn drive_flow_to_status(
+    flow: &mut Flow,
+    task_event_store: &dyn TaskSystemEventStore,
+    expected_status: FlowStatus,
+) {
+    let start_moment = Utc::now();
+
+    if expected_status != FlowStatus::Waiting {
+        flow.activate_at_time(
+            start_moment + Duration::seconds(1),
+            start_moment + Duration::minutes(1),
+        )
+        .unwrap();
+
+        if expected_status != FlowStatus::Queued {
+            let task_id = task_event_store.new_task_id();
+            flow.on_task_scheduled(start_moment + Duration::minutes(5), task_id)
+                .unwrap();
+
+            if expected_status != FlowStatus::Scheduled {
+                flow.on_task_running(start_moment + Duration::minutes(7), task_id)
+                    .unwrap();
+
+                if expected_status == FlowStatus::Finished {
+                    flow.on_task_finished(
+                        start_moment + Duration::minutes(10),
+                        task_id,
+                        kamu_task_system::TaskOutcome::Success,
+                    )
+                    .unwrap();
+                } else if expected_status != FlowStatus::Running {
+                    panic!("Not expecting flow status {expected_status:?}");
+                }
+            }
+        }
     }
 }
 

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -1049,6 +1049,7 @@ impl TestFlowSystemListener {
             .flow_service
             .list_all_flows()
             .unwrap()
+            .matched_stream
             .try_collect()
             .await
             .unwrap();

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -1047,7 +1047,11 @@ impl TestFlowSystemListener {
         use futures::TryStreamExt;
         let flows: Vec<_> = self
             .flow_service
-            .list_all_flows()
+            .list_all_flows(FlowPaginationOpts {
+                limit: 100,
+                offset: 0,
+            })
+            .await
             .unwrap()
             .matched_stream
             .try_collect()

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -605,6 +605,8 @@ async fn test_cron_task_completions_trigger_next_loop_on_success() {
     ]);
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////
+
 #[test_log::test(tokio::test)]
 async fn test_task_completions_trigger_next_loop_on_success() {
     let harness = FlowHarness::new();

--- a/src/infra/task-system-inmem/tests/tests/test_event_store_inmem.rs
+++ b/src/infra/task-system-inmem/tests/tests/test_event_store_inmem.rs
@@ -25,11 +25,18 @@ async fn test_event_store_empty() {
 
     assert_eq!(events, []);
 
+    use futures::StreamExt;
+
     let tasks: Vec<_> = event_store
-        .get_tasks_by_dataset(&DatasetID::new_seeded_ed25519(b"foo"))
-        .try_collect()
-        .await
-        .unwrap();
+        .get_tasks_by_dataset(
+            &DatasetID::new_seeded_ed25519(b"foo"),
+            TaskPaginationOpts {
+                limit: 100,
+                offset: 0,
+            },
+        )
+        .collect()
+        .await;
 
     assert_eq!(tasks, []);
 }
@@ -89,11 +96,18 @@ async fn test_event_store_get_streams() {
 
     assert_eq!(&events[..], [event_1.into(), event_3.into()]);
 
+    use futures::StreamExt;
+
     let tasks: Vec<_> = event_store
-        .get_tasks_by_dataset(&dataset_id)
-        .try_collect()
-        .await
-        .unwrap();
+        .get_tasks_by_dataset(
+            &dataset_id,
+            TaskPaginationOpts {
+                limit: 100,
+                offset: 0,
+            },
+        )
+        .collect()
+        .await;
 
     // Ensure reverse chronological order
     assert_eq!(&tasks[..], [task_id_2, task_id_1]);


### PR DESCRIPTION
## Description

Closes: #476 

Server-side filtering of flows.

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
