### PR TITLE
Activate compacting config by default

### DIFF
--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -205,7 +205,7 @@ impl DatasetFlowConfigsMut {
                 Utc::now(),
                 FlowKeyDataset::new(self.dataset_handle.id.clone(), dataset_flow_type.into())
                     .into(),
-                true,
+                false,
                 FlowConfigurationRule::CompactingRule(compacting_rule),
             )
             .await

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_configs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_configs.rs
@@ -666,7 +666,7 @@ async fn test_crud_compacting_root_dataset() {
                                 "message": "Success",
                                 "config": {
                                     "__typename": "FlowConfiguration",
-                                    "paused": true,
+                                    "paused": false,
                                     "schedule": null,
                                     "batching": null,
                                     "compacting": {

--- a/src/domain/task-system/services/src/task_executor_impl.rs
+++ b/src/domain/task-system/services/src/task_executor_impl.rs
@@ -151,7 +151,15 @@ impl TaskExecutor for TaskExecutorImpl {
                         Ok(result) => {
                             TaskOutcome::Success(TaskResult::CompactingDatasetResult(result.into()))
                         }
-                        Err(_) => TaskOutcome::Failed(TaskError::Empty),
+                        Err(err) => {
+                            tracing::info!(
+                                %task_id,
+                                logical_plan = ?task.logical_plan,
+                                err = ?err,
+                                "Task failed",
+                            );
+                            TaskOutcome::Failed(TaskError::Empty)
+                        }
                     }
                 }
             };

--- a/src/infra/core/src/compacting_service_impl.rs
+++ b/src/infra/core/src/compacting_service_impl.rs
@@ -380,6 +380,7 @@ impl CompactingServiceImpl {
         Ok((old_data_slices, current_head, new_num_blocks))
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     async fn compact_dataset_impl(
         &self,
         dataset: Arc<dyn Dataset>,


### PR DESCRIPTION
Fix regressing that gql config setting was not activated automatically.
In addition, added logs for compacting failure