### PR TITLE
OData: allow queries by id/offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- OData API now supports querying by collection ID/key (e.g. `account/covid.cases(123)`)
 ### Fixed
 - Handle broken pipe panic
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-odata"
-version = "0.4.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219ef6bdabe34456107b96c8ddb5c0cb3241c969ef6205c254478d42fefbeaf7"
+checksum = "92c90ff32165cfc70311db58b18b45f70e276876cd25363c1a021479c6c32137"
 dependencies = [
  "async-trait",
  "axum",
@@ -2137,6 +2137,7 @@ dependencies = [
  "datafusion",
  "http",
  "quick-xml",
+ "regex",
  "serde",
  "thiserror",
  "tracing",

--- a/src/adapter/odata/Cargo.toml
+++ b/src/adapter/odata/Cargo.toml
@@ -28,7 +28,7 @@ kamu-core = { workspace = true }
 axum = { version = "0.6", features = ["headers"] }
 chrono = { version = "0.4", default-features = false }
 datafusion = { version = "36", default-features = false }
-datafusion-odata = { version = "0.4", default-features = false }
+datafusion-odata = { version = "36", default-features = false }
 dill = { version = "0.8" }
 futures = { version = "0.3", default-features = false }
 http = "0.2"


### PR DESCRIPTION
## Description

- OData API now supports querying by collection ID/key (e.g. `account/covid.cases(123)`)
- added env var to make the default number of entries per page configurable

## Checklist before requesting a review

- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
- [x] Unit-tests added
