### PR TITLE
516 flows simplify waiting statuses and replace the differentiation on extended start conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Simplified flow statuses within Flow System (no more Queued or Scheduled status)
+- Extended flow start conditions with more debug information for UI needs
+
 ## [0.162.1] - 2024-02-28
 ### Added
 - `kamu system check-token` command for token debugging

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -844,6 +844,8 @@ type FlowStartConditionSchedule {
 
 type FlowStartConditionThrottling {
 	intervalSec: Int!
+	wakeUpAt: DateTime!
+	shiftedFrom: DateTime!
 }
 
 enum FlowStatus {

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -777,7 +777,7 @@ type FlowEventQueued implements FlowEvent {
 type FlowEventStartConditionUpdated implements FlowEvent {
 	eventId: EventID!
 	eventTime: DateTime!
-	startConditionKind: FlowStartConditionKind
+	startConditionKind: FlowStartConditionKind!
 }
 
 type FlowEventTaskChanged implements FlowEvent {
@@ -824,7 +824,7 @@ enum FlowOutcome {
 	ABORTED
 }
 
-union FlowStartCondition = FlowStartConditionThrottling | FlowStartConditionBatching
+union FlowStartCondition = FlowStartConditionThrottling | FlowStartConditionBatching | FlowStartConditionExecutor
 
 type FlowStartConditionBatching {
 	activeBatchingRule: FlowConfigurationBatching!
@@ -833,9 +833,14 @@ type FlowStartConditionBatching {
 	watermarkModified: Boolean!
 }
 
+type FlowStartConditionExecutor {
+	taskId: TaskID!
+}
+
 enum FlowStartConditionKind {
 	THROTTLING
 	BATCHING
+	EXECUTOR
 }
 
 type FlowStartConditionThrottling {
@@ -845,7 +850,6 @@ type FlowStartConditionThrottling {
 enum FlowStatus {
 	WAITING
 	QUEUED
-	SCHEDULED
 	RUNNING
 	FINISHED
 }

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -856,6 +856,10 @@ enum FlowStatus {
 
 type FlowTimingRecords {
 	"""
+	Recorded time of last task scheduling
+	"""
+	awaitingExecutorSince: DateTime
+	"""
 	Recorded start of running (Running state seen at least once)
 	"""
 	runningSince: DateTime

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -762,16 +762,16 @@ type FlowEventAborted implements FlowEvent {
 	eventTime: DateTime!
 }
 
+type FlowEventActivationTimeDefined implements FlowEvent {
+	eventId: EventID!
+	eventTime: DateTime!
+	activationTime: DateTime!
+}
+
 type FlowEventInitiated implements FlowEvent {
 	eventId: EventID!
 	eventTime: DateTime!
 	trigger: FlowTrigger!
-}
-
-type FlowEventQueued implements FlowEvent {
-	eventId: EventID!
-	eventTime: DateTime!
-	activateAt: DateTime!
 }
 
 type FlowEventStartConditionUpdated implements FlowEvent {
@@ -824,7 +824,7 @@ enum FlowOutcome {
 	ABORTED
 }
 
-union FlowStartCondition = FlowStartConditionThrottling | FlowStartConditionBatching | FlowStartConditionExecutor
+union FlowStartCondition = FlowStartConditionSchedule | FlowStartConditionThrottling | FlowStartConditionBatching | FlowStartConditionExecutor
 
 type FlowStartConditionBatching {
 	activeBatchingRule: FlowConfigurationBatching!
@@ -838,9 +838,14 @@ type FlowStartConditionExecutor {
 }
 
 enum FlowStartConditionKind {
+	SCHEDULE
 	THROTTLING
 	BATCHING
 	EXECUTOR
+}
+
+type FlowStartConditionSchedule {
+	activateAt: DateTime!
 }
 
 type FlowStartConditionThrottling {
@@ -849,7 +854,6 @@ type FlowStartConditionThrottling {
 
 enum FlowStatus {
 	WAITING
-	QUEUED
 	RUNNING
 	FINISHED
 }

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -762,12 +762,6 @@ type FlowEventAborted implements FlowEvent {
 	eventTime: DateTime!
 }
 
-type FlowEventActivationTimeDefined implements FlowEvent {
-	eventId: EventID!
-	eventTime: DateTime!
-	activationTime: DateTime!
-}
-
 type FlowEventInitiated implements FlowEvent {
 	eventId: EventID!
 	eventTime: DateTime!
@@ -845,7 +839,7 @@ enum FlowStartConditionKind {
 }
 
 type FlowStartConditionSchedule {
-	activateAt: DateTime!
+	wakeUpAt: DateTime!
 }
 
 type FlowStartConditionThrottling {
@@ -859,10 +853,6 @@ enum FlowStatus {
 }
 
 type FlowTimingRecords {
-	"""
-	Planned activation time (at least, Queued state)
-	"""
-	activateAt: DateTime
 	"""
 	Recorded start of running (Running state seen at least once)
 	"""

--- a/src/adapter/graphql/src/queries/flows/flow_event.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_event.rs
@@ -29,8 +29,6 @@ pub enum FlowEvent {
     StartConditionUpdated(FlowEventStartConditionUpdated),
     /// Secondary trigger added
     TriggerAdded(FlowEventTriggerAdded),
-    /// Activation time defined
-    ActivationTimeDefined(FlowEventActivationTimeDefined),
     /// Associated task has changed status
     TaskChanged(FlowEventTaskChanged),
     /// Aborted flow (user cancellation or system factor, such as ds delete)
@@ -46,9 +44,6 @@ impl FlowEvent {
             }
             fs::FlowEvent::TriggerAdded(e) => {
                 Self::TriggerAdded(FlowEventTriggerAdded::new(event_id, e))
-            }
-            fs::FlowEvent::ActivationTimeDefined(e) => {
-                Self::ActivationTimeDefined(FlowEventActivationTimeDefined::new(event_id, &e))
             }
             fs::FlowEvent::TaskScheduled(e) => Self::TaskChanged(FlowEventTaskChanged::new(
                 event_id,
@@ -139,25 +134,6 @@ impl FlowEventTriggerAdded {
             event_id: event_id.into(),
             event_time: event.event_time,
             trigger: event.trigger.into(),
-        }
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-#[derive(SimpleObject)]
-pub struct FlowEventActivationTimeDefined {
-    event_id: EventID,
-    event_time: DateTime<Utc>,
-    activation_time: DateTime<Utc>,
-}
-
-impl FlowEventActivationTimeDefined {
-    fn new(event_id: evs::EventID, event: &fs::FlowEventActivationTimeDefined) -> Self {
-        Self {
-            event_id: event_id.into(),
-            event_time: event.event_time,
-            activation_time: event.activation_time,
         }
     }
 }

--- a/src/adapter/graphql/src/queries/flows/flow_event.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_event.rs
@@ -27,10 +27,10 @@ pub enum FlowEvent {
     Initiated(FlowEventInitiated),
     /// Start condition defined
     StartConditionUpdated(FlowEventStartConditionUpdated),
-    /// Queued for time
-    Queued(FlowEventQueued),
     /// Secondary trigger added
     TriggerAdded(FlowEventTriggerAdded),
+    /// Activation time defined
+    ActivationTimeDefined(FlowEventActivationTimeDefined),
     /// Associated task has changed status
     TaskChanged(FlowEventTaskChanged),
     /// Aborted flow (user cancellation or system factor, such as ds delete)
@@ -44,9 +44,11 @@ impl FlowEvent {
             fs::FlowEvent::StartConditionUpdated(e) => {
                 Self::StartConditionUpdated(FlowEventStartConditionUpdated::new(event_id, &e))
             }
-            fs::FlowEvent::Queued(e) => Self::Queued(FlowEventQueued::new(event_id, &e)),
             fs::FlowEvent::TriggerAdded(e) => {
                 Self::TriggerAdded(FlowEventTriggerAdded::new(event_id, e))
+            }
+            fs::FlowEvent::ActivationTimeDefined(e) => {
+                Self::ActivationTimeDefined(FlowEventActivationTimeDefined::new(event_id, &e))
             }
             fs::FlowEvent::TaskScheduled(e) => Self::TaskChanged(FlowEventTaskChanged::new(
                 event_id,
@@ -105,6 +107,7 @@ impl FlowEventStartConditionUpdated {
             event_id: event_id.into(),
             event_time: event.event_time,
             start_condition_kind: match event.start_condition {
+                fs::FlowStartCondition::Schedule(_) => FlowStartConditionKind::Schedule,
                 fs::FlowStartCondition::Throttling(_) => FlowStartConditionKind::Throttling,
                 fs::FlowStartCondition::Batching(_) => FlowStartConditionKind::Batching,
                 fs::FlowStartCondition::Executor(_) => FlowStartConditionKind::Executor,
@@ -115,28 +118,10 @@ impl FlowEventStartConditionUpdated {
 
 #[derive(Enum, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FlowStartConditionKind {
+    Schedule,
     Throttling,
     Batching,
     Executor,
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-#[derive(SimpleObject)]
-pub struct FlowEventQueued {
-    event_id: EventID,
-    event_time: DateTime<Utc>,
-    activate_at: DateTime<Utc>,
-}
-
-impl FlowEventQueued {
-    fn new(event_id: evs::EventID, event: &fs::FlowEventQueued) -> Self {
-        Self {
-            event_id: event_id.into(),
-            event_time: event.event_time,
-            activate_at: event.activate_at,
-        }
-    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -154,6 +139,25 @@ impl FlowEventTriggerAdded {
             event_id: event_id.into(),
             event_time: event.event_time,
             trigger: event.trigger.into(),
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[derive(SimpleObject)]
+pub struct FlowEventActivationTimeDefined {
+    event_id: EventID,
+    event_time: DateTime<Utc>,
+    activation_time: DateTime<Utc>,
+}
+
+impl FlowEventActivationTimeDefined {
+    fn new(event_id: evs::EventID, event: &fs::FlowEventActivationTimeDefined) -> Self {
+        Self {
+            event_id: event_id.into(),
+            event_time: event.event_time,
+            activation_time: event.activation_time,
         }
     }
 }

--- a/src/adapter/graphql/src/queries/flows/flow_event.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_event.rs
@@ -96,7 +96,7 @@ impl FlowEventInitiated {
 pub struct FlowEventStartConditionUpdated {
     event_id: EventID,
     event_time: DateTime<Utc>,
-    start_condition_kind: Option<FlowStartConditionKind>,
+    start_condition_kind: FlowStartConditionKind,
 }
 
 impl FlowEventStartConditionUpdated {
@@ -104,12 +104,11 @@ impl FlowEventStartConditionUpdated {
         Self {
             event_id: event_id.into(),
             event_time: event.event_time,
-            start_condition_kind: event.start_condition.as_ref().map(|start_condition| {
-                match start_condition {
-                    fs::FlowStartCondition::Throttling(_) => FlowStartConditionKind::Throttling,
-                    fs::FlowStartCondition::Batching(_) => FlowStartConditionKind::Batching,
-                }
-            }),
+            start_condition_kind: match event.start_condition {
+                fs::FlowStartCondition::Throttling(_) => FlowStartConditionKind::Throttling,
+                fs::FlowStartCondition::Batching(_) => FlowStartConditionKind::Batching,
+                fs::FlowStartCondition::Executor(_) => FlowStartConditionKind::Executor,
+            },
         }
     }
 }
@@ -118,6 +117,7 @@ impl FlowEventStartConditionUpdated {
 pub enum FlowStartConditionKind {
     Throttling,
     Batching,
+    Executor,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
@@ -85,12 +85,16 @@ pub(crate) struct FlowStartConditionSchedule {
 #[derive(SimpleObject)]
 pub(crate) struct FlowStartConditionThrottling {
     interval_sec: i64,
+    wake_up_at: DateTime<Utc>,
+    shifted_from: DateTime<Utc>,
 }
 
 impl From<fs::FlowStartConditionThrottling> for FlowStartConditionThrottling {
     fn from(value: fs::FlowStartConditionThrottling) -> Self {
         Self {
             interval_sec: value.interval.num_seconds(),
+            wake_up_at: value.wake_up_at,
+            shifted_from: value.shifted_from,
         }
     }
 }

--- a/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
@@ -32,7 +32,7 @@ impl FlowStartCondition {
             None => None,
             Some(fs::FlowStartCondition::Schedule(s)) => {
                 Some(Self::Schedule(FlowStartConditionSchedule {
-                    activate_at: s.activate_at,
+                    wake_up_at: s.wake_up_at,
                 }))
             }
             Some(fs::FlowStartCondition::Throttling(t)) => Some(Self::Throttling((*t).into())),
@@ -79,7 +79,7 @@ impl FlowStartCondition {
 
 #[derive(SimpleObject)]
 pub(crate) struct FlowStartConditionSchedule {
-    activate_at: DateTime<Utc>,
+    wake_up_at: DateTime<Utc>,
 }
 
 #[derive(SimpleObject)]

--- a/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
@@ -17,6 +17,7 @@ use crate::prelude::*;
 
 #[derive(Union)]
 pub(crate) enum FlowStartCondition {
+    Schedule(FlowStartConditionSchedule),
     Throttling(FlowStartConditionThrottling),
     Batching(FlowStartConditionBatching),
     Executor(FlowStartConditionExecutor),
@@ -29,6 +30,11 @@ impl FlowStartCondition {
     ) -> Result<Option<Self>, InternalError> {
         Ok(match &flow_state.start_condition {
             None => None,
+            Some(fs::FlowStartCondition::Schedule(s)) => {
+                Some(Self::Schedule(FlowStartConditionSchedule {
+                    activate_at: s.activate_at,
+                }))
+            }
             Some(fs::FlowStartCondition::Throttling(t)) => Some(Self::Throttling((*t).into())),
             Some(fs::FlowStartCondition::Batching(b)) => {
                 // Start from zero increment
@@ -69,6 +75,11 @@ impl FlowStartCondition {
             }
         })
     }
+}
+
+#[derive(SimpleObject)]
+pub(crate) struct FlowStartConditionSchedule {
+    activate_at: DateTime<Utc>,
 }
 
 #[derive(SimpleObject)]

--- a/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
@@ -19,6 +19,7 @@ use crate::prelude::*;
 pub(crate) enum FlowStartCondition {
     Throttling(FlowStartConditionThrottling),
     Batching(FlowStartConditionBatching),
+    Executor(FlowStartConditionExecutor),
 }
 
 impl FlowStartCondition {
@@ -61,6 +62,11 @@ impl FlowStartCondition {
                     watermark_modified: total_increment.updated_watermark.is_some(),
                 }))
             }
+            Some(fs::FlowStartCondition::Executor(e)) => {
+                Some(Self::Executor(FlowStartConditionExecutor {
+                    task_id: e.task_id.into(),
+                }))
+            }
         })
     }
 }
@@ -85,6 +91,11 @@ pub(crate) struct FlowStartConditionBatching {
     pub accumulated_records_count: u64,
     pub watermark_modified: bool,
     // TODO: we can list all applied input flows, if that is interesting for debugging
+}
+
+#[derive(SimpleObject)]
+pub(crate) struct FlowStartConditionExecutor {
+    pub task_id: TaskID,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/scalars/flow_scalars.rs
+++ b/src/adapter/graphql/src/scalars/flow_scalars.rs
@@ -95,7 +95,6 @@ impl From<fs::FlowTimingRecords> for FlowTimingRecords {
 pub enum FlowStatus {
     Waiting,
     Queued,
-    Scheduled,
     Running,
     Finished,
 }

--- a/src/adapter/graphql/src/scalars/flow_scalars.rs
+++ b/src/adapter/graphql/src/scalars/flow_scalars.rs
@@ -67,6 +67,9 @@ impl From<fs::FlowKeySystem> for FlowKeySystem {
 
 #[derive(SimpleObject, Debug, Clone)]
 pub struct FlowTimingRecords {
+    /// Recorded time of last task scheduling
+    awaiting_executor_since: Option<DateTime<Utc>>,
+
     /// Recorded start of running (Running state seen at least once)
     running_since: Option<DateTime<Utc>>,
 
@@ -78,6 +81,7 @@ pub struct FlowTimingRecords {
 impl From<fs::FlowTimingRecords> for FlowTimingRecords {
     fn from(value: fs::FlowTimingRecords) -> Self {
         Self {
+            awaiting_executor_since: value.awaiting_executor_since,
             running_since: value.running_since,
             finished_at: value.finished_at,
         }

--- a/src/adapter/graphql/src/scalars/flow_scalars.rs
+++ b/src/adapter/graphql/src/scalars/flow_scalars.rs
@@ -94,7 +94,6 @@ impl From<fs::FlowTimingRecords> for FlowTimingRecords {
 #[graphql(remote = "kamu_flow_system::FlowStatus")]
 pub enum FlowStatus {
     Waiting,
-    Queued,
     Running,
     Finished,
 }

--- a/src/adapter/graphql/src/scalars/flow_scalars.rs
+++ b/src/adapter/graphql/src/scalars/flow_scalars.rs
@@ -67,9 +67,6 @@ impl From<fs::FlowKeySystem> for FlowKeySystem {
 
 #[derive(SimpleObject, Debug, Clone)]
 pub struct FlowTimingRecords {
-    /// Planned activation time (at least, Queued state)
-    activate_at: Option<DateTime<Utc>>,
-
     /// Recorded start of running (Running state seen at least once)
     running_since: Option<DateTime<Utc>>,
 
@@ -81,7 +78,6 @@ pub struct FlowTimingRecords {
 impl From<fs::FlowTimingRecords> for FlowTimingRecords {
     fn from(value: fs::FlowTimingRecords) -> Self {
         Self {
-            activate_at: value.activate_at,
             running_since: value.running_since,
             finished_at: value.finished_at,
         }

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -100,7 +100,7 @@ async fn test_trigger_ingest_root_dataset() {
                                 "flow": {
                                     "__typename": "Flow",
                                     "flowId": "0",
-                                    "status": "QUEUED",
+                                    "status": "WAITING",
                                     "outcome": null
                                 }
                             }
@@ -136,7 +136,7 @@ async fn test_trigger_ingest_root_dataset() {
                                             "datasetId": create_result.dataset_handle.id.to_string(),
                                             "ingestResult": null,
                                         },
-                                        "status": "QUEUED",
+                                        "status": "WAITING",
                                         "outcome": null,
                                         "timing": {
                                             "runningSince": null,
@@ -154,7 +154,9 @@ async fn test_trigger_ingest_root_dataset() {
                                                 "accountName": auth::DEFAULT_ACCOUNT_NAME,
                                             }
                                         },
-                                        "startCondition": null,
+                                        "startCondition": {
+                                            "__typename": "FlowStartConditionSchedule"
+                                        },
                                     }
                                 ],
                                 "pageInfo": {
@@ -197,7 +199,7 @@ async fn test_trigger_ingest_root_dataset() {
                                             "datasetId": create_result.dataset_handle.id.to_string(),
                                             "ingestResult": null,
                                         },
-                                        "status": "QUEUED",
+                                        "status": "WAITING",
                                         "outcome": null,
                                         "timing": {
                                             "runningSince": null,
@@ -438,7 +440,7 @@ async fn test_trigger_execute_transform_derived_dataset() {
                                 "flow": {
                                     "__typename": "Flow",
                                     "flowId": "0",
-                                    "status": "QUEUED",
+                                    "status": "WAITING",
                                     "outcome": null
                                 }
                             }
@@ -474,7 +476,7 @@ async fn test_trigger_execute_transform_derived_dataset() {
                                             "datasetId": create_derived_result.dataset_handle.id.to_string(),
                                             "transformResult": null,
                                         },
-                                        "status": "QUEUED",
+                                        "status": "WAITING",
                                         "outcome": null,
                                         "timing": {
                                             "runningSince": null,
@@ -492,7 +494,9 @@ async fn test_trigger_execute_transform_derived_dataset() {
                                                 "accountName": auth::DEFAULT_ACCOUNT_NAME,
                                             }
                                         },
-                                        "startCondition": null,
+                                        "startCondition": {
+                                            "__typename": "FlowStartConditionSchedule"
+                                        },
                                     }
                                 ],
                                 "pageInfo": {
@@ -818,7 +822,7 @@ async fn test_list_flows_with_filters_and_pagination() {
                         runs {
                             listFlows(
                                 filters: {
-                                    byStatus: "QUEUED"
+                                    byStatus: "WAITING"
                                 }
                             ) {
                                 nodes {
@@ -1560,24 +1564,29 @@ async fn test_history_of_completed_flow() {
                                             }
                                         },
                                         {
-                                            "__typename": "FlowEventQueued",
+                                            "__typename": "FlowEventStartConditionUpdated",
                                             "eventId": "1",
+                                            "startConditionKind": "SCHEDULE"
+                                        },
+                                        {
+                                            "__typename": "FlowEventActivationTimeDefined",
+                                            "eventId": "2",
                                         },
                                         {
                                             "__typename": "FlowEventTriggerAdded",
-                                            "eventId": "2",
+                                            "eventId": "3",
                                             "trigger": {
                                                 "__typename": "FlowTriggerAutoPolling"
                                             }
                                         },
                                         {
                                             "__typename": "FlowEventStartConditionUpdated",
-                                            "eventId": "3",
+                                            "eventId": "4",
                                             "startConditionKind": "EXECUTOR"
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "4",
+                                            "eventId": "5",
                                             "taskId": "0",
                                             "taskStatus": "QUEUED",
                                             "task": {
@@ -1586,7 +1595,7 @@ async fn test_history_of_completed_flow() {
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "5",
+                                            "eventId": "6",
                                             "taskId": "0",
                                             "taskStatus": "RUNNING",
                                             "task": {
@@ -1595,7 +1604,7 @@ async fn test_history_of_completed_flow() {
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "6",
+                                            "eventId": "7",
                                             "taskId": "0",
                                             "taskStatus": "FINISHED",
                                             "task": {

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -1952,6 +1952,8 @@ impl FlowRunsHarness {
                                             }
                                             ... on FlowStartConditionThrottling {
                                                 intervalSec
+                                                wakeUpAt
+                                                shiftedFrom
                                             }
                                             ... on FlowStartConditionExecutor {
                                                 taskId

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -155,9 +155,7 @@ async fn test_trigger_ingest_root_dataset() {
                                                 "accountName": auth::DEFAULT_ACCOUNT_NAME,
                                             }
                                         },
-                                        "startCondition": {
-                                            "__typename": "FlowStartConditionSchedule"
-                                        },
+                                        "startCondition": null,
                                     }
                                 ],
                                 "pageInfo": {
@@ -500,9 +498,7 @@ async fn test_trigger_execute_transform_derived_dataset() {
                                                 "accountName": auth::DEFAULT_ACCOUNT_NAME,
                                             }
                                         },
-                                        "startCondition": {
-                                            "__typename": "FlowStartConditionSchedule"
-                                        },
+                                        "startCondition": null,
                                     }
                                 ],
                                 "pageInfo": {
@@ -1572,25 +1568,20 @@ async fn test_history_of_completed_flow() {
                                             }
                                         },
                                         {
-                                            "__typename": "FlowEventStartConditionUpdated",
-                                            "eventId": "1",
-                                            "startConditionKind": "SCHEDULE"
-                                        },
-                                        {
                                             "__typename": "FlowEventTriggerAdded",
-                                            "eventId": "2",
+                                            "eventId": "1",
                                             "trigger": {
                                                 "__typename": "FlowTriggerAutoPolling"
                                             }
                                         },
                                         {
                                             "__typename": "FlowEventStartConditionUpdated",
-                                            "eventId": "3",
+                                            "eventId": "2",
                                             "startConditionKind": "EXECUTOR"
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "4",
+                                            "eventId": "3",
                                             "taskId": "0",
                                             "taskStatus": "QUEUED",
                                             "task": {
@@ -1599,7 +1590,7 @@ async fn test_history_of_completed_flow() {
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "5",
+                                            "eventId": "4",
                                             "taskId": "0",
                                             "taskStatus": "RUNNING",
                                             "task": {
@@ -1608,7 +1599,7 @@ async fn test_history_of_completed_flow() {
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "6",
+                                            "eventId": "5",
                                             "taskId": "0",
                                             "taskStatus": "FINISHED",
                                             "task": {

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -1569,24 +1569,20 @@ async fn test_history_of_completed_flow() {
                                             "startConditionKind": "SCHEDULE"
                                         },
                                         {
-                                            "__typename": "FlowEventActivationTimeDefined",
-                                            "eventId": "2",
-                                        },
-                                        {
                                             "__typename": "FlowEventTriggerAdded",
-                                            "eventId": "3",
+                                            "eventId": "2",
                                             "trigger": {
                                                 "__typename": "FlowTriggerAutoPolling"
                                             }
                                         },
                                         {
                                             "__typename": "FlowEventStartConditionUpdated",
-                                            "eventId": "4",
+                                            "eventId": "3",
                                             "startConditionKind": "EXECUTOR"
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "5",
+                                            "eventId": "4",
                                             "taskId": "0",
                                             "taskStatus": "QUEUED",
                                             "task": {
@@ -1595,7 +1591,7 @@ async fn test_history_of_completed_flow() {
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "6",
+                                            "eventId": "5",
                                             "taskId": "0",
                                             "taskStatus": "RUNNING",
                                             "task": {
@@ -1604,7 +1600,7 @@ async fn test_history_of_completed_flow() {
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
-                                            "eventId": "7",
+                                            "eventId": "6",
                                             "taskId": "0",
                                             "taskStatus": "FINISHED",
                                             "task": {

--- a/src/domain/flow-system/src/aggregates/flow/flow.rs
+++ b/src/domain/flow-system/src/aggregates/flow/flow.rs
@@ -49,20 +49,7 @@ impl Flow {
         let event = FlowEventStartConditionUpdated {
             event_time: now,
             flow_id: self.flow_id,
-            start_condition: Some(start_condition),
-        };
-        self.apply(event)
-    }
-
-    /// Clear start condition to indicate there is no reason of waiting
-    pub fn clear_start_condition(
-        &mut self,
-        now: DateTime<Utc>,
-    ) -> Result<(), ProjectionError<FlowState>> {
-        let event = FlowEventStartConditionUpdated {
-            event_time: now,
-            flow_id: self.flow_id,
-            start_condition: None,
+            start_condition,
         };
         self.apply(event)
     }

--- a/src/domain/flow-system/src/aggregates/flow/flow.rs
+++ b/src/domain/flow-system/src/aggregates/flow/flow.rs
@@ -54,20 +54,6 @@ impl Flow {
         self.apply(event)
     }
 
-    /// Activate at time
-    pub fn activate_at_time(
-        &mut self,
-        now: DateTime<Utc>,
-        activation_time: DateTime<Utc>,
-    ) -> Result<(), ProjectionError<FlowState>> {
-        let event = FlowEventActivationTimeDefined {
-            event_time: now,
-            flow_id: self.flow_id,
-            activation_time,
-        };
-        self.apply(event)
-    }
-
     /// Add extra trigger, if it's unique
     pub fn add_trigger_if_unique(
         &mut self,

--- a/src/domain/flow-system/src/aggregates/flow/flow.rs
+++ b/src/domain/flow-system/src/aggregates/flow/flow.rs
@@ -58,12 +58,12 @@ impl Flow {
     pub fn activate_at_time(
         &mut self,
         now: DateTime<Utc>,
-        activate_at: DateTime<Utc>,
+        activation_time: DateTime<Utc>,
     ) -> Result<(), ProjectionError<FlowState>> {
-        let event = FlowEventQueued {
+        let event = FlowEventActivationTimeDefined {
             event_time: now,
             flow_id: self.flow_id,
-            activate_at,
+            activation_time,
         };
         self.apply(event)
     }

--- a/src/domain/flow-system/src/entities/flow/flow_event.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_event.rs
@@ -23,8 +23,6 @@ pub enum FlowEvent {
     StartConditionUpdated(FlowEventStartConditionUpdated),
     /// Secondary trigger added
     TriggerAdded(FlowEventTriggerAdded),
-    /// Activation time defined
-    ActivationTimeDefined(FlowEventActivationTimeDefined),
     /// Scheduled/Rescheduled a task
     TaskScheduled(FlowEventTaskScheduled),
     /// Task running
@@ -61,15 +59,6 @@ pub struct FlowEventTriggerAdded {
     pub event_time: DateTime<Utc>,
     pub flow_id: FlowID,
     pub trigger: FlowTrigger,
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FlowEventActivationTimeDefined {
-    pub event_time: DateTime<Utc>,
-    pub flow_id: FlowID,
-    pub activation_time: DateTime<Utc>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -116,7 +105,6 @@ impl FlowEvent {
             FlowEvent::Initiated(e) => e.flow_id,
             FlowEvent::StartConditionUpdated(e) => e.flow_id,
             FlowEvent::TriggerAdded(e) => e.flow_id,
-            FlowEvent::ActivationTimeDefined(e) => e.flow_id,
             FlowEvent::TaskScheduled(e) => e.flow_id,
             FlowEvent::TaskRunning(e) => e.flow_id,
             FlowEvent::TaskFinished(e) => e.flow_id,
@@ -129,7 +117,6 @@ impl FlowEvent {
             FlowEvent::Initiated(e) => e.event_time,
             FlowEvent::StartConditionUpdated(e) => e.event_time,
             FlowEvent::TriggerAdded(e) => e.event_time,
-            FlowEvent::ActivationTimeDefined(e) => e.event_time,
             FlowEvent::TaskScheduled(e) => e.event_time,
             FlowEvent::TaskRunning(e) => e.event_time,
             FlowEvent::TaskFinished(e) => e.event_time,
@@ -142,7 +129,6 @@ impl FlowEvent {
             FlowEvent::Initiated(_) => Some(FlowStatus::Waiting),
             FlowEvent::StartConditionUpdated(_)
             | FlowEvent::TriggerAdded(_)
-            | FlowEvent::ActivationTimeDefined(_)
             | FlowEvent::TaskScheduled(_) => None,
             FlowEvent::TaskRunning(_) => Some(FlowStatus::Running),
             FlowEvent::TaskFinished(_) | FlowEvent::Aborted(_) => Some(FlowStatus::Finished),
@@ -157,9 +143,6 @@ impl_enum_variant!(FlowEvent::StartConditionUpdated(
     FlowEventStartConditionUpdated
 ));
 impl_enum_variant!(FlowEvent::TriggerAdded(FlowEventTriggerAdded));
-impl_enum_variant!(FlowEvent::ActivationTimeDefined(
-    FlowEventActivationTimeDefined
-));
 impl_enum_variant!(FlowEvent::TaskScheduled(FlowEventTaskScheduled));
 impl_enum_variant!(FlowEvent::TaskRunning(FlowEventTaskRunning));
 impl_enum_variant!(FlowEvent::TaskFinished(FlowEventTaskFinished));

--- a/src/domain/flow-system/src/entities/flow/flow_event.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_event.rs
@@ -51,7 +51,7 @@ pub struct FlowEventInitiated {
 pub struct FlowEventStartConditionUpdated {
     pub event_time: DateTime<Utc>,
     pub flow_id: FlowID,
-    pub start_condition: Option<FlowStartCondition>,
+    pub start_condition: FlowStartCondition,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -140,9 +140,10 @@ impl FlowEvent {
     pub fn new_status(&self) -> Option<FlowStatus> {
         match self {
             FlowEvent::Initiated(_) => Some(FlowStatus::Waiting),
-            FlowEvent::StartConditionUpdated(_) | FlowEvent::TriggerAdded(_) => None,
+            FlowEvent::StartConditionUpdated(_)
+            | FlowEvent::TriggerAdded(_)
+            | FlowEvent::TaskScheduled(_) => None,
             FlowEvent::Queued(_) => Some(FlowStatus::Queued),
-            FlowEvent::TaskScheduled(_) => Some(FlowStatus::Scheduled),
             FlowEvent::TaskRunning(_) => Some(FlowStatus::Running),
             FlowEvent::TaskFinished(_) | FlowEvent::Aborted(_) => Some(FlowStatus::Finished),
         }

--- a/src/domain/flow-system/src/entities/flow/flow_event.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_event.rs
@@ -21,10 +21,10 @@ pub enum FlowEvent {
     Initiated(FlowEventInitiated),
     /// Start condition updated
     StartConditionUpdated(FlowEventStartConditionUpdated),
-    /// Queued for time
-    Queued(FlowEventQueued),
     /// Secondary trigger added
     TriggerAdded(FlowEventTriggerAdded),
+    /// Activation time defined
+    ActivationTimeDefined(FlowEventActivationTimeDefined),
     /// Scheduled/Rescheduled a task
     TaskScheduled(FlowEventTaskScheduled),
     /// Task running
@@ -57,19 +57,19 @@ pub struct FlowEventStartConditionUpdated {
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FlowEventQueued {
+pub struct FlowEventTriggerAdded {
     pub event_time: DateTime<Utc>,
     pub flow_id: FlowID,
-    pub activate_at: DateTime<Utc>,
+    pub trigger: FlowTrigger,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FlowEventTriggerAdded {
+pub struct FlowEventActivationTimeDefined {
     pub event_time: DateTime<Utc>,
     pub flow_id: FlowID,
-    pub trigger: FlowTrigger,
+    pub activation_time: DateTime<Utc>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -115,8 +115,8 @@ impl FlowEvent {
         match self {
             FlowEvent::Initiated(e) => e.flow_id,
             FlowEvent::StartConditionUpdated(e) => e.flow_id,
-            FlowEvent::Queued(e) => e.flow_id,
             FlowEvent::TriggerAdded(e) => e.flow_id,
+            FlowEvent::ActivationTimeDefined(e) => e.flow_id,
             FlowEvent::TaskScheduled(e) => e.flow_id,
             FlowEvent::TaskRunning(e) => e.flow_id,
             FlowEvent::TaskFinished(e) => e.flow_id,
@@ -128,8 +128,8 @@ impl FlowEvent {
         match self {
             FlowEvent::Initiated(e) => e.event_time,
             FlowEvent::StartConditionUpdated(e) => e.event_time,
-            FlowEvent::Queued(e) => e.event_time,
             FlowEvent::TriggerAdded(e) => e.event_time,
+            FlowEvent::ActivationTimeDefined(e) => e.event_time,
             FlowEvent::TaskScheduled(e) => e.event_time,
             FlowEvent::TaskRunning(e) => e.event_time,
             FlowEvent::TaskFinished(e) => e.event_time,
@@ -142,8 +142,8 @@ impl FlowEvent {
             FlowEvent::Initiated(_) => Some(FlowStatus::Waiting),
             FlowEvent::StartConditionUpdated(_)
             | FlowEvent::TriggerAdded(_)
+            | FlowEvent::ActivationTimeDefined(_)
             | FlowEvent::TaskScheduled(_) => None,
-            FlowEvent::Queued(_) => Some(FlowStatus::Queued),
             FlowEvent::TaskRunning(_) => Some(FlowStatus::Running),
             FlowEvent::TaskFinished(_) | FlowEvent::Aborted(_) => Some(FlowStatus::Finished),
         }
@@ -156,8 +156,10 @@ impl_enum_variant!(FlowEvent::Initiated(FlowEventInitiated));
 impl_enum_variant!(FlowEvent::StartConditionUpdated(
     FlowEventStartConditionUpdated
 ));
-impl_enum_variant!(FlowEvent::Queued(FlowEventQueued));
 impl_enum_variant!(FlowEvent::TriggerAdded(FlowEventTriggerAdded));
+impl_enum_variant!(FlowEvent::ActivationTimeDefined(
+    FlowEventActivationTimeDefined
+));
 impl_enum_variant!(FlowEvent::TaskScheduled(FlowEventTaskScheduled));
 impl_enum_variant!(FlowEvent::TaskRunning(FlowEventTaskRunning));
 impl_enum_variant!(FlowEvent::TaskFinished(FlowEventTaskFinished));

--- a/src/domain/flow-system/src/entities/flow/flow_start_condition.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_start_condition.rs
@@ -34,6 +34,8 @@ pub struct FlowStartConditionSchedule {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FlowStartConditionThrottling {
     pub interval: Duration,
+    pub wake_up_at: DateTime<Utc>,
+    pub shifted_from: DateTime<Utc>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/entities/flow/flow_start_condition.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_start_condition.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use chrono::{DateTime, Duration, Utc};
+use kamu_task_system::TaskID;
 
 use crate::BatchingRule;
 
@@ -17,6 +18,7 @@ use crate::BatchingRule;
 pub enum FlowStartCondition {
     Throttling(FlowStartConditionThrottling),
     Batching(FlowStartConditionBatching),
+    Executor(FlowStartConditionExecutor),
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -32,6 +34,13 @@ pub struct FlowStartConditionThrottling {
 pub struct FlowStartConditionBatching {
     pub active_batching_rule: BatchingRule,
     pub batching_deadline: DateTime<Utc>,
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlowStartConditionExecutor {
+    pub task_id: TaskID,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/entities/flow/flow_start_condition.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_start_condition.rs
@@ -16,9 +16,17 @@ use crate::BatchingRule;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlowStartCondition {
+    Schedule(FlowStartConditionSchedule),
     Throttling(FlowStartConditionThrottling),
     Batching(FlowStartConditionBatching),
     Executor(FlowStartConditionExecutor),
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlowStartConditionSchedule {
+    pub activate_at: DateTime<Utc>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/entities/flow/flow_start_condition.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_start_condition.rs
@@ -26,7 +26,7 @@ pub enum FlowStartCondition {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FlowStartConditionSchedule {
-    pub activate_at: DateTime<Utc>,
+    pub wake_up_at: DateTime<Utc>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/entities/flow/flow_status.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_status.rs
@@ -13,7 +13,6 @@
 pub enum FlowStatus {
     Waiting,
     Queued,
-    Scheduled,
     Running,
     Finished,
 }

--- a/src/domain/flow-system/src/entities/flow/flow_status.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_status.rs
@@ -12,7 +12,6 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlowStatus {
     Waiting,
-    Queued,
     Running,
     Finished,
 }

--- a/src/domain/flow-system/src/services/flow/flow_service_test_driver.rs
+++ b/src/domain/flow-system/src/services/flow/flow_service_test_driver.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use chrono::{DateTime, Utc};
 use internal_error::InternalError;
 use kamu_task_system::TaskID;
 
@@ -20,7 +21,11 @@ pub trait FlowServiceTestDriver: Sync + Send {
     fn mimic_running_started(&self);
 
     /// Pretends it is time to schedule the given flow that was in Queued state
-    async fn mimic_flow_scheduled(&self, flow_id: FlowID) -> Result<TaskID, InternalError>;
+    async fn mimic_flow_scheduled(
+        &self,
+        flow_id: FlowID,
+        schedule_time: DateTime<Utc>,
+    ) -> Result<TaskID, InternalError>;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/flow-system-inmem/src/services/flow/flow_time_wheel.rs
+++ b/src/infra/flow-system-inmem/src/services/flow/flow_time_wheel.rs
@@ -56,7 +56,7 @@ impl FlowTimeWheel {
                     break;
                 }
 
-                if self.is_flow_activation_planned(ar.0.flow_id, activation_moment) {
+                if self.is_flow_activation_planned_at(ar.0.flow_id, activation_moment) {
                     res.push(ar.0.flow_id);
                 }
 
@@ -85,7 +85,11 @@ impl FlowTimeWheel {
         }
     }
 
-    fn is_flow_activation_planned(
+    pub fn get_planned_flow_activation_time(&self, flow_id: FlowID) -> Option<DateTime<Utc>> {
+        self.flow_activation_times_by_id.get(&flow_id).copied()
+    }
+
+    fn is_flow_activation_planned_at(
         &self,
         flow_id: FlowID,
         activation_moment: DateTime<Utc>,
@@ -123,7 +127,7 @@ impl FlowTimeWheel {
 
     fn clean_top_cancellations(&mut self) {
         while let Some(ar) = self.flow_heap.peek() {
-            if self.is_flow_activation_planned(ar.0.flow_id, ar.0.activation_time) {
+            if self.is_flow_activation_planned_at(ar.0.flow_id, ar.0.activation_time) {
                 break;
             }
 

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
@@ -1056,18 +1056,13 @@ fn drive_flow_to_status(
     flow.set_relevant_start_condition(
         start_moment + Duration::seconds(1),
         FlowStartCondition::Schedule(FlowStartConditionSchedule {
-            activate_at: start_moment + Duration::minutes(1),
+            wake_up_at: start_moment + Duration::minutes(1),
         }),
     )
     .unwrap();
 
     if expected_status != FlowStatus::Waiting {
         let task_id = task_event_store.new_task_id();
-        flow.activate_at_time(
-            start_moment + Duration::seconds(1),
-            start_moment + Duration::minutes(1),
-        )
-        .unwrap();
         flow.on_task_scheduled(start_moment + Duration::minutes(5), task_id)
             .unwrap();
         flow.on_task_running(start_moment + Duration::minutes(7), task_id)

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
@@ -38,16 +38,14 @@ async fn test_dataset_flow_empty_filters_distingush_dataset() {
             offset: 0,
             limit: 100,
         },
-        10,
+        8,
         vec![
             foo_cases.compacting_flow_ids.flow_id_finished,
             foo_cases.compacting_flow_ids.flow_id_running,
-            foo_cases.compacting_flow_ids.flow_id_scheduled,
             foo_cases.compacting_flow_ids.flow_id_queued,
             foo_cases.compacting_flow_ids.flow_id_waiting,
             foo_cases.ingest_flow_ids.flow_id_finished,
             foo_cases.ingest_flow_ids.flow_id_running,
-            foo_cases.ingest_flow_ids.flow_id_scheduled,
             foo_cases.ingest_flow_ids.flow_id_queued,
             foo_cases.ingest_flow_ids.flow_id_waiting,
         ],
@@ -62,16 +60,14 @@ async fn test_dataset_flow_empty_filters_distingush_dataset() {
             offset: 0,
             limit: 100,
         },
-        10,
+        8,
         vec![
             bar_cases.compacting_flow_ids.flow_id_finished,
             bar_cases.compacting_flow_ids.flow_id_running,
-            bar_cases.compacting_flow_ids.flow_id_scheduled,
             bar_cases.compacting_flow_ids.flow_id_queued,
             bar_cases.compacting_flow_ids.flow_id_waiting,
             bar_cases.ingest_flow_ids.flow_id_finished,
             bar_cases.ingest_flow_ids.flow_id_running,
-            bar_cases.ingest_flow_ids.flow_id_scheduled,
             bar_cases.ingest_flow_ids.flow_id_queued,
             bar_cases.ingest_flow_ids.flow_id_waiting,
         ],
@@ -107,16 +103,6 @@ async fn test_dataset_flow_filter_by_status() {
             vec![
                 foo_cases.compacting_flow_ids.flow_id_queued,
                 foo_cases.ingest_flow_ids.flow_id_queued,
-            ],
-        ),
-        (
-            DatasetFlowFilters {
-                by_flow_status: Some(FlowStatus::Scheduled),
-                ..Default::default()
-            },
-            vec![
-                foo_cases.compacting_flow_ids.flow_id_scheduled,
-                foo_cases.ingest_flow_ids.flow_id_scheduled,
             ],
         ),
         (
@@ -175,7 +161,6 @@ async fn test_dataset_flow_filter_by_flow_type() {
             vec![
                 foo_cases.ingest_flow_ids.flow_id_finished,
                 foo_cases.ingest_flow_ids.flow_id_running,
-                foo_cases.ingest_flow_ids.flow_id_scheduled,
                 foo_cases.ingest_flow_ids.flow_id_queued,
                 foo_cases.ingest_flow_ids.flow_id_waiting,
             ],
@@ -188,7 +173,6 @@ async fn test_dataset_flow_filter_by_flow_type() {
             vec![
                 foo_cases.compacting_flow_ids.flow_id_finished,
                 foo_cases.compacting_flow_ids.flow_id_running,
-                foo_cases.compacting_flow_ids.flow_id_scheduled,
                 foo_cases.compacting_flow_ids.flow_id_queued,
                 foo_cases.compacting_flow_ids.flow_id_waiting,
             ],
@@ -237,9 +221,7 @@ async fn test_dataset_flow_filter_by_initiator() {
             },
             vec![
                 foo_cases.compacting_flow_ids.flow_id_queued,
-                foo_cases.compacting_flow_ids.flow_id_waiting,
                 foo_cases.ingest_flow_ids.flow_id_queued,
-                foo_cases.ingest_flow_ids.flow_id_waiting,
             ],
         ),
         (
@@ -250,8 +232,8 @@ async fn test_dataset_flow_filter_by_initiator() {
                 ..Default::default()
             },
             vec![
-                foo_cases.compacting_flow_ids.flow_id_scheduled,
-                foo_cases.ingest_flow_ids.flow_id_scheduled,
+                foo_cases.compacting_flow_ids.flow_id_waiting,
+                foo_cases.ingest_flow_ids.flow_id_waiting,
             ],
         ),
         (
@@ -307,7 +289,7 @@ async fn test_dataset_flow_filter_combinations() {
                 by_flow_status: Some(FlowStatus::Waiting),
                 by_flow_type: Some(DatasetFlowType::Compaction),
                 by_initiator: Some(InitiatorFilter::Account(AccountName::new_unchecked(
-                    "wasya",
+                    "petya",
                 ))),
             },
             vec![foo_cases.compacting_flow_ids.flow_id_waiting],
@@ -360,7 +342,7 @@ async fn test_dataset_flow_pagination() {
         ),
         (
             FlowPaginationOpts {
-                offset: 3,
+                offset: 2,
                 limit: 4,
             },
             vec![
@@ -372,7 +354,7 @@ async fn test_dataset_flow_pagination() {
         ),
         (
             FlowPaginationOpts {
-                offset: 8,
+                offset: 6,
                 limit: 2,
             },
             vec![
@@ -382,14 +364,14 @@ async fn test_dataset_flow_pagination() {
         ),
         (
             FlowPaginationOpts {
-                offset: 9,
+                offset: 7,
                 limit: 2,
             },
             vec![foo_cases.ingest_flow_ids.flow_id_waiting],
         ),
         (
             FlowPaginationOpts {
-                offset: 10,
+                offset: 8,
                 limit: 5,
             },
             vec![],
@@ -402,7 +384,7 @@ async fn test_dataset_flow_pagination() {
             &foo_cases,
             Default::default(),
             pagination,
-            10,
+            8,
             expected_flow_ids,
         )
         .await;
@@ -428,7 +410,7 @@ async fn test_dataset_flow_pagination_with_filters() {
                 by_flow_type: Some(DatasetFlowType::Ingest),
                 ..Default::default()
             },
-            5,
+            4,
             vec![
                 foo_cases.ingest_flow_ids.flow_id_finished,
                 foo_cases.ingest_flow_ids.flow_id_running,
@@ -461,18 +443,6 @@ async fn test_dataset_flow_pagination_with_filters() {
                 foo_cases.ingest_flow_ids.flow_id_finished,
             ],
         ),
-        (
-            FlowPaginationOpts {
-                offset: 3,
-                limit: 5,
-            },
-            DatasetFlowFilters {
-                by_flow_status: Some(FlowStatus::Scheduled),
-                ..Default::default()
-            },
-            2,
-            vec![],
-        ),
     ];
 
     for (pagination, filters, expected_total_count, expected_flow_ids) in cases {
@@ -504,11 +474,10 @@ async fn test_unfiltered_system_flows() {
             offset: 0,
             limit: 100,
         },
-        5,
+        4,
         vec![
             system_case.gc_flow_ids.flow_id_finished,
             system_case.gc_flow_ids.flow_id_running,
-            system_case.gc_flow_ids.flow_id_scheduled,
             system_case.gc_flow_ids.flow_id_queued,
             system_case.gc_flow_ids.flow_id_waiting,
         ],
@@ -533,7 +502,6 @@ async fn test_system_flows_filtered_by_flow_type() {
         vec![
             system_case.gc_flow_ids.flow_id_finished,
             system_case.gc_flow_ids.flow_id_running,
-            system_case.gc_flow_ids.flow_id_scheduled,
             system_case.gc_flow_ids.flow_id_queued,
             system_case.gc_flow_ids.flow_id_waiting,
         ],
@@ -622,10 +590,7 @@ async fn test_system_flows_filtered_by_initiator() {
                 ))),
                 ..Default::default()
             },
-            vec![
-                system_case.gc_flow_ids.flow_id_queued,
-                system_case.gc_flow_ids.flow_id_waiting,
-            ],
+            vec![system_case.gc_flow_ids.flow_id_queued],
         ),
         (
             SystemFlowFilters {
@@ -674,7 +639,7 @@ async fn test_system_flows_complex_filter() {
         (
             SystemFlowFilters {
                 by_initiator: Some(InitiatorFilter::Account(AccountName::new_unchecked(
-                    "wasya",
+                    "petya",
                 ))),
                 by_flow_status: Some(FlowStatus::Waiting),
                 by_flow_type: None,
@@ -729,13 +694,6 @@ async fn test_system_flow_pagination() {
         (
             FlowPaginationOpts {
                 offset: 2,
-                limit: 1,
-            },
-            vec![system_case.gc_flow_ids.flow_id_scheduled],
-        ),
-        (
-            FlowPaginationOpts {
-                offset: 3,
                 limit: 2,
             },
             vec![
@@ -745,14 +703,14 @@ async fn test_system_flow_pagination() {
         ),
         (
             FlowPaginationOpts {
-                offset: 4,
+                offset: 3,
                 limit: 2,
             },
             vec![system_case.gc_flow_ids.flow_id_waiting],
         ),
         (
             FlowPaginationOpts {
-                offset: 5,
+                offset: 4,
                 limit: 5,
             },
             vec![],
@@ -764,7 +722,7 @@ async fn test_system_flow_pagination() {
             flow_event_store.clone(),
             Default::default(),
             pagination,
-            5,
+            4,
             expected_flow_ids,
         )
         .await;
@@ -790,7 +748,7 @@ async fn test_system_flow_pagination_with_filters() {
                 by_flow_type: Some(SystemFlowType::GC),
                 ..Default::default()
             },
-            5,
+            4,
             vec![
                 system_case.gc_flow_ids.flow_id_finished,
                 system_case.gc_flow_ids.flow_id_running,
@@ -819,18 +777,6 @@ async fn test_system_flow_pagination_with_filters() {
             },
             2,
             vec![system_case.gc_flow_ids.flow_id_running],
-        ),
-        (
-            FlowPaginationOpts {
-                offset: 1,
-                limit: 5,
-            },
-            SystemFlowFilters {
-                by_flow_status: Some(FlowStatus::Scheduled),
-                ..Default::default()
-            },
-            1,
-            vec![],
         ),
     ];
 
@@ -868,11 +814,10 @@ struct SystemTestCase {
 }
 
 struct TestFlowIDs {
-    flow_id_waiting: FlowID,   // Initiator: wasya
-    flow_id_queued: FlowID,    // Initiator: wasya
-    flow_id_scheduled: FlowID, // Initiator: petya
-    flow_id_running: FlowID,   // Initiator: system
-    flow_id_finished: FlowID,  // Initiator: system
+    flow_id_waiting: FlowID,  // Initiator: wasya
+    flow_id_queued: FlowID,   // Initiator: wasya
+    flow_id_running: FlowID,  // Initiator: system
+    flow_id_finished: FlowID, // Initiator: system
 }
 
 async fn make_dataset_test_case(
@@ -932,21 +877,10 @@ async fn make_dataset_test_flows(
     let automatic_trigger = FlowTrigger::AutoPolling(FlowTriggerAutoPolling {});
 
     let flow_id_waiting = flow_generator
-        .make_new_flow(
-            dataset_flow_type,
-            FlowStatus::Waiting,
-            wasya_manual_trigger.clone(),
-        )
+        .make_new_flow(dataset_flow_type, FlowStatus::Waiting, petya_manual_trigger)
         .await;
     let flow_id_queued = flow_generator
         .make_new_flow(dataset_flow_type, FlowStatus::Queued, wasya_manual_trigger)
-        .await;
-    let flow_id_scheduled = flow_generator
-        .make_new_flow(
-            dataset_flow_type,
-            FlowStatus::Scheduled,
-            petya_manual_trigger.clone(),
-        )
         .await;
     let flow_id_running = flow_generator
         .make_new_flow(
@@ -962,7 +896,6 @@ async fn make_dataset_test_flows(
     TestFlowIDs {
         flow_id_waiting,
         flow_id_queued,
-        flow_id_scheduled,
         flow_id_running,
         flow_id_finished,
     }
@@ -988,21 +921,10 @@ async fn make_system_test_flows(
     let automatic_trigger = FlowTrigger::AutoPolling(FlowTriggerAutoPolling {});
 
     let flow_id_waiting = flow_generator
-        .make_new_flow(
-            system_flow_type,
-            FlowStatus::Waiting,
-            wasya_manual_trigger.clone(),
-        )
+        .make_new_flow(system_flow_type, FlowStatus::Waiting, petya_manual_trigger)
         .await;
     let flow_id_queued = flow_generator
         .make_new_flow(system_flow_type, FlowStatus::Queued, wasya_manual_trigger)
-        .await;
-    let flow_id_scheduled = flow_generator
-        .make_new_flow(
-            system_flow_type,
-            FlowStatus::Scheduled,
-            petya_manual_trigger.clone(),
-        )
         .await;
     let flow_id_running = flow_generator
         .make_new_flow(
@@ -1018,7 +940,6 @@ async fn make_system_test_flows(
     TestFlowIDs {
         flow_id_waiting,
         flow_id_queued,
-        flow_id_scheduled,
         flow_id_running,
         flow_id_finished,
     }
@@ -1180,21 +1101,18 @@ fn drive_flow_to_status(
             let task_id = task_event_store.new_task_id();
             flow.on_task_scheduled(start_moment + Duration::minutes(5), task_id)
                 .unwrap();
+            flow.on_task_running(start_moment + Duration::minutes(7), task_id)
+                .unwrap();
 
-            if expected_status != FlowStatus::Scheduled {
-                flow.on_task_running(start_moment + Duration::minutes(7), task_id)
-                    .unwrap();
-
-                if expected_status == FlowStatus::Finished {
-                    flow.on_task_finished(
-                        start_moment + Duration::minutes(10),
-                        task_id,
-                        TaskOutcome::Success(TaskResult::Empty),
-                    )
-                    .unwrap();
-                } else if expected_status != FlowStatus::Running {
-                    panic!("Not expecting flow status {expected_status:?}");
-                }
+            if expected_status == FlowStatus::Finished {
+                flow.on_task_finished(
+                    start_moment + Duration::minutes(10),
+                    task_id,
+                    TaskOutcome::Success(TaskResult::Empty),
+                )
+                .unwrap();
+            } else if expected_status != FlowStatus::Running {
+                panic!("Not expecting flow status {expected_status:?}");
             }
         }
     }

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_event_store_inmem.rs
@@ -38,15 +38,13 @@ async fn test_dataset_flow_empty_filters_distingush_dataset() {
             offset: 0,
             limit: 100,
         },
-        8,
+        6,
         vec![
             foo_cases.compacting_flow_ids.flow_id_finished,
             foo_cases.compacting_flow_ids.flow_id_running,
-            foo_cases.compacting_flow_ids.flow_id_queued,
             foo_cases.compacting_flow_ids.flow_id_waiting,
             foo_cases.ingest_flow_ids.flow_id_finished,
             foo_cases.ingest_flow_ids.flow_id_running,
-            foo_cases.ingest_flow_ids.flow_id_queued,
             foo_cases.ingest_flow_ids.flow_id_waiting,
         ],
     )
@@ -60,15 +58,13 @@ async fn test_dataset_flow_empty_filters_distingush_dataset() {
             offset: 0,
             limit: 100,
         },
-        8,
+        6,
         vec![
             bar_cases.compacting_flow_ids.flow_id_finished,
             bar_cases.compacting_flow_ids.flow_id_running,
-            bar_cases.compacting_flow_ids.flow_id_queued,
             bar_cases.compacting_flow_ids.flow_id_waiting,
             bar_cases.ingest_flow_ids.flow_id_finished,
             bar_cases.ingest_flow_ids.flow_id_running,
-            bar_cases.ingest_flow_ids.flow_id_queued,
             bar_cases.ingest_flow_ids.flow_id_waiting,
         ],
     )
@@ -93,16 +89,6 @@ async fn test_dataset_flow_filter_by_status() {
             vec![
                 foo_cases.compacting_flow_ids.flow_id_waiting,
                 foo_cases.ingest_flow_ids.flow_id_waiting,
-            ],
-        ),
-        (
-            DatasetFlowFilters {
-                by_flow_status: Some(FlowStatus::Queued),
-                ..Default::default()
-            },
-            vec![
-                foo_cases.compacting_flow_ids.flow_id_queued,
-                foo_cases.ingest_flow_ids.flow_id_queued,
             ],
         ),
         (
@@ -161,7 +147,6 @@ async fn test_dataset_flow_filter_by_flow_type() {
             vec![
                 foo_cases.ingest_flow_ids.flow_id_finished,
                 foo_cases.ingest_flow_ids.flow_id_running,
-                foo_cases.ingest_flow_ids.flow_id_queued,
                 foo_cases.ingest_flow_ids.flow_id_waiting,
             ],
         ),
@@ -173,7 +158,6 @@ async fn test_dataset_flow_filter_by_flow_type() {
             vec![
                 foo_cases.compacting_flow_ids.flow_id_finished,
                 foo_cases.compacting_flow_ids.flow_id_running,
-                foo_cases.compacting_flow_ids.flow_id_queued,
                 foo_cases.compacting_flow_ids.flow_id_waiting,
             ],
         ),
@@ -220,8 +204,8 @@ async fn test_dataset_flow_filter_by_initiator() {
                 ..Default::default()
             },
             vec![
-                foo_cases.compacting_flow_ids.flow_id_queued,
-                foo_cases.ingest_flow_ids.flow_id_queued,
+                foo_cases.compacting_flow_ids.flow_id_running,
+                foo_cases.ingest_flow_ids.flow_id_running,
             ],
         ),
         (
@@ -243,9 +227,7 @@ async fn test_dataset_flow_filter_by_initiator() {
             },
             vec![
                 foo_cases.compacting_flow_ids.flow_id_finished,
-                foo_cases.compacting_flow_ids.flow_id_running,
                 foo_cases.ingest_flow_ids.flow_id_finished,
-                foo_cases.ingest_flow_ids.flow_id_running,
             ],
         ),
     ];
@@ -296,7 +278,7 @@ async fn test_dataset_flow_filter_combinations() {
         ),
         (
             DatasetFlowFilters {
-                by_flow_status: Some(FlowStatus::Queued),
+                by_flow_status: Some(FlowStatus::Running),
                 by_flow_type: Some(DatasetFlowType::Ingest),
                 by_initiator: Some(InitiatorFilter::System),
             },
@@ -343,10 +325,9 @@ async fn test_dataset_flow_pagination() {
         (
             FlowPaginationOpts {
                 offset: 2,
-                limit: 4,
+                limit: 3,
             },
             vec![
-                foo_cases.compacting_flow_ids.flow_id_queued,
                 foo_cases.compacting_flow_ids.flow_id_waiting,
                 foo_cases.ingest_flow_ids.flow_id_finished,
                 foo_cases.ingest_flow_ids.flow_id_running,
@@ -354,24 +335,24 @@ async fn test_dataset_flow_pagination() {
         ),
         (
             FlowPaginationOpts {
-                offset: 6,
+                offset: 4,
                 limit: 2,
             },
             vec![
-                foo_cases.ingest_flow_ids.flow_id_queued,
+                foo_cases.ingest_flow_ids.flow_id_running,
                 foo_cases.ingest_flow_ids.flow_id_waiting,
             ],
         ),
         (
             FlowPaginationOpts {
-                offset: 7,
+                offset: 5,
                 limit: 2,
             },
             vec![foo_cases.ingest_flow_ids.flow_id_waiting],
         ),
         (
             FlowPaginationOpts {
-                offset: 8,
+                offset: 6,
                 limit: 5,
             },
             vec![],
@@ -384,7 +365,7 @@ async fn test_dataset_flow_pagination() {
             &foo_cases,
             Default::default(),
             pagination,
-            8,
+            6,
             expected_flow_ids,
         )
         .await;
@@ -410,7 +391,7 @@ async fn test_dataset_flow_pagination_with_filters() {
                 by_flow_type: Some(DatasetFlowType::Ingest),
                 ..Default::default()
             },
-            4,
+            3,
             vec![
                 foo_cases.ingest_flow_ids.flow_id_finished,
                 foo_cases.ingest_flow_ids.flow_id_running,
@@ -422,11 +403,11 @@ async fn test_dataset_flow_pagination_with_filters() {
                 limit: 2,
             },
             DatasetFlowFilters {
-                by_flow_status: Some(FlowStatus::Queued),
+                by_flow_status: Some(FlowStatus::Waiting),
                 ..Default::default()
             },
             2,
-            vec![foo_cases.ingest_flow_ids.flow_id_queued],
+            vec![foo_cases.ingest_flow_ids.flow_id_waiting],
         ),
         (
             FlowPaginationOpts {
@@ -437,11 +418,8 @@ async fn test_dataset_flow_pagination_with_filters() {
                 by_initiator: Some(InitiatorFilter::System),
                 ..Default::default()
             },
-            4,
-            vec![
-                foo_cases.compacting_flow_ids.flow_id_running,
-                foo_cases.ingest_flow_ids.flow_id_finished,
-            ],
+            2,
+            vec![foo_cases.ingest_flow_ids.flow_id_finished],
         ),
     ];
 
@@ -474,11 +452,10 @@ async fn test_unfiltered_system_flows() {
             offset: 0,
             limit: 100,
         },
-        4,
+        3,
         vec![
             system_case.gc_flow_ids.flow_id_finished,
             system_case.gc_flow_ids.flow_id_running,
-            system_case.gc_flow_ids.flow_id_queued,
             system_case.gc_flow_ids.flow_id_waiting,
         ],
     )
@@ -502,7 +479,6 @@ async fn test_system_flows_filtered_by_flow_type() {
         vec![
             system_case.gc_flow_ids.flow_id_finished,
             system_case.gc_flow_ids.flow_id_running,
-            system_case.gc_flow_ids.flow_id_queued,
             system_case.gc_flow_ids.flow_id_waiting,
         ],
     )];
@@ -534,10 +510,17 @@ async fn test_system_flows_filtered_by_flow_status() {
     let cases = vec![
         (
             SystemFlowFilters {
-                by_flow_status: Some(FlowStatus::Queued),
+                by_flow_status: Some(FlowStatus::Waiting),
                 ..Default::default()
             },
-            vec![system_case.gc_flow_ids.flow_id_queued],
+            vec![system_case.gc_flow_ids.flow_id_waiting],
+        ),
+        (
+            SystemFlowFilters {
+                by_flow_status: Some(FlowStatus::Running),
+                ..Default::default()
+            },
+            vec![system_case.gc_flow_ids.flow_id_running],
         ),
         (
             SystemFlowFilters {
@@ -578,10 +561,7 @@ async fn test_system_flows_filtered_by_initiator() {
                 by_initiator: Some(InitiatorFilter::System),
                 ..Default::default()
             },
-            vec![
-                system_case.gc_flow_ids.flow_id_finished,
-                system_case.gc_flow_ids.flow_id_running,
-            ],
+            vec![system_case.gc_flow_ids.flow_id_finished],
         ),
         (
             SystemFlowFilters {
@@ -590,7 +570,7 @@ async fn test_system_flows_filtered_by_initiator() {
                 ))),
                 ..Default::default()
             },
-            vec![system_case.gc_flow_ids.flow_id_queued],
+            vec![system_case.gc_flow_ids.flow_id_running],
         ),
         (
             SystemFlowFilters {
@@ -648,7 +628,7 @@ async fn test_system_flows_complex_filter() {
         ),
         (
             SystemFlowFilters {
-                by_flow_status: Some(FlowStatus::Queued),
+                by_flow_status: Some(FlowStatus::Running),
                 by_initiator: Some(InitiatorFilter::System),
                 by_flow_type: Some(SystemFlowType::GC),
             },
@@ -693,24 +673,24 @@ async fn test_system_flow_pagination() {
         ),
         (
             FlowPaginationOpts {
-                offset: 2,
+                offset: 1,
                 limit: 2,
             },
             vec![
-                system_case.gc_flow_ids.flow_id_queued,
+                system_case.gc_flow_ids.flow_id_running,
                 system_case.gc_flow_ids.flow_id_waiting,
             ],
         ),
         (
             FlowPaginationOpts {
-                offset: 3,
+                offset: 2,
                 limit: 2,
             },
             vec![system_case.gc_flow_ids.flow_id_waiting],
         ),
         (
             FlowPaginationOpts {
-                offset: 4,
+                offset: 3,
                 limit: 5,
             },
             vec![],
@@ -722,7 +702,7 @@ async fn test_system_flow_pagination() {
             flow_event_store.clone(),
             Default::default(),
             pagination,
-            4,
+            3,
             expected_flow_ids,
         )
         .await;
@@ -748,7 +728,7 @@ async fn test_system_flow_pagination_with_filters() {
                 by_flow_type: Some(SystemFlowType::GC),
                 ..Default::default()
             },
-            4,
+            3,
             vec![
                 system_case.gc_flow_ids.flow_id_finished,
                 system_case.gc_flow_ids.flow_id_running,
@@ -760,11 +740,11 @@ async fn test_system_flow_pagination_with_filters() {
                 limit: 2,
             },
             SystemFlowFilters {
-                by_flow_status: Some(FlowStatus::Queued),
+                by_flow_status: Some(FlowStatus::Waiting),
                 ..Default::default()
             },
             1,
-            vec![system_case.gc_flow_ids.flow_id_queued],
+            vec![system_case.gc_flow_ids.flow_id_waiting],
         ),
         (
             FlowPaginationOpts {
@@ -775,8 +755,8 @@ async fn test_system_flow_pagination_with_filters() {
                 by_initiator: Some(InitiatorFilter::System),
                 ..Default::default()
             },
-            2,
-            vec![system_case.gc_flow_ids.flow_id_running],
+            1,
+            vec![],
         ),
     ];
 
@@ -814,9 +794,8 @@ struct SystemTestCase {
 }
 
 struct TestFlowIDs {
-    flow_id_waiting: FlowID,  // Initiator: wasya
-    flow_id_queued: FlowID,   // Initiator: wasya
-    flow_id_running: FlowID,  // Initiator: system
+    flow_id_waiting: FlowID,  // Initiator: petya
+    flow_id_running: FlowID,  // Initiator: wasya
     flow_id_finished: FlowID, // Initiator: system
 }
 
@@ -879,15 +858,8 @@ async fn make_dataset_test_flows(
     let flow_id_waiting = flow_generator
         .make_new_flow(dataset_flow_type, FlowStatus::Waiting, petya_manual_trigger)
         .await;
-    let flow_id_queued = flow_generator
-        .make_new_flow(dataset_flow_type, FlowStatus::Queued, wasya_manual_trigger)
-        .await;
     let flow_id_running = flow_generator
-        .make_new_flow(
-            dataset_flow_type,
-            FlowStatus::Running,
-            automatic_trigger.clone(),
-        )
+        .make_new_flow(dataset_flow_type, FlowStatus::Running, wasya_manual_trigger)
         .await;
     let flow_id_finished = flow_generator
         .make_new_flow(dataset_flow_type, FlowStatus::Finished, automatic_trigger)
@@ -895,7 +867,6 @@ async fn make_dataset_test_flows(
 
     TestFlowIDs {
         flow_id_waiting,
-        flow_id_queued,
         flow_id_running,
         flow_id_finished,
     }
@@ -923,15 +894,8 @@ async fn make_system_test_flows(
     let flow_id_waiting = flow_generator
         .make_new_flow(system_flow_type, FlowStatus::Waiting, petya_manual_trigger)
         .await;
-    let flow_id_queued = flow_generator
-        .make_new_flow(system_flow_type, FlowStatus::Queued, wasya_manual_trigger)
-        .await;
     let flow_id_running = flow_generator
-        .make_new_flow(
-            system_flow_type,
-            FlowStatus::Running,
-            automatic_trigger.clone(),
-        )
+        .make_new_flow(system_flow_type, FlowStatus::Running, wasya_manual_trigger)
         .await;
     let flow_id_finished = flow_generator
         .make_new_flow(system_flow_type, FlowStatus::Finished, automatic_trigger)
@@ -939,7 +903,6 @@ async fn make_system_test_flows(
 
     TestFlowIDs {
         flow_id_waiting,
-        flow_id_queued,
         flow_id_running,
         flow_id_finished,
     }
@@ -1090,30 +1053,35 @@ fn drive_flow_to_status(
 ) {
     let start_moment = Utc::now();
 
+    flow.set_relevant_start_condition(
+        start_moment + Duration::seconds(1),
+        FlowStartCondition::Schedule(FlowStartConditionSchedule {
+            activate_at: start_moment + Duration::minutes(1),
+        }),
+    )
+    .unwrap();
+
     if expected_status != FlowStatus::Waiting {
+        let task_id = task_event_store.new_task_id();
         flow.activate_at_time(
             start_moment + Duration::seconds(1),
             start_moment + Duration::minutes(1),
         )
         .unwrap();
+        flow.on_task_scheduled(start_moment + Duration::minutes(5), task_id)
+            .unwrap();
+        flow.on_task_running(start_moment + Duration::minutes(7), task_id)
+            .unwrap();
 
-        if expected_status != FlowStatus::Queued {
-            let task_id = task_event_store.new_task_id();
-            flow.on_task_scheduled(start_moment + Duration::minutes(5), task_id)
-                .unwrap();
-            flow.on_task_running(start_moment + Duration::minutes(7), task_id)
-                .unwrap();
-
-            if expected_status == FlowStatus::Finished {
-                flow.on_task_finished(
-                    start_moment + Duration::minutes(10),
-                    task_id,
-                    TaskOutcome::Success(TaskResult::Empty),
-                )
-                .unwrap();
-            } else if expected_status != FlowStatus::Running {
-                panic!("Not expecting flow status {expected_status:?}");
-            }
+        if expected_status == FlowStatus::Finished {
+            flow.on_task_finished(
+                start_moment + Duration::minutes(10),
+                task_id,
+                TaskOutcome::Success(TaskResult::Empty),
+            )
+            .unwrap();
+        } else if expected_status != FlowStatus::Running {
+            panic!("Not expecting flow status {expected_status:?}");
         }
     }
 }

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -101,7 +101,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
             r#"
             #0: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "foo" Ingest:
@@ -343,7 +343,7 @@ async fn test_manual_trigger() {
             r#"
             #0: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "foo" Ingest:
@@ -520,9 +520,9 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 1 Waiting AutoPolling
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "bar" Ingest:
@@ -572,7 +572,7 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=80ms)
+                Flow ID = 4 Waiting AutoPolling
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -717,9 +717,9 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 1 Waiting AutoPolling
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "bar" Ingest:
@@ -765,7 +765,7 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #7: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Waiting AutoPolling Schedule(wakeup=100ms)
+                Flow ID = 5 Waiting AutoPolling
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
@@ -900,9 +900,9 @@ async fn test_dataset_deleted() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 1 Waiting AutoPolling
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "bar" Ingest:
@@ -1069,11 +1069,11 @@ async fn test_task_completions_trigger_next_loop_on_success() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 1 Waiting AutoPolling
               "baz" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 2 Waiting AutoPolling
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "bar" Ingest:
@@ -1275,9 +1275,9 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 1 Waiting AutoPolling
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "bar" ExecuteTransform:
@@ -1683,11 +1683,11 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             r#"
           #0: +0ms:
             "bar" Ingest:
-              Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+              Flow ID = 1 Waiting AutoPolling
             "baz" ExecuteTransform:
-              Flow ID = 2 Waiting AutoPolling Schedule(wakeup=0ms)
+              Flow ID = 2 Waiting AutoPolling
             "foo" Ingest:
-              Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+              Flow ID = 0 Waiting AutoPolling
 
           #1: +0ms:
             "bar" Ingest:
@@ -2074,9 +2074,9 @@ async fn test_batching_condition_records_reached() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 1 Waiting AutoPolling
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "bar" ExecuteTransform:
@@ -2351,9 +2351,9 @@ async fn test_batching_condition_timeout() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 1 Waiting AutoPolling
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+                Flow ID = 0 Waiting AutoPolling
 
             #1: +0ms:
               "bar" ExecuteTransform:
@@ -2596,9 +2596,9 @@ async fn test_batching_condition_watermark() {
             r#"
         #0: +0ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+            Flow ID = 1 Waiting AutoPolling
           "foo" Ingest:
-            Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+            Flow ID = 0 Waiting AutoPolling
 
         #1: +0ms:
           "bar" ExecuteTransform:
@@ -2942,11 +2942,11 @@ async fn test_batching_condition_with_2_inputs() {
             r#"
         #0: +0ms:
           "bar" Ingest:
-            Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
+            Flow ID = 1 Waiting AutoPolling
           "baz" ExecuteTransform:
-            Flow ID = 2 Waiting AutoPolling Schedule(wakeup=0ms)
+            Flow ID = 2 Waiting AutoPolling
           "foo" Ingest:
-            Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
+            Flow ID = 0 Waiting AutoPolling
 
         #1: +0ms:
           "bar" Ingest:

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -105,7 +105,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
 
             #1: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "foo" Ingest:
@@ -118,7 +118,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
 
             #4: +80ms:
               "foo" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=80ms)
                 Flow ID = 0 Finished Success
 
             #5: +90ms:
@@ -206,7 +206,7 @@ async fn test_cron_config() {
 
             #1: +5000ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=5000ms)
 
             #2: +6000ms:
               "foo" Ingest:
@@ -219,7 +219,7 @@ async fn test_cron_config() {
 
             #4: +10000ms:
               "foo" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=10000ms)
                 Flow ID = 0 Finished Success
 
             "#
@@ -347,7 +347,7 @@ async fn test_manual_trigger() {
 
             #1: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "foo" Ingest:
@@ -360,7 +360,7 @@ async fn test_manual_trigger() {
 
             #4: +40ms:
               "foo" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=40ms)
                 Flow ID = 0 Finished Success
 
             #5: +60ms:
@@ -376,7 +376,7 @@ async fn test_manual_trigger() {
 
             #7: +80ms:
               "bar" Ingest:
-                Flow ID = 3 Waiting Manual Executor(task=2)
+                Flow ID = 3 Waiting Manual Executor(task=2, since=80ms)
               "foo" Ingest:
                 Flow ID = 2 Waiting AutoPolling Schedule(wakeup=160ms)
                 Flow ID = 1 Finished Success
@@ -402,7 +402,7 @@ async fn test_manual_trigger() {
               "bar" Ingest:
                 Flow ID = 3 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=3)
+                Flow ID = 2 Waiting AutoPolling Executor(task=3, since=160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -526,19 +526,19 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
@@ -582,17 +582,17 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=2)
+                Flow ID = 4 Waiting AutoPolling Executor(task=2, since=80ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
             #9: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Waiting AutoPolling Executor(task=3)
+                Flow ID = 5 Waiting AutoPolling Executor(task=3, since=100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=2)
+                Flow ID = 4 Waiting AutoPolling Executor(task=2, since=80ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -723,19 +723,19 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 2 Waiting AutoPolling Schedule(wakeup=120ms)
                 Flow ID = 0 Finished Success
@@ -775,7 +775,7 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #8: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Waiting AutoPolling Executor(task=2)
+                Flow ID = 5 Waiting AutoPolling Executor(task=2, since=100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
@@ -785,11 +785,11 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #9: +120ms:
               "bar" Ingest:
-                Flow ID = 5 Waiting AutoPolling Executor(task=2)
+                Flow ID = 5 Waiting AutoPolling Executor(task=2, since=100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3, since=120ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -906,19 +906,19 @@ async fn test_dataset_deleted() {
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
@@ -948,7 +948,7 @@ async fn test_dataset_deleted() {
 
             #7: +100ms:
               "bar" Ingest:
-                Flow ID = 3 Waiting AutoPolling Executor(task=2)
+                Flow ID = 3 Waiting AutoPolling Executor(task=2, since=100ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 2 Finished Aborted
@@ -1077,25 +1077,25 @@ async fn test_task_completions_trigger_next_loop_on_success() {
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "baz" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "baz" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "baz" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
               "foo" Ingest:
                 Flow ID = 3 Waiting AutoPolling Schedule(wakeup=60ms)
                 Flow ID = 0 Finished Success
@@ -1104,7 +1104,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "baz" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
               "foo" Ingest:
                 Flow ID = 3 Waiting AutoPolling Schedule(wakeup=60ms)
                 Flow ID = 0 Finished Success
@@ -1113,7 +1113,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "bar" Ingest:
                 Flow ID = 1 Finished Failed
               "baz" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
               "foo" Ingest:
                 Flow ID = 3 Waiting AutoPolling Schedule(wakeup=60ms)
                 Flow ID = 0 Finished Success
@@ -1142,7 +1142,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Finished Cancelled
               "foo" Ingest:
-                Flow ID = 3 Waiting AutoPolling Executor(task=3)
+                Flow ID = 3 Waiting AutoPolling Executor(task=3, since=60ms)
                 Flow ID = 0 Finished Success
 
             "#
@@ -1281,19 +1281,19 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 2 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 0 Finished Success
@@ -1316,7 +1316,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2, since=100ms)
                 Flow ID = 0 Finished Success
 
             #7: +110ms:
@@ -1337,7 +1337,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
 
             #9: +120ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Waiting Input(foo) Executor(task=3)
+                Flow ID = 3 Waiting Input(foo) Executor(task=3, since=120ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 4 Waiting AutoPolling Schedule(wakeup=200ms)
@@ -1367,7 +1367,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=4)
+                Flow ID = 4 Waiting AutoPolling Executor(task=4, since=200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1462,7 +1462,7 @@ async fn test_throttling_manual_triggers() {
 
             #1: +20ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting Manual Executor(task=0)
+                Flow ID = 0 Waiting Manual Executor(task=0, since=20ms)
 
             #2: +40ms:
               "foo" Ingest:
@@ -1479,7 +1479,7 @@ async fn test_throttling_manual_triggers() {
 
             #5: +150ms:
               "foo" Ingest:
-                Flow ID = 1 Waiting Manual Executor(task=1)
+                Flow ID = 1 Waiting Manual Executor(task=1, since=150ms)
                 Flow ID = 0 Finished Success
 
           "#
@@ -1691,25 +1691,25 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #1: +0ms:
             "bar" Ingest:
-              Flow ID = 1 Waiting AutoPolling Executor(task=1)
+              Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
             "baz" ExecuteTransform:
-              Flow ID = 2 Waiting AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
             "foo" Ingest:
-              Flow ID = 0 Waiting AutoPolling Executor(task=0)
+              Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
           #2: +10ms:
             "bar" Ingest:
-              Flow ID = 1 Waiting AutoPolling Executor(task=1)
+              Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
             "baz" ExecuteTransform:
-              Flow ID = 2 Waiting AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
             "foo" Ingest:
               Flow ID = 0 Running(task=0)
 
           #3: +20ms:
             "bar" Ingest:
-              Flow ID = 1 Waiting AutoPolling Executor(task=1)
+              Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
             "baz" ExecuteTransform:
-              Flow ID = 2 Waiting AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
             "foo" Ingest:
               Flow ID = 3 Waiting AutoPolling Throttling(for=100ms, wakeup=120ms, shifted=70ms)
               Flow ID = 0 Finished Success
@@ -1718,7 +1718,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "bar" Ingest:
               Flow ID = 1 Running(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Waiting AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
             "foo" Ingest:
               Flow ID = 3 Waiting AutoPolling Throttling(for=100ms, wakeup=120ms, shifted=70ms)
               Flow ID = 0 Finished Success
@@ -1728,7 +1728,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 2 Waiting AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
             "foo" Ingest:
               Flow ID = 3 Waiting AutoPolling Throttling(for=100ms, wakeup=120ms, shifted=70ms)
               Flow ID = 0 Finished Success
@@ -1760,7 +1760,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 3 Waiting AutoPolling Executor(task=3)
+              Flow ID = 3 Waiting AutoPolling Executor(task=3, since=120ms)
               Flow ID = 0 Finished Success
 
           #9: +130ms:
@@ -1790,7 +1790,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 5 Waiting Input(foo) Executor(task=4)
+              Flow ID = 5 Waiting Input(foo) Executor(task=4, since=150ms)
               Flow ID = 2 Finished Success
             "foo" Ingest:
               Flow ID = 6 Waiting AutoPolling Throttling(for=100ms, wakeup=240ms, shifted=190ms)
@@ -1823,7 +1823,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #14: +180ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Executor(task=5)
+              Flow ID = 4 Waiting AutoPolling Executor(task=5, since=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Finished Success
@@ -1869,7 +1869,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Executor(task=6)
+              Flow ID = 6 Waiting AutoPolling Executor(task=6, since=240ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1879,25 +1879,25 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Waiting Input(bar) Executor(task=7)
+              Flow ID = 7 Waiting Input(bar) Executor(task=7, since=270ms)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Executor(task=6)
+              Flow ID = 6 Waiting AutoPolling Executor(task=6, since=240ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #19: +350ms:
             "bar" Ingest:
-              Flow ID = 8 Waiting AutoPolling Executor(task=8)
+              Flow ID = 8 Waiting AutoPolling Executor(task=8, since=350ms)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Waiting Input(bar) Executor(task=7)
+              Flow ID = 7 Waiting Input(bar) Executor(task=7, since=270ms)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Executor(task=6)
+              Flow ID = 6 Waiting AutoPolling Executor(task=6, since=240ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -2080,19 +2080,19 @@ async fn test_batching_condition_records_reached() {
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
@@ -2115,7 +2115,7 @@ async fn test_batching_condition_records_reached() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2, since=70ms)
                 Flow ID = 0 Finished Success
 
             #7: +80ms:
@@ -2139,7 +2139,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Waiting Input(foo) Batching(10, until=210ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3, since=140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2164,7 +2164,7 @@ async fn test_batching_condition_records_reached() {
 
             #12: +160ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Waiting Input(foo) Executor(task=4)
+                Flow ID = 3 Waiting Input(foo) Executor(task=4, since=160ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 5 Waiting AutoPolling Schedule(wakeup=210ms)
@@ -2197,7 +2197,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Waiting AutoPolling Executor(task=5)
+                Flow ID = 5 Waiting AutoPolling Executor(task=5, since=210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2357,19 +2357,19 @@ async fn test_batching_condition_timeout() {
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
               "foo" Ingest:
                 Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
@@ -2392,7 +2392,7 @@ async fn test_batching_condition_timeout() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2, since=70ms)
                 Flow ID = 0 Finished Success
 
             #7: +80ms:
@@ -2416,16 +2416,16 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Waiting Input(foo) Batching(10, until=240ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3, since=140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
             #10: +240ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Waiting Input(foo) Executor(task=4)
+                Flow ID = 3 Waiting Input(foo) Executor(task=4, since=240ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3, since=140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2434,7 +2434,7 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Running(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3, since=140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2443,7 +2443,7 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3, since=140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2602,19 +2602,19 @@ async fn test_batching_condition_watermark() {
 
         #1: +0ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Waiting AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
           "foo" Ingest:
-            Flow ID = 0 Waiting AutoPolling Executor(task=0)
+            Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
         #2: +10ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Waiting AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
           "foo" Ingest:
             Flow ID = 0 Running(task=0)
 
         #3: +20ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Waiting AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
           "foo" Ingest:
             Flow ID = 2 Waiting AutoPolling Schedule(wakeup=60ms)
             Flow ID = 0 Finished Success
@@ -2637,7 +2637,7 @@ async fn test_batching_condition_watermark() {
           "bar" ExecuteTransform:
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 2 Waiting AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2, since=60ms)
             Flow ID = 0 Finished Success
 
         #7: +70ms:
@@ -2661,16 +2661,16 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Waiting Input(foo) Batching(10, until=280ms)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Waiting AutoPolling Executor(task=3)
+            Flow ID = 4 Waiting AutoPolling Executor(task=3, since=120ms)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
         #10: +280ms:
           "bar" ExecuteTransform:
-            Flow ID = 3 Waiting Input(foo) Executor(task=4)
+            Flow ID = 3 Waiting Input(foo) Executor(task=4, since=280ms)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Waiting AutoPolling Executor(task=3)
+            Flow ID = 4 Waiting AutoPolling Executor(task=3, since=120ms)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2679,7 +2679,7 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Running(task=4)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Waiting AutoPolling Executor(task=3)
+            Flow ID = 4 Waiting AutoPolling Executor(task=3, since=120ms)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2688,7 +2688,7 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Finished Success
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Waiting AutoPolling Executor(task=3)
+            Flow ID = 4 Waiting AutoPolling Executor(task=3, since=120ms)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2950,25 +2950,25 @@ async fn test_batching_condition_with_2_inputs() {
 
         #1: +0ms:
           "bar" Ingest:
-            Flow ID = 1 Waiting AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
           "baz" ExecuteTransform:
-            Flow ID = 2 Waiting AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
           "foo" Ingest:
-            Flow ID = 0 Waiting AutoPolling Executor(task=0)
+            Flow ID = 0 Waiting AutoPolling Executor(task=0, since=0ms)
 
         #2: +10ms:
           "bar" Ingest:
-            Flow ID = 1 Waiting AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
           "baz" ExecuteTransform:
-            Flow ID = 2 Waiting AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
           "foo" Ingest:
             Flow ID = 0 Running(task=0)
 
         #3: +20ms:
           "bar" Ingest:
-            Flow ID = 1 Waiting AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1, since=0ms)
           "baz" ExecuteTransform:
-            Flow ID = 2 Waiting AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
           "foo" Ingest:
             Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
             Flow ID = 0 Finished Success
@@ -2977,7 +2977,7 @@ async fn test_batching_condition_with_2_inputs() {
           "bar" Ingest:
             Flow ID = 1 Running(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Waiting AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
           "foo" Ingest:
             Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
             Flow ID = 0 Finished Success
@@ -2987,7 +2987,7 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 4 Waiting AutoPolling Schedule(wakeup=150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 2 Waiting AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2, since=0ms)
           "foo" Ingest:
             Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
             Flow ID = 0 Finished Success
@@ -3019,7 +3019,7 @@ async fn test_batching_condition_with_2_inputs() {
           "baz" ExecuteTransform:
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 3 Waiting AutoPolling Executor(task=3)
+            Flow ID = 3 Waiting AutoPolling Executor(task=3, since=100ms)
             Flow ID = 0 Finished Success
 
         #9: +110ms:
@@ -3046,7 +3046,7 @@ async fn test_batching_condition_with_2_inputs() {
 
         #11: +150ms:
           "bar" Ingest:
-            Flow ID = 4 Waiting AutoPolling Executor(task=4)
+            Flow ID = 4 Waiting AutoPolling Executor(task=4, since=150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
@@ -3090,7 +3090,7 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Waiting AutoPolling Executor(task=5)
+            Flow ID = 6 Waiting AutoPolling Executor(task=5, since=200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
@@ -3127,7 +3127,7 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Waiting Input(foo) Executor(task=6)
+            Flow ID = 5 Waiting Input(foo) Executor(task=6, since=220ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
             Flow ID = 8 Waiting AutoPolling Schedule(wakeup=300ms)
@@ -3165,7 +3165,7 @@ async fn test_batching_condition_with_2_inputs() {
 
         #20: +290ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Executor(task=7)
+            Flow ID = 7 Waiting AutoPolling Executor(task=7, since=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
@@ -3179,14 +3179,14 @@ async fn test_batching_condition_with_2_inputs() {
 
         #21: +300ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Executor(task=7)
+            Flow ID = 7 Waiting AutoPolling Executor(task=7, since=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Finished Success
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Waiting AutoPolling Executor(task=8)
+            Flow ID = 8 Waiting AutoPolling Executor(task=8, since=300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -1474,7 +1474,7 @@ async fn test_throttling_manual_triggers() {
 
             #4: +100ms:
               "foo" Ingest:
-                Flow ID = 1 Waiting Manual Throttling(100ms)
+                Flow ID = 1 Waiting Manual Throttling(for=100ms, wakeup=150ms, shifted=70ms)
                 Flow ID = 0 Finished Success
 
             #5: +150ms:
@@ -1711,7 +1711,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "baz" ExecuteTransform:
               Flow ID = 2 Waiting AutoPolling Executor(task=2)
             "foo" Ingest:
-              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(for=100ms, wakeup=120ms, shifted=70ms)
               Flow ID = 0 Finished Success
 
           #4: +20ms:
@@ -1720,7 +1720,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "baz" ExecuteTransform:
               Flow ID = 2 Waiting AutoPolling Executor(task=2)
             "foo" Ingest:
-              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(for=100ms, wakeup=120ms, shifted=70ms)
               Flow ID = 0 Finished Success
 
           #5: +30ms:
@@ -1730,7 +1730,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "baz" ExecuteTransform:
               Flow ID = 2 Waiting AutoPolling Executor(task=2)
             "foo" Ingest:
-              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(for=100ms, wakeup=120ms, shifted=70ms)
               Flow ID = 0 Finished Success
 
           #6: +30ms:
@@ -1740,7 +1740,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "baz" ExecuteTransform:
               Flow ID = 2 Running(task=2)
             "foo" Ingest:
-              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(for=100ms, wakeup=120ms, shifted=70ms)
               Flow ID = 0 Finished Success
 
           #7: +50ms:
@@ -1750,7 +1750,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(for=100ms, wakeup=120ms, shifted=70ms)
               Flow ID = 0 Finished Success
 
           #8: +120ms:
@@ -1778,10 +1778,10 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 5 Waiting Input(foo) Throttling(100ms)
+              Flow ID = 5 Waiting Input(foo) Throttling(for=100ms, wakeup=150ms, shifted=140ms)
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(for=100ms, wakeup=240ms, shifted=190ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1793,7 +1793,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 5 Waiting Input(foo) Executor(task=4)
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(for=100ms, wakeup=240ms, shifted=190ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1805,7 +1805,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 5 Running(task=4)
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(for=100ms, wakeup=240ms, shifted=190ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1817,7 +1817,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(for=100ms, wakeup=240ms, shifted=190ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1829,7 +1829,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(for=100ms, wakeup=240ms, shifted=190ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1841,7 +1841,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(for=100ms, wakeup=240ms, shifted=190ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1851,11 +1851,11 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Waiting Input(bar) Throttling(100ms)
+              Flow ID = 7 Waiting Input(bar) Throttling(for=100ms, wakeup=270ms, shifted=200ms)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(for=100ms, wakeup=240ms, shifted=190ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1865,7 +1865,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Waiting Input(bar) Throttling(100ms)
+              Flow ID = 7 Waiting Input(bar) Throttling(for=100ms, wakeup=270ms, shifted=200ms)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -101,7 +101,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
             r#"
             #0: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "foo" Ingest:
@@ -113,7 +113,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
 
             #3: +20ms:
               "foo" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(80ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=80ms)
                 Flow ID = 0 Finished Success
 
             #4: +80ms:
@@ -128,7 +128,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
 
             #6: +100ms:
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -202,7 +202,7 @@ async fn test_cron_config() {
             r#"
             #0: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(5000ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=5000ms)
 
             #1: +5000ms:
               "foo" Ingest:
@@ -214,7 +214,7 @@ async fn test_cron_config() {
 
             #3: +7000ms:
               "foo" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(10000ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=10000ms)
                 Flow ID = 0 Finished Success
 
             #4: +10000ms:
@@ -343,7 +343,7 @@ async fn test_manual_trigger() {
             r#"
             #0: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "foo" Ingest:
@@ -355,7 +355,7 @@ async fn test_manual_trigger() {
 
             #3: +20ms:
               "foo" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(110ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=110ms)
                 Flow ID = 0 Finished Success
 
             #4: +40ms:
@@ -370,7 +370,7 @@ async fn test_manual_trigger() {
 
             #6: +70ms:
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -378,7 +378,7 @@ async fn test_manual_trigger() {
               "bar" Ingest:
                 Flow ID = 3 Waiting Manual Executor(task=2)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -386,7 +386,7 @@ async fn test_manual_trigger() {
               "bar" Ingest:
                 Flow ID = 3 Running(task=2)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -394,7 +394,7 @@ async fn test_manual_trigger() {
               "bar" Ingest:
                 Flow ID = 3 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -520,9 +520,9 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "bar" Ingest:
@@ -540,22 +540,22 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
               "bar" Ingest:
                 Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(110ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=110ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #6: +50ms:
@@ -568,17 +568,17 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
 
             #7: +80ms:
               "bar" Ingest:
-                Flow ID = 5 Waiting AutoPolling Schedule(100ms)
+                Flow ID = 5 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(80ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=80ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
             #8: +80ms:
               "bar" Ingest:
-                Flow ID = 5 Waiting AutoPolling Schedule(100ms)
+                Flow ID = 5 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
@@ -717,9 +717,9 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "bar" Ingest:
@@ -737,22 +737,22 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
               "bar" Ingest:
                 Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(120ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=120ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(120ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=120ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(90ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=90ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(120ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=120ms)
                 Flow ID = 0 Finished Success
 
             #6: +50ms:
@@ -765,11 +765,11 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #7: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Waiting AutoPolling Schedule(100ms)
+                Flow ID = 5 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(120ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=120ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -779,7 +779,7 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(120ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=120ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -900,9 +900,9 @@ async fn test_dataset_deleted() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "bar" Ingest:
@@ -920,27 +920,27 @@ async fn test_dataset_deleted() {
               "bar" Ingest:
                 Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(100ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #6: +50ms:
               "bar" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(100ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 2 Finished Aborted
@@ -1069,11 +1069,11 @@ async fn test_task_completions_trigger_next_loop_on_success() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
               "baz" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "bar" Ingest:
@@ -1097,7 +1097,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Waiting AutoPolling Executor(task=2)
               "foo" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=60ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
@@ -1106,7 +1106,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Waiting AutoPolling Executor(task=2)
               "foo" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=60ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
@@ -1115,7 +1115,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Waiting AutoPolling Executor(task=2)
               "foo" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=60ms)
                 Flow ID = 0 Finished Success
 
             #6: +30ms:
@@ -1124,7 +1124,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Running(task=2)
               "foo" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=60ms)
                 Flow ID = 0 Finished Success
 
             #7: +40ms:
@@ -1133,7 +1133,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Finished Cancelled
               "foo" Ingest:
-                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
+                Flow ID = 3 Waiting AutoPolling Schedule(wakeup=60ms)
                 Flow ID = 0 Finished Success
 
             #8: +60ms:
@@ -1275,9 +1275,9 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "bar" ExecuteTransform:
@@ -1295,21 +1295,21 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(100ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(100ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(100ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=100ms)
                 Flow ID = 0 Finished Success
 
             #6: +100ms:
@@ -1331,7 +1331,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Waiting Input(foo) Batching(1, until=1120ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(200ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1340,7 +1340,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Waiting Input(foo) Executor(task=3)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(200ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1349,7 +1349,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Running(task=3)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(200ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1358,7 +1358,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(200ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1683,11 +1683,11 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             r#"
           #0: +0ms:
             "bar" Ingest:
-              Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+              Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
             "baz" ExecuteTransform:
-              Flow ID = 2 Waiting AutoPolling Schedule(0ms)
+              Flow ID = 2 Waiting AutoPolling Schedule(wakeup=0ms)
             "foo" Ingest:
-              Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+              Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
           #1: +0ms:
             "bar" Ingest:
@@ -1725,7 +1725,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #5: +30ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Waiting AutoPolling Executor(task=2)
@@ -1735,7 +1735,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #6: +30ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Running(task=2)
@@ -1745,7 +1745,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #7: +50ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
@@ -1755,7 +1755,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #8: +120ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
@@ -1765,7 +1765,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #9: +130ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
@@ -1775,7 +1775,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #10: +140ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Waiting Input(foo) Throttling(for=100ms, wakeup=150ms, shifted=140ms)
@@ -1787,7 +1787,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #11: +150ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Waiting Input(foo) Executor(task=4)
@@ -1799,7 +1799,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #12: +160ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Running(task=4)
@@ -1811,7 +1811,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #13: +170ms:
             "bar" Ingest:
-              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
+              Flow ID = 4 Waiting AutoPolling Schedule(wakeup=180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Finished Success
@@ -1847,7 +1847,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #16: +200ms:
             "bar" Ingest:
-              Flow ID = 8 Waiting AutoPolling Schedule(350ms)
+              Flow ID = 8 Waiting AutoPolling Schedule(wakeup=350ms)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
@@ -1861,7 +1861,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #17: +240ms:
             "bar" Ingest:
-              Flow ID = 8 Waiting AutoPolling Schedule(350ms)
+              Flow ID = 8 Waiting AutoPolling Schedule(wakeup=350ms)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
@@ -1875,7 +1875,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #18: +270ms:
             "bar" Ingest:
-              Flow ID = 8 Waiting AutoPolling Schedule(350ms)
+              Flow ID = 8 Waiting AutoPolling Schedule(wakeup=350ms)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
@@ -2074,9 +2074,9 @@ async fn test_batching_condition_records_reached() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "bar" ExecuteTransform:
@@ -2094,21 +2094,21 @@ async fn test_batching_condition_records_reached() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #6: +70ms:
@@ -2130,7 +2130,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Waiting Input(foo) Batching(10, until=210ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(140ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2157,7 +2157,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Waiting Input(foo) Batching(10, until=210ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Waiting AutoPolling Schedule(210ms)
+                Flow ID = 5 Waiting AutoPolling Schedule(wakeup=210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2167,7 +2167,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Waiting Input(foo) Executor(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Waiting AutoPolling Schedule(210ms)
+                Flow ID = 5 Waiting AutoPolling Schedule(wakeup=210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2177,7 +2177,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Running(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Waiting AutoPolling Schedule(210ms)
+                Flow ID = 5 Waiting AutoPolling Schedule(wakeup=210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2187,7 +2187,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Waiting AutoPolling Schedule(210ms)
+                Flow ID = 5 Waiting AutoPolling Schedule(wakeup=210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2351,9 +2351,9 @@ async fn test_batching_condition_timeout() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
               "foo" Ingest:
-                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+                Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
             #1: +0ms:
               "bar" ExecuteTransform:
@@ -2371,21 +2371,21 @@ async fn test_batching_condition_timeout() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
+                Flow ID = 2 Waiting AutoPolling Schedule(wakeup=70ms)
                 Flow ID = 0 Finished Success
 
             #6: +70ms:
@@ -2407,7 +2407,7 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Waiting Input(foo) Batching(10, until=240ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Waiting AutoPolling Schedule(140ms)
+                Flow ID = 4 Waiting AutoPolling Schedule(wakeup=140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2596,9 +2596,9 @@ async fn test_batching_condition_watermark() {
             r#"
         #0: +0ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+            Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
           "foo" Ingest:
-            Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+            Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
         #1: +0ms:
           "bar" ExecuteTransform:
@@ -2616,21 +2616,21 @@ async fn test_batching_condition_watermark() {
           "bar" ExecuteTransform:
             Flow ID = 1 Waiting AutoPolling Executor(task=1)
           "foo" Ingest:
-            Flow ID = 2 Waiting AutoPolling Schedule(60ms)
+            Flow ID = 2 Waiting AutoPolling Schedule(wakeup=60ms)
             Flow ID = 0 Finished Success
 
         #4: +20ms:
           "bar" ExecuteTransform:
             Flow ID = 1 Running(task=1)
           "foo" Ingest:
-            Flow ID = 2 Waiting AutoPolling Schedule(60ms)
+            Flow ID = 2 Waiting AutoPolling Schedule(wakeup=60ms)
             Flow ID = 0 Finished Success
 
         #5: +30ms:
           "bar" ExecuteTransform:
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 2 Waiting AutoPolling Schedule(60ms)
+            Flow ID = 2 Waiting AutoPolling Schedule(wakeup=60ms)
             Flow ID = 0 Finished Success
 
         #6: +60ms:
@@ -2652,7 +2652,7 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Waiting Input(foo) Batching(10, until=280ms)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Waiting AutoPolling Schedule(120ms)
+            Flow ID = 4 Waiting AutoPolling Schedule(wakeup=120ms)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2942,11 +2942,11 @@ async fn test_batching_condition_with_2_inputs() {
             r#"
         #0: +0ms:
           "bar" Ingest:
-            Flow ID = 1 Waiting AutoPolling Schedule(0ms)
+            Flow ID = 1 Waiting AutoPolling Schedule(wakeup=0ms)
           "baz" ExecuteTransform:
-            Flow ID = 2 Waiting AutoPolling Schedule(0ms)
+            Flow ID = 2 Waiting AutoPolling Schedule(wakeup=0ms)
           "foo" Ingest:
-            Flow ID = 0 Waiting AutoPolling Schedule(0ms)
+            Flow ID = 0 Waiting AutoPolling Schedule(wakeup=0ms)
 
         #1: +0ms:
           "bar" Ingest:
@@ -2970,7 +2970,7 @@ async fn test_batching_condition_with_2_inputs() {
           "baz" ExecuteTransform:
             Flow ID = 2 Waiting AutoPolling Executor(task=2)
           "foo" Ingest:
-            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
+            Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
             Flow ID = 0 Finished Success
 
         #4: +20ms:
@@ -2979,42 +2979,42 @@ async fn test_batching_condition_with_2_inputs() {
           "baz" ExecuteTransform:
             Flow ID = 2 Waiting AutoPolling Executor(task=2)
           "foo" Ingest:
-            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
+            Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
             Flow ID = 0 Finished Success
 
         #5: +30ms:
           "bar" Ingest:
-            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
+            Flow ID = 4 Waiting AutoPolling Schedule(wakeup=150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Waiting AutoPolling Executor(task=2)
           "foo" Ingest:
-            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
+            Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
             Flow ID = 0 Finished Success
 
         #6: +30ms:
           "bar" Ingest:
-            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
+            Flow ID = 4 Waiting AutoPolling Schedule(wakeup=150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Running(task=2)
           "foo" Ingest:
-            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
+            Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
             Flow ID = 0 Finished Success
 
         #7: +40ms:
           "bar" Ingest:
-            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
+            Flow ID = 4 Waiting AutoPolling Schedule(wakeup=150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
+            Flow ID = 3 Waiting AutoPolling Schedule(wakeup=100ms)
             Flow ID = 0 Finished Success
 
         #8: +100ms:
           "bar" Ingest:
-            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
+            Flow ID = 4 Waiting AutoPolling Schedule(wakeup=150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Finished Success
@@ -3024,7 +3024,7 @@ async fn test_batching_condition_with_2_inputs() {
 
         #9: +110ms:
           "bar" Ingest:
-            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
+            Flow ID = 4 Waiting AutoPolling Schedule(wakeup=150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Finished Success
@@ -3034,13 +3034,13 @@ async fn test_batching_condition_with_2_inputs() {
 
         #10: +120ms:
           "bar" Ingest:
-            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
+            Flow ID = 4 Waiting AutoPolling Schedule(wakeup=150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Waiting AutoPolling Schedule(200ms)
+            Flow ID = 6 Waiting AutoPolling Schedule(wakeup=200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
@@ -3052,7 +3052,7 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Waiting AutoPolling Schedule(200ms)
+            Flow ID = 6 Waiting AutoPolling Schedule(wakeup=200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
@@ -3064,26 +3064,26 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Waiting AutoPolling Schedule(200ms)
+            Flow ID = 6 Waiting AutoPolling Schedule(wakeup=200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #13: +170ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
+            Flow ID = 7 Waiting AutoPolling Schedule(wakeup=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Waiting AutoPolling Schedule(200ms)
+            Flow ID = 6 Waiting AutoPolling Schedule(wakeup=200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #14: +200ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
+            Flow ID = 7 Waiting AutoPolling Schedule(wakeup=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
@@ -3096,7 +3096,7 @@ async fn test_batching_condition_with_2_inputs() {
 
         #15: +210ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
+            Flow ID = 7 Waiting AutoPolling Schedule(wakeup=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
@@ -3109,56 +3109,56 @@ async fn test_batching_condition_with_2_inputs() {
 
         #16: +220ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
+            Flow ID = 7 Waiting AutoPolling Schedule(wakeup=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
+            Flow ID = 8 Waiting AutoPolling Schedule(wakeup=300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #17: +220ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
+            Flow ID = 7 Waiting AutoPolling Schedule(wakeup=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Waiting Input(foo) Executor(task=6)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
+            Flow ID = 8 Waiting AutoPolling Schedule(wakeup=300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #18: +230ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
+            Flow ID = 7 Waiting AutoPolling Schedule(wakeup=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Running(task=6)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
+            Flow ID = 8 Waiting AutoPolling Schedule(wakeup=300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #19: +240ms:
           "bar" Ingest:
-            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
+            Flow ID = 7 Waiting AutoPolling Schedule(wakeup=290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Finished Success
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
+            Flow ID = 8 Waiting AutoPolling Schedule(wakeup=300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
@@ -3172,7 +3172,7 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 5 Finished Success
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
+            Flow ID = 8 Waiting AutoPolling Schedule(wakeup=300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -105,7 +105,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
 
             #1: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "foo" Ingest:
@@ -118,7 +118,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
 
             #4: +80ms:
               "foo" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(80ms) AutoPolling Executor(task=1)
                 Flow ID = 0 Finished Success
 
             #5: +90ms:
@@ -206,7 +206,7 @@ async fn test_cron_config() {
 
             #1: +5000ms:
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(5000ms) AutoPolling Executor(task=0)
 
             #2: +6000ms:
               "foo" Ingest:
@@ -219,7 +219,7 @@ async fn test_cron_config() {
 
             #4: +10000ms:
               "foo" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(10000ms) AutoPolling Executor(task=1)
                 Flow ID = 0 Finished Success
 
             "#
@@ -347,7 +347,7 @@ async fn test_manual_trigger() {
 
             #1: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "foo" Ingest:
@@ -360,7 +360,7 @@ async fn test_manual_trigger() {
 
             #4: +40ms:
               "foo" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(40ms) AutoPolling Executor(task=1)
                 Flow ID = 0 Finished Success
 
             #5: +60ms:
@@ -376,7 +376,7 @@ async fn test_manual_trigger() {
 
             #7: +80ms:
               "bar" Ingest:
-                Flow ID = 3 Scheduled(task=2) Manual
+                Flow ID = 3 Queued(80ms) Manual Executor(task=2)
               "foo" Ingest:
                 Flow ID = 2 Queued(160ms) AutoPolling
                 Flow ID = 1 Finished Success
@@ -402,7 +402,7 @@ async fn test_manual_trigger() {
               "bar" Ingest:
                 Flow ID = 3 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Scheduled(task=3) AutoPolling
+                Flow ID = 2 Queued(160ms) AutoPolling Executor(task=3)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -526,19 +526,19 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 2 Queued(70ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -582,17 +582,17 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=2) AutoPolling
+                Flow ID = 4 Queued(80ms) AutoPolling Executor(task=2)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
             #9: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Scheduled(task=3) AutoPolling
+                Flow ID = 5 Queued(100ms) AutoPolling Executor(task=3)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=2) AutoPolling
+                Flow ID = 4 Queued(80ms) AutoPolling Executor(task=2)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -723,19 +723,19 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 2 Queued(120ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -775,7 +775,7 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #8: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Scheduled(task=2) AutoPolling
+                Flow ID = 5 Queued(100ms) AutoPolling Executor(task=2)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
@@ -785,11 +785,11 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #9: +120ms:
               "bar" Ingest:
-                Flow ID = 5 Scheduled(task=2) AutoPolling
+                Flow ID = 5 Queued(100ms) AutoPolling Executor(task=2)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=3) AutoPolling
+                Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -906,19 +906,19 @@ async fn test_dataset_deleted() {
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 2 Queued(70ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -948,7 +948,7 @@ async fn test_dataset_deleted() {
 
             #7: +100ms:
               "bar" Ingest:
-                Flow ID = 3 Scheduled(task=2) AutoPolling
+                Flow ID = 3 Queued(100ms) AutoPolling Executor(task=2)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 2 Finished Aborted
@@ -1077,25 +1077,25 @@ async fn test_task_completions_trigger_next_loop_on_success() {
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "baz" Ingest:
-                Flow ID = 2 Scheduled(task=2) AutoPolling
+                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "baz" Ingest:
-                Flow ID = 2 Scheduled(task=2) AutoPolling
+                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "baz" Ingest:
-                Flow ID = 2 Scheduled(task=2) AutoPolling
+                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
               "foo" Ingest:
                 Flow ID = 3 Queued(60ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -1104,7 +1104,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "baz" Ingest:
-                Flow ID = 2 Scheduled(task=2) AutoPolling
+                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
               "foo" Ingest:
                 Flow ID = 3 Queued(60ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -1113,7 +1113,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "bar" Ingest:
                 Flow ID = 1 Finished Failed
               "baz" Ingest:
-                Flow ID = 2 Scheduled(task=2) AutoPolling
+                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
               "foo" Ingest:
                 Flow ID = 3 Queued(60ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -1142,7 +1142,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Finished Cancelled
               "foo" Ingest:
-                Flow ID = 3 Scheduled(task=3) AutoPolling
+                Flow ID = 3 Queued(60ms) AutoPolling Executor(task=3)
                 Flow ID = 0 Finished Success
 
             "#
@@ -1281,19 +1281,19 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 2 Queued(100ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -1316,7 +1316,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Scheduled(task=2) AutoPolling
+                Flow ID = 2 Queued(100ms) AutoPolling Executor(task=2)
                 Flow ID = 0 Finished Success
 
             #7: +110ms:
@@ -1337,7 +1337,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
 
             #9: +120ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Scheduled(task=3) Input(foo)
+                Flow ID = 3 Queued(120ms) Input(foo) Executor(task=3)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 4 Queued(200ms) AutoPolling
@@ -1367,7 +1367,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=4) AutoPolling
+                Flow ID = 4 Queued(200ms) AutoPolling Executor(task=4)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1462,7 +1462,7 @@ async fn test_throttling_manual_triggers() {
 
             #1: +20ms:
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) Manual
+                Flow ID = 0 Queued(20ms) Manual Executor(task=0)
 
             #2: +40ms:
               "foo" Ingest:
@@ -1479,7 +1479,7 @@ async fn test_throttling_manual_triggers() {
 
             #5: +150ms:
               "foo" Ingest:
-                Flow ID = 1 Scheduled(task=1) Manual
+                Flow ID = 1 Queued(150ms) Manual Executor(task=1)
                 Flow ID = 0 Finished Success
 
           "#
@@ -1691,25 +1691,25 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #1: +0ms:
             "bar" Ingest:
-              Flow ID = 1 Scheduled(task=1) AutoPolling
+              Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Scheduled(task=2) AutoPolling
+              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
             "foo" Ingest:
-              Flow ID = 0 Scheduled(task=0) AutoPolling
+              Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
           #2: +10ms:
             "bar" Ingest:
-              Flow ID = 1 Scheduled(task=1) AutoPolling
+              Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Scheduled(task=2) AutoPolling
+              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
             "foo" Ingest:
               Flow ID = 0 Running(task=0)
 
           #3: +20ms:
             "bar" Ingest:
-              Flow ID = 1 Scheduled(task=1) AutoPolling
+              Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Scheduled(task=2) AutoPolling
+              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
             "foo" Ingest:
               Flow ID = 3 Queued(120ms) AutoPolling Throttling(100ms)
               Flow ID = 0 Finished Success
@@ -1718,7 +1718,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "bar" Ingest:
               Flow ID = 1 Running(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Scheduled(task=2) AutoPolling
+              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
             "foo" Ingest:
               Flow ID = 3 Queued(120ms) AutoPolling Throttling(100ms)
               Flow ID = 0 Finished Success
@@ -1728,7 +1728,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Queued(180ms) AutoPolling
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 2 Scheduled(task=2) AutoPolling
+              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
             "foo" Ingest:
               Flow ID = 3 Queued(120ms) AutoPolling Throttling(100ms)
               Flow ID = 0 Finished Success
@@ -1760,7 +1760,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 3 Scheduled(task=3) AutoPolling
+              Flow ID = 3 Queued(120ms) AutoPolling Executor(task=3)
               Flow ID = 0 Finished Success
 
           #9: +130ms:
@@ -1790,7 +1790,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Queued(180ms) AutoPolling
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 5 Scheduled(task=4) Input(foo)
+              Flow ID = 5 Queued(150ms) Input(foo) Executor(task=4)
               Flow ID = 2 Finished Success
             "foo" Ingest:
               Flow ID = 6 Queued(240ms) AutoPolling Throttling(100ms)
@@ -1823,7 +1823,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #14: +180ms:
             "bar" Ingest:
-              Flow ID = 4 Scheduled(task=5) AutoPolling
+              Flow ID = 4 Queued(180ms) AutoPolling Executor(task=5)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Finished Success
@@ -1869,7 +1869,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Scheduled(task=6) AutoPolling
+              Flow ID = 6 Queued(240ms) AutoPolling Executor(task=6)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1879,25 +1879,25 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Scheduled(task=7) Input(bar)
+              Flow ID = 7 Queued(270ms) Input(bar) Executor(task=7)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Scheduled(task=6) AutoPolling
+              Flow ID = 6 Queued(240ms) AutoPolling Executor(task=6)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #19: +350ms:
             "bar" Ingest:
-              Flow ID = 8 Scheduled(task=8) AutoPolling
+              Flow ID = 8 Queued(350ms) AutoPolling Executor(task=8)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Scheduled(task=7) Input(bar)
+              Flow ID = 7 Queued(270ms) Input(bar) Executor(task=7)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Scheduled(task=6) AutoPolling
+              Flow ID = 6 Queued(240ms) AutoPolling Executor(task=6)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -2080,19 +2080,19 @@ async fn test_batching_condition_records_reached() {
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 2 Queued(70ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -2115,7 +2115,7 @@ async fn test_batching_condition_records_reached() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Scheduled(task=2) AutoPolling
+                Flow ID = 2 Queued(70ms) AutoPolling Executor(task=2)
                 Flow ID = 0 Finished Success
 
             #7: +80ms:
@@ -2139,7 +2139,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Queued(210ms) Input(foo) Batching(10, until=210ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=3) AutoPolling
+                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2164,7 +2164,7 @@ async fn test_batching_condition_records_reached() {
 
             #12: +160ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Scheduled(task=4) Input(foo)
+                Flow ID = 3 Queued(160ms) Input(foo) Executor(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 5 Queued(210ms) AutoPolling
@@ -2197,7 +2197,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Scheduled(task=5) AutoPolling
+                Flow ID = 5 Queued(210ms) AutoPolling Executor(task=5)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2357,19 +2357,19 @@ async fn test_batching_condition_timeout() {
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Scheduled(task=0) AutoPolling
+                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Scheduled(task=1) AutoPolling
+                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 2 Queued(70ms) AutoPolling
                 Flow ID = 0 Finished Success
@@ -2392,7 +2392,7 @@ async fn test_batching_condition_timeout() {
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Scheduled(task=2) AutoPolling
+                Flow ID = 2 Queued(70ms) AutoPolling Executor(task=2)
                 Flow ID = 0 Finished Success
 
             #7: +80ms:
@@ -2416,16 +2416,16 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Queued(240ms) Input(foo) Batching(10, until=240ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=3) AutoPolling
+                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
             #10: +240ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Scheduled(task=4) Input(foo)
+                Flow ID = 3 Queued(240ms) Input(foo) Executor(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=3) AutoPolling
+                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2434,7 +2434,7 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Running(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=3) AutoPolling
+                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2443,7 +2443,7 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Scheduled(task=3) AutoPolling
+                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2602,19 +2602,19 @@ async fn test_batching_condition_watermark() {
 
         #1: +0ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Scheduled(task=1) AutoPolling
+            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
           "foo" Ingest:
-            Flow ID = 0 Scheduled(task=0) AutoPolling
+            Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
         #2: +10ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Scheduled(task=1) AutoPolling
+            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
           "foo" Ingest:
             Flow ID = 0 Running(task=0)
 
         #3: +20ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Scheduled(task=1) AutoPolling
+            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
           "foo" Ingest:
             Flow ID = 2 Queued(60ms) AutoPolling
             Flow ID = 0 Finished Success
@@ -2637,7 +2637,7 @@ async fn test_batching_condition_watermark() {
           "bar" ExecuteTransform:
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 2 Scheduled(task=2) AutoPolling
+            Flow ID = 2 Queued(60ms) AutoPolling Executor(task=2)
             Flow ID = 0 Finished Success
 
         #7: +70ms:
@@ -2661,16 +2661,16 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Queued(280ms) Input(foo) Batching(10, until=280ms)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Scheduled(task=3) AutoPolling
+            Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
         #10: +280ms:
           "bar" ExecuteTransform:
-            Flow ID = 3 Scheduled(task=4) Input(foo)
+            Flow ID = 3 Queued(280ms) Input(foo) Executor(task=4)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Scheduled(task=3) AutoPolling
+            Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2679,7 +2679,7 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Running(task=4)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Scheduled(task=3) AutoPolling
+            Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2688,7 +2688,7 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Finished Success
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Scheduled(task=3) AutoPolling
+            Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2950,25 +2950,25 @@ async fn test_batching_condition_with_2_inputs() {
 
         #1: +0ms:
           "bar" Ingest:
-            Flow ID = 1 Scheduled(task=1) AutoPolling
+            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Scheduled(task=2) AutoPolling
+            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
           "foo" Ingest:
-            Flow ID = 0 Scheduled(task=0) AutoPolling
+            Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
 
         #2: +10ms:
           "bar" Ingest:
-            Flow ID = 1 Scheduled(task=1) AutoPolling
+            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Scheduled(task=2) AutoPolling
+            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
           "foo" Ingest:
             Flow ID = 0 Running(task=0)
 
         #3: +20ms:
           "bar" Ingest:
-            Flow ID = 1 Scheduled(task=1) AutoPolling
+            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Scheduled(task=2) AutoPolling
+            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
           "foo" Ingest:
             Flow ID = 3 Queued(100ms) AutoPolling
             Flow ID = 0 Finished Success
@@ -2977,7 +2977,7 @@ async fn test_batching_condition_with_2_inputs() {
           "bar" Ingest:
             Flow ID = 1 Running(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Scheduled(task=2) AutoPolling
+            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
           "foo" Ingest:
             Flow ID = 3 Queued(100ms) AutoPolling
             Flow ID = 0 Finished Success
@@ -2987,7 +2987,7 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 4 Queued(150ms) AutoPolling
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 2 Scheduled(task=2) AutoPolling
+            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
           "foo" Ingest:
             Flow ID = 3 Queued(100ms) AutoPolling
             Flow ID = 0 Finished Success
@@ -3019,7 +3019,7 @@ async fn test_batching_condition_with_2_inputs() {
           "baz" ExecuteTransform:
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 3 Scheduled(task=3) AutoPolling
+            Flow ID = 3 Queued(100ms) AutoPolling Executor(task=3)
             Flow ID = 0 Finished Success
 
         #9: +110ms:
@@ -3046,7 +3046,7 @@ async fn test_batching_condition_with_2_inputs() {
 
         #11: +150ms:
           "bar" Ingest:
-            Flow ID = 4 Scheduled(task=4) AutoPolling
+            Flow ID = 4 Queued(150ms) AutoPolling Executor(task=4)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Queued(320ms) Input(foo) Batching(15, until=320ms)
@@ -3090,7 +3090,7 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 5 Queued(320ms) Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Scheduled(task=5) AutoPolling
+            Flow ID = 6 Queued(200ms) AutoPolling Executor(task=5)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
@@ -3127,7 +3127,7 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Scheduled(task=6) Input(foo)
+            Flow ID = 5 Queued(220ms) Input(foo) Executor(task=6)
             Flow ID = 2 Finished Success
           "foo" Ingest:
             Flow ID = 8 Queued(300ms) AutoPolling
@@ -3165,7 +3165,7 @@ async fn test_batching_condition_with_2_inputs() {
 
         #20: +290ms:
           "bar" Ingest:
-            Flow ID = 7 Scheduled(task=7) AutoPolling
+            Flow ID = 7 Queued(290ms) AutoPolling Executor(task=7)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
@@ -3179,14 +3179,14 @@ async fn test_batching_condition_with_2_inputs() {
 
         #21: +300ms:
           "bar" Ingest:
-            Flow ID = 7 Scheduled(task=7) AutoPolling
+            Flow ID = 7 Queued(290ms) AutoPolling Executor(task=7)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Finished Success
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Scheduled(task=8) AutoPolling
+            Flow ID = 8 Queued(300ms) AutoPolling Executor(task=8)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success

--- a/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/tests/tests/test_flow_service_inmem.rs
@@ -101,11 +101,11 @@ async fn test_read_initial_config_and_queue_without_waiting() {
             r#"
             #0: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "foo" Ingest:
@@ -113,12 +113,12 @@ async fn test_read_initial_config_and_queue_without_waiting() {
 
             #3: +20ms:
               "foo" Ingest:
-                Flow ID = 1 Queued(80ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(80ms)
                 Flow ID = 0 Finished Success
 
             #4: +80ms:
               "foo" Ingest:
-                Flow ID = 1 Queued(80ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
                 Flow ID = 0 Finished Success
 
             #5: +90ms:
@@ -128,7 +128,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
 
             #6: +100ms:
               "foo" Ingest:
-                Flow ID = 2 Queued(160ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -202,11 +202,11 @@ async fn test_cron_config() {
             r#"
             #0: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Queued(5000ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(5000ms)
 
             #1: +5000ms:
               "foo" Ingest:
-                Flow ID = 0 Queued(5000ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +6000ms:
               "foo" Ingest:
@@ -214,12 +214,12 @@ async fn test_cron_config() {
 
             #3: +7000ms:
               "foo" Ingest:
-                Flow ID = 1 Queued(10000ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(10000ms)
                 Flow ID = 0 Finished Success
 
             #4: +10000ms:
               "foo" Ingest:
-                Flow ID = 1 Queued(10000ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
                 Flow ID = 0 Finished Success
 
             "#
@@ -343,11 +343,11 @@ async fn test_manual_trigger() {
             r#"
             #0: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "foo" Ingest:
@@ -355,12 +355,12 @@ async fn test_manual_trigger() {
 
             #3: +20ms:
               "foo" Ingest:
-                Flow ID = 1 Queued(110ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(110ms)
                 Flow ID = 0 Finished Success
 
             #4: +40ms:
               "foo" Ingest:
-                Flow ID = 1 Queued(40ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
                 Flow ID = 0 Finished Success
 
             #5: +60ms:
@@ -370,15 +370,15 @@ async fn test_manual_trigger() {
 
             #6: +70ms:
               "foo" Ingest:
-                Flow ID = 2 Queued(160ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
             #7: +80ms:
               "bar" Ingest:
-                Flow ID = 3 Queued(80ms) Manual Executor(task=2)
+                Flow ID = 3 Waiting Manual Executor(task=2)
               "foo" Ingest:
-                Flow ID = 2 Queued(160ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -386,7 +386,7 @@ async fn test_manual_trigger() {
               "bar" Ingest:
                 Flow ID = 3 Running(task=2)
               "foo" Ingest:
-                Flow ID = 2 Queued(160ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -394,7 +394,7 @@ async fn test_manual_trigger() {
               "bar" Ingest:
                 Flow ID = 3 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(160ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(160ms)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -402,7 +402,7 @@ async fn test_manual_trigger() {
               "bar" Ingest:
                 Flow ID = 3 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(160ms) AutoPolling Executor(task=3)
+                Flow ID = 2 Waiting AutoPolling Executor(task=3)
                 Flow ID = 1 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -520,42 +520,42 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" Ingest:
-                Flow ID = 3 Queued(110ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(110ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #6: +50ms:
@@ -568,31 +568,31 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
 
             #7: +80ms:
               "bar" Ingest:
-                Flow ID = 5 Queued(100ms) AutoPolling
+                Flow ID = 5 Waiting AutoPolling Schedule(100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(80ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(80ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
             #8: +80ms:
               "bar" Ingest:
-                Flow ID = 5 Queued(100ms) AutoPolling
+                Flow ID = 5 Waiting AutoPolling Schedule(100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(80ms) AutoPolling Executor(task=2)
+                Flow ID = 4 Waiting AutoPolling Executor(task=2)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
             #9: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Queued(100ms) AutoPolling Executor(task=3)
+                Flow ID = 5 Waiting AutoPolling Executor(task=3)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(80ms) AutoPolling Executor(task=2)
+                Flow ID = 4 Waiting AutoPolling Executor(task=2)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -717,42 +717,42 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(120ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(120ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(120ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(120ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" Ingest:
-                Flow ID = 3 Queued(90ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(90ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(120ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(120ms)
                 Flow ID = 0 Finished Success
 
             #6: +50ms:
@@ -765,31 +765,31 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
 
             #7: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Queued(100ms) AutoPolling
+                Flow ID = 5 Waiting AutoPolling Schedule(100ms)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(120ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(120ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
             #8: +100ms:
               "bar" Ingest:
-                Flow ID = 5 Queued(100ms) AutoPolling Executor(task=2)
+                Flow ID = 5 Waiting AutoPolling Executor(task=2)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(120ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(120ms)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
             #9: +120ms:
               "bar" Ingest:
-                Flow ID = 5 Queued(100ms) AutoPolling Executor(task=2)
+                Flow ID = 5 Waiting AutoPolling Executor(task=2)
                 Flow ID = 3 Finished Aborted
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Aborted
                 Flow ID = 0 Finished Success
 
@@ -900,47 +900,47 @@ async fn test_dataset_deleted() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" Ingest:
-                Flow ID = 3 Queued(100ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(100ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #6: +50ms:
               "bar" Ingest:
-                Flow ID = 3 Queued(100ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(100ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 2 Finished Aborted
@@ -948,7 +948,7 @@ async fn test_dataset_deleted() {
 
             #7: +100ms:
               "bar" Ingest:
-                Flow ID = 3 Queued(100ms) AutoPolling Executor(task=2)
+                Flow ID = 3 Waiting AutoPolling Executor(task=2)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 2 Finished Aborted
@@ -1069,53 +1069,53 @@ async fn test_task_completions_trigger_next_loop_on_success() {
             r#"
             #0: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
               "baz" Ingest:
-                Flow ID = 2 Queued(0ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(0ms)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "baz" Ingest:
-                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "baz" Ingest:
-                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" Ingest:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "baz" Ingest:
-                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2)
               "foo" Ingest:
-                Flow ID = 3 Queued(60ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" Ingest:
                 Flow ID = 1 Running(task=1)
               "baz" Ingest:
-                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2)
               "foo" Ingest:
-                Flow ID = 3 Queued(60ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" Ingest:
                 Flow ID = 1 Finished Failed
               "baz" Ingest:
-                Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2)
               "foo" Ingest:
-                Flow ID = 3 Queued(60ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
                 Flow ID = 0 Finished Success
 
             #6: +30ms:
@@ -1124,7 +1124,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Running(task=2)
               "foo" Ingest:
-                Flow ID = 3 Queued(60ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
                 Flow ID = 0 Finished Success
 
             #7: +40ms:
@@ -1133,7 +1133,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Finished Cancelled
               "foo" Ingest:
-                Flow ID = 3 Queued(60ms) AutoPolling
+                Flow ID = 3 Waiting AutoPolling Schedule(60ms)
                 Flow ID = 0 Finished Success
 
             #8: +60ms:
@@ -1142,7 +1142,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
               "baz" Ingest:
                 Flow ID = 2 Finished Cancelled
               "foo" Ingest:
-                Flow ID = 3 Queued(60ms) AutoPolling Executor(task=3)
+                Flow ID = 3 Waiting AutoPolling Executor(task=3)
                 Flow ID = 0 Finished Success
 
             "#
@@ -1275,48 +1275,48 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(100ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(100ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(100ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(100ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(100ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(100ms)
                 Flow ID = 0 Finished Success
 
             #6: +100ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(100ms) AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2)
                 Flow ID = 0 Finished Success
 
             #7: +110ms:
@@ -1328,19 +1328,19 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
 
             #8: +120ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(120ms) Input(foo) Batching(1, until=1120ms)
+                Flow ID = 3 Waiting Input(foo) Batching(1, until=1120ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(200ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
             #9: +120ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(120ms) Input(foo) Executor(task=3)
+                Flow ID = 3 Waiting Input(foo) Executor(task=3)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(200ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1349,7 +1349,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Running(task=3)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(200ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1358,7 +1358,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(200ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(200ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1367,7 +1367,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(200ms) AutoPolling Executor(task=4)
+                Flow ID = 4 Waiting AutoPolling Executor(task=4)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -1462,7 +1462,7 @@ async fn test_throttling_manual_triggers() {
 
             #1: +20ms:
               "foo" Ingest:
-                Flow ID = 0 Queued(20ms) Manual Executor(task=0)
+                Flow ID = 0 Waiting Manual Executor(task=0)
 
             #2: +40ms:
               "foo" Ingest:
@@ -1474,12 +1474,12 @@ async fn test_throttling_manual_triggers() {
 
             #4: +100ms:
               "foo" Ingest:
-                Flow ID = 1 Queued(150ms) Manual Throttling(100ms)
+                Flow ID = 1 Waiting Manual Throttling(100ms)
                 Flow ID = 0 Finished Success
 
             #5: +150ms:
               "foo" Ingest:
-                Flow ID = 1 Queued(150ms) Manual Executor(task=1)
+                Flow ID = 1 Waiting Manual Executor(task=1)
                 Flow ID = 0 Finished Success
 
           "#
@@ -1683,89 +1683,89 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             r#"
           #0: +0ms:
             "bar" Ingest:
-              Flow ID = 1 Queued(0ms) AutoPolling
+              Flow ID = 1 Waiting AutoPolling Schedule(0ms)
             "baz" ExecuteTransform:
-              Flow ID = 2 Queued(0ms) AutoPolling
+              Flow ID = 2 Waiting AutoPolling Schedule(0ms)
             "foo" Ingest:
-              Flow ID = 0 Queued(0ms) AutoPolling
+              Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
           #1: +0ms:
             "bar" Ingest:
-              Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+              Flow ID = 1 Waiting AutoPolling Executor(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2)
             "foo" Ingest:
-              Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+              Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
           #2: +10ms:
             "bar" Ingest:
-              Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+              Flow ID = 1 Waiting AutoPolling Executor(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2)
             "foo" Ingest:
               Flow ID = 0 Running(task=0)
 
           #3: +20ms:
             "bar" Ingest:
-              Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+              Flow ID = 1 Waiting AutoPolling Executor(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2)
             "foo" Ingest:
-              Flow ID = 3 Queued(120ms) AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
               Flow ID = 0 Finished Success
 
           #4: +20ms:
             "bar" Ingest:
               Flow ID = 1 Running(task=1)
             "baz" ExecuteTransform:
-              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2)
             "foo" Ingest:
-              Flow ID = 3 Queued(120ms) AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
               Flow ID = 0 Finished Success
 
           #5: +30ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+              Flow ID = 2 Waiting AutoPolling Executor(task=2)
             "foo" Ingest:
-              Flow ID = 3 Queued(120ms) AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
               Flow ID = 0 Finished Success
 
           #6: +30ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Running(task=2)
             "foo" Ingest:
-              Flow ID = 3 Queued(120ms) AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
               Flow ID = 0 Finished Success
 
           #7: +50ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 3 Queued(120ms) AutoPolling Throttling(100ms)
+              Flow ID = 3 Waiting AutoPolling Throttling(100ms)
               Flow ID = 0 Finished Success
 
           #8: +120ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 3 Queued(120ms) AutoPolling Executor(task=3)
+              Flow ID = 3 Waiting AutoPolling Executor(task=3)
               Flow ID = 0 Finished Success
 
           #9: +130ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 2 Finished Success
@@ -1775,61 +1775,61 @@ async fn test_throttling_derived_dataset_with_2_parents() {
 
           #10: +140ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 5 Queued(150ms) Input(foo) Throttling(100ms)
+              Flow ID = 5 Waiting Input(foo) Throttling(100ms)
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #11: +150ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 5 Queued(150ms) Input(foo) Executor(task=4)
+              Flow ID = 5 Waiting Input(foo) Executor(task=4)
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #12: +160ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Running(task=4)
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #13: +170ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling
+              Flow ID = 4 Waiting AutoPolling Schedule(180ms)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #14: +180ms:
             "bar" Ingest:
-              Flow ID = 4 Queued(180ms) AutoPolling Executor(task=5)
+              Flow ID = 4 Waiting AutoPolling Executor(task=5)
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -1841,63 +1841,63 @@ async fn test_throttling_derived_dataset_with_2_parents() {
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #16: +200ms:
             "bar" Ingest:
-              Flow ID = 8 Queued(350ms) AutoPolling
+              Flow ID = 8 Waiting AutoPolling Schedule(350ms)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Queued(270ms) Input(bar) Throttling(100ms)
+              Flow ID = 7 Waiting Input(bar) Throttling(100ms)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Throttling(100ms)
+              Flow ID = 6 Waiting AutoPolling Throttling(100ms)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #17: +240ms:
             "bar" Ingest:
-              Flow ID = 8 Queued(350ms) AutoPolling
+              Flow ID = 8 Waiting AutoPolling Schedule(350ms)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Queued(270ms) Input(bar) Throttling(100ms)
+              Flow ID = 7 Waiting Input(bar) Throttling(100ms)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Executor(task=6)
+              Flow ID = 6 Waiting AutoPolling Executor(task=6)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #18: +270ms:
             "bar" Ingest:
-              Flow ID = 8 Queued(350ms) AutoPolling
+              Flow ID = 8 Waiting AutoPolling Schedule(350ms)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Queued(270ms) Input(bar) Executor(task=7)
+              Flow ID = 7 Waiting Input(bar) Executor(task=7)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Executor(task=6)
+              Flow ID = 6 Waiting AutoPolling Executor(task=6)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
           #19: +350ms:
             "bar" Ingest:
-              Flow ID = 8 Queued(350ms) AutoPolling Executor(task=8)
+              Flow ID = 8 Waiting AutoPolling Executor(task=8)
               Flow ID = 4 Finished Success
               Flow ID = 1 Finished Success
             "baz" ExecuteTransform:
-              Flow ID = 7 Queued(270ms) Input(bar) Executor(task=7)
+              Flow ID = 7 Waiting Input(bar) Executor(task=7)
               Flow ID = 5 Finished Success
               Flow ID = 2 Finished Success
             "foo" Ingest:
-              Flow ID = 6 Queued(240ms) AutoPolling Executor(task=6)
+              Flow ID = 6 Waiting AutoPolling Executor(task=6)
               Flow ID = 3 Finished Success
               Flow ID = 0 Finished Success
 
@@ -2074,48 +2074,48 @@ async fn test_batching_condition_records_reached() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #6: +70ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2)
                 Flow ID = 0 Finished Success
 
             #7: +80ms:
@@ -2127,25 +2127,25 @@ async fn test_batching_condition_records_reached() {
 
             #8: +90ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(210ms) Input(foo) Batching(10, until=210ms)
+                Flow ID = 3 Waiting Input(foo) Batching(10, until=210ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(140ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
             #9: +140ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(210ms) Input(foo) Batching(10, until=210ms)
+                Flow ID = 3 Waiting Input(foo) Batching(10, until=210ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
             #10: +150ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(210ms) Input(foo) Batching(10, until=210ms)
+                Flow ID = 3 Waiting Input(foo) Batching(10, until=210ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
                 Flow ID = 4 Running(task=3)
@@ -2154,20 +2154,20 @@ async fn test_batching_condition_records_reached() {
 
             #11: +160ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(160ms) Input(foo) Batching(10, until=210ms)
+                Flow ID = 3 Waiting Input(foo) Batching(10, until=210ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Queued(210ms) AutoPolling
+                Flow ID = 5 Waiting AutoPolling Schedule(210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
             #12: +160ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(160ms) Input(foo) Executor(task=4)
+                Flow ID = 3 Waiting Input(foo) Executor(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Queued(210ms) AutoPolling
+                Flow ID = 5 Waiting AutoPolling Schedule(210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2177,7 +2177,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Running(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Queued(210ms) AutoPolling
+                Flow ID = 5 Waiting AutoPolling Schedule(210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2187,7 +2187,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Queued(210ms) AutoPolling
+                Flow ID = 5 Waiting AutoPolling Schedule(210ms)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2197,7 +2197,7 @@ async fn test_batching_condition_records_reached() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 5 Queued(210ms) AutoPolling Executor(task=5)
+                Flow ID = 5 Waiting AutoPolling Executor(task=5)
                 Flow ID = 4 Finished Success
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
@@ -2351,48 +2351,48 @@ async fn test_batching_condition_timeout() {
             r#"
             #0: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling
+                Flow ID = 1 Waiting AutoPolling Schedule(0ms)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling
+                Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
             #1: +0ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+                Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
             #2: +10ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
                 Flow ID = 0 Running(task=0)
 
             #3: +20ms:
               "bar" ExecuteTransform:
-                Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+                Flow ID = 1 Waiting AutoPolling Executor(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #4: +20ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Running(task=1)
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #5: +30ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling
+                Flow ID = 2 Waiting AutoPolling Schedule(70ms)
                 Flow ID = 0 Finished Success
 
             #6: +70ms:
               "bar" ExecuteTransform:
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 2 Queued(70ms) AutoPolling Executor(task=2)
+                Flow ID = 2 Waiting AutoPolling Executor(task=2)
                 Flow ID = 0 Finished Success
 
             #7: +80ms:
@@ -2404,28 +2404,28 @@ async fn test_batching_condition_timeout() {
 
             #8: +90ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(240ms) Input(foo) Batching(10, until=240ms)
+                Flow ID = 3 Waiting Input(foo) Batching(10, until=240ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(140ms) AutoPolling
+                Flow ID = 4 Waiting AutoPolling Schedule(140ms)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
             #9: +140ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(240ms) Input(foo) Batching(10, until=240ms)
+                Flow ID = 3 Waiting Input(foo) Batching(10, until=240ms)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
             #10: +240ms:
               "bar" ExecuteTransform:
-                Flow ID = 3 Queued(240ms) Input(foo) Executor(task=4)
+                Flow ID = 3 Waiting Input(foo) Executor(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2434,7 +2434,7 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Running(task=4)
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2443,7 +2443,7 @@ async fn test_batching_condition_timeout() {
                 Flow ID = 3 Finished Success
                 Flow ID = 1 Finished Success
               "foo" Ingest:
-                Flow ID = 4 Queued(140ms) AutoPolling Executor(task=3)
+                Flow ID = 4 Waiting AutoPolling Executor(task=3)
                 Flow ID = 2 Finished Success
                 Flow ID = 0 Finished Success
 
@@ -2596,48 +2596,48 @@ async fn test_batching_condition_watermark() {
             r#"
         #0: +0ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Queued(0ms) AutoPolling
+            Flow ID = 1 Waiting AutoPolling Schedule(0ms)
           "foo" Ingest:
-            Flow ID = 0 Queued(0ms) AutoPolling
+            Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
         #1: +0ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1)
           "foo" Ingest:
-            Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+            Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
         #2: +10ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1)
           "foo" Ingest:
             Flow ID = 0 Running(task=0)
 
         #3: +20ms:
           "bar" ExecuteTransform:
-            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1)
           "foo" Ingest:
-            Flow ID = 2 Queued(60ms) AutoPolling
+            Flow ID = 2 Waiting AutoPolling Schedule(60ms)
             Flow ID = 0 Finished Success
 
         #4: +20ms:
           "bar" ExecuteTransform:
             Flow ID = 1 Running(task=1)
           "foo" Ingest:
-            Flow ID = 2 Queued(60ms) AutoPolling
+            Flow ID = 2 Waiting AutoPolling Schedule(60ms)
             Flow ID = 0 Finished Success
 
         #5: +30ms:
           "bar" ExecuteTransform:
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 2 Queued(60ms) AutoPolling
+            Flow ID = 2 Waiting AutoPolling Schedule(60ms)
             Flow ID = 0 Finished Success
 
         #6: +60ms:
           "bar" ExecuteTransform:
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 2 Queued(60ms) AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2)
             Flow ID = 0 Finished Success
 
         #7: +70ms:
@@ -2649,28 +2649,28 @@ async fn test_batching_condition_watermark() {
 
         #8: +80ms:
           "bar" ExecuteTransform:
-            Flow ID = 3 Queued(280ms) Input(foo) Batching(10, until=280ms)
+            Flow ID = 3 Waiting Input(foo) Batching(10, until=280ms)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Queued(120ms) AutoPolling
+            Flow ID = 4 Waiting AutoPolling Schedule(120ms)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
         #9: +120ms:
           "bar" ExecuteTransform:
-            Flow ID = 3 Queued(280ms) Input(foo) Batching(10, until=280ms)
+            Flow ID = 3 Waiting Input(foo) Batching(10, until=280ms)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
+            Flow ID = 4 Waiting AutoPolling Executor(task=3)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
         #10: +280ms:
           "bar" ExecuteTransform:
-            Flow ID = 3 Queued(280ms) Input(foo) Executor(task=4)
+            Flow ID = 3 Waiting Input(foo) Executor(task=4)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
+            Flow ID = 4 Waiting AutoPolling Executor(task=3)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2679,7 +2679,7 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Running(task=4)
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
+            Flow ID = 4 Waiting AutoPolling Executor(task=3)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2688,7 +2688,7 @@ async fn test_batching_condition_watermark() {
             Flow ID = 3 Finished Success
             Flow ID = 1 Finished Success
           "foo" Ingest:
-            Flow ID = 4 Queued(120ms) AutoPolling Executor(task=3)
+            Flow ID = 4 Waiting AutoPolling Executor(task=3)
             Flow ID = 2 Finished Success
             Flow ID = 0 Finished Success
 
@@ -2942,89 +2942,89 @@ async fn test_batching_condition_with_2_inputs() {
             r#"
         #0: +0ms:
           "bar" Ingest:
-            Flow ID = 1 Queued(0ms) AutoPolling
+            Flow ID = 1 Waiting AutoPolling Schedule(0ms)
           "baz" ExecuteTransform:
-            Flow ID = 2 Queued(0ms) AutoPolling
+            Flow ID = 2 Waiting AutoPolling Schedule(0ms)
           "foo" Ingest:
-            Flow ID = 0 Queued(0ms) AutoPolling
+            Flow ID = 0 Waiting AutoPolling Schedule(0ms)
 
         #1: +0ms:
           "bar" Ingest:
-            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2)
           "foo" Ingest:
-            Flow ID = 0 Queued(0ms) AutoPolling Executor(task=0)
+            Flow ID = 0 Waiting AutoPolling Executor(task=0)
 
         #2: +10ms:
           "bar" Ingest:
-            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2)
           "foo" Ingest:
             Flow ID = 0 Running(task=0)
 
         #3: +20ms:
           "bar" Ingest:
-            Flow ID = 1 Queued(0ms) AutoPolling Executor(task=1)
+            Flow ID = 1 Waiting AutoPolling Executor(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2)
           "foo" Ingest:
-            Flow ID = 3 Queued(100ms) AutoPolling
+            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
             Flow ID = 0 Finished Success
 
         #4: +20ms:
           "bar" Ingest:
             Flow ID = 1 Running(task=1)
           "baz" ExecuteTransform:
-            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2)
           "foo" Ingest:
-            Flow ID = 3 Queued(100ms) AutoPolling
+            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
             Flow ID = 0 Finished Success
 
         #5: +30ms:
           "bar" Ingest:
-            Flow ID = 4 Queued(150ms) AutoPolling
+            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 2 Queued(0ms) AutoPolling Executor(task=2)
+            Flow ID = 2 Waiting AutoPolling Executor(task=2)
           "foo" Ingest:
-            Flow ID = 3 Queued(100ms) AutoPolling
+            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
             Flow ID = 0 Finished Success
 
         #6: +30ms:
           "bar" Ingest:
-            Flow ID = 4 Queued(150ms) AutoPolling
+            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Running(task=2)
           "foo" Ingest:
-            Flow ID = 3 Queued(100ms) AutoPolling
+            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
             Flow ID = 0 Finished Success
 
         #7: +40ms:
           "bar" Ingest:
-            Flow ID = 4 Queued(150ms) AutoPolling
+            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 3 Queued(100ms) AutoPolling
+            Flow ID = 3 Waiting AutoPolling Schedule(100ms)
             Flow ID = 0 Finished Success
 
         #8: +100ms:
           "bar" Ingest:
-            Flow ID = 4 Queued(150ms) AutoPolling
+            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 3 Queued(100ms) AutoPolling Executor(task=3)
+            Flow ID = 3 Waiting AutoPolling Executor(task=3)
             Flow ID = 0 Finished Success
 
         #9: +110ms:
           "bar" Ingest:
-            Flow ID = 4 Queued(150ms) AutoPolling
+            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 2 Finished Success
@@ -3034,25 +3034,25 @@ async fn test_batching_condition_with_2_inputs() {
 
         #10: +120ms:
           "bar" Ingest:
-            Flow ID = 4 Queued(150ms) AutoPolling
+            Flow ID = 4 Waiting AutoPolling Schedule(150ms)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Queued(320ms) Input(foo) Batching(15, until=320ms)
+            Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Queued(200ms) AutoPolling
+            Flow ID = 6 Waiting AutoPolling Schedule(200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #11: +150ms:
           "bar" Ingest:
-            Flow ID = 4 Queued(150ms) AutoPolling Executor(task=4)
+            Flow ID = 4 Waiting AutoPolling Executor(task=4)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Queued(320ms) Input(foo) Batching(15, until=320ms)
+            Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Queued(200ms) AutoPolling
+            Flow ID = 6 Waiting AutoPolling Schedule(200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
@@ -3061,46 +3061,46 @@ async fn test_batching_condition_with_2_inputs() {
             Flow ID = 4 Running(task=4)
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Queued(320ms) Input(foo) Batching(15, until=320ms)
+            Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Queued(200ms) AutoPolling
+            Flow ID = 6 Waiting AutoPolling Schedule(200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #13: +170ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling
+            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Queued(320ms) Input(foo) Batching(15, until=320ms)
+            Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Queued(200ms) AutoPolling
+            Flow ID = 6 Waiting AutoPolling Schedule(200ms)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #14: +200ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling
+            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Queued(320ms) Input(foo) Batching(15, until=320ms)
+            Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 6 Queued(200ms) AutoPolling Executor(task=5)
+            Flow ID = 6 Waiting AutoPolling Executor(task=5)
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #15: +210ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling
+            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Queued(320ms) Input(foo) Batching(15, until=320ms)
+            Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
             Flow ID = 6 Running(task=5)
@@ -3109,84 +3109,84 @@ async fn test_batching_condition_with_2_inputs() {
 
         #16: +220ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling
+            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Queued(220ms) Input(foo) Batching(15, until=320ms)
+            Flow ID = 5 Waiting Input(foo) Batching(15, until=320ms)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Queued(300ms) AutoPolling
+            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #17: +220ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling
+            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
-            Flow ID = 5 Queued(220ms) Input(foo) Executor(task=6)
+            Flow ID = 5 Waiting Input(foo) Executor(task=6)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Queued(300ms) AutoPolling
+            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #18: +230ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling
+            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Running(task=6)
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Queued(300ms) AutoPolling
+            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #19: +240ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling
+            Flow ID = 7 Waiting AutoPolling Schedule(290ms)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Finished Success
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Queued(300ms) AutoPolling
+            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #20: +290ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling Executor(task=7)
+            Flow ID = 7 Waiting AutoPolling Executor(task=7)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Finished Success
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Queued(300ms) AutoPolling
+            Flow ID = 8 Waiting AutoPolling Schedule(300ms)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success
 
         #21: +300ms:
           "bar" Ingest:
-            Flow ID = 7 Queued(290ms) AutoPolling Executor(task=7)
+            Flow ID = 7 Waiting AutoPolling Executor(task=7)
             Flow ID = 4 Finished Success
             Flow ID = 1 Finished Success
           "baz" ExecuteTransform:
             Flow ID = 5 Finished Success
             Flow ID = 2 Finished Success
           "foo" Ingest:
-            Flow ID = 8 Queued(300ms) AutoPolling Executor(task=8)
+            Flow ID = 8 Waiting AutoPolling Executor(task=8)
             Flow ID = 6 Finished Success
             Flow ID = 3 Finished Success
             Flow ID = 0 Finished Success

--- a/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
+++ b/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
@@ -189,7 +189,14 @@ impl std::fmt::Display for FlowSystemTestListener {
                                 (b.batching_deadline - initial_time).num_milliseconds(),
                             )?,
                             FlowStartCondition::Executor(e) => {
-                                write!(f, " Executor(task={})", e.task_id)?;
+                                write!(
+                                    f,
+                                    " Executor(task={}, since={}ms)",
+                                    e.task_id,
+                                    (flow_state.timing.awaiting_executor_since.unwrap()
+                                        - initial_time)
+                                        .num_milliseconds()
+                                )?;
                             }
                             FlowStartCondition::Schedule(s) => {
                                 write!(

--- a/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
+++ b/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
@@ -189,7 +189,7 @@ impl std::fmt::Display for FlowSystemTestListener {
                                 write!(
                                     f,
                                     " Schedule({}ms)",
-                                    (s.activate_at - initial_time).num_milliseconds(),
+                                    (s.wake_up_at - initial_time).num_milliseconds(),
                                 )?;
                             }
                         }

--- a/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
+++ b/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
@@ -194,7 +194,7 @@ impl std::fmt::Display for FlowSystemTestListener {
                             FlowStartCondition::Schedule(s) => {
                                 write!(
                                     f,
-                                    " Schedule({}ms)",
+                                    " Schedule(wakeup={}ms)",
                                     (s.wake_up_at - initial_time).num_milliseconds(),
                                 )?;
                             }

--- a/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
+++ b/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
@@ -174,7 +174,13 @@ impl std::fmt::Display for FlowSystemTestListener {
                     if let Some(start_condition) = flow_state.start_condition {
                         match start_condition {
                             FlowStartCondition::Throttling(t) => {
-                                write!(f, " Throttling({}ms)", t.interval.num_milliseconds())?;
+                                write!(
+                                    f,
+                                    " Throttling(for={}ms, wakeup={}ms, shifted={}ms)",
+                                    t.interval.num_milliseconds(),
+                                    (t.wake_up_at - initial_time).num_milliseconds(),
+                                    (t.shifted_from - initial_time).num_milliseconds()
+                                )?;
                             }
                             FlowStartCondition::Batching(b) => write!(
                                 f,

--- a/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
+++ b/src/infra/flow-system-inmem/tests/tests/utils/flow_system_test_listener.rs
@@ -141,7 +141,7 @@ impl std::fmt::Display for FlowSystemTestListener {
                                 (flow_state.timing.activate_at.unwrap() - initial_time)
                                     .num_milliseconds()
                             ),
-                            FlowStatus::Scheduled | FlowStatus::Running => format!(
+                            FlowStatus::Running => format!(
                                 "{:?}(task={})",
                                 flow_state.status(),
                                 flow_state
@@ -156,7 +156,7 @@ impl std::fmt::Display for FlowSystemTestListener {
                     )?;
 
                     match flow_state.status() {
-                        FlowStatus::Waiting | FlowStatus::Queued | FlowStatus::Scheduled => write!(
+                        FlowStatus::Waiting | FlowStatus::Queued => write!(
                             f,
                             " {}",
                             match flow_state.primary_trigger() {
@@ -187,6 +187,9 @@ impl std::fmt::Display for FlowSystemTestListener {
                                 b.active_batching_rule.min_records_to_await(),
                                 (b.batching_deadline - initial_time).num_milliseconds(),
                             )?,
+                            FlowStartCondition::Executor(e) => {
+                                write!(f, " Executor(task={})", e.task_id)?;
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Description

Closes: #516

-2 flow statuses (-Queued, -Scheduled)
+2 flow conditoins (Schedule, Executor).

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [ ] API changes are backwards-compatible: NO, breaking changes, require UI update
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
