### PR TITLE
Fix crash diagnose command not in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgraded to `datafusion` `v37.1.0`
 - Split the Flow system crates
+### Fixed
+- `kamu system diagnose` command crashes when executed outside the workspace directory
 
 ## [0.176.3] - 2024-04-18
 ### Changed

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -448,16 +448,12 @@ pub fn get_command(
                 cli_catalog.get_one()?,
                 info_matches.get_one("output-format").map(String::as_str),
             )),
-            Some(("diagnose", _)) => {
-                let workspace_svc = cli_catalog.get_one::<WorkspaceService>()?;
-                Box::new(SystemDiagnoseCommand::new(
-                    cli_catalog.get_one()?,
-                    cli_catalog.get_one()?,
-                    cli_catalog.get_one()?,
-                    workspace_svc.is_in_workspace(),
-                    workspace_svc.layout().unwrap().run_info_dir.clone(),
-                ))
-            }
+            Some(("diagnose", _)) => Box::new(SystemDiagnoseCommand::new(
+                cli_catalog.get_one()?,
+                cli_catalog.get_one()?,
+                cli_catalog.get_one()?,
+                cli_catalog.get_one()?,
+            )),
             Some(("check-token", matches)) => Box::new(CheckTokenCommand::new(
                 cli_catalog.get_one()?,
                 matches.get_one("token").cloned().unwrap(),


### PR DESCRIPTION
## Description

Closes: [System diagnose command crashes when not in workspace](https://github.com/kamu-data/kamu-cli/issues/610)

<!--- Describe your changes in detail -->

## Checklist before requesting a review

- [x] [CHANGELOG.md](./CHANGELOG.md) updated
- [x] API changes are backwards-compatible
- [x] Workspace layout changes include a migration
- [x] Documentation update PR: <link or N/A>
- [x] Dataset pipelines update scheduled if needed
- [x] Unit-tests added
