### PR TITLE
Support searching in ODF repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `kamu search` command now works with ODF repositories
+
 ## [0.160.0] - 2024-02-26
 ### Changed
 - Upgraded to latest `datafusion` `v36.0.0`

--- a/src/app/cli/src/services/odf_server/access_token_registry_service.rs
+++ b/src/app/cli/src/services/odf_server/access_token_registry_service.rs
@@ -225,6 +225,8 @@ impl AccessTokenRegistryService {
 #[async_trait::async_trait]
 impl kamu::domain::auth::OdfServerAccessTokenResolver for AccessTokenRegistryService {
     fn resolve_odf_dataset_access_token(&self, odf_dataset_http_url: &Url) -> Option<String> {
+        assert!(!odf_dataset_http_url.scheme().starts_with("odf+"));
+
         let origin = odf_dataset_http_url.origin().unicode_serialization();
         let odf_server_backend_url = Url::parse(origin.as_str()).unwrap();
 

--- a/src/domain/core/src/services/search_service.rs
+++ b/src/domain/core/src/services/search_service.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use opendatafabric::{DatasetAliasRemote, RepoName};
+use opendatafabric::*;
 use thiserror::Error;
 
 use crate::*;
@@ -32,14 +32,17 @@ pub struct SearchOptions {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SearchResult {
-    pub datasets: Vec<DatasetAliasRemote>,
+    pub datasets: Vec<SearchResultDataset>,
 }
 
-impl SearchResult {
-    pub fn merge(mut self, mut other: Self) -> Self {
-        self.datasets.append(&mut other.datasets);
-        self
-    }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchResultDataset {
+    pub id: Option<DatasetID>,
+    pub alias: DatasetAliasRemote,
+    pub kind: Option<DatasetKind>,
+    pub num_blocks: Option<u64>,
+    pub num_records: Option<u64>,
+    pub estimated_size: Option<u64>,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/infra/core/src/pull_service_impl.rs
+++ b/src/infra/core/src/pull_service_impl.rs
@@ -139,7 +139,7 @@ impl PullServiceImpl {
                 Some(
                     DatasetRefRemote::Alias(alias)
                     | DatasetRefRemote::Handle(DatasetHandleRemote { alias, .. }),
-                ) => DatasetAlias::new(alias.account_name.clone(), alias.dataset_name.clone()),
+                ) => DatasetAlias::new(None, alias.dataset_name.clone()),
                 Some(DatasetRefRemote::Url(url)) => DatasetAlias::new(
                     if self.dataset_repo.is_multi_tenant() {
                         match self.current_account_subject.as_ref() {

--- a/src/infra/core/src/repos/dataset_factory_impl.rs
+++ b/src/infra/core/src/repos/dataset_factory_impl.rs
@@ -328,8 +328,18 @@ impl DatasetFactory for DatasetFactoryImpl {
                 let ds = Self::get_local_fs(layout, self.event_bus.clone());
                 Ok(Arc::new(ds) as Arc<dyn Dataset>)
             }
-            "http" | "https" | "odf+http" | "odf+https" => {
+            "http" | "https" => {
                 let ds = Self::get_http(url, self.build_header_map(url), self.event_bus.clone());
+                Ok(Arc::new(ds))
+            }
+            "odf+http" | "odf+https" => {
+                // TODO: PERF: Consider what speedups are possible in smart protocol
+                let http_url = Url::parse(url.as_str().strip_prefix("odf+").unwrap()).unwrap();
+                let ds = Self::get_http(
+                    &http_url,
+                    self.build_header_map(&http_url),
+                    self.event_bus.clone(),
+                );
                 Ok(Arc::new(ds))
             }
             "ipfs" | "ipns" | "ipfs+http" | "ipfs+https" | "ipns+http" | "ipns+https" => {

--- a/src/infra/core/src/search_service_impl.rs
+++ b/src/infra/core/src/search_service_impl.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use dill::*;
 use kamu_core::*;
 use opendatafabric::*;
+use serde_json::json;
 use url::Url;
 
 use crate::utils::s3_context::S3Context;
@@ -27,62 +28,176 @@ impl SearchServiceImpl {
         Self { remote_repo_reg }
     }
 
+    fn search_in_repo_localfs(
+        &self,
+        url: &Url,
+        query: Option<&str>,
+        repo_name: &RepoName,
+    ) -> Result<Vec<SearchResultDataset>, SearchError> {
+        let mut datasets = Vec::new();
+
+        let path = url
+            .to_file_path()
+            .map_err(|_| "Invalid path URL")
+            .int_err()?;
+        let query = query.unwrap_or_default();
+        for entry in std::fs::read_dir(path).int_err()? {
+            if let Some(file_name) = entry.int_err()?.file_name().to_str() {
+                if query.is_empty() || file_name.contains(query) {
+                    datasets.push(SearchResultDataset {
+                        id: None,
+                        alias: DatasetAliasRemote::new(
+                            repo_name.clone(),
+                            None,
+                            DatasetName::try_from(file_name).int_err()?,
+                        ),
+                        kind: None,
+                        num_blocks: None,
+                        num_records: None,
+                        estimated_size: None,
+                    });
+                }
+            }
+        }
+
+        Ok(datasets)
+    }
+
+    async fn search_in_repo_s3(
+        &self,
+        url: &Url,
+        query: Option<&str>,
+        repo_name: &RepoName,
+    ) -> Result<Vec<SearchResultDataset>, SearchError> {
+        let mut datasets = Vec::new();
+
+        let s3_context = S3Context::from_url(url).await;
+        let folders_common_prefixes = s3_context.bucket_list_folders().await?;
+
+        let query = query.unwrap_or_default();
+
+        for prefix in folders_common_prefixes {
+            let mut prefix = prefix.prefix.unwrap();
+            while prefix.ends_with('/') {
+                prefix.pop();
+            }
+
+            let name = DatasetName::try_from(prefix).int_err()?;
+
+            if query.is_empty() || name.contains(query) {
+                datasets.push(SearchResultDataset {
+                    id: None,
+                    alias: DatasetAliasRemote::new(repo_name.clone(), None, name),
+                    kind: None,
+                    num_blocks: None,
+                    num_records: None,
+                    estimated_size: None,
+                });
+            }
+        }
+
+        Ok(datasets)
+    }
+
+    // TODO: This is a quick and dirty implementation that will soon be replaced
+    async fn search_in_repo_odf(
+        &self,
+        url: &Url,
+        query: Option<&str>,
+        repo_name: &RepoName,
+    ) -> Result<Vec<SearchResultDataset>, SearchError> {
+        let gql_query = r#"
+            {
+              search {
+                query(query: "{query}") {
+                  nodes {
+                    ... on Dataset {
+                      id
+                      name
+                      owner {
+                        accountName
+                      }
+                      kind
+                      metadata {
+                        chain {
+                          blocks(page: 0, perPage: 1) {
+                            totalCount
+                          }
+                        }
+                      }
+                      data {
+                        numRecordsTotal
+                        estimatedSize
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            "#
+        .replace("{query}", query.unwrap_or_default());
+
+        let mut gql_url = Url::parse(url.as_str().strip_prefix("odf+").unwrap()).unwrap();
+        gql_url.path_segments_mut().unwrap().push("graphql");
+
+        // TODO: Include auth token if we have one in store
+        let cl = reqwest::Client::new();
+        let response = cl
+            .post(gql_url)
+            .json(&json!({"query": gql_query}))
+            .send()
+            .await
+            .int_err()?
+            .error_for_status()
+            .int_err()?;
+
+        let gql_response: serde_json::Value = response.json().await.int_err()?;
+
+        let invalid_response = || {
+            SearchError::Internal(
+                format!("GQL endpoint returned invalid response:\n{gql_response}").int_err(),
+            )
+        };
+
+        let Some(nodes) = gql_response["data"]["search"]["query"]["nodes"].as_array() else {
+            return Err(invalid_response());
+        };
+
+        let mut datasets = Vec::new();
+
+        for node in nodes {
+            let ds: GqlDataset = serde_json::from_value(node.clone()).int_err()?;
+            datasets.push(SearchResultDataset {
+                id: Some(ds.id),
+                alias: DatasetAliasRemote::new(repo_name.clone(), ds.owner.account_name, ds.name),
+                kind: Some(ds.kind),
+                num_blocks: Some(ds.metadata.chain.blocks.total_count),
+                num_records: Some(ds.data.num_records_total),
+                estimated_size: Some(ds.data.estimated_size),
+            });
+        }
+
+        Ok(datasets)
+    }
+
     // TODO: This is crude temporary implementation until ODF specifies registry
     // interface
     async fn search_in_resource(
         &self,
         url: &Url,
         query: Option<&str>,
-    ) -> Result<Vec<DatasetAlias>, SearchError> {
-        let mut datasets = Vec::new();
-
+        repo_name: &RepoName,
+    ) -> Result<Vec<SearchResultDataset>, SearchError> {
         match url.scheme() {
-            "file" => {
-                let path = url
-                    .to_file_path()
-                    .map_err(|_| "Invalid path URL")
-                    .int_err()?;
-                let query = query.unwrap_or_default();
-                for entry in std::fs::read_dir(path).int_err()? {
-                    if let Some(file_name) = entry.int_err()?.file_name().to_str() {
-                        if query.is_empty() || file_name.contains(query) {
-                            datasets.push(DatasetAlias::new(
-                                None,
-                                DatasetName::try_from(file_name).int_err()?,
-                            ));
-                        }
-                    }
-                }
+            "file" => self.search_in_repo_localfs(url, query, repo_name),
+            "s3" | "s3+http" | "s3+https" => self.search_in_repo_s3(url, query, repo_name).await,
+            "odf+http" | "odf+https" => self.search_in_repo_odf(url, query, repo_name).await,
+            _ => Err(UnsupportedProtocolError {
+                message: None,
+                url: url.clone(),
             }
-            "s3" | "s3+http" | "s3+https" => {
-                let s3_context = S3Context::from_url(url).await;
-                let folders_common_prefixes = s3_context.bucket_list_folders().await?;
-
-                let query = query.unwrap_or_default();
-
-                for prefix in folders_common_prefixes {
-                    let mut prefix = prefix.prefix.unwrap();
-                    while prefix.ends_with('/') {
-                        prefix.pop();
-                    }
-
-                    let name = DatasetName::try_from(prefix).int_err()?;
-
-                    if query.is_empty() || name.contains(query) {
-                        datasets.push(DatasetAlias::new(None, name));
-                    }
-                }
-            }
-            _ => {
-                return Err(UnsupportedProtocolError {
-                    message: None,
-                    url: url.clone(),
-                }
-                .into())
-            }
+            .into()),
         }
-
-        Ok(datasets)
     }
 
     async fn search_in_repo(
@@ -94,14 +209,9 @@ impl SearchServiceImpl {
 
         tracing::info!(repo_id = repo_name.as_str(), repo_url = ?repo.url, query = ?query, "Searching remote repository");
 
-        let datasets = self.search_in_resource(&repo.url, query).await?;
+        let datasets = self.search_in_resource(&repo.url, query, repo_name).await?;
 
-        Ok(SearchResult {
-            datasets: datasets
-                .into_iter()
-                .map(|alias| alias.as_remote_alias(repo_name))
-                .collect(),
-        })
+        Ok(SearchResult { datasets })
     }
 }
 
@@ -120,10 +230,64 @@ impl SearchService for SearchServiceImpl {
 
         let mut result = SearchResult::default();
         for repo in &repo_names {
-            let repo_result = self.search_in_repo(query, repo).await?;
-            result = result.merge(repo_result);
+            let mut repo_result = self.search_in_repo(query, repo).await?;
+            result.datasets.append(&mut repo_result.datasets);
         }
 
         Ok(result)
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GQL deserializers
+////////////////////////////////////////////////////////////////////////////////
+
+#[derive(::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GqlDataset {
+    id: DatasetID,
+    name: DatasetName,
+    owner: GqlAccount,
+    #[serde(with = "DatasetKindDef")]
+    kind: DatasetKind,
+    metadata: GqlMetadata,
+    data: GqlData,
+}
+
+#[derive(::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GqlAccount {
+    account_name: Option<AccountName>,
+}
+
+#[derive(::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GqlMetadata {
+    chain: GqlMetadataChain,
+}
+
+#[derive(::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GqlMetadataChain {
+    blocks: GqlMetadataChainBlocks,
+}
+
+#[derive(::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GqlMetadataChainBlocks {
+    total_count: u64,
+}
+
+#[derive(::serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GqlData {
+    num_records_total: u64,
+    estimated_size: u64,
+}
+
+#[derive(::serde::Deserialize)]
+#[serde(remote = "DatasetKind", rename_all = "SCREAMING_SNAKE_CASE")]
+enum DatasetKindDef {
+    Root,
+    Derivative,
 }

--- a/src/infra/core/tests/tests/test_search_service_impl.rs
+++ b/src/infra/core/tests/tests/test_search_service_impl.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::assert_matches::assert_matches;
 use std::path::Path;
 
 use dill::Component;
@@ -79,17 +78,46 @@ async fn do_test_search(tmp_workspace_dir: &Path, repo_url: Url) {
         .unwrap();
 
     // Search!
-    assert_matches!(
-        search_svc.search(None, SearchOptions::default()).await,
-        Ok(SearchResult { datasets }) if datasets == vec![dataset_remote_alias.clone()]
+    assert_eq!(
+        search_svc
+            .search(None, SearchOptions::default())
+            .await
+            .unwrap(),
+        SearchResult {
+            datasets: vec![SearchResultDataset {
+                id: None,
+                alias: dataset_remote_alias.clone(),
+                kind: None,
+                num_blocks: None,
+                num_records: None,
+                estimated_size: None,
+            }]
+        }
     );
-    assert_matches!(
-        search_svc.search(Some("bar"), SearchOptions::default()).await,
-        Ok(SearchResult { datasets }) if datasets == vec![dataset_remote_alias.clone()]
+
+    assert_eq!(
+        search_svc
+            .search(Some("bar"), SearchOptions::default())
+            .await
+            .unwrap(),
+        SearchResult {
+            datasets: vec![SearchResultDataset {
+                id: None,
+                alias: dataset_remote_alias.clone(),
+                kind: None,
+                num_blocks: None,
+                num_records: None,
+                estimated_size: None,
+            }]
+        }
     );
-    assert_matches!(
-        search_svc.search(Some("foo"), SearchOptions::default()).await,
-        Ok(SearchResult { datasets }) if datasets.is_empty()
+
+    assert_eq!(
+        search_svc
+            .search(Some("foo"), SearchOptions::default())
+            .await
+            .unwrap(),
+        SearchResult { datasets: vec![] }
     );
 }
 


### PR DESCRIPTION
## Description

Closes: #508 

- Search service now supports `odf+http[s]` protocol
- As with other protocols the implementation is very crude - it's not using some established interfaces but reaches directly to GQL API
  - this is a technical debt and we will clean it up in future, once #342 will bring more understanding on how remote registries will be organized
- Search results now include more details (number of blocks, records, estimated size)
- Search command output updated to avoid boilerplate

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: N/A
- [x] Dataset pipelines update scheduled if needed
