### PR TITLE
Add arm64 targets to tests and release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,74 +47,79 @@ jobs:
       - run: cargo install cargo-deny
       - run: cargo deny check
 
-  test_linux:
-    name: Test / Linux
-    runs-on: ubuntu-latest
-    env:
-      CARGO_FLAGS: --profile ci --features ftp
-      NEXTEST_FLAGS: --cargo-profile ci --features ftp
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux / amd64
+            runs-on: ubuntu-latest
+            cargo-flags: --profile ci --features ftp
+            nextest-flags: --cargo-profile ci --features ftp
+            container-runtime: podman
+            ipfs: true
+          # TODO: Not running docker as it takes ~7 minutes to install
+          # See: https://github.com/actions/runner/issues/1456
+          - name: MacOS / amd64
+            runs-on: macos-13
+            cargo-flags: --profile ci --features ftp
+            nextest-flags: --cargo-profile ci --features ftp -E '!test(::containerized::)'
+            container-runtime: ''
+            ipfs: false
+          # TODO: M1 cannot run docker due to lack of nested virtualization
+          # See: https://github.com/marketplace/actions/setup-docker-on-macos#arm64-processors-m1-m2-m3-series-used-on-macos-14-images-are-unsupported
+          - name: MacOS / arm64
+            runs-on: macos-14
+            cargo-flags: --profile ci
+            nextest-flags: --cargo-profile ci -E '!test(::containerized::)'
+            container-runtime: ''
+            ipfs: false
+          # TODO: DataFusion tests are temporarily disabled
+          # See: https://github.com/kamu-data/kamu-cli/issues/226
+          - name: Windows / amd64
+            runs-on: windows-latest
+            cargo-flags: --profile ci
+            nextest-flags: --cargo-profile ci -E 'not (test(::containerized::) | test(::datafusion::))'
+            container-runtime: ''
+            ipfs: false
+    name: Test / ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: ibnesayeed/setup-ipfs@master
+      - name: Setup IPFS
+        uses: ibnesayeed/setup-ipfs@master
+        if: matrix.ipfs
         with:
           ipfs_version: "0.19"
+
       - uses: actions/checkout@v4
+
       - uses: actions-rs/toolchain@v1
+
       - uses: swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+
       - name: Install cargo tools
         run: |
           cargo install --locked cargo-nextest
-      - name: Configure podman runtime
+
+      - name: Configure runtime
+        if: matrix.container-runtime != ''
         run: |
-          echo '{ "kind": "CLIConfig", "version": 1, "content": {"engine": { "runtime": "podman" } } }' > ~/.kamuconfig
-      - name: build
-        run: cargo test ${{ env.CARGO_FLAGS }} --no-run
-      - name: pull test images
-        run: cargo nextest run ${{ env.NEXTEST_FLAGS }} -E 'test(::setup::)' --no-capture
-      - name: run tests
-        run: cargo nextest run ${{ env.NEXTEST_FLAGS }}
-      - name: check git diff # Ensures all generated files are up-to-date
+          echo '{ "kind": "CLIConfig", "version": 1, "content": {"engine": { "runtime": "${{ matrix.container-runtime }}" } } }' > ~/.kamuconfig
+          echo "KAMU_CONTAINER_RUNTIME_TYPE=${{ matrix.container-runtime }}" >> $GITHUB_ENV
+
+      - name: Build
+        run: cargo test ${{ matrix.cargo-flags }} --no-run
+
+      - name: Pull test images
+        if: matrix.container-runtime != ''
+        run: cargo nextest run ${{ matrix.nextest-flags }} -E 'test(::setup::)' --no-capture
+
+      - name: Run tests
+        run: cargo nextest run ${{ matrix.nextest-flags }}
+
+      # Not running on windows due to line ending differences
+      - name: Check generated files
+        if: "!contains(matrix.runs-on, 'windows')"
         run: git diff && git diff-index --quiet HEAD
-
-  test_macos:
-    name: Test / MacOS
-    runs-on: macos-latest
-    env:
-      CARGO_FLAGS: --profile ci
-      NEXTEST_FLAGS: --cargo-profile ci -E '!test(::containerized::)'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-      - uses: swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - name: Install cargo tools
-        run: |
-          cargo install --locked cargo-nextest
-      - name: build
-        run: cargo test ${{ env.CARGO_FLAGS }} --no-run
-      - name: run tests
-        run: cargo nextest run ${{ env.NEXTEST_FLAGS }}
-
-  test_windows:
-    name: Test / Windows
-    runs-on: windows-latest
-    env:
-      CARGO_FLAGS: --profile ci
-      # TODO: FIXME: DataFusion tests are temporarily disabled
-      # See: https://github.com/kamu-data/kamu-cli/issues/226
-      NEXTEST_FLAGS: --cargo-profile ci -E 'not (test(::containerized::) | test(::datafusion::))'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-      - uses: swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - name: Install cargo tools
-        run: |
-          cargo install --locked cargo-nextest
-      - name: build
-        run: cargo test ${{ env.CARGO_FLAGS }} --no-run
-      - name: run tests
-        run: cargo nextest run ${{ env.NEXTEST_FLAGS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,105 +8,113 @@ env:
   BINARY_NAME: kamu
   KAMU_WEB_UI_VERSION: "0.15.0"
 jobs:
-  build_linux:
-    name: Build / Linux
-    runs-on: ubuntu-latest
+  build:
     strategy:
+      fail-fast: true
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
+        include:
+          # Keep in sync with artifact upload matrix below
+          #
+          # TODO: Add minimal targets that are stripped and do not embed WebUI
+          - name: Linux / amd64 / glibc
+            runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            use-cross: true
+            features: ftp,web-ui
+          - name: Linux / amd64 / musl
+            runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            use-cross: true
+            features: ftp,web-ui
+          - name: Linux / arm64 / glibc
+            runs-on: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
+            features: ftp,web-ui
+          - name: Linux / arm64 / musl
+            runs-on: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            use-cross: true
+            features: ftp,web-ui
+          - name: MacOS / amd64
+            runs-on: macos-13
+            target: x86_64-apple-darwin
+            use-cross: false
+            features: ftp,web-ui
+          - name: MacOS / arm64
+            runs-on: macos-14
+            target: aarch64-apple-darwin
+            use-cross: false
+            features: ftp,web-ui
+          - name: Windows / amd64
+            runs-on: windows-latest
+            target: x86_64-pc-windows-msvc
+            use-cross: false
+            features: ftp
+            binary-ext: '.exe'
+    name: Build (${{ matrix.name }})
+    runs-on: ${{ matrix.runs-on }}
+    env:
+      # This will be replaced with `cross` for cross-compilation targets
+      CARGO: cargo
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
         with:
           target: ${{ matrix.target }}
           override: true
+
       - name: Install cross
-        run: cargo install cross --locked
-      - name: Fetch web UI artifacts # TODO: Add target without UI
+        if: matrix.use-cross
+        shell: bash
         run: |
-          wget https://github.com/kamu-data/kamu-web-ui/releases/download/v${{ env.KAMU_WEB_UI_VERSION }}/kamu-web-ui-any.tar.gz && \
-          tar -xf kamu-web-ui-any.tar.gz
-      - name: Build
-        run: >-
-          KAMU_WEB_UI_DIR=../../../kamu-web-ui-any
-          cross build
-          -p kamu-cli
-          --release
-          --target=${{ matrix.target }}
-          --features ftp,web-ui
-      - name: Rename binary
-        run: mv target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }} target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
-          if-no-files-found: error
-  build_macos:
-    name: Build / MacOS
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-apple-darwin
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-      - name: Fetch web UI artifacts # TODO: Add target without UI
+          cargo install cross --locked
+          echo "CARGO=cross" >> $GITHUB_ENV
+
+      - name: Fetch web UI artifacts
+        if: contains(matrix.features, 'web-ui')
+        shell: bash
         run: |
-          wget https://github.com/kamu-data/kamu-web-ui/releases/download/v${{ env.KAMU_WEB_UI_VERSION }}/kamu-web-ui-any.tar.gz && \
+          wget https://github.com/kamu-data/kamu-web-ui/releases/download/v${{ env.KAMU_WEB_UI_VERSION }}/kamu-web-ui-any.tar.gz
           tar -xf kamu-web-ui-any.tar.gz
+          echo "KAMU_WEB_UI_DIR=../../../kamu-web-ui-any" >> $GITHUB_ENV
+
       - name: Build
-        run: >-
-          KAMU_WEB_UI_DIR=../../../kamu-web-ui-any
-          cargo build
-          -p kamu-cli
-          --release
-          --target=${{ matrix.target }}
-          --features ftp,web-ui
-      - name: Rename binary
-        run: mv target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }} target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
-          if-no-files-found: error
-  build_windows:
-    name: Build / Windows
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-pc-windows-msvc
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1 # Uses rust-toolchain file
-      - name: Build
-        run: >-
-          cargo build
-          -p kamu-cli
-          --release
-          --target=${{ matrix.target }}
-          --features ftp
+        shell: bash
+        run: |
+          ${{ env.CARGO }} build \
+            -p kamu-cli \
+            --release \
+            --target=${{ matrix.target }} \
+            --features=${{ matrix.features }}
+
       - name: Rename binary
         shell: bash
-        run: mv target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }}.exe target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe
+        run: |
+          mv \
+            target/${{ matrix.target }}/release/${{ env.PACKAGE_NAME }}${{ matrix.binary-ext }} \
+            target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}${{ matrix.binary-ext }}
+
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe
+          path: target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}${{ matrix.binary-ext }}
           if-no-files-found: error
+  
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build_linux, build_macos, build_windows]
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
+
       # Sets the header for the release description
       - run: echo "" > RELEASE_HEAD.md
+
       # Extracts relevant section from CHANGELOG.md and outputs it into RELEASE.md
       - uses: CSchoel/release-notes-from-changelog@v1
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -120,55 +128,63 @@ jobs:
           body_path: RELEASE.md
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
-  upload_assets_targz:
-    name: Upload Assets (tar.gz)
+  
+  upload_assets:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            format: tar.gz
+            media-type: application/gzip
+          - target: x86_64-unknown-linux-musl
+            format: tar.gz
+            media-type: application/gzip
+          - target: aarch64-unknown-linux-gnu
+            format: tar.gz
+            media-type: application/gzip
+          - target: aarch64-unknown-linux-musl
+            format: tar.gz
+            media-type: application/gzip
+          - target: x86_64-apple-darwin
+            format: tar.gz
+            media-type: application/gzip
+          - target: aarch64-apple-darwin
+            format: tar.gz
+            media-type: application/gzip
+          - target: x86_64-pc-windows-msvc
+            format: zip
+            media-type: application/zip
+    name: Upload Assets (${{ matrix.target }})
     runs-on: ubuntu-latest
     needs: [create_release]
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - x86_64-apple-darwin
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
           path: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
-      - name: Compress Artifacts
-        run: tar -czvf ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.tar.gz ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
+
+      - name: Archive (tar.gz)
+        if: matrix.format == 'tar.gz'
+        run: |
+          tar -czvf \
+            ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.tar.gz \
+            ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
+
+      - name: Archive (zip)
+        if: matrix.format == 'zip'
+        run: |
+          zip -r \
+            ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.zip \
+            ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
+
       - name: Upload Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.tar.gz
-          asset_name: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.tar.gz
-          asset_content_type: application/gzip
-  upload_assets_zip:
-    name: Upload Assets (zip)
-    runs-on: ubuntu-latest
-    needs: [create_release]
-    strategy:
-      matrix:
-        target:
-          - x86_64-pc-windows-msvc
-    steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
-          path: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
-      - name: Compress Artifacts
-        run: zip -r ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.zip ${{ env.PACKAGE_NAME }}-${{ matrix.target }}
-      - name: Upload Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.zip
-          asset_name: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.zip
-          asset_content_type: application/gzip
+          asset_path: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.${{ matrix.format }}
+          asset_name: ${{ env.PACKAGE_NAME }}-${{ matrix.target }}.${{ matrix.format }}
+          asset_content_type: ${{ matrix.media-type }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.156.3] - 2024-02-09
+### Added
+- Native support for `arm64` architecture (including M-series Apple silicon) in `kamu-cli` and `kamu-engine-datafusion`
+  - Note: Flink and Spark engine images still don't provide `arm64` architecture and continue to require QEMU
 ### Changed
- - Flow system scheduling rules improved to respect system-wide throttling setting and 
-    take last succesful run into account when rescheduling a flow or after restart
+- Flow system scheduling rules improved to respect system-wide throttling setting and take last successful run into account when rescheduling a flow or after a restart
 
 ## [0.156.2] - 2024-02-07
 ### Changed

--- a/src/infra/core/src/utils/docker_images.rs
+++ b/src/infra/core/src/utils/docker_images.rs
@@ -9,7 +9,7 @@
 
 pub const SPARK: &str = "ghcr.io/kamu-data/engine-spark:0.22.1-spark_3.1.2";
 pub const FLINK: &str = "ghcr.io/kamu-data/engine-flink:0.18.0-flink_1.16.0-scala_2.12-java8";
-pub const DATAFUSION: &str = "ghcr.io/kamu-data/engine-datafusion:0.7.1";
+pub const DATAFUSION: &str = "ghcr.io/kamu-data/engine-datafusion:0.7.2";
 
 pub const LIVY: &str = SPARK;
 pub const JUPYTER: &str = "ghcr.io/kamu-data/jupyter:0.5.2";


### PR DESCRIPTION
## Description

Partially addresses: #246 

- General restructuring of `build` and `release` flows towards cleaner matrix workflows
- Adds testing on M1 processors (albeit omitting the dockerized tests)
- Adds `aarch64` release binaries for Linux and Mac
  - Linux can be useful for AWS Graviton

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: Docs will be updated after we support arm64 architecture in flink/spark images
- [x] Dataset pipelines update scheduled if needed
