### PR TITLE
S3 tolerance and caching fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- S3 Repo: Ignore dataset entries without a valid alias and leave them to be cleaned up by GC
+- Caching object repo: Ensure directory exists before writing objects
+
 ## [0.168.0] - 2024-03-23
 ### Changed
 - FlightSQL: For expensive queries `GetFlightInfo` we will only prepare schemas and not compute results - this avoids doing double the work just to return `total_records` and `total_bytes` in `FlightInfo` before result is fetched via `DoGet`

--- a/src/infra/core/src/repos/object_repository_caching_local_fs.rs
+++ b/src/infra/core/src/repos/object_repository_caching_local_fs.rs
@@ -102,6 +102,8 @@ where
             Err(err) if err.kind() == ErrorKind::NotFound => {
                 let mut stream = self.wrapped.get_stream(hash).await?;
 
+                self.ensure_cache_dir().int_err()?;
+
                 let mut file = tokio::fs::File::create(cache_path).await.int_err()?;
                 tokio::io::copy(&mut stream, &mut file).await.int_err()?;
                 file.flush().await.int_err()?;
@@ -139,6 +141,7 @@ where
         options: InsertOpts<'a>,
     ) -> Result<InsertResult, InsertError> {
         let res = self.wrapped.insert_bytes(data, options).await?;
+        self.ensure_cache_dir().int_err()?;
         let cache_path = self.cache_path(&res.hash);
         std::fs::write(cache_path, data).int_err()?;
         Ok(res)


### PR DESCRIPTION
- S3 Repo: Ignore dataset entries without a valid alias and leave them to be cleaned up by GC
- Caching object repo: Ensure directory exists before writing objects
