### PR TITLE
In-memory MetadataChain caching: follow-up changes

### DIFF
--- a/src/adapter/graphql/src/queries/datasets/metadata_chain.rs
+++ b/src/adapter/graphql/src/queries/datasets/metadata_chain.rs
@@ -59,7 +59,7 @@ impl MetadataChain {
             name: "head".to_owned(),
             block_hash: dataset
                 .as_metadata_chain()
-                .get_ref(&domain::BlockRef::Head)
+                .resolve_ref(&domain::BlockRef::Head)
                 .await
                 .int_err()?
                 .into(),

--- a/src/adapter/http/src/simple_protocol/handlers.rs
+++ b/src/adapter/http/src/simple_protocol/handlers.rs
@@ -61,7 +61,7 @@ pub async fn dataset_refs_handler(
         Err(e) => Err(ApiError::not_found(e)),
     }?;
 
-    match dataset.as_metadata_chain().get_ref(&block_ref).await {
+    match dataset.as_metadata_chain().resolve_ref(&block_ref).await {
         Ok(hash) => Ok(hash.to_string()),
         Err(e @ GetRefError::NotFound(_)) => Err(ApiError::not_found(e)),
         Err(e) => Err(e.api_err()),

--- a/src/adapter/http/src/smart_protocol/axum_server_pull_protocol.rs
+++ b/src/adapter/http/src/smart_protocol/axum_server_pull_protocol.rs
@@ -105,7 +105,7 @@ impl AxumServerPullProtocolInstance {
 
         let metadata_chain = self.dataset.as_metadata_chain();
         let head = metadata_chain
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .map_err(|e| PullServerError::Internal(e.int_err()))?;
 
@@ -163,7 +163,7 @@ impl AxumServerPullProtocolInstance {
 
                 let metadata_chain = self.dataset.as_metadata_chain();
                 let head = metadata_chain
-                    .get_ref(&BlockRef::Head)
+                    .resolve_ref(&BlockRef::Head)
                     .await
                     .map_err(|e| PullServerError::Internal(e.int_err()))?;
 

--- a/src/adapter/http/src/smart_protocol/axum_server_push_protocol.rs
+++ b/src/adapter/http/src/smart_protocol/axum_server_push_protocol.rs
@@ -152,7 +152,11 @@ impl AxumServerPushProtocolInstance {
         // TODO: consider size estimate and maybe cancel too large pushes
 
         let actual_head = if let Some(dataset) = self.dataset.as_ref() {
-            match dataset.as_metadata_chain().get_ref(&BlockRef::Head).await {
+            match dataset
+                .as_metadata_chain()
+                .resolve_ref(&BlockRef::Head)
+                .await
+            {
                 Ok(head) => Some(head),
                 Err(kamu::domain::GetRefError::NotFound(_)) => None,
                 Err(e) => return Err(PushServerError::Internal(e.int_err())),

--- a/src/adapter/http/src/smart_protocol/ws_tungstenite_client.rs
+++ b/src/adapter/http/src/smart_protocol/ws_tungstenite_client.rs
@@ -504,7 +504,7 @@ impl SmartTransferProtocolClient for WsSmartTransferProtocolClient {
         };
 
         let dst_head = if let Some(dst) = &dst {
-            match dst.as_metadata_chain().get_ref(&BlockRef::Head).await {
+            match dst.as_metadata_chain().resolve_ref(&BlockRef::Head).await {
                 Ok(head) => Ok(Some(head)),
                 Err(GetRefError::NotFound(_)) => Ok(None),
                 Err(GetRefError::Access(e)) => Err(SyncError::Access(e)),
@@ -622,7 +622,7 @@ impl SmartTransferProtocolClient for WsSmartTransferProtocolClient {
 
             let new_dst_head = dst
                 .as_metadata_chain()
-                .get_ref(&BlockRef::Head)
+                .resolve_ref(&BlockRef::Head)
                 .await
                 .int_err()?;
 
@@ -661,7 +661,7 @@ impl SmartTransferProtocolClient for WsSmartTransferProtocolClient {
 
         let src_head = src
             .as_metadata_chain()
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .int_err()?;
 

--- a/src/adapter/http/tests/tests/test_routing.rs
+++ b/src/adapter/http/tests/tests/test_routing.rs
@@ -126,7 +126,7 @@ async fn setup_client(dataset_url: url::Url, head_expected: Multihash) {
 
     let head_actual = dataset
         .as_metadata_chain()
-        .get_ref(&BlockRef::Head)
+        .resolve_ref(&BlockRef::Head)
         .await
         .unwrap();
 

--- a/src/app/cli/src/commands/list_command.rs
+++ b/src/app/cli/src/commands/list_command.rs
@@ -237,7 +237,10 @@ impl Command for ListCommand {
 
         for hdl in &datasets {
             let dataset = self.dataset_repo.get_dataset(&hdl.as_local_ref()).await?;
-            let current_head = dataset.as_metadata_chain().get_ref(&BlockRef::Head).await?;
+            let current_head = dataset
+                .as_metadata_chain()
+                .resolve_ref(&BlockRef::Head)
+                .await?;
             let summary = dataset.get_summary(GetSummaryOpts::default()).await?;
 
             name.push(hdl.alias.dataset_name.to_string());

--- a/src/domain/core/src/entities/metadata_chain.rs
+++ b/src/domain/core/src/entities/metadata_chain.rs
@@ -266,42 +266,6 @@ impl Default for AppendOpts<'_> {
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Error, Debug)]
-pub enum GetBlockError {
-    #[error(transparent)]
-    NotFound(#[from] BlockNotFoundError),
-    #[error(transparent)]
-    BlockVersion(#[from] BlockVersionError),
-    #[error(transparent)]
-    BlockMalformed(#[from] BlockMalformedError),
-    #[error(transparent)]
-    Access(
-        #[from]
-        #[backtrace]
-        AccessError,
-    ),
-    #[error(transparent)]
-    Internal(
-        #[from]
-        #[backtrace]
-        InternalError,
-    ),
-}
-
-impl From<GetError> for GetBlockError {
-    fn from(v: GetError) -> Self {
-        match v {
-            GetError::NotFound(ObjectNotFoundError { hash }) => {
-                GetBlockError::NotFound(BlockNotFoundError { hash })
-            }
-            GetError::Access(e) => GetBlockError::Access(e),
-            GetError::Internal(e) => GetBlockError::Internal(e),
-        }
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-#[derive(Error, Debug)]
 pub enum IterBlocksError {
     #[error(transparent)]
     RefNotFound(RefNotFoundError),

--- a/src/domain/core/src/entities/metadata_chain.rs
+++ b/src/domain/core/src/entities/metadata_chain.rs
@@ -22,7 +22,7 @@ use crate::repos::{SetRefError as SetRefErrorRepo, *};
 #[async_trait]
 pub trait MetadataChain: Send + Sync {
     /// Resolves reference to the block hash it's pointing to
-    async fn get_ref(&self, r: &BlockRef) -> Result<Multihash, GetRefError>;
+    async fn resolve_ref(&self, r: &BlockRef) -> Result<Multihash, GetRefError>;
 
     /// Returns the specified block
     async fn get_block(&self, hash: &Multihash) -> Result<MetadataBlock, GetBlockError>;
@@ -88,7 +88,7 @@ pub trait MetadataChain: Send + Sync {
 pub trait MetadataChainExt: MetadataChain {
     /// Resolves reference to the block hash it's pointing to if it exists
     async fn try_get_ref(&self, r: &BlockRef) -> Result<Option<Multihash>, InternalError> {
-        match self.get_ref(r).await {
+        match self.resolve_ref(r).await {
             Ok(h) => Ok(Some(h)),
             Err(GetRefError::NotFound(_)) => Ok(None),
             Err(e) => Err(e.int_err()),

--- a/src/domain/core/src/repos/metadata_block_repository.rs
+++ b/src/domain/core/src/repos/metadata_block_repository.rs
@@ -15,9 +15,10 @@ use thiserror::Error;
 
 use crate::{
     AccessError,
+    BlockMalformedError,
     BlockNotFoundError,
+    BlockVersionError,
     ContainsError,
-    GetBlockError,
     GetError,
     HashMismatchError,
     InsertError,
@@ -92,6 +93,42 @@ impl From<ContainsError> for ContainsBlockError {
         match v {
             ContainsError::Access(e) => Self::Access(e),
             ContainsError::Internal(e) => Self::Internal(e),
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Error, Debug)]
+pub enum GetBlockError {
+    #[error(transparent)]
+    NotFound(#[from] BlockNotFoundError),
+    #[error(transparent)]
+    BlockVersion(#[from] BlockVersionError),
+    #[error(transparent)]
+    BlockMalformed(#[from] BlockMalformedError),
+    #[error(transparent)]
+    Access(
+        #[from]
+        #[backtrace]
+        AccessError,
+    ),
+    #[error(transparent)]
+    Internal(
+        #[from]
+        #[backtrace]
+        InternalError,
+    ),
+}
+
+impl From<GetError> for GetBlockError {
+    fn from(v: GetError) -> Self {
+        match v {
+            GetError::NotFound(ObjectNotFoundError { hash }) => {
+                GetBlockError::NotFound(BlockNotFoundError { hash })
+            }
+            GetError::Access(e) => GetBlockError::Access(e),
+            GetError::Internal(e) => GetBlockError::Internal(e),
         }
     }
 }

--- a/src/domain/core/src/utils/metadata_chain_comparator.rs
+++ b/src/domain/core/src/utils/metadata_chain_comparator.rs
@@ -399,8 +399,8 @@ impl<'a> MetadataChainWithStats<'a> {
 
 #[async_trait]
 impl<'a> MetadataChain for MetadataChainWithStats<'a> {
-    async fn get_ref(&self, r: &BlockRef) -> Result<Multihash, GetRefError> {
-        self.chain.get_ref(r).await
+    async fn resolve_ref(&self, r: &BlockRef) -> Result<Multihash, GetRefError> {
+        self.chain.resolve_ref(r).await
     }
 
     async fn get_block(&self, hash: &Multihash) -> Result<MetadataBlock, GetBlockError> {

--- a/src/infra/core/src/repos/dataset_impl.rs
+++ b/src/infra/core/src/repos/dataset_impl.rs
@@ -97,7 +97,7 @@ where
         &self,
         prev: Option<DatasetSummary>,
     ) -> Result<Option<DatasetSummary>, GetSummaryError> {
-        let current_head = match self.metadata_chain.get_ref(&BlockRef::Head).await {
+        let current_head = match self.metadata_chain.resolve_ref(&BlockRef::Head).await {
             Ok(h) => h,
             Err(GetRefError::NotFound(_)) => return Ok(prev),
             Err(GetRefError::Access(e)) => return Err(GetSummaryError::Access(e)),
@@ -402,7 +402,7 @@ where
         let prev_block_hash = if let Some(prev_block_hash) = opts.prev_block_hash {
             prev_block_hash.cloned()
         } else {
-            match chain.get_ref(opts.block_ref).await {
+            match chain.resolve_ref(opts.block_ref).await {
                 Ok(h) => Some(h),
                 Err(GetRefError::NotFound(_)) => None,
                 Err(e) => return Err(e.int_err().into()),

--- a/src/infra/core/src/repos/dataset_repository_local_fs.rs
+++ b/src/infra/core/src/repos/dataset_repository_local_fs.rs
@@ -204,7 +204,7 @@ impl DatasetRepository for DatasetRepositoryLocalFs {
 
             match existing_dataset
                 .as_metadata_chain()
-                .get_ref(&BlockRef::Head)
+                .resolve_ref(&BlockRef::Head)
                 .await
             {
                 // Existing head

--- a/src/infra/core/src/repos/dataset_repository_s3.rs
+++ b/src/infra/core/src/repos/dataset_repository_s3.rs
@@ -247,7 +247,7 @@ impl DatasetRepository for DatasetRepositoryS3 {
 
             match existing_dataset
                 .as_metadata_chain()
-                .get_ref(&BlockRef::Head)
+                .resolve_ref(&BlockRef::Head)
                 .await
             {
                 // Existing head

--- a/src/infra/core/src/repos/metadata_chain_impl.rs
+++ b/src/infra/core/src/repos/metadata_chain_impl.rs
@@ -579,7 +579,7 @@ where
     MetaBlockRepo: MetadataBlockRepository + Sync + Send,
     RefRepo: ReferenceRepository + Sync + Send,
 {
-    async fn get_ref(&self, r: &BlockRef) -> Result<Multihash, GetRefError> {
+    async fn resolve_ref(&self, r: &BlockRef) -> Result<Multihash, GetRefError> {
         self.ref_repo.get(r).await
     }
 
@@ -650,10 +650,10 @@ where
         tail: Option<&'a BlockRef>,
     ) -> DynMetadataStream<'a> {
         Box::pin(async_stream::try_stream! {
-            let head_hash = self.get_ref(head).await?;
+            let head_hash = self.resolve_ref(head).await?;
             let tail_hash = match tail {
                 None => None,
-                Some(r) => Some(self.get_ref(r).await?),
+                Some(r) => Some(self.resolve_ref(r).await?),
             };
 
             let mut current = Some(head_hash.clone());

--- a/src/infra/core/src/sync_service_impl.rs
+++ b/src/infra/core/src/sync_service_impl.rs
@@ -96,7 +96,11 @@ impl SyncServiceImpl {
             }
         };
 
-        match dataset.as_metadata_chain().get_ref(&BlockRef::Head).await {
+        match dataset
+            .as_metadata_chain()
+            .resolve_ref(&BlockRef::Head)
+            .await
+        {
             Ok(_) => Ok(dataset),
             Err(GetRefError::NotFound(_)) => Err(DatasetNotFoundError {
                 dataset_ref: dataset_ref.clone(),
@@ -143,7 +147,11 @@ impl SyncServiceImpl {
                     .await?;
 
                 if !create_if_not_exists {
-                    match dataset.as_metadata_chain().get_ref(&BlockRef::Head).await {
+                    match dataset
+                        .as_metadata_chain()
+                        .resolve_ref(&BlockRef::Head)
+                        .await
+                    {
                         Ok(_) => Ok(()),
                         Err(GetRefError::NotFound(_)) => Err(DatasetNotFoundError {
                             dataset_ref: dataset_ref.clone(),
@@ -241,7 +249,7 @@ impl SyncServiceImpl {
         let maybe_dst_head = match self.get_dataset_reader(&http_dst_ref).await {
             Ok(http_dst_dataset_view) => match http_dst_dataset_view
                 .as_metadata_chain()
-                .get_ref(&BlockRef::Head)
+                .resolve_ref(&BlockRef::Head)
                 .await
             {
                 Ok(head) => Ok(Some(head)),
@@ -296,7 +304,7 @@ impl SyncServiceImpl {
         let src_dataset = self.dataset_repo.get_dataset(src).await?;
         let src_head = src_dataset
             .as_metadata_chain()
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .int_err()?;
 
@@ -322,7 +330,7 @@ impl SyncServiceImpl {
                         .await?;
                     match dst_dataset
                         .as_metadata_chain()
-                        .get_ref(&BlockRef::Head)
+                        .resolve_ref(&BlockRef::Head)
                         .await
                     {
                         Ok(dst_head) => {

--- a/src/infra/core/src/testing/dataset_data_helper.rs
+++ b/src/infra/core/src/testing/dataset_data_helper.rs
@@ -33,7 +33,7 @@ impl DatasetDataHelper {
         let hash = self
             .dataset
             .as_metadata_chain()
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .unwrap();
         let block = self
@@ -51,7 +51,7 @@ impl DatasetDataHelper {
         let hash = self
             .dataset
             .as_metadata_chain()
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .unwrap();
         let block = self

--- a/src/infra/core/src/transform_service_impl.rs
+++ b/src/infra/core/src/transform_service_impl.rs
@@ -210,7 +210,7 @@ impl TransformServiceImpl {
 
         // TODO: externalize
         let block_ref = BlockRef::Head;
-        let head = output_chain.get_ref(&block_ref).await.int_err()?;
+        let head = output_chain.resolve_ref(&block_ref).await.int_err()?;
 
         let mut source = None;
         let mut schema = None;
@@ -381,7 +381,7 @@ impl TransformServiceImpl {
         let last_processed_offset = input_state.and_then(ExecuteTransformInput::last_offset);
 
         // Determine unprocessed block and offset range
-        let last_unprocessed_block = input_chain.get_ref(&BlockRef::Head).await.int_err()?;
+        let last_unprocessed_block = input_chain.resolve_ref(&BlockRef::Head).await.int_err()?;
         let last_unprocessed_offset = input_chain
             .iter_blocks_interval(&last_unprocessed_block, last_processed_block, false)
             .filter_map_ok(|(_, b)| b.into_data_stream_block())
@@ -542,7 +542,7 @@ impl TransformServiceImpl {
         let metadata_chain = dataset.as_metadata_chain();
 
         let head = match block_range.1 {
-            None => metadata_chain.get_ref(&BlockRef::Head).await?,
+            None => metadata_chain.resolve_ref(&BlockRef::Head).await?,
             Some(hash) => hash,
         };
         let tail = block_range.0;

--- a/src/infra/core/src/utils/simple_transfer_protocol.rs
+++ b/src/infra/core/src/utils/simple_transfer_protocol.rs
@@ -193,7 +193,7 @@ impl SimpleTransferProtocol {
         src_ref: &DatasetRefAny,
         src_chain: &dyn MetadataChain,
     ) -> Result<Multihash, SyncError> {
-        match src_chain.get_ref(&BlockRef::Head).await {
+        match src_chain.resolve_ref(&BlockRef::Head).await {
             Ok(head) => Ok(head),
             Err(GetRefError::NotFound(_)) => Err(DatasetNotFoundError {
                 dataset_ref: src_ref.clone(),
@@ -208,7 +208,7 @@ impl SimpleTransferProtocol {
         &self,
         dst_chain: &dyn MetadataChain,
     ) -> Result<Option<Multihash>, SyncError> {
-        match dst_chain.get_ref(&BlockRef::Head).await {
+        match dst_chain.resolve_ref(&BlockRef::Head).await {
             Ok(h) => Ok(Some(h)),
             Err(GetRefError::NotFound(_)) => Ok(None),
             Err(GetRefError::Access(e)) => Err(SyncError::Access(e)),

--- a/src/infra/core/src/verification_service_impl.rs
+++ b/src/infra/core/src/verification_service_impl.rs
@@ -55,7 +55,7 @@ impl VerificationServiceImpl {
         let chain = dataset.as_metadata_chain();
 
         let head = match block_range.1 {
-            None => chain.get_ref(&BlockRef::Head).await?,
+            None => chain.resolve_ref(&BlockRef::Head).await?,
             Some(hash) => hash,
         };
         let tail = block_range.0;
@@ -209,7 +209,7 @@ impl VerificationServiceImpl {
         let chain = dataset.as_metadata_chain();
 
         let head = match block_range.1 {
-            None => chain.get_ref(&BlockRef::Head).await?,
+            None => chain.resolve_ref(&BlockRef::Head).await?,
             Some(hash) => hash,
         };
         let tail = block_range.0;

--- a/src/infra/core/tests/tests/engine/test_engine_transform.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_transform.rs
@@ -74,7 +74,7 @@ impl DatasetHelper {
         let old_head = self
             .dataset
             .as_metadata_chain()
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .unwrap();
 

--- a/src/infra/core/tests/tests/ingest/test_writer.rs
+++ b/src/infra/core/tests/tests/ingest/test_writer.rs
@@ -798,7 +798,7 @@ async fn test_data_writer_builder_scan_no_source() {
     let head = harness
         .dataset
         .as_metadata_chain()
-        .get_ref(&BlockRef::Head)
+        .resolve_ref(&BlockRef::Head)
         .await
         .unwrap();
 

--- a/src/infra/core/tests/tests/repos/test_dataset_repository_shared.rs
+++ b/src/infra/core/tests/tests/repos/test_dataset_repository_shared.rs
@@ -186,7 +186,7 @@ pub async fn test_create_dataset_from_snapshot(
 
     let actual_head = dataset
         .as_metadata_chain()
-        .get_ref(&BlockRef::Head)
+        .resolve_ref(&BlockRef::Head)
         .await
         .unwrap();
 
@@ -312,7 +312,7 @@ pub async fn test_rename_dataset_same_name_multiple_tenants(repo: &dyn DatasetRe
     assert_eq!(
         my_bar
             .as_metadata_chain()
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .unwrap(),
         create_result_my_foo.head
@@ -320,7 +320,7 @@ pub async fn test_rename_dataset_same_name_multiple_tenants(repo: &dyn DatasetRe
     assert_eq!(
         her_bar
             .as_metadata_chain()
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .unwrap(),
         create_result_her_bar.head

--- a/src/infra/core/tests/tests/repos/test_metadata_chain_impl.rs
+++ b/src/infra/core/tests/tests/repos/test_metadata_chain_impl.rs
@@ -35,7 +35,7 @@ async fn test_empty() {
     let tmp_dir = tempfile::tempdir().unwrap();
     let chain = init_chain(tmp_dir.path());
     assert_matches!(
-        chain.get_ref(&BlockRef::Head).await,
+        chain.resolve_ref(&BlockRef::Head).await,
         Err(GetRefError::NotFound(_))
     );
 }
@@ -53,7 +53,7 @@ async fn test_append_and_get() {
         .await
         .unwrap();
 
-    assert_eq!(chain.get_ref(&BlockRef::Head).await.unwrap(), hash_1);
+    assert_eq!(chain.resolve_ref(&BlockRef::Head).await.unwrap(), hash_1);
     assert_eq!(0, block_1.sequence_number);
 
     let block_2 = MetadataFactory::metadata_block(MetadataFactory::set_data_schema().build())
@@ -65,7 +65,7 @@ async fn test_append_and_get() {
         .await
         .unwrap();
 
-    assert_eq!(chain.get_ref(&BlockRef::Head).await.unwrap(), hash_2);
+    assert_eq!(chain.resolve_ref(&BlockRef::Head).await.unwrap(), hash_2);
     assert_eq!(1, block_2.sequence_number);
 
     assert_eq!(chain.get_block(&hash_1).await.unwrap(), block_1);
@@ -92,7 +92,7 @@ async fn test_set_ref() {
         .unwrap();
 
     assert_matches!(
-        chain.get_ref(&BlockRef::Head).await,
+        chain.resolve_ref(&BlockRef::Head).await,
         Err(GetRefError::NotFound(_))
     );
 
@@ -125,7 +125,7 @@ async fn test_set_ref() {
         .set_ref(&BlockRef::Head, &hash_1, SetRefOpts::default())
         .await
         .unwrap();
-    assert_eq!(chain.get_ref(&BlockRef::Head).await.unwrap(), hash_1);
+    assert_eq!(chain.resolve_ref(&BlockRef::Head).await.unwrap(), hash_1);
 }
 
 #[tokio::test]
@@ -164,7 +164,7 @@ async fn test_append_prev_block_not_found() {
 
     let hash_1 = chain.append(block_1, AppendOpts::default()).await.unwrap();
 
-    assert_eq!(chain.get_ref(&BlockRef::Head).await.unwrap(), hash_1);
+    assert_eq!(chain.resolve_ref(&BlockRef::Head).await.unwrap(), hash_1);
 
     let block_2 = MetadataFactory::metadata_block(MetadataFactory::add_data().build())
         .prev(
@@ -180,7 +180,7 @@ async fn test_append_prev_block_not_found() {
         ))
     );
 
-    assert_eq!(chain.get_ref(&BlockRef::Head).await.unwrap(), hash_1);
+    assert_eq!(chain.resolve_ref(&BlockRef::Head).await.unwrap(), hash_1);
 }
 
 #[tokio::test]
@@ -206,7 +206,7 @@ async fn test_append_prev_block_sequence_integrity_broken() {
         )
         .await
         .unwrap();
-    assert_eq!(chain.get_ref(&BlockRef::Head).await.unwrap(), hash);
+    assert_eq!(chain.resolve_ref(&BlockRef::Head).await.unwrap(), hash);
 
     let hash = chain
         .append(
@@ -276,7 +276,7 @@ async fn test_append_prev_block_sequence_integrity_broken() {
         .unwrap();
 
     assert_eq!(
-        chain.get_ref(&BlockRef::Head).await.unwrap(),
+        chain.resolve_ref(&BlockRef::Head).await.unwrap(),
         hash_just_right
     );
 }
@@ -294,7 +294,7 @@ async fn test_append_unexpected_ref() {
         )
         .await
         .unwrap();
-    assert_eq!(chain.get_ref(&BlockRef::Head).await.unwrap(), hash);
+    assert_eq!(chain.resolve_ref(&BlockRef::Head).await.unwrap(), hash);
 
     let invalid_hash = Multihash::from_digest_sha3_256(b"does-not-exist");
     assert_matches!(
@@ -312,7 +312,7 @@ async fn test_append_unexpected_ref() {
         Err(AppendError::RefCASFailed(_))
     );
 
-    assert_eq!(chain.get_ref(&BlockRef::Head).await.unwrap(), hash);
+    assert_eq!(chain.resolve_ref(&BlockRef::Head).await.unwrap(), hash);
 }
 
 #[tokio::test]

--- a/src/infra/core/tests/tests/test_metadata_chain_comparator.rs
+++ b/src/infra/core/tests/tests/test_metadata_chain_comparator.rs
@@ -32,8 +32,8 @@ async fn compare_chains(
     lhs_chain: &dyn MetadataChain,
     rhs_chain: &dyn MetadataChain,
 ) -> CompareChainsResult {
-    let lhs_head = lhs_chain.get_ref(&BlockRef::Head).await.unwrap();
-    let rhs_head = match rhs_chain.get_ref(&BlockRef::Head).await {
+    let lhs_head = lhs_chain.resolve_ref(&BlockRef::Head).await.unwrap();
+    let rhs_head = match rhs_chain.resolve_ref(&BlockRef::Head).await {
         Ok(h) => Some(h),
         Err(_) => None,
     };

--- a/src/infra/core/tests/tests/test_reset_service_impl.rs
+++ b/src/infra/core/tests/tests/test_reset_service_impl.rs
@@ -172,7 +172,7 @@ impl ResetTestHarness {
         let dataset = self.resolve_dataset(dataset_handle).await;
         dataset
             .as_metadata_chain()
-            .get_ref(&BlockRef::Head)
+            .resolve_ref(&BlockRef::Head)
             .await
             .unwrap()
     }

--- a/src/infra/core/tests/tests/test_transform_service_impl.rs
+++ b/src/infra/core/tests/tests/test_transform_service_impl.rs
@@ -150,7 +150,7 @@ impl TransformTestHarness {
             .unwrap()
             .unwrap_or(0);
 
-        let prev_head = chain.get_ref(&BlockRef::Head).await.unwrap();
+        let prev_head = chain.resolve_ref(&BlockRef::Head).await.unwrap();
         let prev_block = chain.get_block(&prev_head).await.unwrap();
 
         let block = MetadataFactory::metadata_block(

--- a/src/infra/ingest-datafusion/src/writer.rs
+++ b/src/infra/ingest-datafusion/src/writer.rs
@@ -848,7 +848,7 @@ impl DataWriterDataFusionBuilder {
         let head = self
             .dataset
             .as_metadata_chain()
-            .get_ref(&self.block_ref)
+            .resolve_ref(&self.block_ref)
             .await
             .int_err()?;
 


### PR DESCRIPTION
## Description

Related issue: https://github.com/kamu-data/kamu-cli/issues/389

Address 2 comments:
- [x] https://github.com/kamu-data/kamu-cli/pull/484#discussion_r1476557483
  - Commit: [MetadataChain: rename get_ref() -> resolve_ref()](https://github.com/kamu-data/kamu-cli/commit/2ce073de7e834dee3f37d81d0dd1408d07156e43)
- [x] https://github.com/kamu-data/kamu-cli/pull/484#discussion_r1488229187
  - Commit: [GetBlockError: move closer to MetadataBlockRepository](https://github.com/kamu-data/kamu-cli/commit/6cf0d945b0ee3b7ed8208563de094b6ad22e3fa3)

<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
