### PR TITLE
Add installer test workflow

### DIFF
--- a/.github/workflows/release-test-installer.yaml
+++ b/.github/workflows/release-test-installer.yaml
@@ -1,0 +1,78 @@
+name: release-test-installer
+on:
+  # Manual trigger
+  workflow_dispatch: {}
+  # Automatic trigger after each release
+  # Note: Triggers on both successes and failures (see conditional below)
+  workflow_run:
+    workflows:
+      - release
+    types:
+      - completed
+jobs:
+  install_script:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Keep in sync with artifact upload matrix below
+          #
+          # TODO: Add minimal targets that are stripped and do not embed WebUI
+          - name: Linux / amd64 / glibc
+            runs-on: ubuntu-latest
+            expected-target: x86_64-unknown-linux-gnu
+            expected-install-path: /home/runner/.local/bin/kamu
+          - name: Linux / amd64 / musl
+            runs-on: ubuntu-latest
+            installer-vars: KAMU_LIBC=musl
+            expected-target: x86_64-unknown-linux-musl
+            expected-install-path: /home/runner/.local/bin/kamu
+          - name: MacOS / amd64
+            runs-on: macos-13
+            expected-target: x86_64-apple-darwin
+            expected-install-path: /Users/runner/.local/bin/kamu
+          - name: MacOS / arm64
+            runs-on: macos-14
+            expected-target: aarch64-apple-darwin
+            expected-install-path: /Users/runner/.local/bin/kamu
+    name: Install via script (${{ matrix.name }})
+    runs-on: ${{ matrix.runs-on }}
+    if: |
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == null
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read latest version
+        uses: SebRollen/toml-action@v1.0.2
+        id: read_version
+        with:
+          file: Cargo.toml
+          field: workspace.package.version
+      
+      - name: Install release
+        shell: bash
+        run: |
+          curl -s "https://get.kamu.dev" | \
+            KAMU_VERSION=${{ steps.read_version.outputs.value }} \
+            ${{ matrix.installer-vars }} \
+            sh -s
+
+          echo $(dirname ${{ matrix.expected-install-path }}) >> $GITHUB_PATH
+
+      - name: Test release
+        shell: bash
+        run: |
+          echo "Installed version info:"
+          kamu version
+
+          assert_eq() { if [[ "$1" == "$2" ]]; then true; else echo "$3, expected $2 but got $1"; false; fi }
+
+          assert_eq "$(kamu version --output-format json | jq -r .appVersion)" "${{ steps.read_version.outputs.value }}" "Invalid version"
+          assert_eq "$(kamu version --output-format json | jq -r .cargoOptLevel)" "3" "Invalid optimization level"
+          assert_eq "$(kamu version --output-format json | jq -r .cargoTargetTriple)" "${{ matrix.expected-target }}" "Invalid target"
+
+          assert_eq "$(which kamu)" "${{ matrix.expected-install-path }}" "Invalid install path"
+
+          kamu init
+          assert_eq "$(kamu list --output-format csv)" "Name,Kind,Pulled,Records,Size" "Unexpected list output"

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,4 +1,4 @@
 publish:
 	aws s3 rm --recursive s3://get.kamu.dev
 	aws s3 cp kamu-install.sh s3://get.kamu.dev/kamu-install.sh
-	aws cloudfront create-invalidation --distribution-id E2KGCU2ISYOYUU --paths '/*'
+	aws --no-cli-pager cloudfront create-invalidation --distribution-id E2KGCU2ISYOYUU --paths '/*'

--- a/installer/kamu-install.sh
+++ b/installer/kamu-install.sh
@@ -18,6 +18,7 @@ KAMU_DOCS_INSTALL_URL="https://docs.kamu.dev/cli/get-started/installation/"
 KAMU_VERSION="${KAMU_VERSION:-}"
 KAMU_ALIAS="${KAMU_ALIAS:-kamu}"
 KAMU_INSTALL_PATH="${KAMU_INSTALL_PATH:-${HOME}/.local/bin/${KAMU_ALIAS}}"
+KAMU_LIBC="${KAMU_LIBC:-}"
 KAMU_RELEASES_URL="${KAMU_RELEASES_URL:-https://github.com/kamu-data/kamu-cli/releases}"
 KAMU_DOWNLOADS_URL="${KAMU_DOWNLOADS_URL:-https://github.com/kamu-data/kamu-cli/releases/download}"
 
@@ -42,6 +43,7 @@ ENV VARS:
     KAMU_VERSION            Use to specify a version to be installed
     KAMU_ALIAS              Use to install the executable under a different name
     KAMU_INSTALL_PATH       Use to override the installation path
+    KAMU_LIBC               Use 'gnu' (default) or 'musl' libc on Linux
 " 1>&2
 }
 
@@ -411,7 +413,9 @@ get_architecture() {
         if [ "$(uname -o)" = Android ]; then
             _ostype=Android
         fi
-        if ldd --version 2>&1 | grep -q 'musl'; then
+        if [ -n "$KAMU_LIBC" ]; then
+            _clibtype="$KAMU_LIBC"
+        elif ldd --version 2>&1 | grep -q 'musl'; then
             _clibtype="musl"
         fi
     fi


### PR DESCRIPTION
## Description

Related to: #246

- Adds a workflow that will test our hosted installer script on linux (gnu / musl) and mac (intel / arm) 
- Workflow will automatically run after every `release`

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
