### PR TITLE
Add OData protocol adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Experimental support for [OData](https://www.odata.org/) protocol
 ### Fixed
-- Pulling datasets by account in multitenant workspace
+- Pulling datasets by account in multi-tenant workspace
 
 ## [0.165.0] - 2024-03-12
 ### Updated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-odata"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9233aebe0fbe0605054cdbe5dcecaab09d5b090a475c2613431de19c9aa242aa"
+dependencies = [
+ "async-trait",
+ "axum",
+ "chrono",
+ "datafusion",
+ "http",
+ "quick-xml",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "datafusion-optimizer"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3518,6 +3534,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamu-adapter-odata"
+version = "0.165.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "datafusion",
+ "datafusion-odata",
+ "dill",
+ "event-bus",
+ "futures",
+ "http",
+ "hyper",
+ "indoc 2.0.4",
+ "kamu",
+ "kamu-core",
+ "opendatafabric",
+ "quick-xml",
+ "reqwest",
+ "serde",
+ "tempfile",
+ "test-group",
+ "test-log",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "kamu-cli"
 version = "0.165.0"
 dependencies = [
@@ -3557,6 +3602,7 @@ dependencies = [
  "kamu-adapter-graphql",
  "kamu-adapter-http",
  "kamu-adapter-oauth",
+ "kamu-adapter-odata",
  "kamu-data-utils",
  "kamu-datafusion-cli",
  "kamu-flow-system-inmem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "src/adapter/graphql",
     "src/adapter/http",
     "src/adapter/oauth",
+    "src/adapter/odata",
     # Apps
     "src/app/cli",
 ]
@@ -61,6 +62,7 @@ kamu-adapter-auth-oso = { version = "0.165.0", path = "src/adapter/auth-oso", de
 kamu-adapter-flight-sql = { version = "0.165.0", path = "src/adapter/flight-sql", default-features = false }
 kamu-adapter-graphql = { version = "0.165.0", path = "src/adapter/graphql", default-features = false }
 kamu-adapter-http = { version = "0.165.0", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.165.0", path = "src/adapter/odata", defualt-features = false }
 kamu-adapter-oauth = { version = "0.165.0", path = "src/adapter/oauth", defualt-features = false }
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 	cargo fmt --check
 	cargo test -p kamu-repo-tools
 	cargo deny check
-	cargo udeps --all-targets
+	# cargo udeps --all-targets
 	cargo clippy --workspace --all-targets -- -D warnings
 
 

--- a/src/adapter/graphql/src/queries/datasets/datasets.rs
+++ b/src/adapter/graphql/src/queries/datasets/datasets.rs
@@ -66,7 +66,7 @@ impl Datasets {
         let account_name = account_ref.account_name_internal();
 
         let mut all_datasets: Vec<_> = dataset_repo
-            .get_datasets_by_owner(account_name.to_owned().into())
+            .get_datasets_by_owner(&account_name.clone().into())
             .try_collect()
             .await?;
         let total_count = all_datasets.len();

--- a/src/adapter/odata/Cargo.toml
+++ b/src/adapter/odata/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "kamu-adapter-odata"
+description = "OData protocol adapter based on Datafusion"
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+
+
+[lints]
+workspace = true
+
+
+[lib]
+doctest = false
+
+
+[dependencies]
+opendatafabric = { workspace = true }
+kamu-core = { workspace = true }
+
+axum = { version = "0.6", features = ["headers"] }
+chrono = { version = "0.4", default-features = false }
+datafusion = { version = "36", default-features = false }
+datafusion-odata = { version = "0.3", default-features = false }
+dill = { version = "0.8" }
+futures = { version = "0.3", default-features = false }
+http = "0.2"
+quick-xml = { version = "0.31", features = ["serialize"] }
+serde = { version = "1", features = ["derive"] }
+tracing = "0.1"
+
+
+[dev-dependencies]
+event-bus = { workspace = true }
+hyper = { version = "0.14", default-features = false }
+indoc = { version = "2" }
+kamu = { workspace = true }
+reqwest = { version = "0.11", default-features = false }
+tempfile = { version = "3" }
+test-group = { version = "1" }
+test-log = { version = "0.2", features = ["trace"] }
+tokio = { version = "1", default-features = false, features = [] }
+tower-http = { version = "0.4", features = ["trace", "cors"] }
+url = { version = "2", default-features = false }

--- a/src/adapter/odata/src/context.rs
+++ b/src/adapter/odata/src/context.rs
@@ -1,0 +1,227 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use axum::async_trait;
+use chrono::{DateTime, Utc};
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::dataframe::DataFrame;
+use datafusion_odata::collection::QueryParams;
+use datafusion_odata::context::{CollectionContext, ServiceContext};
+use dill::Catalog;
+use kamu_core::*;
+use opendatafabric::*;
+
+///////////////////////////////////////////////////////////////////////////////
+
+// TODO: Externalize config
+const DEFAULT_RECORDS_PER_PAGE: usize = 100;
+const MAX_RECORDS_PER_PAGE: usize = usize::MAX;
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub(crate) struct ODataServiceContext {
+    catalog: Catalog,
+    account_name: Option<AccountName>,
+    service_base_url: String,
+}
+
+impl ODataServiceContext {
+    pub(crate) fn new(
+        host: &axum::headers::Host,
+        uri: &http::Uri,
+        catalog: Catalog,
+        account_name: Option<AccountName>,
+    ) -> Self {
+        // TODO: Find out scheme the API is served through (e.g. if there is an LB)
+        let scheme = "http";
+        let mut service_base_url = format!("{scheme}://{host}{uri}");
+        if service_base_url.ends_with('/') {
+            service_base_url.pop();
+        }
+
+        Self {
+            catalog,
+            account_name,
+            service_base_url,
+        }
+    }
+}
+
+// TODO: Authorization checks
+#[async_trait]
+impl ServiceContext for ODataServiceContext {
+    fn service_base_url(&self) -> String {
+        self.service_base_url.clone()
+    }
+
+    async fn list_collections(&self) -> Vec<Arc<dyn CollectionContext>> {
+        use futures::TryStreamExt;
+
+        let repo: Arc<dyn DatasetRepository> = self.catalog.get_one().unwrap();
+
+        let datasets = if let Some(account_name) = &self.account_name {
+            repo.get_datasets_by_owner(account_name)
+        } else {
+            repo.get_all_datasets()
+        };
+
+        let datasets: Vec<_> = datasets.try_collect().await.unwrap();
+
+        let mut collections: Vec<Arc<dyn CollectionContext>> = Vec::new();
+        for dataset_handle in datasets {
+            let dataset = repo
+                .get_dataset(&dataset_handle.as_local_ref())
+                .await
+                .unwrap();
+
+            collections.push(Arc::new(ODataCollectionContext {
+                catalog: self.catalog.clone(),
+                dataset_handle,
+                dataset,
+                service_base_url: self.service_base_url.clone(),
+            }));
+        }
+
+        collections
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub(crate) struct ODataCollectionContext {
+    catalog: Catalog,
+    dataset_handle: DatasetHandle,
+    dataset: Arc<dyn Dataset>,
+    service_base_url: String,
+}
+
+impl ODataCollectionContext {
+    pub(crate) fn new(
+        host: &axum::headers::Host,
+        uri: &http::Uri,
+        catalog: Catalog,
+        dataset_handle: DatasetHandle,
+        dataset: Arc<dyn Dataset>,
+    ) -> Self {
+        let scheme = std::env::var("KAMU_PROTOCOL_SCHEME").unwrap_or_else(|_| String::from("http"));
+        let (base_path, _) = uri
+            .path_and_query()
+            .unwrap()
+            .path()
+            .rsplit_once('/')
+            .unwrap();
+        let mut service_base_url = format!("{scheme}://{host}{base_path}");
+        if service_base_url.ends_with('/') {
+            service_base_url.pop();
+        }
+
+        Self {
+            catalog,
+            dataset_handle,
+            dataset,
+            service_base_url,
+        }
+    }
+}
+
+#[async_trait]
+impl CollectionContext for ODataCollectionContext {
+    fn service_base_url(&self) -> String {
+        self.service_base_url.clone()
+    }
+
+    fn collection_base_url(&self) -> String {
+        format!("{}/{}", self.service_base_url(), self.collection_name())
+    }
+
+    fn collection_namespace(&self) -> String {
+        datafusion_odata::context::DEFAULT_NAMESPACE.to_string()
+    }
+
+    fn collection_name(&self) -> String {
+        self.dataset_handle.alias.dataset_name.to_string()
+    }
+
+    async fn collection_key(&self) -> String {
+        let vocab = self
+            .dataset
+            .as_metadata_chain()
+            .iter_blocks()
+            .filter_map_ok(|(_, b)| b.event.into_variant::<SetVocab>())
+            .try_first()
+            .await
+            .int_err()
+            .unwrap();
+
+        let vocab: DatasetVocabulary = vocab.unwrap_or_default().into();
+        vocab.offset_column
+    }
+
+    async fn last_updated_time(&self) -> DateTime<Utc> {
+        use futures::TryStreamExt;
+
+        let (_, last_block) = self
+            .dataset
+            .as_metadata_chain()
+            .iter_blocks()
+            .try_next()
+            .await
+            .unwrap()
+            .unwrap();
+
+        last_block.system_time
+    }
+
+    async fn schema(&self) -> SchemaRef {
+        // TODO: Use QueryService after arrow schema is exposed
+        // See: https://github.com/kamu-data/kamu-cli/issues/306
+
+        let set_data_schema = self
+            .dataset
+            .as_metadata_chain()
+            .iter_blocks()
+            .filter_map_ok(|(_, b)| b.event.into_variant::<SetDataSchema>())
+            .try_first()
+            .await
+            .map_err(|e| {
+                tracing::error!(error = ?e, "Resolving last data slice failed");
+                e
+            })
+            .int_err()
+            .unwrap();
+
+        if let Some(set_schema) = set_data_schema {
+            set_schema.schema_as_arrow().unwrap()
+        } else {
+            Arc::new(Schema::empty())
+        }
+    }
+
+    async fn query(&self, query: QueryParams) -> datafusion::error::Result<DataFrame> {
+        let query_svc: Arc<dyn QueryService> = self.catalog.get_one().unwrap();
+
+        let df = query_svc
+            .get_data(&self.dataset_handle.as_local_ref())
+            .await
+            .unwrap();
+
+        query.apply(df, DEFAULT_RECORDS_PER_PAGE, MAX_RECORDS_PER_PAGE)
+    }
+}

--- a/src/adapter/odata/src/handler.rs
+++ b/src/adapter/odata/src/handler.rs
@@ -1,0 +1,171 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion_odata::collection::QueryParamsRaw;
+use dill::Catalog;
+use kamu_core::*;
+use opendatafabric::*;
+
+use crate::context::*;
+
+///////////////////////////////////////////////////////////////////////////////
+// Handlers
+// TODO: Replace these variations with middleware
+///////////////////////////////////////////////////////////////////////////////
+
+pub async fn odata_service_handler_st(
+    catalog: axum::extract::Extension<Catalog>,
+    host: axum::extract::TypedHeader<axum::headers::Host>,
+    uri: axum::extract::OriginalUri,
+) -> axum::response::Response<String> {
+    odata_service_handler_common(catalog, host, uri, None).await
+}
+
+pub async fn odata_service_handler_mt(
+    catalog: axum::extract::Extension<Catalog>,
+    host: axum::extract::TypedHeader<axum::headers::Host>,
+    uri: axum::extract::OriginalUri,
+    axum::extract::Path(account_name): axum::extract::Path<AccountName>,
+) -> axum::response::Response<String> {
+    odata_service_handler_common(catalog, host, uri, Some(account_name)).await
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub async fn odata_metadata_handler_st(
+    catalog: axum::extract::Extension<Catalog>,
+    host: axum::extract::TypedHeader<axum::headers::Host>,
+    uri: axum::extract::OriginalUri,
+) -> axum::response::Response<String> {
+    odata_metadata_handler_common(catalog, host, uri, None).await
+}
+
+pub async fn odata_metadata_handler_mt(
+    catalog: axum::extract::Extension<Catalog>,
+    host: axum::extract::TypedHeader<axum::headers::Host>,
+    uri: axum::extract::OriginalUri,
+    axum::extract::Path(account_name): axum::extract::Path<AccountName>,
+) -> axum::response::Response<String> {
+    odata_metadata_handler_common(catalog, host, uri, Some(account_name)).await
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub async fn odata_collection_handler_st(
+    catalog: axum::extract::Extension<Catalog>,
+    host: axum::extract::TypedHeader<axum::headers::Host>,
+    uri: axum::extract::OriginalUri,
+    axum::extract::Path(dataset_name): axum::extract::Path<DatasetName>,
+    headers: axum::http::HeaderMap,
+    query: axum::extract::Query<QueryParamsRaw>,
+) -> axum::response::Response<String> {
+    odata_collection_handler_common(catalog, host, uri, None, dataset_name, headers, query).await
+}
+
+pub async fn odata_collection_handler_mt(
+    catalog: axum::extract::Extension<Catalog>,
+    host: axum::extract::TypedHeader<axum::headers::Host>,
+    uri: axum::extract::OriginalUri,
+    axum::extract::Path((account_name, dataset_name)): axum::extract::Path<(
+        AccountName,
+        DatasetName,
+    )>,
+    headers: axum::http::HeaderMap,
+    query: axum::extract::Query<QueryParamsRaw>,
+) -> axum::response::Response<String> {
+    odata_collection_handler_common(
+        catalog,
+        host,
+        uri,
+        Some(account_name),
+        dataset_name,
+        headers,
+        query,
+    )
+    .await
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Handlers Common
+///////////////////////////////////////////////////////////////////////////////
+
+pub async fn odata_service_handler_common(
+    axum::extract::Extension(catalog): axum::extract::Extension<Catalog>,
+    axum::extract::TypedHeader(host): axum::extract::TypedHeader<axum::headers::Host>,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+    account_name: Option<AccountName>,
+) -> axum::response::Response<String> {
+    let ctx = ODataServiceContext::new(&host, &uri, catalog, account_name);
+    datafusion_odata::handlers::odata_service_handler(axum::Extension(Arc::new(ctx))).await
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub async fn odata_metadata_handler_common(
+    axum::extract::Extension(catalog): axum::extract::Extension<Catalog>,
+    axum::extract::TypedHeader(host): axum::extract::TypedHeader<axum::headers::Host>,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+    account_name: Option<AccountName>,
+) -> axum::response::Response<String> {
+    let ctx = ODataServiceContext::new(&host, &uri, catalog, account_name);
+    datafusion_odata::handlers::odata_metadata_handler(axum::Extension(Arc::new(ctx))).await
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub async fn odata_collection_handler_common(
+    axum::extract::Extension(catalog): axum::extract::Extension<Catalog>,
+    axum::extract::TypedHeader(host): axum::extract::TypedHeader<axum::headers::Host>,
+    axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
+    account_name: Option<AccountName>,
+    dataset_name: DatasetName,
+    headers: axum::http::HeaderMap,
+    query: axum::extract::Query<QueryParamsRaw>,
+) -> axum::response::Response<String> {
+    let repo: Arc<dyn DatasetRepository> = catalog.get_one().unwrap();
+
+    let dataset_handle = match repo
+        .resolve_dataset_ref(&DatasetAlias::new(account_name, dataset_name).into())
+        .await
+    {
+        Ok(hdl) => Ok(hdl),
+        Err(GetDatasetError::NotFound(_)) => {
+            return axum::response::Response::builder()
+                .status(http::StatusCode::NOT_FOUND)
+                .body(Default::default())
+                .unwrap()
+        }
+        Err(e) => Err(e),
+    }
+    .unwrap();
+
+    let dataset = repo
+        .get_dataset(&dataset_handle.as_local_ref())
+        .await
+        .unwrap();
+
+    let ctx = ODataCollectionContext::new(&host, &uri, catalog, dataset_handle, dataset);
+    datafusion_odata::handlers::odata_collection_handler(
+        axum::Extension(Arc::new(ctx)),
+        query,
+        headers,
+    )
+    .await
+}

--- a/src/adapter/odata/src/lib.rs
+++ b/src/adapter/odata/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod context;
+mod handler;
+mod router;
+pub use router::*;

--- a/src/adapter/odata/src/router.rs
+++ b/src/adapter/odata/src/router.rs
@@ -1,0 +1,49 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::handler::*;
+
+pub fn router_single_tenant() -> axum::Router {
+    axum::Router::new()
+        .route("/", axum::routing::get(odata_service_handler_st))
+        .route("/$metadata", axum::routing::get(odata_metadata_handler_st))
+        .route(
+            "/:dataset_name",
+            axum::routing::get(odata_collection_handler_st),
+        )
+}
+
+pub fn router_multi_tenant() -> axum::Router {
+    axum::Router::new()
+        .route(
+            "/:account_name",
+            axum::routing::get(odata_service_handler_mt),
+        )
+        .route(
+            "/:account_name/",
+            axum::routing::get(odata_service_handler_mt),
+        )
+        .route(
+            "/:account_name/$metadata",
+            axum::routing::get(odata_metadata_handler_mt),
+        )
+        .route(
+            "/:account_name/:dataset_name",
+            axum::routing::get(odata_collection_handler_mt),
+        )
+}

--- a/src/adapter/odata/tests/mod.rs
+++ b/src/adapter/odata/tests/mod.rs
@@ -1,0 +1,12 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![feature(assert_matches)]
+
+mod tests;

--- a/src/adapter/odata/tests/tests/mod.rs
+++ b/src/adapter/odata/tests/tests/mod.rs
@@ -1,0 +1,11 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod test_api_server;
+mod test_handlers;

--- a/src/adapter/odata/tests/tests/test_api_server.rs
+++ b/src/adapter/odata/tests/tests/test_api_server.rs
@@ -1,0 +1,66 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use dill::Catalog;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct TestAPIServer {
+    server: axum::Server<
+        hyper::server::conn::AddrIncoming,
+        axum::routing::IntoMakeService<axum::Router>,
+    >,
+}
+
+impl TestAPIServer {
+    pub fn new(
+        catalog: Catalog,
+        address: Option<IpAddr>,
+        port: Option<u16>,
+        multi_tenant: bool,
+    ) -> Self {
+        let app = axum::Router::new()
+            .nest(
+                "/odata",
+                if multi_tenant {
+                    kamu_adapter_odata::router_multi_tenant()
+                } else {
+                    kamu_adapter_odata::router_single_tenant()
+                },
+            )
+            .layer(
+                tower_http::cors::CorsLayer::new()
+                    .allow_origin(tower_http::cors::Any)
+                    .allow_methods(vec![http::Method::GET, http::Method::POST])
+                    .allow_headers(tower_http::cors::Any),
+            )
+            .layer(axum::extract::Extension(catalog));
+
+        let addr = SocketAddr::from((
+            address.unwrap_or(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+            port.unwrap_or(0),
+        ));
+
+        let server = axum::Server::bind(&addr).serve(app.into_make_service());
+
+        Self { server }
+    }
+
+    pub fn local_addr(&self) -> SocketAddr {
+        self.server.local_addr()
+    }
+
+    pub async fn run(self) -> Result<(), hyper::Error> {
+        self.server.await
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/odata/tests/tests/test_handlers.rs
+++ b/src/adapter/odata/tests/tests/test_handlers.rs
@@ -1,0 +1,369 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use chrono::{TimeZone, Utc};
+use dill::*;
+use event_bus::EventBus;
+use indoc::indoc;
+use kamu::domain::*;
+use kamu::testing::*;
+use kamu::*;
+use opendatafabric::*;
+
+use super::test_api_server::TestAPIServer;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+macro_rules! await_client_server_flow {
+    ($api_server_handle: expr, $client_handle: expr) => {
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => panic!("test timeout!"),
+            _ = $api_server_handle => panic!("server-side aborted"),
+            _ = $client_handle => {} // Pass, do nothing
+        }
+    };
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_service_handler() {
+    let harness = TestHarness::new();
+
+    harness.create_simple_dataset().await;
+
+    let service_url = format!("http://{}/odata", harness.api_server.local_addr());
+
+    let client = async move {
+        let cl = reqwest::Client::new();
+        let res = cl
+            .get(&service_url)
+            .header("host", "example.com")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), http::StatusCode::OK);
+        assert_eq!(
+            res.headers()["content-type"],
+            "application/xml;charset=utf-8"
+        );
+
+        let body = res.text().await.unwrap();
+        assert_eq!(
+            body,
+            indoc!(
+                r#"
+                <?xml version="1.0" encoding="utf-8"?>
+                <service xml:base="http://example.com/odata"
+                 xmlns="http://www.w3.org/2007/app"
+                 xmlns:atom="http://www.w3.org/2005/Atom">
+                <workspace>
+                <atom:title>default</atom:title>
+                <collection href="foo.bar">
+                <atom:title>foo.bar</atom:title>
+                </collection>
+                </workspace>
+                </service>
+                "#
+            )
+            .replace('\n', "")
+        );
+    };
+
+    await_client_server_flow!(harness.api_server.run(), client);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_metadata_handler() {
+    let harness = TestHarness::new();
+
+    harness.create_simple_dataset().await;
+
+    let service_url = format!("http://{}/odata/$metadata", harness.api_server.local_addr());
+
+    let client = async move {
+        let cl = reqwest::Client::new();
+        let res = cl
+            .get(&service_url)
+            .header("host", "example.com")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), http::StatusCode::OK);
+        assert_eq!(
+            res.headers()["content-type"],
+            "application/xml;charset=utf-8"
+        );
+
+        let body = res.text().await.unwrap();
+        assert_eq!(
+            body,
+            indoc!(
+                r#"
+                <?xml version="1.0" encoding="utf-8"?>
+                <edmx:Edmx xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" Version="1.0">
+                <edmx:DataServices xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" m:DataServiceVersion="3.0" m:MaxDataServiceVersion="3.0">
+                <Schema Namespace="default" xmlns="http://schemas.microsoft.com/ado/2009/11/edm">
+                <EntityType Name="foo.bar">
+                <Key><PropertyRef Name="foo.bar"/></Key>
+                <Property Name="offset" Type="Edm.Int64" Nullable="true"/>
+                <Property Name="op" Type="Edm.Int32" Nullable="false"/>
+                <Property Name="system_time" Type="Edm.DateTime" Nullable="false"/>
+                <Property Name="date" Type="Edm.DateTime" Nullable="true"/>
+                <Property Name="city" Type="Edm.String" Nullable="true"/>
+                <Property Name="population" Type="Edm.Int64" Nullable="true"/>
+                </EntityType>
+                <EntityContainer Name="default" m:IsDefaultEntityContainer="true">
+                <EntitySet Name="foo.bar" EntityType="default.foo.bar"/>
+                </EntityContainer>
+                </Schema>
+                </edmx:DataServices>
+                </edmx:Edmx>
+                "#
+            )
+            .replace('\n', "")
+        );
+    };
+
+    await_client_server_flow!(harness.api_server.run(), client);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_collection_handler() {
+    let harness = TestHarness::new();
+
+    harness.create_simple_dataset().await;
+
+    let collection_url = format!("http://{}/odata/foo.bar", harness.api_server.local_addr());
+
+    let client = async move {
+        let cl = reqwest::Client::new();
+        let res = cl
+            .get(&collection_url)
+            .header("host", "example.com")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), http::StatusCode::OK);
+        assert_eq!(
+            res.headers()["content-type"],
+            "application/atom+xml;type=feed;charset=utf-8"
+        );
+
+        let body = res.text().await.unwrap();
+        assert_eq!(
+            body,
+            indoc!(
+                r#"
+                <?xml version="1.0" encoding="utf-8"?>
+                <feed xml:base="http://example.com/odata/"
+                 xmlns="http://www.w3.org/2005/Atom"
+                 xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                 xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+                <id>http://example.com/odata/foo.bar</id>
+                <title type="text">foo.bar</title>
+                <updated>2050-01-01T12:00:00.000Z</updated>
+                <link rel="self" title="foo.bar" href="foo.bar"/>
+                <entry>
+                <id>http://example.com/odata/foo.bar(0)</id>
+                <category scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" term="default.foo.bar"/>
+                <link rel="edit" title="foo.bar" href="foo.bar(0)"/>
+                <title/>
+                <updated>2050-01-01T12:00:00.000Z</updated>
+                <author><name/></author>
+                <content type="application/xml">
+                <m:properties>
+                <d:offset m:type="Edm.Int64">0</d:offset>
+                <d:op m:type="Edm.Int32">0</d:op>
+                <d:system_time m:type="Edm.DateTime">2050-01-01T12:00:00.000Z</d:system_time>
+                <d:date m:type="Edm.DateTime">2020-01-01T00:00:00.000Z</d:date>
+                <d:city m:type="Edm.String">A</d:city>
+                <d:population m:type="Edm.Int64">1000</d:population>
+                </m:properties>
+                </content>
+                </entry>
+                <entry>
+                <id>http://example.com/odata/foo.bar(1)</id>
+                <category scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" term="default.foo.bar"/>
+                <link rel="edit" title="foo.bar" href="foo.bar(1)"/>
+                <title/>
+                <updated>2050-01-01T12:00:00.000Z</updated>
+                <author><name/></author>
+                <content type="application/xml">
+                <m:properties>
+                <d:offset m:type="Edm.Int64">1</d:offset>
+                <d:op m:type="Edm.Int32">0</d:op>
+                <d:system_time m:type="Edm.DateTime">2050-01-01T12:00:00.000Z</d:system_time>
+                <d:date m:type="Edm.DateTime">2020-01-01T00:00:00.000Z</d:date>
+                <d:city m:type="Edm.String">B</d:city>
+                <d:population m:type="Edm.Int64">2000</d:population>
+                </m:properties>
+                </content>
+                </entry>
+                <entry>
+                <id>http://example.com/odata/foo.bar(2)</id>
+                <category scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" term="default.foo.bar"/>
+                <link rel="edit" title="foo.bar" href="foo.bar(2)"/>
+                <title/>
+                <updated>2050-01-01T12:00:00.000Z</updated>
+                <author><name/></author>
+                <content type="application/xml">
+                <m:properties>
+                <d:offset m:type="Edm.Int64">2</d:offset>
+                <d:op m:type="Edm.Int32">0</d:op><d:system_time m:type="Edm.DateTime">2050-01-01T12:00:00.000Z</d:system_time>
+                <d:date m:type="Edm.DateTime">2020-01-01T00:00:00.000Z</d:date>
+                <d:city m:type="Edm.String">C</d:city><d:population m:type="Edm.Int64">3000</d:population>
+                </m:properties>
+                </content>
+                </entry>
+                </feed>
+                "#
+            )
+            .replace('\n', "")
+        );
+    };
+
+    await_client_server_flow!(harness.api_server.run(), client);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+struct TestHarness {
+    temp_dir: tempfile::TempDir,
+    dataset_repo: Arc<dyn DatasetRepository>,
+    push_ingest_svc: Arc<dyn PushIngestService>,
+    api_server: TestAPIServer,
+}
+
+impl TestHarness {
+    fn new() -> Self {
+        Self::new_with_authorizer(kamu_core::auth::AlwaysHappyDatasetActionAuthorizer::new())
+    }
+
+    fn new_with_authorizer<TDatasetAuthorizer: auth::DatasetActionAuthorizer + 'static>(
+        dataset_action_authorizer: TDatasetAuthorizer,
+    ) -> Self {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let run_info_dir = temp_dir.path().join("run");
+        let cache_dir = temp_dir.path().join("cache");
+        std::fs::create_dir(&run_info_dir).unwrap();
+        std::fs::create_dir(cache_dir).unwrap();
+
+        let catalog = dill::CatalogBuilder::new()
+            .add::<ObjectStoreRegistryImpl>()
+            .add::<ObjectStoreBuilderLocalFs>()
+            .add::<EventBus>()
+            .add::<DependencyGraphServiceInMemory>()
+            .add_value(CurrentAccountSubject::new_test())
+            .add_value(dataset_action_authorizer)
+            .bind::<dyn auth::DatasetActionAuthorizer, TDatasetAuthorizer>()
+            .add_builder(
+                DatasetRepositoryLocalFs::builder()
+                    .with_root(temp_dir.path().join("datasets"))
+                    .with_multi_tenant(false),
+            )
+            .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
+            .add_value(SystemTimeSourceStub::new_set(
+                Utc.with_ymd_and_hms(2050, 1, 1, 12, 0, 0).unwrap(),
+            ))
+            .bind::<dyn SystemTimeSource, SystemTimeSourceStub>()
+            .add::<EngineProvisionerNull>()
+            .add_builder(
+                PushIngestServiceImpl::builder()
+                    .with_object_store_registry(Arc::new(ObjectStoreRegistryImpl::new(vec![
+                        Arc::new(ObjectStoreBuilderLocalFs::new()),
+                    ])))
+                    .with_data_format_registry(Arc::new(DataFormatRegistryImpl::new()))
+                    .with_run_info_dir(run_info_dir),
+            )
+            .bind::<dyn PushIngestService, PushIngestServiceImpl>()
+            .add::<QueryServiceImpl>()
+            .build();
+
+        let dataset_repo = catalog.get_one::<dyn DatasetRepository>().unwrap();
+        let push_ingest_svc = catalog.get_one::<dyn PushIngestService>().unwrap();
+
+        let api_server = TestAPIServer::new(catalog.clone(), None, None, false);
+
+        Self {
+            temp_dir,
+            dataset_repo,
+            push_ingest_svc,
+            api_server,
+        }
+    }
+
+    async fn create_simple_dataset(&self) -> CreateDatasetResult {
+        let ds = self
+            .dataset_repo
+            .create_dataset_from_snapshot(
+                MetadataFactory::dataset_snapshot()
+                    .name("foo.bar")
+                    .kind(DatasetKind::Root)
+                    .push_event(
+                        MetadataFactory::add_push_source()
+                            .read(ReadStepCsv {
+                                header: Some(true),
+                                schema: Some(
+                                    ["date TIMESTAMP", "city STRING", "population BIGINT"]
+                                        .iter()
+                                        .map(|s| (*s).to_string())
+                                        .collect(),
+                                ),
+                                ..ReadStepCsv::default()
+                            })
+                            .merge(MergeStrategyAppend {})
+                            .build(),
+                    )
+                    .push_event(SetVocab {
+                        event_time_column: Some("date".to_string()),
+                        ..Default::default()
+                    })
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        let src_path = self.temp_dir.path().join("data.csv");
+        std::fs::write(
+            &src_path,
+            indoc!(
+                "
+                date,city,population
+                2020-01-01,A,1000
+                2020-01-01,B,2000
+                2020-01-01,C,3000
+                "
+            ),
+        )
+        .unwrap();
+
+        self.push_ingest_svc
+            .ingest_from_url(
+                &ds.dataset_handle.as_local_ref(),
+                None,
+                url::Url::from_file_path(&src_path).unwrap(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        ds
+    }
+}

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -50,6 +50,7 @@ kamu-adapter-flight-sql = { workspace = true }
 kamu-adapter-graphql = { workspace = true }
 kamu-adapter-http = { workspace = true }
 kamu-adapter-oauth = { workspace = true }
+kamu-adapter-odata = { workspace = true }
 kamu-datafusion-cli = { workspace = true }
 
 # CLI

--- a/src/app/cli/src/commands/list_command.rs
+++ b/src/app/cli/src/commands/list_command.rs
@@ -179,12 +179,12 @@ impl ListCommand {
             match &self.related_account.target_account {
                 accounts::TargetAccountSelection::Current => self
                     .dataset_repo
-                    .get_datasets_by_owner(self.current_account.account_name.clone()),
+                    .get_datasets_by_owner(&self.current_account.account_name),
                 accounts::TargetAccountSelection::Specific {
                     account_name: user_name,
                 } => self
                     .dataset_repo
-                    .get_datasets_by_owner(AccountName::from_str(user_name.as_str()).unwrap()),
+                    .get_datasets_by_owner(&AccountName::from_str(user_name.as_str()).unwrap()),
                 accounts::TargetAccountSelection::AllUsers => self.dataset_repo.get_all_datasets(),
             }
         } else {

--- a/src/app/cli/src/commands/pull_command.rs
+++ b/src/app/cli/src/commands/pull_command.rs
@@ -107,14 +107,14 @@ impl PullCommand {
     async fn pull_multi(
         &self,
         listener: Option<Arc<dyn PullMultiListener>>,
-        current_account_name: AccountName,
+        current_account_name: &AccountName,
     ) -> Result<Vec<PullResponse>, CLIError> {
         let dataset_refs: Vec<_> = if !self.all {
             filter_datasets_by_any_pattern(
                 self.dataset_repo.as_ref(),
                 self.search_svc.clone(),
                 self.refs.clone(),
-                current_account_name.clone(),
+                current_account_name,
             )
             .try_collect()
             .await?
@@ -161,7 +161,7 @@ impl PullCommand {
                     "Anonymous account misused, use multi-tenant alias",
                 ))
             }
-            CurrentAccountSubject::Logged(l) => l.account_name.clone(),
+            CurrentAccountSubject::Logged(l) => &l.account_name,
         };
         if self.as_name.is_some() {
             self.sync_from(listener).await

--- a/src/app/cli/src/commands/push_command.rs
+++ b/src/app/cli/src/commands/push_command.rs
@@ -78,7 +78,7 @@ impl PushCommand {
                     "Anonymous account misused, use multi-tenant alias",
                 ))
             }
-            CurrentAccountSubject::Logged(l) => l.account_name.clone(),
+            CurrentAccountSubject::Logged(l) => &l.account_name,
         };
 
         if let Some(remote_ref) = &self.to {

--- a/src/app/cli/src/explore/api_server.rs
+++ b/src/app/cli/src/explore/api_server.rs
@@ -60,6 +60,14 @@ impl APIServer {
             )
             .nest("/", kamu_adapter_http::data::root_router())
             .nest(
+                "/odata",
+                if multi_tenant_workspace {
+                    kamu_adapter_odata::router_multi_tenant()
+                } else {
+                    kamu_adapter_odata::router_single_tenant()
+                },
+            )
+            .nest(
                 if multi_tenant_workspace {
                     "/:account_name/:dataset_name"
                 } else {

--- a/src/app/cli/src/explore/web_ui_server.rs
+++ b/src/app/cli/src/explore/web_ui_server.rs
@@ -130,6 +130,14 @@ impl WebUIServer {
             )
             .nest("/", kamu_adapter_http::data::root_router())
             .nest(
+                "/odata",
+                if multi_tenant_workspace {
+                    kamu_adapter_odata::router_multi_tenant()
+                } else {
+                    kamu_adapter_odata::router_single_tenant()
+                },
+            )
+            .nest(
                 if multi_tenant_workspace {
                     "/:account_name/:dataset_name"
                 } else {

--- a/src/domain/core/src/repos/dataset_repository.rs
+++ b/src/domain/core/src/repos/dataset_repository.rs
@@ -52,7 +52,7 @@ pub trait DatasetRepository: DatasetRegistry + Sync + Send {
 
     fn get_all_datasets(&self) -> DatasetHandleStream<'_>;
 
-    fn get_datasets_by_owner(&self, account_name: AccountName) -> DatasetHandleStream<'_>;
+    fn get_datasets_by_owner(&self, account_name: &AccountName) -> DatasetHandleStream<'_>;
 
     async fn get_dataset(
         &self,

--- a/src/domain/core/src/services/query_service.rs
+++ b/src/domain/core/src/services/query_service.rs
@@ -55,6 +55,12 @@ pub trait QueryService: Send + Sync {
     /// this moment, None otherwise
     async fn get_schema(&self, dataset_ref: &DatasetRef) -> Result<Option<Type>, QueryError>;
 
+    // TODO: Introduce additional options that could be used to narrow down the
+    // number of files we collect to construct the dataframe.
+    //
+    /// Returns a [DataFrame] representing the contents of an entire dataset
+    async fn get_data(&self, dataset_ref: &DatasetRef) -> Result<DataFrame, QueryError>;
+
     /// Lists engines known to the system and recommended for use
     async fn get_known_engines(&self) -> Result<Vec<EngineDesc>, InternalError>;
 }

--- a/src/infra/core/src/pull_service_impl.rs
+++ b/src/infra/core/src/pull_service_impl.rs
@@ -273,9 +273,7 @@ impl PullServiceImpl {
         // No luck - now have to search through aliases (of current user)
         if let CurrentAccountSubject::Logged(l) = self.current_account_subject.as_ref() {
             use tokio_stream::StreamExt;
-            let mut datasets = self
-                .dataset_repo
-                .get_datasets_by_owner(l.account_name.clone());
+            let mut datasets = self.dataset_repo.get_datasets_by_owner(&l.account_name);
             while let Some(dataset_handle) = datasets.next().await {
                 let dataset_handle = dataset_handle?;
 
@@ -521,7 +519,7 @@ impl PullService for PullServiceImpl {
         } else {
             use futures::TryStreamExt;
             self.dataset_repo
-                .get_datasets_by_owner(current_account_name)
+                .get_datasets_by_owner(&current_account_name)
                 .map_ok(|hdl| PullRequest {
                     local_ref: Some(hdl.into()),
                     remote_ref: None,

--- a/src/infra/core/src/query_service_impl.rs
+++ b/src/infra/core/src/query_service_impl.rs
@@ -74,6 +74,48 @@ impl QueryServiceImpl {
         session_context
     }
 
+    async fn single_dataset(
+        &self,
+        dataset_ref: &DatasetRef,
+        last_records_to_consider: Option<u64>,
+    ) -> Result<(Arc<dyn Dataset>, DataFrame), QueryError> {
+        let dataset_handle = self.dataset_repo.resolve_dataset_ref(dataset_ref).await?;
+
+        self.dataset_action_authorizer
+            .check_action_allowed(&dataset_handle, DatasetAction::Read)
+            .await?;
+
+        let dataset = self
+            .dataset_repo
+            .get_dataset(&dataset_handle.as_local_ref())
+            .await?;
+
+        let summary = dataset
+            .get_summary(GetSummaryOpts::default())
+            .await
+            .int_err()?;
+
+        if summary.num_records == 0 {
+            return Err(DatasetSchemaNotAvailableError {
+                dataset_ref: dataset_ref.clone(),
+            }
+            .into());
+        }
+
+        let ctx = self.session_context(QueryOptions {
+            datasets: vec![DatasetQueryOptions {
+                dataset_ref: dataset_handle.as_local_ref(),
+                last_records_to_consider,
+            }],
+        });
+
+        let df = ctx
+            .table(TableReference::bare(dataset_handle.alias.to_string()))
+            .await?;
+
+        Ok((dataset, df))
+    }
+
     #[tracing::instrument(level = "debug", skip_all)]
     async fn get_schema_impl(
         &self,
@@ -152,28 +194,7 @@ impl QueryService for QueryServiceImpl {
         skip: u64,
         limit: u64,
     ) -> Result<DataFrame, QueryError> {
-        let dataset_handle = self.dataset_repo.resolve_dataset_ref(dataset_ref).await?;
-
-        self.dataset_action_authorizer
-            .check_action_allowed(&dataset_handle, DatasetAction::Read)
-            .await?;
-
-        let dataset = self
-            .dataset_repo
-            .get_dataset(&dataset_handle.as_local_ref())
-            .await?;
-
-        let summary = dataset
-            .get_summary(GetSummaryOpts::default())
-            .await
-            .int_err()?;
-
-        if summary.num_records == 0 {
-            return Err(DatasetSchemaNotAvailableError {
-                dataset_ref: dataset_ref.clone(),
-            }
-            .into());
-        }
+        let (dataset, df) = self.single_dataset(dataset_ref, Some(skip + limit)).await?;
 
         // TODO: PERF: Avoid full scan of metadata
         let vocab: DatasetVocabulary = dataset
@@ -185,17 +206,6 @@ impl QueryService for QueryServiceImpl {
             .int_err()?
             .unwrap_or_default()
             .into();
-
-        let ctx = self.session_context(QueryOptions {
-            datasets: vec![DatasetQueryOptions {
-                dataset_ref: dataset_handle.as_local_ref(),
-                last_records_to_consider: Some(skip + limit),
-            }],
-        });
-
-        let df = ctx
-            .table(TableReference::bare(dataset_handle.alias.to_string()))
-            .await?;
 
         let df = df
             .sort(vec![col(&vocab.offset_column).sort(false, true)])?
@@ -222,6 +232,13 @@ impl QueryService for QueryServiceImpl {
     async fn get_schema(&self, dataset_ref: &DatasetRef) -> Result<Option<Type>, QueryError> {
         let ctx = self.session_context(QueryOptions::default());
         self.get_schema_impl(&ctx, dataset_ref).await
+    }
+
+    #[tracing::instrument(level = "info", skip_all, fields(dataset_ref))]
+    async fn get_data(&self, dataset_ref: &DatasetRef) -> Result<DataFrame, QueryError> {
+        // TODO: PERF: Limit push-down opportunity
+        let (_dataset, df) = self.single_dataset(dataset_ref, None).await?;
+        Ok(df)
     }
 
     async fn get_known_engines(&self) -> Result<Vec<EngineDesc>, InternalError> {

--- a/src/infra/core/src/repos/dataset_repository_local_fs.rs
+++ b/src/infra/core/src/repos/dataset_repository_local_fs.rs
@@ -163,7 +163,7 @@ impl DatasetRepository for DatasetRepositoryLocalFs {
         self.storage_strategy.get_all_datasets()
     }
 
-    fn get_datasets_by_owner(&self, account_name: AccountName) -> DatasetHandleStream<'_> {
+    fn get_datasets_by_owner(&self, account_name: &AccountName) -> DatasetHandleStream<'_> {
         self.storage_strategy.get_datasets_by_owner(account_name)
     }
 
@@ -396,7 +396,7 @@ trait DatasetStorageStrategy: Sync + Send {
 
     fn get_all_datasets(&self) -> DatasetHandleStream<'_>;
 
-    fn get_datasets_by_owner(&self, account_name: AccountName) -> DatasetHandleStream<'_>;
+    fn get_datasets_by_owner(&self, account_name: &AccountName) -> DatasetHandleStream<'_>;
 
     async fn resolve_dataset_alias(
         &self,
@@ -515,8 +515,8 @@ impl DatasetStorageStrategy for DatasetSingleTenantStorageStrategy {
         })
     }
 
-    fn get_datasets_by_owner(&self, account_name: AccountName) -> DatasetHandleStream<'_> {
-        if account_name == DEFAULT_ACCOUNT_NAME {
+    fn get_datasets_by_owner(&self, account_name: &AccountName) -> DatasetHandleStream<'_> {
+        if *account_name == DEFAULT_ACCOUNT_NAME {
             self.get_all_datasets()
         } else {
             Box::pin(futures::stream::empty())
@@ -758,7 +758,8 @@ impl DatasetStorageStrategy for DatasetMultiTenantStorageStrategy {
         })
     }
 
-    fn get_datasets_by_owner(&self, account_name: AccountName) -> DatasetHandleStream<'_> {
+    fn get_datasets_by_owner(&self, account_name: &AccountName) -> DatasetHandleStream<'_> {
+        let account_name = account_name.clone();
         Box::pin(async_stream::try_stream! {
             let account_dir_path = self.root.join(account_name.clone());
             if !account_dir_path.is_dir() {

--- a/src/infra/core/src/repos/dataset_repository_s3.rs
+++ b/src/infra/core/src/repos/dataset_repository_s3.rs
@@ -196,14 +196,15 @@ impl DatasetRepository for DatasetRepositoryS3 {
         self.stream_datasets_if(|_| true)
     }
 
-    fn get_datasets_by_owner(&self, account_name: AccountName) -> DatasetHandleStream<'_> {
-        if !self.is_multi_tenant() && account_name != DEFAULT_ACCOUNT_NAME {
+    fn get_datasets_by_owner(&self, account_name: &AccountName) -> DatasetHandleStream<'_> {
+        if !self.is_multi_tenant() && *account_name != DEFAULT_ACCOUNT_NAME {
             return Box::pin(futures::stream::empty());
         }
 
+        let account_name = account_name.clone();
         self.stream_datasets_if(move |dataset_alias| {
             if let Some(dataset_account_name) = &dataset_alias.account_name {
-                dataset_account_name == &account_name
+                *dataset_account_name == account_name
             } else {
                 true
             }

--- a/src/infra/core/src/utils/datasets_filtering.rs
+++ b/src/infra/core/src/utils/datasets_filtering.rs
@@ -73,12 +73,12 @@ pub fn filter_datasets_by_local_pattern(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-pub fn filter_datasets_by_any_pattern(
-    dataset_repo: &dyn DatasetRepository,
+pub fn filter_datasets_by_any_pattern<'a>(
+    dataset_repo: &'a dyn DatasetRepository,
     search_svc: Arc<dyn SearchService>,
     dataset_ref_any_patterns: Vec<DatasetRefAnyPattern>,
-    current_account_name: AccountName,
-) -> FilteredDatasetRefAnyStream {
+    current_account_name: &AccountName,
+) -> FilteredDatasetRefAnyStream<'a> {
     let is_multitenant_mode = dataset_repo.is_multi_tenant();
 
     let (all_ref_patterns, static_refs): (Vec<_>, Vec<_>) = dataset_ref_any_patterns
@@ -171,11 +171,11 @@ pub fn matches_remote_ref_pattern(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-pub fn get_local_datasets_stream(
-    dataset_repo: &dyn DatasetRepository,
+pub fn get_local_datasets_stream<'a>(
+    dataset_repo: &'a dyn DatasetRepository,
     dataset_ref_patterns: Vec<DatasetRefAnyPattern>,
-    current_account_name: AccountName,
-) -> impl Stream<Item = Result<DatasetRefAny, GetDatasetError>> + '_ {
+    current_account_name: &AccountName,
+) -> impl Stream<Item = Result<DatasetRefAny, GetDatasetError>> + 'a {
     dataset_repo
         .get_datasets_by_owner(current_account_name)
         .try_filter(move |dataset_handle| {

--- a/src/infra/core/tests/tests/repos/test_dataset_repository_shared.rs
+++ b/src/infra/core/tests/tests/repos/test_dataset_repository_shared.rs
@@ -473,14 +473,14 @@ pub async fn test_iterate_datasets(repo: &dyn DatasetRepository) {
     // Default account
     check_expected_datasets(
         vec![alias_bar, alias_foo],
-        repo.get_datasets_by_owner(AccountName::new_unchecked(auth::DEFAULT_ACCOUNT_NAME)),
+        repo.get_datasets_by_owner(&AccountName::new_unchecked(auth::DEFAULT_ACCOUNT_NAME)),
     )
     .await;
 
     // Random account
     check_expected_datasets(
         vec![],
-        repo.get_datasets_by_owner(AccountName::new_unchecked("unknown-account")),
+        repo.get_datasets_by_owner(&AccountName::new_unchecked("unknown-account")),
     )
     .await;
 }
@@ -549,20 +549,20 @@ pub async fn test_iterate_datasets_multi_tenant(repo: &dyn DatasetRepository) {
 
     check_expected_datasets(
         vec![alias_my_baz, alias_my_foo],
-        repo.get_datasets_by_owner(account_my),
+        repo.get_datasets_by_owner(&account_my),
     )
     .await;
 
     check_expected_datasets(
         vec![alias_her_bar, alias_her_foo],
-        repo.get_datasets_by_owner(account_her),
+        repo.get_datasets_by_owner(&account_her),
     )
     .await;
 
     // Random account
     check_expected_datasets(
         vec![],
-        repo.get_datasets_by_owner(AccountName::new_unchecked("unknown-account")),
+        repo.get_datasets_by_owner(&AccountName::new_unchecked("unknown-account")),
     )
     .await;
 }

--- a/src/infra/core/tests/tests/test_datasets_filtering.rs
+++ b/src/infra/core/tests/tests/test_datasets_filtering.rs
@@ -170,7 +170,7 @@ async fn test_get_local_datasets_stream_single_tenant() {
     let res: Vec<_> = get_local_datasets_stream(
         dataset_filtering_harness.dataset_repo.as_ref(),
         vec![pattern],
-        dafault_account_name.clone(),
+        &dafault_account_name,
     )
     .try_collect()
     .await
@@ -182,7 +182,7 @@ async fn test_get_local_datasets_stream_single_tenant() {
     let mut res: Vec<_> = get_local_datasets_stream(
         dataset_filtering_harness.dataset_repo.as_ref(),
         vec![pattern],
-        dafault_account_name.clone(),
+        &dafault_account_name,
     )
     .try_collect()
     .await
@@ -195,7 +195,7 @@ async fn test_get_local_datasets_stream_single_tenant() {
     let res: Vec<_> = get_local_datasets_stream(
         dataset_filtering_harness.dataset_repo.as_ref(),
         vec![pattern.clone()],
-        dafault_account_name.clone(),
+        &dafault_account_name,
     )
     .try_collect()
     .await
@@ -226,7 +226,7 @@ async fn test_get_local_datasets_stream_multi_tenant() {
     let res: Vec<_> = get_local_datasets_stream(
         dataset_filtering_harness.dataset_repo.as_ref(),
         vec![pattern],
-        account_1.clone(),
+        &account_1,
     )
     .try_collect()
     .await
@@ -238,7 +238,7 @@ async fn test_get_local_datasets_stream_multi_tenant() {
     let res: Vec<_> = get_local_datasets_stream(
         dataset_filtering_harness.dataset_repo.as_ref(),
         vec![pattern],
-        account_2.clone(),
+        &account_2,
     )
     .try_collect()
     .await
@@ -250,7 +250,7 @@ async fn test_get_local_datasets_stream_multi_tenant() {
     let res: Vec<_> = get_local_datasets_stream(
         dataset_filtering_harness.dataset_repo.as_ref(),
         vec![pattern],
-        account_1.clone(),
+        &account_1,
     )
     .try_collect()
     .await


### PR DESCRIPTION
## Description

Closes: https://github.com/kamu-data/kamu-node/issues/54

Not proud of this code:
- it's missing a lot of error handling
- it does not enforce permissions on the top level

But this is a stop-gap measure to unblock customer integration. We can improve it as we go if there will be further demand for OData.

## Checklist before requesting a review

- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: https://github.com/kamu-data/kamu-docs/pull/16
- [x] Dataset pipelines update scheduled if needed
- [x] Unit-tests added
