### PR TITLE
Fix instant run of transform flow after compacting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fix the instant run of `ExecuteTransform` flow after the successful finish of `HardCompacting` flow 
+- Add new error type `FlowDatasetCompactedFailedError` to indicate `ExecuteTransform` failed due to `HardCompacting` of root dataset
+
 ## [0.176.1] - 2024-04-16
 ### Fixed
 - Split result for different(`setFlowConfigResult`, `setFlowBatchingConfigResult`, `setFlowCompactingConfigResult`) flow configuration mutations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fix the instant run of `ExecuteTransform` flow after the successful finish of `HardCompacting` flow 
-- Add new error type `FlowDatasetCompactedFailedError` to indicate `ExecuteTransform` failed due to `HardCompacting` of root dataset
+- Extend `FlowFailed` error type to indicate when `ExecuteTransform` failed due to `HardCompacting` of root dataset
 
 ## [0.176.1] - 2024-04-16
 ### Fixed

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -1198,20 +1198,20 @@ Compact a dataset
 * `--max-slice-records <RECORDS>` — Maximum amount of records in a single data slice file
 
   Default value: `10000`
-* `--hard` — Perform 'hard' compaction that rewrites the history of a dataset
-* `--verify` — Perform verification of the dataset before running a compaction
+* `--hard` — Perform 'hard' compacting that rewrites the history of a dataset
+* `--verify` — Perform verification of the dataset before running a compacting
 
 For datasets that get frequent small appends the number of data slices can grow over time and affect the performance of querying. This command allows to merge multiple small data slices into a few large files, which can be beneficial in terms of size from more compact encoding, and in query performance, as data engines will have to scan through far fewer file headers.
 
-There are two types of compactions: soft and hard.
+There are two types of compactings: soft and hard.
 
-Soft compactions produce new files while leaving the old blocks intact. This allows for faster queries, while still preserving the accurate history of how dataset evolved over time.
+Soft compactings produce new files while leaving the old blocks intact. This allows for faster queries, while still preserving the accurate history of how dataset evolved over time.
 
-Hard compactions rewrite the history of the dataset as if data was originally written in big batches. They allow to shrink the history of a dataset to just a few blocks, reclaim the space used by old data files, but at the expense of history loss. Hard compactions will rewrite the metadata chain, changing block hashes. Therefore, they will **break all downstream datasets** that depend on them.
+Hard compactings rewrite the history of the dataset as if data was originally written in big batches. They allow to shrink the history of a dataset to just a few blocks, reclaim the space used by old data files, but at the expense of history loss. Hard compactings will rewrite the metadata chain, changing block hashes. Therefore, they will **break all downstream datasets** that depend on them.
 
 **Examples:**
 
-Perform a history-altering hard compaction:
+Perform a history-altering hard compacting:
 
     kamu system compact --hard my.dataset
 

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -753,7 +753,7 @@ type FlowConnection {
 }
 
 type FlowDatasetCompactedFailedError {
-	rootDatasetId: DatasetID!
+	rootDataset: Dataset!
 	reason: String!
 }
 

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -754,7 +754,7 @@ type FlowConnection {
 
 type FlowDatasetCompactedFailedError {
 	rootDataset: Dataset!
-	reason: String!
+	message: String!
 }
 
 union FlowDescription = FlowDescriptionDatasetPollingIngest | FlowDescriptionDatasetPushIngest | FlowDescriptionDatasetExecuteTransform | FlowDescriptionDatasetHardCompacting | FlowDescriptionSystemGC
@@ -845,8 +845,14 @@ type FlowEventTriggerAdded implements FlowEvent {
 }
 
 type FlowFailedError {
-	reason: String!
+	reason: FlowFailedReason!
 }
+
+type FlowFailedMessage {
+	message: String!
+}
+
+union FlowFailedReason = FlowFailedMessage | FlowDatasetCompactedFailedError
 
 scalar FlowID
 
@@ -871,7 +877,7 @@ type FlowNotFound implements GetFlowResult & CancelScheduledTasksResult {
 	message: String!
 }
 
-union FlowOutcome = FlowSuccessResult | FlowFailedError | FlowDatasetCompactedFailedError | FlowAbortedResult
+union FlowOutcome = FlowSuccessResult | FlowFailedError | FlowAbortedResult
 
 type FlowPreconditionsNotMet implements SetFlowConfigResult & SetFlowBatchingConfigResult & TriggerFlowResult {
 	preconditions: String!

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -752,6 +752,11 @@ type FlowConnection {
 	edges: [FlowEdge!]!
 }
 
+type FlowDatasetCompactedFailedError {
+	rootDatasetId: DatasetID!
+	reason: String!
+}
+
 union FlowDescription = FlowDescriptionDatasetPollingIngest | FlowDescriptionDatasetPushIngest | FlowDescriptionDatasetExecuteTransform | FlowDescriptionDatasetHardCompacting | FlowDescriptionSystemGC
 
 type FlowDescriptionDatasetExecuteTransform {
@@ -866,7 +871,7 @@ type FlowNotFound implements GetFlowResult & CancelScheduledTasksResult {
 	message: String!
 }
 
-union FlowOutcome = FlowSuccessResult | FlowFailedError | FlowAbortedResult
+union FlowOutcome = FlowSuccessResult | FlowFailedError | FlowDatasetCompactedFailedError | FlowAbortedResult
 
 type FlowPreconditionsNotMet implements SetFlowConfigResult & SetFlowBatchingConfigResult & TriggerFlowResult {
 	preconditions: String!

--- a/src/adapter/graphql/src/queries/flows/flow.rs
+++ b/src/adapter/graphql/src/queries/flows/flow.rs
@@ -130,8 +130,12 @@ impl Flow {
     }
 
     /// Outcome of the flow (Finished state only)
-    async fn outcome(&self) -> Option<FlowOutcome> {
-        self.flow_state.outcome.as_ref().map(Into::into)
+    async fn outcome(&self, ctx: &Context<'_>) -> Result<Option<FlowOutcome>> {
+        Ok(
+            FlowOutcome::from_maybe_flow_outcome(&self.flow_state.outcome, ctx)
+                .await
+                .int_err()?,
+        )
     }
 
     /// Timing records associated with the flow lifecycle

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -2552,7 +2552,17 @@ impl FlowRunsHarness {
                                                 message
                                             }
                                             ...on FlowFailedError {
-                                                reason
+                                                reason {
+                                                    ...on FlowFailedMessage {
+                                                        message
+                                                    }
+                                                    ...on FlowDatasetCompactedFailedError {
+                                                        message
+                                                        rootDataset {
+                                                            id
+                                                        }
+                                                    }
+                                                }
                                             }
                                         }
                                         timing {
@@ -2707,7 +2717,17 @@ impl FlowRunsHarness {
                                                     message
                                                 }
                                                 ...on FlowFailedError {
-                                                    reason
+                                                    reason {
+                                                        ...on FlowFailedMessage {
+                                                            message
+                                                        }
+                                                        ...on FlowDatasetCompactedFailedError {
+                                                            message
+                                                            rootDataset {
+                                                                id
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
@@ -2750,7 +2770,17 @@ impl FlowRunsHarness {
                                                     message
                                                 }
                                                 ...on FlowFailedError {
-                                                    reason
+                                                    reason {
+                                                        ...on FlowFailedMessage {
+                                                            message
+                                                        }
+                                                        ...on FlowDatasetCompactedFailedError {
+                                                            message
+                                                            rootDataset {
+                                                                id
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -1290,25 +1290,25 @@ pub fn cli() -> Command {
                                 Arg::new("hard")
                                     .long("hard")
                                     .action(ArgAction::SetTrue)
-                                    .help("Perform 'hard' compaction that rewrites the history of a dataset"),
+                                    .help("Perform 'hard' compacting that rewrites the history of a dataset"),
                                 Arg::new("verify")
                                     .long("verify")
                                     .action(ArgAction::SetTrue)
-                                    .help("Perform verification of the dataset before running a compaction"),
+                                    .help("Perform verification of the dataset before running a compacting"),
                             ])
                             .after_help(indoc::indoc!(
                                 r#"
                                 For datasets that get frequent small appends the number of data slices can grow over time and affect the performance of querying. This command allows to merge multiple small data slices into a few large files, which can be beneficial in terms of size from more compact encoding, and in query performance, as data engines will have to scan through far fewer file headers.
 
-                                There are two types of compactions: soft and hard.
+                                There are two types of compactings: soft and hard.
 
-                                Soft compactions produce new files while leaving the old blocks intact. This allows for faster queries, while still preserving the accurate history of how dataset evolved over time.
+                                Soft compactings produce new files while leaving the old blocks intact. This allows for faster queries, while still preserving the accurate history of how dataset evolved over time.
 
-                                Hard compactions rewrite the history of the dataset as if data was originally written in big batches. They allow to shrink the history of a dataset to just a few blocks, reclaim the space used by old data files, but at the expense of history loss. Hard compactions will rewrite the metadata chain, changing block hashes. Therefore, they will **break all downstream datasets** that depend on them.
+                                Hard compactings rewrite the history of the dataset as if data was originally written in big batches. They allow to shrink the history of a dataset to just a few blocks, reclaim the space used by old data files, but at the expense of history loss. Hard compactings will rewrite the metadata chain, changing block hashes. Therefore, they will **break all downstream datasets** that depend on them.
 
                                 **Examples:**
 
-                                Perform a history-altering hard compaction:
+                                Perform a history-altering hard compacting:
 
                                     kamu system compact --hard my.dataset
                                 "#

--- a/src/app/cli/src/commands/compact_command.rs
+++ b/src/app/cli/src/commands/compact_command.rs
@@ -84,7 +84,7 @@ impl Command for CompactCommand {
     async fn run(&mut self) -> Result<(), CLIError> {
         if !self.is_hard {
             return Err(CLIError::usage_error(
-                "Soft compactions are not yet supported",
+                "Soft compactings are not yet supported",
             ));
         }
         let dataset_handle = self

--- a/src/infra/flow-system-inmem/src/services/flow/flow_service_inmem.rs
+++ b/src/infra/flow-system-inmem/src/services/flow/flow_service_inmem.rs
@@ -550,7 +550,7 @@ impl FlowServiceInMemory {
         //   the upper bound of potential finish time for batching is known
         if accumulated_something || is_compacted {
             // Finish immediately if satisfied, or not later than the deadline
-            let batching_finish_time = if satisfied {
+            let batching_finish_time = if satisfied || is_compacted {
                 evaluation_time
             } else {
                 batching_deadline
@@ -570,7 +570,7 @@ impl FlowServiceInMemory {
 
             // If batching is over, it's start condition is no longer valid.
             // However, set throttling condition, if it applies
-            if satisfied && throttling_boundary_time > batching_finish_time {
+            if (satisfied || is_compacted) && throttling_boundary_time > batching_finish_time {
                 self.indicate_throttling_activity(
                     flow,
                     throttling_boundary_time,


### PR DESCRIPTION
- Fix the instant run of `ExecuteTransform` flow after the successful finish of `HardCompacting` flow 
- Rename `compaction` -> `compacting` in CLI reference
- Add new error type `FlowDatasetCompactedFailedError`


<!--- Describe your changes in detail -->

## Checklist before requesting a review

- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
- [x] Unit-tests added
