### PR TITLE
Simplify workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,32 +36,32 @@ resolver = "2"
 
 [workspace.dependencies]
 # Utils
-container-runtime = { version = "0.164.2", path = "src/utils/container-runtime", default-features = false }
-enum-variants = { version = "0.164.2", path = "src/utils/enum-variants", default-features = false }
-event-bus = { version = "0.164.2", path = "src/utils/event-bus", default-features = false }
-event-sourcing = { version = "0.164.2", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.164.2", path = "src/utils/event-sourcing-macros", default-features = false }
-internal-error = { version = "0.164.2", path = "src/utils/internal-error", default-features = false }
-multiformats = { version = "0.164.2", path = "src/utils/multiformats", default-features = false }
-kamu-data-utils = { version = "0.164.2", path = "src/utils/data-utils", default-features = false }
-kamu-datafusion-cli = { version = "0.164.2", path = "src/utils/datafusion-cli", default-features = false }
-tracing-perfetto = { version = "0.164.2", path = "src/utils/tracing-perfetto", default-features = false }
+container-runtime = { path = "src/utils/container-runtime", default-features = false }
+enum-variants = { path = "src/utils/enum-variants", default-features = false }
+event-bus = { path = "src/utils/event-bus", default-features = false }
+event-sourcing = { path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { path = "src/utils/event-sourcing-macros", default-features = false }
+internal-error = { path = "src/utils/internal-error", default-features = false }
+multiformats = { path = "src/utils/multiformats", default-features = false }
+kamu-data-utils = { path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { path = "src/utils/datafusion-cli", default-features = false }
+tracing-perfetto = { path = "src/utils/tracing-perfetto", default-features = false }
 # Domain
-opendatafabric = { version = "0.164.2", path = "src/domain/opendatafabric", default-features = false }
-kamu-core = { version = "0.164.2", path = "src/domain/core", default-features = false }
-kamu-task-system = { version = "0.164.2", path = "src/domain/task-system", default-features = false }
-kamu-flow-system = { version = "0.164.2", path = "src/domain/flow-system", default-features = false }
+opendatafabric = { path = "src/domain/opendatafabric", default-features = false }
+kamu-core = { path = "src/domain/core", default-features = false }
+kamu-task-system = { path = "src/domain/task-system", default-features = false }
+kamu-flow-system = { path = "src/domain/flow-system", default-features = false }
 # Infra
-kamu = { version = "0.164.2", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.164.2", path = "src/infra/ingest-datafusion", default-features = false }
-kamu-task-system-inmem = { version = "0.164.2", path = "src/infra/task-system-inmem", default-features = false }
-kamu-flow-system-inmem = { version = "0.164.2", path = "src/infra/flow-system-inmem", default-features = false }
+kamu = { path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { path = "src/infra/ingest-datafusion", default-features = false }
+kamu-task-system-inmem = { path = "src/infra/task-system-inmem", default-features = false }
+kamu-flow-system-inmem = { path = "src/infra/flow-system-inmem", default-features = false }
 # Adapters
-kamu-adapter-auth-oso = { version = "0.164.2", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.164.2", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.164.2", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.164.2", path = "src/adapter/http", default-features = false }
-kamu-adapter-oauth = { version = "0.164.2", path = "src/adapter/oauth", defualt-features = false }
+kamu-adapter-auth-oso = { path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { path = "src/adapter/http", default-features = false }
+kamu-adapter-oauth = { path = "src/adapter/oauth", defualt-features = false }
 
 [workspace.package]
 version = "0.164.2"


### PR DESCRIPTION
I looked at some other projects' `Cargo.toml` and it doesn't look like we need to specify these versions explicitly.

This will reduce the amount of `diff` when we bump the release version.