### PR TITLE
clippy: fix "pedantic::large_enum_variant" warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,6 @@ publish = false
 #      https://github.com/kamu-data/kamu-cli/issues/332
 new_without_default = "allow"
 too_many_arguments = "allow"
-large_enum_variant = "allow"
 module_inception = "allow"
 
 # clippy::pedantic

--- a/src/domain/core/src/services/verification_service.rs
+++ b/src/domain/core/src/services/verification_service.rs
@@ -336,8 +336,8 @@ impl Display for DataDoesNotMatchMetadata {
 #[derive(Error, Debug)]
 pub struct DataNotReproducible {
     pub block_hash: Multihash,
-    pub expected_event: MetadataEvent,
-    pub actual_event: MetadataEvent,
+    pub expected_event: Box<MetadataEvent>,
+    pub actual_event: Box<MetadataEvent>,
 }
 
 impl Display for DataNotReproducible {

--- a/src/infra/core/src/transform_service_impl.rs
+++ b/src/infra/core/src/transform_service_impl.rs
@@ -902,8 +902,8 @@ impl TransformService for TransformServiceImpl {
 
                 let err = VerificationError::DataNotReproducible(DataNotReproducible {
                     block_hash,
-                    expected_event: expected_event.into(),
-                    actual_event: actual_event.into(),
+                    expected_event: Box::new(expected_event.into()),
+                    actual_event: Box::new(actual_event.into()),
                 });
                 listener.error(&err);
                 return Err(err);


### PR DESCRIPTION
## Description

Related issue: https://github.com/kamu-data/kamu-cli/issues/332

<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
