### PR TITLE
Utilized `cargo-udeps` application to detect unused dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
+      - run: carg install cargo-udeps
+      - run: cargo udeps
       - run: cargo install cargo-deny
       - run: cargo deny check
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
+      - run: cargo install binstall
       - run: cargo binstall cargo-udeps -y
       - run: cargo udeps
       - run: cargo install cargo-deny

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,10 +45,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
       - uses: cargo-bins/cargo-binstall@main
-      - run: cargo binstall cargo-udeps -y
-      - run: cargo udeps
-      - run: cargo install cargo-deny
+      - run: cargo binstall cargo-deny -y
       - run: cargo deny check
+      - run: cargo binstall cargo-udeps -y
+      - run: cargo udeps --all-targets
 
   test:
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
-      - run: cargo install cargo-udeps
+      - run: cargo binstall cargo-udeps -y
       - run: cargo udeps
       - run: cargo install cargo-deny
       - run: cargo deny check

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,9 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
-      - run: cargo install cargo-binstall
-      - run: cargo binstall cargo-udeps -y
-      - run: cargo udeps
       - run: cargo install cargo-deny
       - run: cargo deny check
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
+      - uses: cargo-bins/cargo-binstall@main
+      - run: cargo binstall cargo-udeps
+      - run: cargo udeps
       - run: cargo install cargo-deny
       - run: cargo deny check
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
-      - run: cargo install binstall
+      - run: cargo install cargo-binstall
       - run: cargo binstall cargo-udeps -y
       - run: cargo udeps
       - run: cargo install cargo-deny

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
       - uses: cargo-bins/cargo-binstall@main
-      - run: cargo binstall cargo-udeps
+      - run: cargo binstall cargo-udeps -y
       - run: cargo udeps
       - run: cargo install cargo-deny
       - run: cargo deny check

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
-      - run: carg install cargo-udeps
+      - run: cargo install cargo-udeps
       - run: cargo udeps
       - run: cargo install cargo-deny
       - run: cargo deny check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support of wildcard patterns for `kamu pull` and `kamu push` commands
 - Added `{dataset}/tail` and `/query` REST API endpoints
+### Changed
+- Using `cargo udeps` to detect unused dependencies during linting
 
 ## [0.163.1] - 2024-03-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Using `cargo udeps` to detect unused dependencies during linting
+
 ## [0.164.1] - 2024-03-06
 ### Changed:
 - Flow status `Cancelled` was finally replaced with `Aborted`, unifying cancellation types for simplicity
 ### Fixed
 - Flow system now pauses flow configuration, even when cancelling an already completed flow
 
-
 ## [0.164.0] - 2024-03-06
 ### Added
 - Added support of wildcard patterns for `kamu pull` and `kamu push` commands
 - Added `{dataset}/tail` and `/query` REST API endpoints
-### Changed
-- Using `cargo udeps` to detect unused dependencies during linting
 
 ## [0.163.1] - 2024-03-01
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,7 +2467,6 @@ dependencies = [
  "env_logger 0.10.2",
  "futures",
  "internal-error",
- "test-group",
  "test-log",
  "thiserror",
  "tokio",
@@ -3189,7 +3188,6 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 name = "internal-error"
 version = "0.164.1"
 dependencies = [
- "test-log",
  "thiserror",
 ]
 
@@ -3401,7 +3399,6 @@ dependencies = [
  "oso",
  "oso-derive",
  "tempfile",
- "test-group",
  "test-log",
  "tokio",
  "tracing",
@@ -3522,21 +3519,16 @@ version = "0.164.1"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger 0.10.2",
  "http",
- "kamu",
  "kamu-core",
  "opendatafabric",
  "reqwest",
  "serde",
  "serde_json",
  "tempfile",
- "test-group",
- "test-log",
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3833,7 +3825,6 @@ dependencies = [
  "futures",
  "kamu-core",
  "kamu-task-system",
- "mockall",
  "opendatafabric",
  "serde",
  "serde_with",
@@ -6636,11 +6627,8 @@ name = "tracing-perfetto"
 version = "0.164.1"
 dependencies = [
  "conv",
- "env_logger 0.10.2",
  "serde",
  "serde_json",
- "test-group",
- "test-log",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,6 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "dill",
- "env_logger 0.10.2",
  "libc",
  "rand",
  "regex",
@@ -2411,19 +2410,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
@@ -2464,7 +2450,6 @@ version = "0.164.1"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger 0.10.2",
  "futures",
  "internal-error",
  "test-log",
@@ -3332,7 +3317,6 @@ dependencies = [
  "datafusion",
  "digest",
  "dill",
- "env_logger 0.10.2",
  "event-bus",
  "filetime",
  "flatbuffers",
@@ -3391,7 +3375,6 @@ version = "0.164.1"
 dependencies = [
  "async-trait",
  "dill",
- "env_logger 0.10.2",
  "event-bus",
  "kamu",
  "kamu-core",
@@ -3414,7 +3397,6 @@ dependencies = [
  "base64 0.21.7",
  "dashmap",
  "datafusion",
- "env_logger 0.10.2",
  "futures",
  "indoc 2.0.4",
  "kamu-data-utils",
@@ -3440,7 +3422,6 @@ dependencies = [
  "cron",
  "datafusion",
  "dill",
- "env_logger 0.10.2",
  "event-bus",
  "event-sourcing",
  "futures",
@@ -3479,7 +3460,6 @@ dependencies = [
  "container-runtime",
  "datafusion",
  "dill",
- "env_logger 0.10.2",
  "event-bus",
  "flate2",
  "fs_extra",
@@ -3554,7 +3534,6 @@ dependencies = [
  "dill",
  "dirs",
  "duration-string",
- "env_logger 0.10.2",
  "event-bus",
  "fs_extra",
  "futures",
@@ -3653,7 +3632,6 @@ dependencies = [
  "async-trait",
  "datafusion",
  "digest",
- "env_logger 0.10.2",
  "opendatafabric",
  "pretty_assertions",
  "sha3",
@@ -3718,7 +3696,6 @@ dependencies = [
  "chrono",
  "cron",
  "dill",
- "env_logger 0.10.2",
  "event-bus",
  "futures",
  "indoc 2.0.4",
@@ -3751,7 +3728,6 @@ dependencies = [
  "criterion",
  "datafusion",
  "digest",
- "env_logger 0.10.2",
  "futures",
  "geo-types",
  "geojson",
@@ -3820,7 +3796,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "dill",
- "env_logger 0.10.2",
  "event-bus",
  "futures",
  "kamu-core",
@@ -6154,15 +6129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6187,7 +6153,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
 dependencies = [
- "env_logger 0.11.3",
+ "env_logger",
  "test-log-macros",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,7 +2480,6 @@ version = "0.164.1"
 dependencies = [
  "async-stream",
  "async-trait",
- "chrono",
  "event-sourcing-macros",
  "futures",
  "internal-error",
@@ -3371,7 +3370,6 @@ dependencies = [
  "sha3",
  "strum 0.25.0",
  "strum_macros 0.25.3",
- "tar",
  "tempfile",
  "test-group",
  "test-log",
@@ -3449,7 +3447,7 @@ dependencies = [
  "event-bus",
  "event-sourcing",
  "futures",
- "indoc 1.0.9",
+ "indoc 2.0.4",
  "internal-error",
  "kamu",
  "kamu-core",
@@ -3801,7 +3799,6 @@ dependencies = [
  "regex",
  "semver",
  "toml",
- "url",
 ]
 
 [[package]]
@@ -4540,7 +4537,6 @@ version = "0.164.1"
 dependencies = [
  "arrow",
  "base64 0.21.7",
- "byteorder",
  "chrono",
  "digest",
  "ed25519-dalek",

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -54,6 +54,7 @@ Prerequisites:
     * `cargo binstall cargo-edit -y` - for setting crate versions during release
     * `cargo binstall cargo-update -y` - for keeping up with major dependency updates
     * `cargo binstall cargo-deny -y` - for linting dependencies
+    * `cargo binstall cargo-udeps -y` - for linting dependencies (detecting unused)
   * To keep all these cargo tools up-to-date use `cargo install-update -a`
 
 Clone the repository:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ TEST_LOG_PARAMS=RUST_LOG_SPAN_EVENTS=new,close RUST_LOG=debug
 lint:
 	cargo fmt --check
 	cargo test -p kamu-repo-tools
+	cargo udeps
 	cargo deny check
 	cargo clippy --workspace --all-targets -- -D warnings
 

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ TEST_LOG_PARAMS=RUST_LOG_SPAN_EVENTS=new,close RUST_LOG=debug
 lint:
 	cargo fmt --check
 	cargo test -p kamu-repo-tools
-	cargo udeps
 	cargo deny check
+	cargo udeps --all-targets
 	cargo clippy --workspace --all-targets -- -D warnings
 
 

--- a/src/adapter/auth-oso/Cargo.toml
+++ b/src/adapter/auth-oso/Cargo.toml
@@ -35,7 +35,6 @@ oso-derive = "0.27"
 kamu = { workspace = true }
 event-bus = { workspace = true }
 
-env_logger = "0.10"
 tempfile = "3"
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features = [] }

--- a/src/adapter/auth-oso/Cargo.toml
+++ b/src/adapter/auth-oso/Cargo.toml
@@ -37,7 +37,6 @@ event-bus = { workspace = true }
 
 env_logger = "0.10"
 tempfile = "3"
-test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features = [] }
 tracing = "0.1"

--- a/src/adapter/flight-sql/Cargo.toml
+++ b/src/adapter/flight-sql/Cargo.toml
@@ -37,7 +37,6 @@ uuid = { version = "1", default-features = false }
 
 [dev-dependencies]
 kamu-data-utils = { workspace = true }
-env_logger = "0.10"
 indoc = "2"
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features = [] }

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -56,7 +56,6 @@ kamu-flow-system-inmem = { workspace = true }
 kamu-task-system-inmem = { workspace = true }
 
 
-env_logger = "0.10"
 indoc = "2"
 mockall = "0.11"
 tempfile = "3"

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -23,14 +23,14 @@ doctest = false
 
 [dependencies]
 internal-error = { workspace = true }
-opendatafabric = { workspace = true }
+opendatafabric = { workspace = true, features=["arrow"] }
 
 kamu-data-utils = { workspace = true }
 kamu-core = { workspace = true }
 kamu-task-system = { workspace = true }
 kamu-flow-system  = { workspace = true }
-event-bus = { workspace = true }
 event-sourcing = { workspace = true }
+
 
 async-graphql = { version = "6", features = ["chrono", "url", "apollo_tracing"] }
 async-trait = { version = "0.1", default-features = false }
@@ -39,7 +39,6 @@ chrono = "0.4"
 datafusion = { version = "36", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.8"
 futures = "0.3"
-indoc = "1.0.6"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", default-features = false, features = [] }
@@ -58,6 +57,7 @@ kamu-task-system-inmem = { workspace = true }
 
 
 env_logger = "0.10"
+indoc = "2"
 mockall = "0.11"
 tempfile = "3"
 test-group = { version = "1" }

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -57,7 +57,6 @@ url = { version = "2", features = ["serde"] }
 container-runtime = { workspace = true }
 event-bus = { workspace = true }
 
-env_logger = "0.10"
 fs_extra = "1.3"                                                    # Recursive folder copy
 indoc = "2"
 paste = "1"

--- a/src/adapter/oauth/Cargo.toml
+++ b/src/adapter/oauth/Cargo.toml
@@ -33,12 +33,6 @@ serde_json = "1"
 thiserror = "1"
 
 [dev-dependencies]
-kamu = { workspace = true }
-
-env_logger = "0.10"
 tempfile = "3"
-test-group = { version = "1" }
-test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features = [] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 [features]
 default = []
 
-web-ui = []
+web-ui = ["rust-embed"]
 ftp = ["kamu/ftp"]
 
 
@@ -81,7 +81,7 @@ tower = "0.4"
 tower-http = { version = "0.4", features = ["trace", "cors"] }
 
 # Web UI
-rust-embed = { version = "8", features = ["interpolate-folder-path", "compression"] }
+rust-embed = { optional = true, version = "8", features = ["interpolate-folder-path", "compression"] }
 mime = "0.3"
 mime_guess = "2"
 

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -133,7 +133,6 @@ libc = "0.2"  # For getting uid:gid
 
 [dev-dependencies]
 assert_cmd = "2"
-env_logger = "0.10"
 test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 

--- a/src/domain/opendatafabric/Cargo.toml
+++ b/src/domain/opendatafabric/Cargo.toml
@@ -33,7 +33,6 @@ multiformats = { workspace = true }
 
 chrono = { version = "0.4", features = ["serde"] }
 digest = "0.10"
-indoc = "2"
 futures-core = "0.3"
 thiserror = { version = "1", default-features = false }
 
@@ -47,7 +46,6 @@ rand = "0.8"
 
 # Serialization
 base64 = "0.21"
-byteorder = "1"
 flatbuffers = "23"
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
@@ -60,3 +58,6 @@ tonic = "0.10"
 
 # Optional
 arrow = { optional = true, version = "50", default-features = false, features = ["ipc"] }
+
+[dev-dependencies]
+indoc = "2"

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -53,7 +53,6 @@ curl-sys = { optional = true, version = "0.4" }
 flate2 = "1"  # GZip decoder
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "deflate"] }
 ringbuf = "0.3"
-tar = "0.4"  # Checkpoint archival
 zip = "0.6"
 
 # Data
@@ -83,7 +82,6 @@ dill = "0.8"
 futures = "0.3"
 glob = "0.3"  # Used for glob fetch
 hyper = "0.14"
-indoc = "2"
 itertools = "0.11"
 jsonwebtoken = "9"
 libc = "0.2"  # Signal names
@@ -117,6 +115,7 @@ libc = "0.2"  # For getting uid:gid
 criterion = { version = "0.5", features = ["async_tokio"] }
 env_logger = "0.10"
 filetime = "0.2"
+indoc = "2"
 tokio = { version = "1", default-features = false, features=["rt", "macros"] }
 
 test-group = { version = "1" }

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -113,7 +113,6 @@ libc = "0.2"  # For getting uid:gid
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
-env_logger = "0.10"
 filetime = "0.2"
 indoc = "2"
 tokio = { version = "1", default-features = false, features=["rt", "macros"] }

--- a/src/infra/flow-system-inmem/Cargo.toml
+++ b/src/infra/flow-system-inmem/Cargo.toml
@@ -49,7 +49,6 @@ kamu = { workspace = true }
 kamu-task-system-inmem = { workspace = true }
 
 cron = { version = "0.12.0", default-features = false }
-env_logger = "0.10"
 indoc = "2"
 mockall = "0.11"
 pretty_assertions = "1"

--- a/src/infra/flow-system-inmem/Cargo.toml
+++ b/src/infra/flow-system-inmem/Cargo.toml
@@ -23,7 +23,6 @@ doctest = false
 
 [dependencies]
 opendatafabric = { workspace = true }
-kamu = { workspace = true }
 kamu-core = { workspace = true }
 kamu-task-system = { workspace = true }
 kamu-flow-system = { workspace = true }
@@ -46,6 +45,7 @@ serde_with = { version = "3", default-features = false }
 
 
 [dev-dependencies]
+kamu = { workspace = true }
 kamu-task-system-inmem = { workspace = true }
 
 cron = { version = "0.12.0", default-features = false }

--- a/src/infra/ingest-datafusion/Cargo.toml
+++ b/src/infra/ingest-datafusion/Cargo.toml
@@ -52,7 +52,6 @@ url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
-env_logger = "0.10"
 indoc = "2"
 pretty_assertions = "1"
 rand = "0.8"

--- a/src/infra/task-system-inmem/Cargo.toml
+++ b/src/infra/task-system-inmem/Cargo.toml
@@ -45,7 +45,6 @@ serde_with = { version = "3", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.10"
-mockall = "0.11"
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features=["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/infra/task-system-inmem/Cargo.toml
+++ b/src/infra/task-system-inmem/Cargo.toml
@@ -44,7 +44,6 @@ serde_with = { version = "3", default-features = false }
 
 
 [dev-dependencies]
-env_logger = "0.10"
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features=["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/utils/container-runtime/Cargo.toml
+++ b/src/utils/container-runtime/Cargo.toml
@@ -36,7 +36,6 @@ url = "2"
 
 
 [dev-dependencies]
-env_logger = "0.10"
 test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tempfile = "3"

--- a/src/utils/data-utils/Cargo.toml
+++ b/src/utils/data-utils/Cargo.toml
@@ -37,7 +37,6 @@ url = "2"
 
 
 [dev-dependencies]
-env_logger = "0.10"
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features=["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/utils/event-bus/Cargo.toml
+++ b/src/utils/event-bus/Cargo.toml
@@ -29,7 +29,6 @@ dill = "0.8"
 futures = "0.3"
 
 [dev-dependencies]
-env_logger = "0.10"
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features=["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/utils/event-bus/Cargo.toml
+++ b/src/utils/event-bus/Cargo.toml
@@ -30,7 +30,6 @@ futures = "0.3"
 
 [dev-dependencies]
 env_logger = "0.10"
-test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features=["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/utils/event-sourcing/Cargo.toml
+++ b/src/utils/event-sourcing/Cargo.toml
@@ -27,7 +27,6 @@ internal-error = { workspace = true }
 
 async-stream = "0.3"
 async-trait = { version = "0.1", default-features = false }
-chrono = { version = "0.4", default-features = false }
 thiserror = { version = "1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }

--- a/src/utils/internal-error/Cargo.toml
+++ b/src/utils/internal-error/Cargo.toml
@@ -23,7 +23,3 @@ doctest = false
 
 [dependencies]
 thiserror = { version = "1", default-features = false }
-
-
-[dev-dependencies]
-test-log = { version = "0.2" }

--- a/src/utils/repo-tools/Cargo.toml
+++ b/src/utils/repo-tools/Cargo.toml
@@ -20,11 +20,10 @@ workspace = true
 [dependencies]
 clap = { version = "4", default-features = false, features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-glob = { version = "0.3", default-features = false }
 regex = { version = "1", default-features = false, features = ["std", "unicode"] }
 semver = { version = "1", default-features = false }
 toml = { version = "0.8", default-features = false, features = ["parse"] }
-url = { version = "2", default-features = false }
 
 [dev-dependencies]
 indoc = "2"
+glob = { version = "0.3", default-features = false }

--- a/src/utils/tracing-perfetto/Cargo.toml
+++ b/src/utils/tracing-perfetto/Cargo.toml
@@ -30,8 +30,5 @@ tracing-subscriber = { version = "0.3", default-features = false }
 
 
 [dev-dependencies]
-env_logger = "0.10"
-test-group = { version = "1" }
-test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features=["rt", "rt-multi-thread", "macros", "time"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## Description

Added `cargo-udeps` step into `make lint` and GH build action (Lint dependencies).
Added GH action to quickly install latest version of `binstall` so that `udeps` and `deny` are quickly installed.
Cleaned all unused dependencies in our TOML.

## Checklist before requesting a review
- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible  - not applicable
- [x] Workspace layout changes include a migration - not applicable
- [x] Documentation update PR: added notes in `DEVELOPER.md`
- [x] Dataset pipelines update scheduled if needed - not applicable
