### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,30 @@
 ## Description
 
-Closes: <#issue>
+Closes: #issue
 
-<!--- Describe your changes in detail -->
+<!--- Describe your changes in detail and include your changelog entries -->
 
 ## Checklist before requesting a review
 
-- [ ] [CHANGELOG.md](./CHANGELOG.md) updated
-- [ ] API changes are backwards-compatible
-- [ ] Workspace layout changes include a migration
-- [ ] Documentation update PR: <link or N/A>
-- [ ] Dataset pipelines update scheduled if needed
-- [ ] Unit-tests added
+- [ ] Unit and integration tests added
+  <!-- Replace with ❌ if the statement is false and include an explanation -->
+- [ ] Compatibility:
+    <!-- Old clients can communicate to the new version without upgrading -->
+  - [ ] Network APIs: ✅
+    <!-- New version will work with the old workspaces, repositories, and metadata -->
+  - [ ] Workspace layout and metadata: ✅ 
+    <!-- New version can read existing user configs -->
+  - [ ] Configuration: ✅
+    <!-- Change does not includes new versions of any container images -->
+  - [ ] Container images: ✅
+- [ ] Documentation:
+    <!-- Document how your changes benefit or affect the *end user* -->
+  - [ ] [Changelog](./CHANGELOG.md): ✅
+    <!-- How will users find out about and learn how to use this feature?
+         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
+         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
+  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
+  <!-- If this change will require some updates in downstream services mark with ❌ -->
+- [ ] Downstream effects:
+    <!-- Will node need to be updated with new services or DI catalog configuration? -->
+  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅


### PR DESCRIPTION
## Description

Closes: N/A

Updating PR checklist - rendered version can be seen below.

Main motivation for this is the last entry. I suggest a **process change** where if we are merging an update to `kamu` core that affects `kamu-node` - we should have a tested and reviewed PR for `kamu-node` ready **prior to merging**. This is to prevent situations where a large feature lands in `kamu-cli` that requires significant work in `kamu-node` to upgrade, thus blocking all other releases.

The alternative would be to create maintenance releases in `kamu-cli`, but IMO that's too messy.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅