### PR TITLE
Fix repo command crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - List of flows by account(including filters `byDatasetName`, `byFlowType`, `byStatus`, `byInitiator`)
   - Pause all flows by account
   - Resume all flows by account
+### Fixed
+- `kamu repo alias rm` command regression crash. Changed accepted type and cove by integration test
 
 ## [0.179.1] - 2024-05-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pause all flows by account
   - Resume all flows by account
 ### Fixed
-- `kamu repo alias rm` command regression crash. Changed accepted type and cove by integration test
+- `kamu repo alias rm` command regression crash. Changed accepted type and covered by integration test
 
 ## [0.179.1] - 2024-05-07
 ### Changed

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -1043,7 +1043,7 @@ pub fn cli() -> Command {
                                         Arg::new("dataset")
                                             .required(true)
                                             .index(1)
-                                            .value_parser(value_parse_dataset_ref_pattern_local)
+                                            .value_parser(value_parse_dataset_ref_local)
                                             .help("Local dataset reference"),
                                         Arg::new("alias")
                                             .index(2)

--- a/src/app/cli/tests/tests/mod.rs
+++ b/src/app/cli/tests/tests/mod.rs
@@ -16,5 +16,6 @@ mod test_generate_cli_markdown;
 mod test_ingest_command;
 mod test_new_dataset_command;
 mod test_output;
+mod test_repository_alias_commands;
 mod test_system_info_command;
 mod test_workspace_svc;

--- a/src/app/cli/tests/tests/test_repository_alias_commands.rs
+++ b/src/app/cli/tests/tests/test_repository_alias_commands.rs
@@ -1,0 +1,79 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use opendatafabric::*;
+
+use crate::utils::Kamu;
+
+#[test_log::test(tokio::test)]
+async fn test_repository_alias_commands() {
+    let kamu = Kamu::new_workspace_tmp().await;
+    kamu.add_dataset(DatasetSnapshot {
+        name: "test".try_into().unwrap(),
+        kind: DatasetKind::Root,
+        metadata: vec![AddPushSource {
+            source_name: SourceState::DEFAULT_SOURCE_NAME.to_string(),
+            read: ReadStepNdJson {
+                schema: Some(vec![
+                    "event_time TIMESTAMP".to_owned(),
+                    "test STRING".to_owned(),
+                ]),
+                ..Default::default()
+            }
+            .into(),
+            preprocess: None,
+            merge: MergeStrategyLedger {
+                primary_key: vec!["event_time".to_owned(), "test".to_owned()],
+            }
+            .into(),
+        }
+        .into()],
+    })
+    .await
+    .unwrap();
+    let dataset_aliases = vec![
+        "http://net.test.com/".to_string(),
+        "http://net.test1.com/".to_string(),
+    ];
+
+    let cmd_result = kamu
+        .execute([
+            "repo",
+            "alias",
+            "add",
+            "test",
+            dataset_aliases[0].as_str(),
+            "--pull",
+        ])
+        .await;
+    assert!(cmd_result.is_ok());
+    let cmd_result = kamu
+        .execute([
+            "repo",
+            "alias",
+            "add",
+            "test",
+            dataset_aliases[1].as_str(),
+            "--pull",
+        ])
+        .await;
+    assert!(cmd_result.is_ok());
+
+    let (pull_aliases, _push_aliases) = kamu
+        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("test")))
+        .await;
+    assert_eq!(pull_aliases, dataset_aliases);
+
+    let cmd_result = kamu.execute(["repo", "alias", "rm", "--all", "test"]).await;
+    assert!(cmd_result.is_ok());
+    let (pull_aliases, _push_aliases) = kamu
+        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("test")))
+        .await;
+    assert!(pull_aliases.is_empty());
+}

--- a/src/app/cli/tests/tests/test_repository_alias_commands.rs
+++ b/src/app/cli/tests/tests/test_repository_alias_commands.rs
@@ -12,24 +12,24 @@ use opendatafabric::*;
 use crate::utils::Kamu;
 
 #[test_log::test(tokio::test)]
-async fn test_repository_alias_commands() {
+async fn test_repository_pull_aliases_commands() {
     let kamu = Kamu::new_workspace_tmp().await;
     kamu.add_dataset(DatasetSnapshot {
-        name: "test".try_into().unwrap(),
+        name: "foo".try_into().unwrap(),
         kind: DatasetKind::Root,
         metadata: vec![AddPushSource {
             source_name: SourceState::DEFAULT_SOURCE_NAME.to_string(),
             read: ReadStepNdJson {
                 schema: Some(vec![
                     "event_time TIMESTAMP".to_owned(),
-                    "test STRING".to_owned(),
+                    "foo_string STRING".to_owned(),
                 ]),
                 ..Default::default()
             }
             .into(),
             preprocess: None,
             merge: MergeStrategyLedger {
-                primary_key: vec!["event_time".to_owned(), "test".to_owned()],
+                primary_key: vec!["event_time".to_owned(), "foo_string".to_owned()],
             }
             .into(),
         }
@@ -38,42 +38,100 @@ async fn test_repository_alias_commands() {
     .await
     .unwrap();
     let dataset_aliases = vec![
-        "http://net.test.com/".to_string(),
-        "http://net.test1.com/".to_string(),
+        "http://pull.example.com/".to_string(),
+        "http://pull.example1.com/".to_string(),
+        "http://pull.example2.com/".to_string(),
     ];
 
-    let cmd_result = kamu
-        .execute([
-            "repo",
-            "alias",
-            "add",
-            "test",
-            dataset_aliases[0].as_str(),
-            "--pull",
-        ])
-        .await;
-    assert!(cmd_result.is_ok());
-    let cmd_result = kamu
-        .execute([
-            "repo",
-            "alias",
-            "add",
-            "test",
-            dataset_aliases[1].as_str(),
-            "--pull",
-        ])
-        .await;
-    assert!(cmd_result.is_ok());
+    for dataset_alias in &dataset_aliases {
+        let cmd_result = kamu
+            .execute(["repo", "alias", "add", "foo", dataset_alias, "--pull"])
+            .await;
+        assert!(cmd_result.is_ok());
+    }
 
     let (pull_aliases, _push_aliases) = kamu
-        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("test")))
+        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
         .await;
     assert_eq!(pull_aliases, dataset_aliases);
 
-    let cmd_result = kamu.execute(["repo", "alias", "rm", "--all", "test"]).await;
+    // Test remove single pull alias
+    let cmd_result = kamu
+        .execute(["repo", "alias", "rm", "foo", dataset_aliases[2].as_str()])
+        .await;
     assert!(cmd_result.is_ok());
     let (pull_aliases, _push_aliases) = kamu
-        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("test")))
+        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
+        .await;
+    assert_eq!(pull_aliases, dataset_aliases[..2]);
+
+    // Test remove all pull aliases
+    let cmd_result = kamu.execute(["repo", "alias", "rm", "--all", "foo"]).await;
+    assert!(cmd_result.is_ok());
+    let (pull_aliases, _push_aliases) = kamu
+        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
         .await;
     assert!(pull_aliases.is_empty());
+}
+
+#[test_log::test(tokio::test)]
+async fn test_repository_push_aliases_commands() {
+    let kamu = Kamu::new_workspace_tmp().await;
+    kamu.add_dataset(DatasetSnapshot {
+        name: "foo".try_into().unwrap(),
+        kind: DatasetKind::Root,
+        metadata: vec![AddPushSource {
+            source_name: SourceState::DEFAULT_SOURCE_NAME.to_string(),
+            read: ReadStepNdJson {
+                schema: Some(vec![
+                    "event_time TIMESTAMP".to_owned(),
+                    "foo_string STRING".to_owned(),
+                ]),
+                ..Default::default()
+            }
+            .into(),
+            preprocess: None,
+            merge: MergeStrategyLedger {
+                primary_key: vec!["event_time".to_owned(), "foo_string".to_owned()],
+            }
+            .into(),
+        }
+        .into()],
+    })
+    .await
+    .unwrap();
+    let dataset_aliases = vec![
+        "http://push.example.com/".to_string(),
+        "http://push.example1.com/".to_string(),
+        "http://push.example2.com/".to_string(),
+    ];
+
+    for dataset_alias in &dataset_aliases {
+        let cmd_result = kamu
+            .execute(["repo", "alias", "add", "foo", dataset_alias, "--push"])
+            .await;
+        assert!(cmd_result.is_ok());
+    }
+
+    let (_pull_aliases, push_aliases) = kamu
+        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
+        .await;
+    assert_eq!(push_aliases, dataset_aliases);
+
+    // Test remove single push alias
+    let cmd_result = kamu
+        .execute(["repo", "alias", "rm", "foo", dataset_aliases[2].as_str()])
+        .await;
+    assert!(cmd_result.is_ok());
+    let (_pull_aliases, push_aliases) = kamu
+        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
+        .await;
+    assert_eq!(push_aliases, dataset_aliases[..2]);
+    // Test remove all push aliases
+    let cmd_result = kamu.execute(["repo", "alias", "rm", "--all", "foo"]).await;
+    assert!(cmd_result.is_ok());
+    let (_pull_aliases, push_aliases) = kamu
+        .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
+        .await;
+    assert!(push_aliases.is_empty());
 }


### PR DESCRIPTION
## Description

Closes: [
Regression: Repo alias commands fail](https://github.com/kamu-data/kamu-cli/issues/608)

<!--- Describe your changes in detail and include your changelog entries -->
Fix Repo alias command crash regression
Added integration test to cover regression in the future

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅