### PR TITLE
Bug/swallow error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- CLI show errors not only under TTY
+- Removed `paused` from `setConfigCompacting` mutation
+
 ## [0.174.1] - 2024-04-12
 ### Fixed
 - Set correct ODF push/pull websocket protocol

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -373,7 +373,7 @@ type DatasetFlowConfigs {
 type DatasetFlowConfigsMut {
 	setConfigSchedule(datasetFlowType: DatasetFlowType!, paused: Boolean!, schedule: ScheduleInput!): SetFlowConfigResult!
 	setConfigBatching(datasetFlowType: DatasetFlowType!, paused: Boolean!, batching: BatchingConditionInput!): SetFlowConfigResult!
-	setConfigCompacting(datasetFlowType: DatasetFlowType!, paused: Boolean!, compactingArgs: CompactingConditionInput!): SetFlowConfigResult!
+	setConfigCompacting(datasetFlowType: DatasetFlowType!, compactingArgs: CompactingConditionInput!): SetFlowConfigResult!
 	pauseFlows(datasetFlowType: DatasetFlowType): Boolean!
 	resumeFlows(datasetFlowType: DatasetFlowType): Boolean!
 }

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -167,7 +167,6 @@ impl DatasetFlowConfigsMut {
         &self,
         ctx: &Context<'_>,
         dataset_flow_type: DatasetFlowType,
-        paused: bool,
         compacting_args: CompactingConditionInput,
     ) -> Result<SetFlowConfigResult> {
         if !ensure_set_config_flow_supported(
@@ -206,7 +205,7 @@ impl DatasetFlowConfigsMut {
                 Utc::now(),
                 FlowKeyDataset::new(self.dataset_handle.id.clone(), dataset_flow_type.into())
                     .into(),
-                paused,
+                true,
                 FlowConfigurationRule::CompactingRule(compacting_rule),
             )
             .await

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_configs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_configs.rs
@@ -641,7 +641,6 @@ async fn test_crud_compacting_root_dataset() {
     let mutation_code = FlowConfigHarness::set_config_compacting_mutation(
         &create_result.dataset_handle.id,
         "HARD_COMPACTING",
-        false,
         1_000_000,
         10000,
     );
@@ -666,7 +665,7 @@ async fn test_crud_compacting_root_dataset() {
                                 "message": "Success",
                                 "config": {
                                     "__typename": "FlowConfiguration",
-                                    "paused": false,
+                                    "paused": true,
                                     "schedule": null,
                                     "batching": null,
                                     "compacting": {
@@ -776,7 +775,6 @@ async fn test_compacting_config_validation() {
         let mutation_code = FlowConfigHarness::set_config_compacting_mutation(
             &create_derived_result.dataset_handle.id,
             "HARD_COMPACTING",
-            false,
             test_case.0,
             test_case.1,
         );
@@ -1305,7 +1303,6 @@ async fn test_incorrect_dataset_kinds_for_flow_type() {
     let mutation_code = FlowConfigHarness::set_config_compacting_mutation(
         &create_derived_result.dataset_handle.id,
         "HARD_COMPACTING",
-        false,
         1000,
         1000,
     );
@@ -1756,7 +1753,6 @@ impl FlowConfigHarness {
     fn set_config_compacting_mutation(
         id: &DatasetID,
         dataset_flow_type: &str,
-        paused: bool,
         max_slice_size: u64,
         max_slice_records: u64,
     ) -> String {
@@ -1769,7 +1765,6 @@ impl FlowConfigHarness {
                             configs {
                                 setConfigCompacting (
                                     datasetFlowType: "<dataset_flow_type>",
-                                    paused: <paused>,
                                     compactingArgs: {
                                         maxSliceSize: <maxSliceSize>,
                                         maxSliceRecords: <maxSliceRecords>
@@ -1808,7 +1803,6 @@ impl FlowConfigHarness {
         )
         .replace("<id>", &id.to_string())
         .replace("<dataset_flow_type>", dataset_flow_type)
-        .replace("<paused>", if paused { "true" } else { "false" })
         .replace("<maxSliceRecords>", &max_slice_records.to_string())
         .replace("<maxSliceSize>", &max_slice_size.to_string())
     }

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -153,7 +153,7 @@ pub async fn run(
                 "Command failed",
             );
 
-            if output_config.is_tty && output_config.verbosity_level == 0 {
+            if output_config.verbosity_level == 0 {
                 eprintln!("{}", err.pretty(false));
             }
         }


### PR DESCRIPTION
## Description

Closes: [Kamu swallows error messages when not under TTY](https://github.com/kamu-data/kamu-cli/issues/514)
In addition, removed `paused` value from `setConfigCompacting` gql mutation

<!--- Describe your changes in detail -->

## Checklist before requesting a review

- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
- [x] Unit-tests added
