### PR TITLE
Fix panic while ingesting data in derived dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Panic while performing data ingesting in the derived datasets
+
 ## [0.180.0] - 2024-05-08
 ### Added
 - GraphQL account flows endpoints:

--- a/src/app/cli/src/commands/ingest_command.rs
+++ b/src/app/cli/src/commands/ingest_command.rs
@@ -102,6 +102,21 @@ impl IngestCommand {
                 pull_aliases.join("\n- ")
             )));
         }
+
+        let dataset = self
+            .dataset_repo
+            .get_dataset(&dataset_handle.as_local_ref())
+            .await?;
+        let dataset_kind = dataset
+            .get_summary(GetSummaryOpts::default())
+            .await
+            .int_err()?
+            .kind;
+        if dataset_kind != DatasetKind::Root {
+            return Err(CLIError::usage_error(
+                "Ingesting data available for root datasets only",
+            ));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Closes: [Ingest command panic during ingesting derived dataset](https://github.com/kamu-data/kamu-cli/issues/627)

Fix panic while performing data ingestion in the derived dataset.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅