### PR TITLE
JwtAuthenticationConfig::new(): make "jwt_secret" as optional for `kamu-node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.180.0] - 2024-05-08
 ### Added
 - GraphQL account flows endpoints:
   - List of flows by account(including filters `byDatasetName`, `byFlowType`, `byStatus`, `byInitiator`)
   - Pause all flows by account
   - Resume all flows by account
+### Changed
+- Correct JWT config creation for `kamu-node`
 ### Fixed
 - `kamu repo alias rm` command regression crash. Changed accepted type and covered by integration test
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "container-runtime"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2008,7 +2008,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.179.1"
+version = "0.180.0"
 
 [[package]]
 name = "env_filter"
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "event-bus"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -2678,7 +2678,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-sourcing"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "quote",
  "syn 2.0.60",
@@ -3447,7 +3447,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "thiserror",
 ]
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-recursion",
  "async-stream",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "argon2",
  "chrono",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "arrow-flight",
  "assert_cmd",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4140,7 +4140,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "chrono",
  "dill",
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "chrono",
  "clap",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "chrono",
  "dill",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "bs58",
  "digest",
@@ -5150,7 +5150,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendatafabric"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "arrow",
  "base64 0.21.7",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "rand",
 ]
@@ -7567,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.179.1"
+version = "0.180.0"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,61 +59,61 @@ resolver = "2"
 [workspace.dependencies]
 
 # Utils
-container-runtime = { version = "0.179.1", path = "src/utils/container-runtime", default-features = false }
-database-common = { version = "0.179.1", path = "src/utils/database-common", default-features = false }
-enum-variants = { version = "0.179.1", path = "src/utils/enum-variants", default-features = false }
-event-bus = { version = "0.179.1", path = "src/utils/event-bus", default-features = false }
-event-sourcing = { version = "0.179.1", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.179.1", path = "src/utils/event-sourcing-macros", default-features = false }
-internal-error = { version = "0.179.1", path = "src/utils/internal-error", default-features = false }
-multiformats = { version = "0.179.1", path = "src/utils/multiformats", default-features = false }
-kamu-data-utils = { version = "0.179.1", path = "src/utils/data-utils", default-features = false }
-kamu-datafusion-cli = { version = "0.179.1", path = "src/utils/datafusion-cli", default-features = false }
-random-names = { version = "0.179.1", path = "src/utils/random-names", default-features = false }
-tracing-perfetto = { version = "0.179.1", path = "src/utils/tracing-perfetto", default-features = false }
+container-runtime = { version = "0.180.0", path = "src/utils/container-runtime", default-features = false }
+database-common = { version = "0.180.0", path = "src/utils/database-common", default-features = false }
+enum-variants = { version = "0.180.0", path = "src/utils/enum-variants", default-features = false }
+event-bus = { version = "0.180.0", path = "src/utils/event-bus", default-features = false }
+event-sourcing = { version = "0.180.0", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.180.0", path = "src/utils/event-sourcing-macros", default-features = false }
+internal-error = { version = "0.180.0", path = "src/utils/internal-error", default-features = false }
+multiformats = { version = "0.180.0", path = "src/utils/multiformats", default-features = false }
+kamu-data-utils = { version = "0.180.0", path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { version = "0.180.0", path = "src/utils/datafusion-cli", default-features = false }
+random-names = { version = "0.180.0", path = "src/utils/random-names", default-features = false }
+tracing-perfetto = { version = "0.180.0", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-opendatafabric = { version = "0.179.1", path = "src/domain/opendatafabric", default-features = false }
-kamu-core = { version = "0.179.1", path = "src/domain/core", default-features = false }
-kamu-accounts = { version = "0.179.1", path = "src/domain/accounts/domain", default-features = false }
-kamu-task-system = { version = "0.179.1", path = "src/domain/task-system/domain", default-features = false }
-kamu-flow-system = { version = "0.179.1", path = "src/domain/flow-system/domain", default-features = false }
+opendatafabric = { version = "0.180.0", path = "src/domain/opendatafabric", default-features = false }
+kamu-core = { version = "0.180.0", path = "src/domain/core", default-features = false }
+kamu-accounts = { version = "0.180.0", path = "src/domain/accounts/domain", default-features = false }
+kamu-task-system = { version = "0.180.0", path = "src/domain/task-system/domain", default-features = false }
+kamu-flow-system = { version = "0.180.0", path = "src/domain/flow-system/domain", default-features = false }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.179.1", path = "src/domain/accounts/services", default-features = false }
-kamu-task-system-services = { version = "0.179.1", path = "src/domain/task-system/services", default-features = false }
-kamu-flow-system-services = { version = "0.179.1", path = "src/domain/flow-system/services", default-features = false }
+kamu-accounts-services = { version = "0.180.0", path = "src/domain/accounts/services", default-features = false }
+kamu-task-system-services = { version = "0.180.0", path = "src/domain/task-system/services", default-features = false }
+kamu-flow-system-services = { version = "0.180.0", path = "src/domain/flow-system/services", default-features = false }
 
 # Infra
-kamu = { version = "0.179.1", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.179.1", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.180.0", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.180.0", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.179.1", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.179.1", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.179.1", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.179.1", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.180.0", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.180.0", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.180.0", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.180.0", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.179.1", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.179.1", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.179.1", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.179.1", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.179.1", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.180.0", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.180.0", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.180.0", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.180.0", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.180.0", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.179.1", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.179.1", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.179.1", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.179.1", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.180.0", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.180.0", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.180.0", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.180.0", path = "src/infra/task-system/repo-tests", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso = { version = "0.179.1", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.179.1", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.179.1", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.179.1", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.179.1", path = "src/adapter/odata", defualt-features = false }
-kamu-adapter-oauth = { version = "0.179.1", path = "src/adapter/oauth", defualt-features = false }
+kamu-adapter-auth-oso = { version = "0.180.0", path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { version = "0.180.0", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.180.0", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.180.0", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.180.0", path = "src/adapter/odata", defualt-features = false }
+kamu-adapter-oauth = { version = "0.180.0", path = "src/adapter/oauth", defualt-features = false }
 
 [workspace.package]
-version = "0.179.1"
+version = "0.180.0"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.179.1
+Licensed Work:             Kamu CLI Version 0.180.0
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2028-05-06
+Change Date:               2028-05-08
 
 Change License:            Apache License, Version 2.0
 

--- a/src/domain/accounts/domain/src/services/authentication_config.rs
+++ b/src/domain/accounts/domain/src/services/authentication_config.rs
@@ -21,16 +21,14 @@ pub struct JwtAuthenticationConfig {
 }
 
 impl JwtAuthenticationConfig {
-    pub fn new(jwt_secret: String) -> Self {
-        Self { jwt_secret }
+    pub fn new(maybe_jwt_secret: Option<String>) -> Self {
+        Self {
+            jwt_secret: maybe_jwt_secret.unwrap_or_else(|| get_random_name(None, 64)),
+        }
     }
 
     pub fn load_from_env() -> Self {
-        Self {
-            jwt_secret: std::env::var(ENV_VAR_KAMU_JWT_SECRET)
-                .ok()
-                .unwrap_or_else(|| get_random_name(None, 64)),
-        }
+        Self::new(std::env::var(ENV_VAR_KAMU_JWT_SECRET).ok())
     }
 }
 


### PR DESCRIPTION
## Description

Related issue: https://github.com/kamu-data/kamu-node/issues/45

## Checklist before requesting a review

- [ ] Unit and integration tests added ❌ -- not needed
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌ -- not needed
  <!-- If this change will require some updates in downstream services mark with  -->
- [ ] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ❌ -- will be added after