### PR TITLE
Explicit push source event time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- The `kamu ingest` command can now accept `--event-time` hint which is useful for snapshot-style data that doesn't have an event time column
+- The `/ingest` REST API endpoint also supports event time hints via `odf-event-time` header
+- New `--system-time` root parameter allows overriding time for all CLI commands
 ### Fixed
 - CLI show errors not only under TTY
 - Removed `paused` from `setConfigCompacting` mutation

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -42,6 +42,7 @@ To regenerate this schema from existing code, use the following command:
 * `-v` — Sets the level of verbosity (repeat for more)
 * `-q`, `--quiet` — Suppress all non-essential output
 * `--trace` — Record and visualize the command execution as perfetto.dev trace
+* `--system-time <T>` — Overrides system time clock with provided value
 * `-a`, `--account <ACCOUNT>`
 
 To get help for individual commands use:
@@ -266,6 +267,7 @@ Adds data to the root dataset according to its push source configuration
 **Options:**
 
 * `--source-name <SRC>` — Name of the push source to use for ingestion
+* `--event-time <T>` — Event time to be used if data does not contain one
 * `--stdin` — Read data from the standard input
 * `-r`, `--recursive` — Recursively propagate the updates into all downstream datasets
 * `--input-format <FMT>` — Overrides the media type of the data expected by the push source
@@ -286,6 +288,10 @@ Ingest data from standard input (assumes source is defined to use NDJSON):
 Ingest data with format conversion:
 
     echo '[{"key": "value1"}, {"key": "value2"}]' | kamu ingest org.example.data --stdin --input-format json
+
+Ingest data with event time hint:
+
+    kamu ingest org.example.data data.json --event-time 2050-01-02T12:00:00Z
 
 
 

--- a/src/adapter/auth-oso/tests/tests/test_oso_dataset_authorizer.rs
+++ b/src/adapter/auth-oso/tests/tests/test_oso_dataset_authorizer.rs
@@ -17,7 +17,7 @@ use kamu::testing::MetadataFactory;
 use kamu::{DatasetRepositoryLocalFs, DependencyGraphServiceInMemory};
 use kamu_adapter_auth_oso::{KamuAuthOso, OsoDatasetAuthorizer};
 use kamu_core::auth::{DatasetAction, DatasetActionAuthorizer, DatasetActionUnauthorizedError};
-use kamu_core::{AccessError, CurrentAccountSubject, DatasetRepository};
+use kamu_core::{AccessError, CurrentAccountSubject, DatasetRepository, SystemTimeSourceDefault};
 use opendatafabric::{AccountName, DatasetAlias, DatasetHandle, DatasetKind};
 use tempfile::TempDir;
 
@@ -105,6 +105,7 @@ impl DatasetAuthorizerHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add_value(CurrentAccountSubject::logged(
                 AccountName::new_unchecked(current_account_name),

--- a/src/adapter/graphql/tests/tests/test_error_handling.rs
+++ b/src/adapter/graphql/tests/tests/test_error_handling.rs
@@ -58,6 +58,7 @@ async fn test_internal_error() {
     let tempdir = tempfile::tempdir().unwrap();
 
     let cat = dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add_value(CurrentAccountSubject::new_test())
         .add::<auth::AlwaysHappyDatasetActionAuthorizer>()

--- a/src/adapter/graphql/tests/tests/test_gql_data.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_data.rs
@@ -27,6 +27,7 @@ fn create_catalog_with_local_workspace(tempdir: &Path, is_multitenant: bool) -> 
     std::fs::create_dir(&datasets_dir).unwrap();
 
     dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<DependencyGraphServiceInMemory>()
         .add_builder(

--- a/src/adapter/graphql/tests/tests/test_gql_datasets.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_datasets.rs
@@ -597,6 +597,7 @@ impl GraphQLDatasetsHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let base_catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_builder(

--- a/src/adapter/graphql/tests/tests/test_gql_metadata_chain.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_metadata_chain.rs
@@ -511,6 +511,7 @@ impl GraphQLMetadataChainHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let base_catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_builder(

--- a/src/adapter/graphql/tests/tests/test_gql_search.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_search.rs
@@ -16,12 +16,13 @@ use kamu_core::*;
 use opendatafabric::*;
 
 #[tokio::test]
-async fn query() {
+async fn test_search_query() {
     let tempdir = tempfile::tempdir().unwrap();
     let datasets_dir = tempdir.path().join("datasets");
     std::fs::create_dir(&datasets_dir).unwrap();
 
     let cat = dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<DependencyGraphServiceInMemory>()
         .add_value(CurrentAccountSubject::new_test())

--- a/src/adapter/http/tests/tests/test_dataset_authorization_layer.rs
+++ b/src/adapter/http/tests/tests/test_dataset_authorization_layer.rs
@@ -21,6 +21,7 @@ use kamu::domain::{
     DatasetRepository,
     InternalError,
     ResultIntoInternal,
+    SystemTimeSourceDefault,
 };
 use kamu::testing::{MetadataFactory, MockDatasetActionAuthorizer};
 use kamu::{DatasetRepositoryLocalFs, DependencyGraphServiceInMemory};
@@ -215,6 +216,7 @@ impl ServerHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let mut catalog_builder = dill::CatalogBuilder::new();
+        catalog_builder.add::<SystemTimeSourceDefault>();
         catalog_builder.add::<EventBus>();
         catalog_builder.add::<DependencyGraphServiceInMemory>();
         catalog_builder.add_value(

--- a/src/adapter/http/tests/tests/test_routing.rs
+++ b/src/adapter/http/tests/tests/test_routing.rs
@@ -38,6 +38,7 @@ async fn setup_repo() -> RepoFixture {
     std::fs::create_dir(&datasets_dir).unwrap();
 
     let catalog = dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<DependencyGraphServiceInMemory>()
         .add_builder(

--- a/src/adapter/odata/tests/tests/test_handlers.rs
+++ b/src/adapter/odata/tests/tests/test_handlers.rs
@@ -431,7 +431,7 @@ impl TestHarness {
                 &ds.dataset_handle.as_local_ref(),
                 None,
                 url::Url::from_file_path(&src_path).unwrap(),
-                None,
+                PushIngestOpts::default(),
                 None,
             )
             .await

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -112,6 +112,7 @@ pub fn get_command(
                 .unwrap_or_default()
                 .map(String::as_str),
             submatches.get_one("source-name").map(String::as_str),
+            submatches.get_one("event-time").map(String::as_str),
             submatches.get_flag("stdin"),
             submatches.get_flag("recursive"),
             submatches.get_one("input-format").map(String::as_str),

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -94,6 +94,11 @@ pub fn cli() -> Command {
                 .long("trace")
                 .action(ArgAction::SetTrue)
                 .help("Record and visualize the command execution as perfetto.dev trace"),
+            Arg::new("system-time")
+                .long("system-time")
+                .value_name("T")
+                .help("Overrides system time clock with provided value")
+                .hide(true),
             Arg::new("account")
                 .long("account")
                 .short('a')
@@ -347,6 +352,10 @@ pub fn cli() -> Command {
                             .long("source-name")
                             .value_name("SRC")
                             .help("Name of the push source to use for ingestion"),
+                        Arg::new("event-time")
+                            .long("event-time")
+                            .value_name("T")
+                            .help("Event time to be used if data does not contain one"),
                         Arg::new("stdin")
                             .long("stdin")
                             .action(ArgAction::SetTrue)
@@ -384,6 +393,10 @@ pub fn cli() -> Command {
                         Ingest data with format conversion:
 
                             echo '[{"key": "value1"}, {"key": "value2"}]' | kamu ingest org.example.data --stdin --input-format json
+
+                        Ingest data with event time hint:
+
+                            kamu ingest org.example.data data.json --event-time 2050-01-02T12:00:00Z
                         "#
                     )),
                 Command::new("init")

--- a/src/app/cli/tests/tests/test_di_graph.rs
+++ b/src/app/cli/tests/tests/test_di_graph.rs
@@ -15,7 +15,7 @@ use kamu_cli::{self, OutputConfig, WorkspaceLayout};
 async fn test_di_graph_validates() {
     let tempdir = tempfile::tempdir().unwrap();
     let workspace_layout = WorkspaceLayout::new(tempdir.path());
-    let mut base_catalog_builder = kamu_cli::configure_base_catalog(&workspace_layout, false);
+    let mut base_catalog_builder = kamu_cli::configure_base_catalog(&workspace_layout, false, None);
     base_catalog_builder.add_value(OutputConfig::default());
 
     kamu_cli::register_config_in_catalog(

--- a/src/domain/core/src/services/ingest/push_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_service.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use opendatafabric::*;
 use thiserror::Error;
 use tokio::io::AsyncRead;
@@ -36,7 +37,7 @@ pub trait PushIngestService: Send + Sync {
         dataset_ref: &DatasetRef,
         source_name: Option<&str>,
         url: url::Url,
-        media_type: Option<MediaType>,
+        opts: PushIngestOpts,
         listener: Option<Arc<dyn PushIngestListener>>,
     ) -> Result<PushIngestResult, PushIngestError>;
 
@@ -49,10 +50,20 @@ pub trait PushIngestService: Send + Sync {
         dataset_ref: &DatasetRef,
         source_name: Option<&str>,
         data: Box<dyn AsyncRead + Send + Unpin>,
-        media_type: Option<MediaType>,
+        opts: PushIngestOpts,
         listener: Option<Arc<dyn PushIngestListener>>,
     ) -> Result<PushIngestResult, PushIngestError>;
 }
+
+///////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Default)]
+pub struct PushIngestOpts {
+    pub media_type: Option<MediaType>,
+    pub source_event_time: Option<DateTime<Utc>>,
+}
+
+///////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug)]
 pub enum PushIngestResult {

--- a/src/infra/core/src/repos/dataset_repository_helpers.rs
+++ b/src/infra/core/src/repos/dataset_repository_helpers.rs
@@ -9,7 +9,7 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use event_bus::EventBus;
 use internal_error::*;
 use kamu_core::events::DatasetEventDependenciesUpdated;
@@ -30,6 +30,7 @@ pub async fn create_dataset_from_snapshot_impl(
     dataset_repo: &dyn DatasetRepositoryExt,
     event_bus: &EventBus,
     mut snapshot: DatasetSnapshot,
+    system_time: DateTime<Utc>,
 ) -> Result<CreateDatasetResult, CreateDatasetFromSnapshotError> {
     // Validate / resolve events
     for event in &mut snapshot.metadata {
@@ -102,8 +103,6 @@ pub async fn create_dataset_from_snapshot_impl(
     // The key pair is discarded for now, but in future can be used for
     // proof of control over dataset and metadata signing.
     let (_keypair, dataset_id) = DatasetID::new_generated_ed25519();
-
-    let system_time = Utc::now();
 
     let create_result = dataset_repo
         .create_dataset(

--- a/src/infra/core/src/repos/metadata_chain_impl.rs
+++ b/src/infra/core/src/repos/metadata_chain_impl.rs
@@ -195,6 +195,8 @@ where
         block: MetadataBlock,
         opts: AppendOpts<'a>,
     ) -> Result<Multihash, AppendError> {
+        tracing::trace!(?block, "Trying to append block");
+
         if opts.validation == AppendValidation::Full {
             let mut validators = [
                 &mut ValidateAddDataVisitor::new(&block)
@@ -269,7 +271,10 @@ where
                 InsertBlockError::Internal(e) => AppendError::Internal(e),
             })?;
 
+        tracing::debug!(?block, "Sucessfully appended block");
+
         if let Some(r) = opts.update_ref {
+            tracing::debug!(?r, new_hash = %res.hash, "Updating reference");
             self.ref_repo.set(r, &res.hash).await?;
         }
 

--- a/src/infra/core/tests/tests/engine/test_engine_io.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_io.rs
@@ -229,6 +229,7 @@ async fn test_engine_io_local_file_mount() {
     std::fs::create_dir(&cache_dir).unwrap();
 
     let catalog = dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<kamu_core::auth::AlwaysHappyDatasetActionAuthorizer>()
         .add::<kamu::DependencyGraphServiceInMemory>()
@@ -271,6 +272,7 @@ async fn test_engine_io_s3_to_local_file_mount_proxy() {
     let s3_context = kamu::utils::s3_context::S3Context::from_url(&s3.url).await;
 
     let catalog = dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<kamu_core::auth::AlwaysHappyDatasetActionAuthorizer>()
         .add::<kamu::DependencyGraphServiceInMemory>()

--- a/src/infra/core/tests/tests/ingest/test_push_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_push_ingest.rs
@@ -80,7 +80,7 @@ async fn test_ingest_push_url_stream() {
             &dataset_ref,
             None,
             url::Url::from_file_path(&src_path).unwrap(),
-            None,
+            PushIngestOpts::default(),
             None,
         )
         .await
@@ -136,7 +136,13 @@ async fn test_ingest_push_url_stream() {
 
     harness
         .push_ingest_svc
-        .ingest_from_file_stream(&dataset_ref, None, Box::new(data), None, None)
+        .ingest_from_file_stream(
+            &dataset_ref,
+            None,
+            Box::new(data),
+            PushIngestOpts::default(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -219,7 +225,10 @@ async fn test_ingest_push_media_type_override() {
             &dataset_ref,
             None,
             url::Url::from_file_path(&src_path).unwrap(),
-            Some(MediaType::CSV.to_owned()),
+            PushIngestOpts {
+                media_type: Some(MediaType::CSV.to_owned()),
+                ..Default::default()
+            },
             None,
         )
         .await
@@ -269,7 +278,10 @@ async fn test_ingest_push_media_type_override() {
             &dataset_ref,
             None,
             url::Url::from_file_path(&src_path).unwrap(),
-            Some(MediaType::NDJSON.to_owned()),
+            PushIngestOpts {
+                media_type: Some(MediaType::NDJSON.to_owned()),
+                ..Default::default()
+            },
             None,
         )
         .await
@@ -321,7 +333,10 @@ async fn test_ingest_push_media_type_override() {
             &dataset_ref,
             None,
             url::Url::from_file_path(&src_path).unwrap(),
-            Some(MediaType::JSON.to_owned()),
+            PushIngestOpts {
+                media_type: Some(MediaType::JSON.to_owned()),
+                ..Default::default()
+            },
             None,
         )
         .await
@@ -408,7 +423,7 @@ async fn test_ingest_push_schema_stability() {
             &dataset_ref,
             None,
             url::Url::from_file_path(&src_path).unwrap(),
-            None,
+            PushIngestOpts::default(),
             None,
         )
         .await

--- a/src/infra/core/tests/tests/ingest/test_writer.rs
+++ b/src/infra/core/tests/tests/ingest/test_writer.rs
@@ -939,6 +939,7 @@ impl Harness {
         let system_time = Utc.with_ymd_and_hms(2010, 1, 1, 12, 0, 0).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add::<kamu_core::auth::AlwaysHappyDatasetActionAuthorizer>()

--- a/src/infra/core/tests/tests/repos/test_dataset_repository_local_fs.rs
+++ b/src/infra/core/tests/tests/repos/test_dataset_repository_local_fs.rs
@@ -10,7 +10,13 @@
 use std::sync::Arc;
 
 use dill::Component;
-use domain::{auth, CurrentAccountSubject, DatasetRepository, DependencyGraphService};
+use domain::{
+    auth,
+    CurrentAccountSubject,
+    DatasetRepository,
+    DependencyGraphService,
+    SystemTimeSourceDefault,
+};
 use event_bus::EventBus;
 use kamu::testing::MockDatasetActionAuthorizer;
 use kamu::*;
@@ -36,6 +42,7 @@ impl LocalFsRepoHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_value(CurrentAccountSubject::new_test())

--- a/src/infra/core/tests/tests/repos/test_dataset_repository_s3.rs
+++ b/src/infra/core/tests/tests/repos/test_dataset_repository_s3.rs
@@ -20,7 +20,7 @@ use kamu::{
     DependencyGraphServiceInMemory,
     S3RegistryCache,
 };
-use kamu_core::{DatasetRepository, DependencyGraphService};
+use kamu_core::{DatasetRepository, DependencyGraphService, SystemTimeSourceDefault};
 use opendatafabric::AccountName;
 
 use super::test_dataset_repository_shared;
@@ -44,6 +44,7 @@ impl S3RepoHarness {
         let mut catalog = dill::CatalogBuilder::new();
 
         catalog
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_value(CurrentAccountSubject::new_test())

--- a/src/infra/core/tests/tests/test_compact_service_impl.rs
+++ b/src/infra/core/tests/tests/test_compact_service_impl.rs
@@ -989,7 +989,13 @@ impl CompactTestHarness {
         let data = std::io::Cursor::new(data_str);
 
         self.push_ingest_svc
-            .ingest_from_file_stream(dataset_ref, None, Box::new(data), None, None)
+            .ingest_from_file_stream(
+                dataset_ref,
+                None,
+                Box::new(data),
+                PushIngestOpts::default(),
+                None,
+            )
             .await
             .unwrap();
     }

--- a/src/infra/core/tests/tests/test_dataset_changes_service_impl.rs
+++ b/src/infra/core/tests/tests/test_dataset_changes_service_impl.rs
@@ -22,6 +22,7 @@ use kamu_core::{
     DatasetChangesService,
     DatasetIntervalIncrement,
     DatasetRepository,
+    SystemTimeSourceDefault,
 };
 use opendatafabric::{
     Checkpoint,
@@ -809,6 +810,7 @@ impl DatasetChangesHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add_builder(
                 DatasetRepositoryLocalFs::builder()

--- a/src/infra/core/tests/tests/test_datasets_filtering.rs
+++ b/src/infra/core/tests/tests/test_datasets_filtering.rs
@@ -21,7 +21,7 @@ use kamu::utils::datasets_filtering::{
 };
 use kamu::{DatasetRepositoryLocalFs, DependencyGraphServiceInMemory};
 use kamu_core::auth::DEFAULT_ACCOUNT_NAME;
-use kamu_core::{auth, CurrentAccountSubject, DatasetRepository};
+use kamu_core::{auth, CurrentAccountSubject, DatasetRepository, SystemTimeSourceDefault};
 use opendatafabric::{
     AccountName,
     DatasetAlias,
@@ -274,6 +274,7 @@ impl DatasetFilteringHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add_builder(
                 DatasetRepositoryLocalFs::builder()

--- a/src/infra/core/tests/tests/test_dependency_graph_inmem.rs
+++ b/src/infra/core/tests/tests/test_dependency_graph_inmem.rs
@@ -27,6 +27,7 @@ use kamu_core::{
     DatasetRepository,
     DependencyGraphRepository,
     DependencyGraphService,
+    SystemTimeSourceDefault,
 };
 use opendatafabric::{
     AccountName,
@@ -587,6 +588,7 @@ impl DependencyGraphHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add_builder(
                 DatasetRepositoryLocalFs::builder()

--- a/src/infra/core/tests/tests/test_pull_service_impl.rs
+++ b/src/infra/core/tests/tests/test_pull_service_impl.rs
@@ -154,6 +154,7 @@ async fn create_graph_remote(
         Arc::new(DependencyGraphServiceInMemory::new(None)),
         Arc::new(EventBus::new(Arc::new(CatalogBuilder::new().build()))),
         false,
+        Arc::new(SystemTimeSourceDefault),
     );
 
     create_graph(&remote_dataset_repo, datasets).await;

--- a/src/infra/core/tests/tests/test_query_service_impl.rs
+++ b/src/infra/core/tests/tests/test_query_service_impl.rs
@@ -119,6 +119,7 @@ fn create_catalog_with_local_workspace(
     std::fs::create_dir(&datasets_dir).unwrap();
 
     dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<DependencyGraphServiceInMemory>()
         .add_builder(
@@ -146,6 +147,7 @@ async fn create_catalog_with_s3_workspace(
     let s3_context = S3Context::from_items(endpoint.clone(), bucket, key_prefix).await;
 
     dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<DependencyGraphServiceInMemory>()
         .add_builder(

--- a/src/infra/core/tests/tests/test_reset_service_impl.rs
+++ b/src/infra/core/tests/tests/test_reset_service_impl.rs
@@ -115,6 +115,7 @@ impl ResetTestHarness {
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add::<SystemTimeSourceDefault>()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_value(CurrentAccountSubject::new_test())

--- a/src/infra/core/tests/tests/test_search_service_impl.rs
+++ b/src/infra/core/tests/tests/test_search_service_impl.rs
@@ -26,6 +26,7 @@ async fn do_test_search(tmp_workspace_dir: &Path, repo_url: Url) {
     std::fs::create_dir(&datasets_dir).unwrap();
 
     let catalog = dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<DependencyGraphServiceInMemory>()
         .add_value(CurrentAccountSubject::new_test())

--- a/src/infra/core/tests/tests/test_sync_service_impl.rs
+++ b/src/infra/core/tests/tests/test_sync_service_impl.rs
@@ -87,6 +87,7 @@ async fn do_test_sync(
     std::fs::create_dir(&datasets_dir).unwrap();
 
     let catalog = dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<DependencyGraphServiceInMemory>()
         .add_value(ipfs_gateway)

--- a/src/infra/core/tests/tests/test_verification_service_impl.rs
+++ b/src/infra/core/tests/tests/test_verification_service_impl.rs
@@ -31,6 +31,7 @@ async fn test_verify_data_consistency() {
     let dataset_alias = DatasetAlias::new(None, DatasetName::new_unchecked("bar"));
 
     let catalog = dill::CatalogBuilder::new()
+        .add::<SystemTimeSourceDefault>()
         .add::<EventBus>()
         .add::<DependencyGraphServiceInMemory>()
         .add_value(CurrentAccountSubject::new_test())


### PR DESCRIPTION
## Description

This is a quick feature I needed to create better integration tests for the new streaming engine. There I use kamu-cli to setup all tests datasets, and need full control over event and system times.

- The `kamu ingest` command can now accept `--event-time` hint
- The `/ingest` REST API endpoint also supports event time hints via `odf-event-time` header
- New `--system-time` root parameter allows overriding time for all CLI commands

## Checklist before requesting a review

- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
- [x] Unit-tests added
