### PR TITLE
Ensure handle has correct alias after dataset creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Bug when handle created during dataset creation had empty account name in a multi-tenant repo.
+
 ## [0.167.0] - 2024-03-19
 ### Added
 - Implementation of `ObjectRepository` that can cache small objects on local file system (e.g. to avoid too many calls to S3 repo)


### PR DESCRIPTION
Fixes a bug when handle assigned to the dataset during its creation in a multi-tenant S3 repo had an empty account name.