### PR TITLE
Split results for different config mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Split result for different(`setFlowConfigResult`, `setFlowBatchingConfigResult`, `setFlowCompactingConfigResult`) flow configuration mutations
+
 ## [0.176.0] - 2024-04-15
 - New engine based on RisingWave streaming database ([repo](https://github.com/kamu-data/kamu-engine-risingwave)) that provides mature streaming alternative to Flink. See:
   - Updated [supported engines](https://docs.kamu.dev/cli/supported-engines/) documentation

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -372,8 +372,8 @@ type DatasetFlowConfigs {
 
 type DatasetFlowConfigsMut {
 	setConfigSchedule(datasetFlowType: DatasetFlowType!, paused: Boolean!, schedule: ScheduleInput!): SetFlowConfigResult!
-	setConfigBatching(datasetFlowType: DatasetFlowType!, paused: Boolean!, batching: BatchingConditionInput!): SetFlowConfigResult!
-	setConfigCompacting(datasetFlowType: DatasetFlowType!, compactingArgs: CompactingConditionInput!): SetFlowConfigResult!
+	setConfigBatching(datasetFlowType: DatasetFlowType!, paused: Boolean!, batching: BatchingConditionInput!): SetFlowBatchingConfigResult!
+	setConfigCompacting(datasetFlowType: DatasetFlowType!, compactingArgs: CompactingConditionInput!): SetFlowCompactingConfigResult!
 	pauseFlows(datasetFlowType: DatasetFlowType): Boolean!
 	resumeFlows(datasetFlowType: DatasetFlowType): Boolean!
 }
@@ -845,18 +845,18 @@ type FlowFailedError {
 
 scalar FlowID
 
-type FlowIncompatibleDatasetKind implements SetFlowConfigResult & TriggerFlowResult {
+type FlowIncompatibleDatasetKind implements SetFlowConfigResult & SetFlowBatchingConfigResult & SetFlowCompactingConfigResult & TriggerFlowResult {
 	expectedDatasetKind: DatasetKind!
 	actualDatasetKind: DatasetKind!
 	message: String!
 }
 
-type FlowInvalidBatchingConfig implements SetFlowConfigResult {
+type FlowInvalidBatchingConfig implements SetFlowBatchingConfigResult {
 	reason: String!
 	message: String!
 }
 
-type FlowInvalidCompactingConfig implements SetFlowConfigResult {
+type FlowInvalidCompactingConfig implements SetFlowCompactingConfigResult {
 	reason: String!
 	message: String!
 }
@@ -868,7 +868,7 @@ type FlowNotFound implements GetFlowResult & CancelScheduledTasksResult {
 
 union FlowOutcome = FlowSuccessResult | FlowFailedError | FlowAbortedResult
 
-type FlowPreconditionsNotMet implements SetFlowConfigResult & TriggerFlowResult {
+type FlowPreconditionsNotMet implements SetFlowConfigResult & SetFlowBatchingConfigResult & TriggerFlowResult {
 	preconditions: String!
 	message: String!
 }
@@ -942,7 +942,7 @@ type FlowTriggerPush {
 	dummy: Boolean!
 }
 
-type FlowTypeIsNotSupported implements SetFlowConfigResult {
+type FlowTypeIsNotSupported implements SetFlowConfigResult & SetFlowBatchingConfigResult & SetFlowCompactingConfigResult {
 	message: String!
 }
 
@@ -1312,11 +1312,19 @@ type SetDataSchema {
 	schema: DataSchema!
 }
 
+interface SetFlowBatchingConfigResult {
+	message: String!
+}
+
+interface SetFlowCompactingConfigResult {
+	message: String!
+}
+
 interface SetFlowConfigResult {
 	message: String!
 }
 
-type SetFlowConfigSuccess implements SetFlowConfigResult {
+type SetFlowConfigSuccess implements SetFlowConfigResult & SetFlowBatchingConfigResult & SetFlowCompactingConfigResult {
 	config: FlowConfiguration!
 	message: String!
 }


### PR DESCRIPTION
## Description

Split results for different(`setFlowConfigResult`, `setFlowBatchingConfigResult`, `setFlowCompactingConfigResult`) config mutations

<!--- Describe your changes in detail -->

## Checklist before requesting a review

- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
- [x] Unit-tests added
