### PR TITLE
Add keep-metadata-only flag to compact command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- The `kamu system compact` command now accepts the `--keep-metadata-only` flag, which performs hard
+  compaction of dataset(root or derived) without retaining `AddData` or `ExecuteTransform` blocks
 ### Fixed
 - Panic while performing data ingesting in the derived datasets
 

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -1239,6 +1239,7 @@ Compact a dataset
 
   Default value: `10000`
 * `--hard` — Perform 'hard' compacting that rewrites the history of a dataset
+* `--keep-metadata-only` — Perform compacting without saving data blocks
 * `--verify` — Perform verification of the dataset before running a compacting
 
 For datasets that get frequent small appends the number of data slices can grow over time and affect the performance of querying. This command allows to merge multiple small data slices into a few large files, which can be beneficial in terms of size from more compact encoding, and in query performance, as data engines will have to scan through far fewer file headers.

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -517,6 +517,7 @@ pub fn get_command(
                 *(submatches.get_one("max-slice-records").unwrap()),
                 submatches.get_flag("hard"),
                 submatches.get_flag("verify"),
+                submatches.get_flag("keep-metadata-only"),
             )),
             _ => return Err(CommandInterpretationFailed.into()),
         },

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -1323,6 +1323,10 @@ pub fn cli() -> Command {
                                     .long("hard")
                                     .action(ArgAction::SetTrue)
                                     .help("Perform 'hard' compacting that rewrites the history of a dataset"),
+                                Arg::new("keep-metadata-only")
+                                    .long("keep-metadata-only")
+                                    .action(ArgAction::SetTrue)
+                                    .help("Perform compacting without saving data blocks"),
                                 Arg::new("verify")
                                     .long("verify")
                                     .action(ArgAction::SetTrue)

--- a/src/app/cli/src/commands/compact_command.rs
+++ b/src/app/cli/src/commands/compact_command.rs
@@ -30,6 +30,7 @@ pub struct CompactCommand {
     max_slice_records: u64,
     is_hard: bool,
     is_verify: bool,
+    is_keep_metadata_only: bool,
 }
 
 impl CompactCommand {
@@ -42,6 +43,7 @@ impl CompactCommand {
         max_slice_records: u64,
         is_hard: bool,
         is_verify: bool,
+        is_keep_metadata_only: bool,
     ) -> Self {
         Self {
             dataset_repo,
@@ -52,6 +54,7 @@ impl CompactCommand {
             max_slice_records,
             is_hard,
             is_verify,
+            is_keep_metadata_only,
         }
     }
 
@@ -117,6 +120,7 @@ impl Command for CompactCommand {
                 CompactingOptions {
                     max_slice_size: Some(self.max_slice_size),
                     max_slice_records: Some(self.max_slice_records),
+                    is_keep_metadata_only: self.is_keep_metadata_only,
                 },
                 Some(listener.clone()),
             )

--- a/src/domain/core/src/services/compacting_service.rs
+++ b/src/domain/core/src/services/compacting_service.rs
@@ -165,6 +165,7 @@ pub enum CompactingResult {
 pub struct CompactingOptions {
     pub max_slice_size: Option<u64>,
     pub max_slice_records: Option<u64>,
+    pub is_keep_metadata_only: bool,
 }
 
 impl Default for CompactingOptions {
@@ -172,6 +173,7 @@ impl Default for CompactingOptions {
         Self {
             max_slice_size: Some(DEFAULT_MAX_SLICE_SIZE),
             max_slice_records: Some(DEFAULT_MAX_SLICE_RECORDS),
+            is_keep_metadata_only: false,
         }
     }
 }

--- a/src/domain/task-system/services/src/task_executor_impl.rs
+++ b/src/domain/task-system/services/src/task_executor_impl.rs
@@ -142,6 +142,7 @@ impl TaskExecutor for TaskExecutorImpl {
                             CompactingOptions {
                                 max_slice_size: *max_slice_size,
                                 max_slice_records: *max_slice_records,
+                                ..CompactingOptions::default()
                             },
                             None,
                         )

--- a/src/infra/core/src/repos/dataset_impl.rs
+++ b/src/infra/core/src/repos/dataset_impl.rs
@@ -434,7 +434,9 @@ where
         };
 
         let mut new_upstream_ids: Vec<opendatafabric::DatasetID> = vec![];
-        if let opendatafabric::MetadataEvent::SetTransform(transform) = &event {
+        if opts.update_block_ref
+            && let opendatafabric::MetadataEvent::SetTransform(transform) = &event
+        {
             for new_input in &transform.inputs {
                 if let Some(id) = new_input.dataset_ref.id() {
                     new_upstream_ids.push(id.clone());


### PR DESCRIPTION
## Description

Closes: [Add --keep-metadata-only flag to compact command](https://github.com/kamu-data/kamu-cli/issues/625)

Extend compact command with new flag `--keep-metadata-only` which remove all data(`AddData`/`ExecuteTransfrom`) blocks

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅