### PR TITLE
Hotfix/flow history details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Updated
-- Extended flow history: start condition update event now holds a snapshot of the start condition
+- Extended flow history: 
+   - start condition update event now holds a snapshot of the start condition
+   - input dataset trigger now returns a queryable Dataset object instead of simply identifier
 ### Fixed
 - Zero value handling for `per_page` value in GraphQL
 - Flow history: more corrections to show natural time of flow events and keep flow system testable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Updated
+- Extended flow history: start condition update event now holds a snapshot of the start condition
 ### Fixed
 - Zero value handling for `per_page` value in GraphQL
 - Flow history: more corrections to show natural time of flow events and keep flow system testable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended flow history: 
    - start condition update event now holds a snapshot of the start condition
    - input dataset trigger now returns a queryable Dataset object instead of simply identifier
+   - dependent dataset flows should not be launched after Up-To-Date input flow
 ### Fixed
 - Zero value handling for `per_page` value in GraphQL
 - Flow history: more corrections to show natural time of flow events and keep flow system testable

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -771,7 +771,7 @@ type FlowEventInitiated implements FlowEvent {
 type FlowEventStartConditionUpdated implements FlowEvent {
 	eventId: EventID!
 	eventTime: DateTime!
-	startConditionKind: FlowStartConditionKind!
+	startCondition: FlowStartCondition!
 }
 
 type FlowEventTaskChanged implements FlowEvent {
@@ -823,13 +823,6 @@ type FlowStartConditionBatching {
 
 type FlowStartConditionExecutor {
 	taskId: TaskID!
-}
-
-enum FlowStartConditionKind {
-	SCHEDULE
-	THROTTLING
-	BATCHING
-	EXECUTOR
 }
 
 type FlowStartConditionSchedule {

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -864,7 +864,7 @@ type FlowTriggerAutoPolling {
 }
 
 type FlowTriggerInputDatasetFlow {
-	datasetId: DatasetID!
+	dataset: Dataset!
 	flowType: DatasetFlowType!
 	flowId: FlowID!
 }

--- a/src/adapter/graphql/src/queries/flows/flow.rs
+++ b/src/adapter/graphql/src/queries/flows/flow.rs
@@ -152,7 +152,6 @@ impl Flow {
     /// History of flow events
     async fn history(&self, ctx: &Context<'_>) -> Result<Vec<FlowEvent>> {
         let flow_event_store = from_catalog::<dyn fs::FlowEventStore>(ctx).unwrap();
-        let dataset_changes_service = from_catalog::<dyn DatasetChangesService>(ctx).unwrap();
 
         let flow_events: Vec<_> = flow_event_store
             .get_events(&self.flow_state.flow_id, Default::default())
@@ -162,15 +161,7 @@ impl Flow {
 
         let mut history = Vec::new();
         for (event_id, flow_event) in flow_events {
-            history.push(
-                FlowEvent::build(
-                    event_id,
-                    flow_event,
-                    &self.flow_state,
-                    dataset_changes_service.as_ref(),
-                )
-                .await?,
-            );
+            history.push(FlowEvent::build(event_id, flow_event, &self.flow_state, ctx).await?);
         }
         Ok(history)
     }
@@ -184,21 +175,19 @@ impl Flow {
     }
 
     /// Primary flow trigger
-    async fn primary_trigger(&self) -> FlowTrigger {
-        self.flow_state.primary_trigger().clone().into()
+    async fn primary_trigger(&self, ctx: &Context<'_>) -> Result<FlowTrigger, InternalError> {
+        FlowTrigger::build(self.flow_state.primary_trigger().clone(), ctx).await
     }
 
     /// Start condition
     async fn start_condition(&self, ctx: &Context<'_>) -> Result<Option<FlowStartCondition>> {
-        let dataset_changes_service = from_catalog::<dyn DatasetChangesService>(ctx).unwrap();
-
         let maybe_condition =
             if let Some(start_condition) = self.flow_state.start_condition.as_ref() {
                 Some(
                     FlowStartCondition::create_from_raw_flow_data(
                         start_condition,
                         &self.flow_state.triggers,
-                        dataset_changes_service.as_ref(),
+                        ctx,
                     )
                     .await
                     .int_err()?,

--- a/src/adapter/graphql/src/queries/flows/flow_event.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_event.rs
@@ -8,9 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use chrono::{DateTime, Utc};
+use kamu_core::DatasetChangesService;
 use {event_sourcing as evs, kamu_flow_system as fs, kamu_task_system as ts};
 
-use super::FlowTrigger;
+use super::{FlowStartCondition, FlowTrigger};
 use crate::prelude::*;
 use crate::queries::Task;
 use crate::utils;
@@ -36,11 +37,26 @@ pub enum FlowEvent {
 }
 
 impl FlowEvent {
-    pub fn new(event_id: evs::EventID, event: fs::FlowEvent) -> Self {
-        match event {
+    pub async fn build(
+        event_id: evs::EventID,
+        event: fs::FlowEvent,
+        flow_state: &fs::FlowState,
+        dataset_changes_service: &dyn DatasetChangesService,
+    ) -> Result<Self, InternalError> {
+        Ok(match event {
             fs::FlowEvent::Initiated(e) => Self::Initiated(FlowEventInitiated::new(event_id, e)),
             fs::FlowEvent::StartConditionUpdated(e) => {
-                Self::StartConditionUpdated(FlowEventStartConditionUpdated::new(event_id, &e))
+                let start_condition = FlowStartCondition::create_from_raw_flow_data(
+                    &e.start_condition,
+                    &flow_state.triggers[0..e.last_trigger_index],
+                    dataset_changes_service,
+                )
+                .await?;
+                Self::StartConditionUpdated(FlowEventStartConditionUpdated::new(
+                    event_id,
+                    e.event_time,
+                    start_condition,
+                ))
             }
             fs::FlowEvent::TriggerAdded(e) => {
                 Self::TriggerAdded(FlowEventTriggerAdded::new(event_id, e))
@@ -64,7 +80,7 @@ impl FlowEvent {
                 TaskStatus::Finished,
             )),
             fs::FlowEvent::Aborted(e) => Self::Aborted(FlowEventAborted::new(event_id, &e)),
-        }
+        })
     }
 }
 
@@ -93,30 +109,21 @@ impl FlowEventInitiated {
 pub struct FlowEventStartConditionUpdated {
     event_id: EventID,
     event_time: DateTime<Utc>,
-    start_condition_kind: FlowStartConditionKind,
+    start_condition: FlowStartCondition,
 }
 
 impl FlowEventStartConditionUpdated {
-    fn new(event_id: evs::EventID, event: &fs::FlowEventStartConditionUpdated) -> Self {
+    fn new(
+        event_id: evs::EventID,
+        event_time: DateTime<Utc>,
+        start_condition: FlowStartCondition,
+    ) -> Self {
         Self {
             event_id: event_id.into(),
-            event_time: event.event_time,
-            start_condition_kind: match event.start_condition {
-                fs::FlowStartCondition::Schedule(_) => FlowStartConditionKind::Schedule,
-                fs::FlowStartCondition::Throttling(_) => FlowStartConditionKind::Throttling,
-                fs::FlowStartCondition::Batching(_) => FlowStartConditionKind::Batching,
-                fs::FlowStartCondition::Executor(_) => FlowStartConditionKind::Executor,
-            },
+            event_time,
+            start_condition,
         }
     }
-}
-
-#[derive(Enum, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum FlowStartConditionKind {
-    Schedule,
-    Throttling,
-    Batching,
-    Executor,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
@@ -27,7 +27,7 @@ impl FlowStartCondition {
     pub async fn create_from_raw_flow_data(
         start_condition: &fs::FlowStartCondition,
         matching_triggers: &[fs::FlowTrigger],
-        dataset_changes_service: &dyn DatasetChangesService,
+        ctx: &Context<'_>,
     ) -> Result<Self, InternalError> {
         Ok(match start_condition {
             fs::FlowStartCondition::Schedule(s) => Self::Schedule(FlowStartConditionSchedule {
@@ -35,6 +35,9 @@ impl FlowStartCondition {
             }),
             fs::FlowStartCondition::Throttling(t) => Self::Throttling((*t).into()),
             fs::FlowStartCondition::Batching(b) => {
+                let dataset_changes_service =
+                    from_catalog::<dyn DatasetChangesService>(ctx).unwrap();
+
                 // Start from zero increment
                 let mut total_increment = DatasetIntervalIncrement::default();
 

--- a/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_start_condition.rs
@@ -25,18 +25,16 @@ pub(crate) enum FlowStartCondition {
 
 impl FlowStartCondition {
     pub async fn create_from_raw_flow_data(
-        flow_state: &fs::FlowState,
+        start_condition: &fs::FlowStartCondition,
+        matching_triggers: &[fs::FlowTrigger],
         dataset_changes_service: &dyn DatasetChangesService,
-    ) -> Result<Option<Self>, InternalError> {
-        Ok(match &flow_state.start_condition {
-            None => None,
-            Some(fs::FlowStartCondition::Schedule(s)) => {
-                Some(Self::Schedule(FlowStartConditionSchedule {
-                    wake_up_at: s.wake_up_at,
-                }))
-            }
-            Some(fs::FlowStartCondition::Throttling(t)) => Some(Self::Throttling((*t).into())),
-            Some(fs::FlowStartCondition::Batching(b)) => {
+    ) -> Result<Self, InternalError> {
+        Ok(match start_condition {
+            fs::FlowStartCondition::Schedule(s) => Self::Schedule(FlowStartConditionSchedule {
+                wake_up_at: s.wake_up_at,
+            }),
+            fs::FlowStartCondition::Throttling(t) => Self::Throttling((*t).into()),
+            fs::FlowStartCondition::Batching(b) => {
                 // Start from zero increment
                 let mut total_increment = DatasetIntervalIncrement::default();
 
@@ -44,7 +42,7 @@ impl FlowStartCondition {
                 // flow latest event, as they might have evolved after this state was loaded
 
                 // For each dataset trigger, add accumulated changes since trigger first fired
-                for trigger in &flow_state.triggers {
+                for trigger in matching_triggers {
                     if let fs::FlowTrigger::InputDatasetFlow(dataset_trigger) = trigger {
                         if let fs::FlowResult::DatasetUpdate(dataset_update) =
                             &dataset_trigger.flow_result
@@ -61,18 +59,16 @@ impl FlowStartCondition {
                 }
 
                 // Finally, present the full picture from condition + computed view results
-                Some(Self::Batching(FlowStartConditionBatching {
+                Self::Batching(FlowStartConditionBatching {
                     active_batching_rule: b.active_batching_rule.into(),
                     batching_deadline: b.batching_deadline,
                     accumulated_records_count: total_increment.num_records,
                     watermark_modified: total_increment.updated_watermark.is_some(),
-                }))
+                })
             }
-            Some(fs::FlowStartCondition::Executor(e)) => {
-                Some(Self::Executor(FlowStartConditionExecutor {
-                    task_id: e.task_id.into(),
-                }))
-            }
+            fs::FlowStartCondition::Executor(e) => Self::Executor(FlowStartConditionExecutor {
+                task_id: e.task_id.into(),
+            }),
         })
     }
 }

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -1954,7 +1954,10 @@ impl FlowRunsHarness {
                                         primaryTrigger {
                                             __typename
                                             ... on FlowTriggerInputDatasetFlow {
-                                                datasetId
+                                                dataset {
+                                                    id
+                                                    name
+                                                }
                                                 flowType
                                                 flowId
                                             }

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -1600,7 +1600,9 @@ async fn test_history_of_completed_flow() {
                                         {
                                             "__typename": "FlowEventStartConditionUpdated",
                                             "eventId": "2",
-                                            "startConditionKind": "EXECUTOR"
+                                            "startCondition": {
+                                                "__typename" : "FlowStartConditionExecutor"
+                                            }
                                         },
                                         {
                                             "__typename": "FlowEventTaskChanged",
@@ -2027,7 +2029,9 @@ impl FlowRunsHarness {
                                                     }
                                                 }
                                                 ... on FlowEventStartConditionUpdated {
-                                                    startConditionKind
+                                                    startCondition {
+                                                        __typename
+                                                    }
                                                 }
                                                 ... on FlowEventTriggerAdded {
                                                     trigger {

--- a/src/domain/flow-system/src/aggregates/flow/flow.rs
+++ b/src/domain/flow-system/src/aggregates/flow/flow.rs
@@ -51,6 +51,7 @@ impl Flow {
                 event_time: now,
                 flow_id: self.flow_id,
                 start_condition,
+                last_trigger_index: self.triggers.len(),
             };
             self.apply(event)
         } else {

--- a/src/domain/flow-system/src/entities/flow/flow_event.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_event.rs
@@ -50,6 +50,7 @@ pub struct FlowEventStartConditionUpdated {
     pub event_time: DateTime<Utc>,
     pub flow_id: FlowID,
     pub start_condition: FlowStartCondition,
+    pub last_trigger_index: usize,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/src/entities/flow/flow_outcome.rs
+++ b/src/domain/flow-system/src/entities/flow/flow_outcome.rs
@@ -40,6 +40,15 @@ pub enum FlowResult {
     DatasetUpdate(FlowResultDatasetUpdate),
 }
 
+impl FlowResult {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            FlowResult::Empty => true,
+            FlowResult::DatasetUpdate(_) => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FlowResultDatasetUpdate {
     pub old_head: Option<Multihash>,

--- a/src/infra/flow-system-inmem/src/services/flow/flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/src/services/flow/flow_service_inmem.rs
@@ -1055,7 +1055,9 @@ impl AsyncEventHandler<TaskEventFinished> for FlowServiceInMemory {
 
             // In case of success:
             //  - execute followup method
-            if let Some(flow_result) = flow.try_result_as_ref() {
+            if let Some(flow_result) = flow.try_result_as_ref()
+                && !flow_result.is_empty()
+            {
                 match flow.flow_key.get_type().success_followup_method() {
                     FlowSuccessFollowupMethod::Ignore => {}
                     FlowSuccessFollowupMethod::TriggerDependent => {


### PR DESCRIPTION
Hotfixes of flow system & flow history feature, preparing for demo:
- Extended flow history: start condition update event now holds a snapshot of the start condition
- Input dataset trigger now returns a queryable Dataset object instead of simply identifier
- Dependent dataset flows should not be launched after Up-To-Date input flow