### PR TITLE
Add initial MQTT support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- Introduced MQTT protocol support (see [FetchStepMqtt](https://docs.kamu.dev/odf/reference/#fetchstepmqtt) and the new [`mqtt` example](/examples/mqtt))
 - The `kamu system compact` command now accepts the `--keep-metadata-only` flag, which performs hard
   compaction of dataset(root or derived) without retaining `AddData` or `ExecuteTransform` blocks
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,6 +3628,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ringbuf",
+ "rumqttc",
  "serde",
  "serde_json",
  "serde_with",
@@ -6087,6 +6088,24 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8941c6791801b667d52bfe9ff4fc7c968d4f3f9ae8ae7abdaaa1c966feafc8"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile 1.0.4",
+ "rustls-webpki",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]

--- a/examples/mqtt/pub.py
+++ b/examples/mqtt/pub.py
@@ -1,0 +1,18 @@
+import datetime
+import json
+import paho.mqtt.publish as publish
+
+for i in range(10):
+    payload = json.dumps({
+        "event_time": datetime.datetime.now().isoformat(),
+        "value": i,
+    })
+    print("Publishing:", payload)
+    publish.single(
+        hostname="test.mosquitto.org",
+        port=1883,
+        topic="dev.kamu.example.mqtt.temp",
+        payload=payload,
+        retain=True,
+        qos=1,
+    )

--- a/examples/mqtt/requirements.txt
+++ b/examples/mqtt/requirements.txt
@@ -1,0 +1,1 @@
+paho-mqtt

--- a/examples/mqtt/temp.yaml
+++ b/examples/mqtt/temp.yaml
@@ -1,0 +1,23 @@
+kind: DatasetSnapshot
+version: 1
+content:
+  name: temp
+  kind: Root
+  metadata:
+    - kind: SetPollingSource
+      fetch:
+        kind: mqtt
+        host: test.mosquitto.org
+        port: 1883
+        topics:
+          - path: dev.kamu.example.mqtt.temp
+            qos: AtMostOnce
+      read:
+        kind: NdJson
+        schema:
+          - event_time TIMESTAMP
+          - value FLOAT
+      merge:
+        kind: Ledger
+        primaryKey:
+          - event_time

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -696,7 +696,7 @@ type ExecuteTransformInput {
 	newOffset: Int
 }
 
-union FetchStep = FetchStepUrl | FetchStepFilesGlob | FetchStepContainer
+union FetchStep = FetchStepUrl | FetchStepFilesGlob | FetchStepContainer | FetchStepMqtt
 
 type FetchStepContainer {
 	image: String!
@@ -710,6 +710,14 @@ type FetchStepFilesGlob {
 	eventTime: EventTimeSource
 	cache: SourceCaching
 	order: SourceOrdering
+}
+
+type FetchStepMqtt {
+	host: String!
+	port: Int!
+	username: String
+	password: String
+	topics: [MqttTopicSubscription!]!
 }
 
 type FetchStepUrl {
@@ -1127,6 +1135,17 @@ type MetadataManifestMalformed implements CommitResult & CreateDatasetFromSnapsh
 
 type MetadataManifestUnsupportedVersion implements CommitResult & CreateDatasetFromSnapshotResult {
 	message: String!
+}
+
+enum MqttQos {
+	AT_MOST_ONCE
+	AT_LEAST_ONCE
+	EXACTLY_ONCE
+}
+
+type MqttTopicSubscription {
+	path: String!
+	qos: MqttQos
 }
 
 scalar Multihash

--- a/src/adapter/graphql/src/scalars/odf_generated.rs
+++ b/src/adapter/graphql/src/scalars/odf_generated.rs
@@ -421,6 +421,7 @@ pub enum FetchStep {
     Url(FetchStepUrl),
     FilesGlob(FetchStepFilesGlob),
     Container(FetchStepContainer),
+    Mqtt(FetchStepMqtt),
 }
 
 impl From<odf::FetchStep> for FetchStep {
@@ -429,6 +430,7 @@ impl From<odf::FetchStep> for FetchStep {
             odf::FetchStep::Url(v) => Self::Url(v.into()),
             odf::FetchStep::FilesGlob(v) => Self::FilesGlob(v.into()),
             odf::FetchStep::Container(v) => Self::Container(v.into()),
+            odf::FetchStep::Mqtt(v) => Self::Mqtt(v.into()),
         }
     }
 }
@@ -486,6 +488,27 @@ impl From<odf::FetchStepContainer> for FetchStepContainer {
             command: v.command.map(|v| v.into_iter().map(Into::into).collect()),
             args: v.args.map(|v| v.into_iter().map(Into::into).collect()),
             env: v.env.map(|v| v.into_iter().map(Into::into).collect()),
+        }
+    }
+}
+
+#[derive(SimpleObject, Debug, Clone, PartialEq, Eq)]
+pub struct FetchStepMqtt {
+    pub host: String,
+    pub port: i32,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub topics: Vec<MqttTopicSubscription>,
+}
+
+impl From<odf::FetchStepMqtt> for FetchStepMqtt {
+    fn from(v: odf::FetchStepMqtt) -> Self {
+        Self {
+            host: v.host.into(),
+            port: v.port.into(),
+            username: v.username.map(Into::into),
+            password: v.password.map(Into::into),
+            topics: v.topics.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -639,6 +662,53 @@ impl From<odf::MetadataEvent> for MetadataEvent {
             odf::MetadataEvent::AddPushSource(v) => Self::AddPushSource(v.into()),
             odf::MetadataEvent::DisablePushSource(v) => Self::DisablePushSource(v.into()),
             odf::MetadataEvent::DisablePollingSource(v) => Self::DisablePollingSource(v.into()),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MqttTopicSubscription
+// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#mqtttopicsubscription-schema
+////////////////////////////////////////////////////////////////////////////////
+
+#[derive(SimpleObject, Debug, Clone, PartialEq, Eq)]
+pub struct MqttTopicSubscription {
+    pub path: String,
+    pub qos: Option<MqttQos>,
+}
+
+impl From<odf::MqttTopicSubscription> for MqttTopicSubscription {
+    fn from(v: odf::MqttTopicSubscription) -> Self {
+        Self {
+            path: v.path.into(),
+            qos: v.qos.map(Into::into),
+        }
+    }
+}
+
+#[derive(Enum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MqttQos {
+    AtMostOnce,
+    AtLeastOnce,
+    ExactlyOnce,
+}
+
+impl From<odf::MqttQos> for MqttQos {
+    fn from(v: odf::MqttQos) -> Self {
+        match v {
+            odf::MqttQos::AtMostOnce => Self::AtMostOnce,
+            odf::MqttQos::AtLeastOnce => Self::AtLeastOnce,
+            odf::MqttQos::ExactlyOnce => Self::ExactlyOnce,
+        }
+    }
+}
+
+impl Into<odf::MqttQos> for MqttQos {
+    fn into(self) -> odf::MqttQos {
+        match self {
+            Self::AtMostOnce => odf::MqttQos::AtMostOnce,
+            Self::AtLeastOnce => odf::MqttQos::AtLeastOnce,
+            Self::ExactlyOnce => odf::MqttQos::ExactlyOnce,
         }
     }
 }

--- a/src/domain/opendatafabric/schemas/odf.fbs
+++ b/src/domain/opendatafabric/schemas/odf.fbs
@@ -324,6 +324,22 @@ table EnvVar {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// MqttTopicSubscription
+// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#mqtttopicsubscription-schema
+////////////////////////////////////////////////////////////////////////////////
+
+enum MqttQos: int32 {
+  AtMostOnce,
+  AtLeastOnce,
+  ExactlyOnce,
+}
+
+table MqttTopicSubscription {
+  path: string;
+  qos: MqttQos = null;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // FetchStep
 // https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#fetchstep-schema
 ////////////////////////////////////////////////////////////////////////////////
@@ -354,10 +370,19 @@ table FetchStepContainer {
   env: [EnvVar];
 }
 
+table FetchStepMqtt {
+  host: string;
+  port: int32;
+  username: string;
+  password: string;
+  topics: [MqttTopicSubscription];
+}
+
 union FetchStep {
   FetchStepUrl,
   FetchStepFilesGlob,
   FetchStepContainer,
+  FetchStepMqtt,
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/opendatafabric/src/dtos/dtos_generated.rs
+++ b/src/domain/opendatafabric/src/dtos/dtos_generated.rs
@@ -339,6 +339,7 @@ pub enum FetchStep {
     Url(FetchStepUrl),
     FilesGlob(FetchStepFilesGlob),
     Container(FetchStepContainer),
+    Mqtt(FetchStepMqtt),
 }
 
 impl_enum_with_variants!(FetchStep);
@@ -391,6 +392,23 @@ pub struct FetchStepContainer {
 }
 
 impl_enum_variant!(FetchStep::Container(FetchStepContainer));
+
+/// Connects to an MQTT broker to fetch events from the specified topic.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FetchStepMqtt {
+    /// Hostname of the MQTT broker.
+    pub host: String,
+    /// Port of the MQTT broker.
+    pub port: i32,
+    /// Username to use for auth with the broker.
+    pub username: Option<String>,
+    /// Password to use for auth with the broker (can be templated).
+    pub password: Option<String>,
+    /// List of topic subscription parameters.
+    pub topics: Vec<MqttTopicSubscription>,
+}
+
+impl_enum_variant!(FetchStep::Mqtt(FetchStepMqtt));
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SourceOrdering {
@@ -543,6 +561,27 @@ impl_enum_variant!(MetadataEvent::AddPushSource(AddPushSource));
 impl_enum_variant!(MetadataEvent::DisablePushSource(DisablePushSource));
 
 impl_enum_variant!(MetadataEvent::DisablePollingSource(DisablePollingSource));
+
+////////////////////////////////////////////////////////////////////////////////
+// MqttTopicSubscription
+// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#mqtttopicsubscription-schema
+////////////////////////////////////////////////////////////////////////////////
+
+/// MQTT topic subscription parameters.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct MqttTopicSubscription {
+    /// Name of the topic (may include patterns).
+    pub path: String,
+    /// Quality of service class
+    pub qos: Option<MqttQos>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MqttQos {
+    AtMostOnce,
+    AtLeastOnce,
+    ExactlyOnce,
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // OffsetInterval

--- a/src/domain/opendatafabric/src/serde/flatbuffers/proxies_generated.rs
+++ b/src/domain/opendatafabric/src/serde/flatbuffers/proxies_generated.rs
@@ -719,6 +719,103 @@ pub struct SourceCachingUnionTableOffset {}
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
+pub const ENUM_MIN_MQTT_QOS: i32 = 0;
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+pub const ENUM_MAX_MQTT_QOS: i32 = 2;
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_MQTT_QOS: [MqttQos; 3] = [
+    MqttQos::AtMostOnce,
+    MqttQos::AtLeastOnce,
+    MqttQos::ExactlyOnce,
+];
+
+////////////////////////////////////////////////////////////////////////////////
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct MqttQos(pub i32);
+#[allow(non_upper_case_globals)]
+impl MqttQos {
+    pub const AtMostOnce: Self = Self(0);
+    pub const AtLeastOnce: Self = Self(1);
+    pub const ExactlyOnce: Self = Self(2);
+
+    pub const ENUM_MIN: i32 = 0;
+    pub const ENUM_MAX: i32 = 2;
+    pub const ENUM_VALUES: &'static [Self] =
+        &[Self::AtMostOnce, Self::AtLeastOnce, Self::ExactlyOnce];
+    /// Returns the variant's name or "" if unknown.
+    pub fn variant_name(self) -> Option<&'static str> {
+        match self {
+            Self::AtMostOnce => Some("AtMostOnce"),
+            Self::AtLeastOnce => Some("AtLeastOnce"),
+            Self::ExactlyOnce => Some("ExactlyOnce"),
+            _ => None,
+        }
+    }
+}
+impl core::fmt::Debug for MqttQos {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if let Some(name) = self.variant_name() {
+            f.write_str(name)
+        } else {
+            f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+        }
+    }
+}
+impl<'a> flatbuffers::Follow<'a> for MqttQos {
+    type Inner = Self;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        let b = flatbuffers::read_scalar_at::<i32>(buf, loc);
+        Self(b)
+    }
+}
+
+impl flatbuffers::Push for MqttQos {
+    type Output = MqttQos;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        flatbuffers::emplace_scalar::<i32>(dst, self.0);
+    }
+}
+
+impl flatbuffers::EndianScalar for MqttQos {
+    type Scalar = i32;
+    #[inline]
+    fn to_little_endian(self) -> i32 {
+        self.0.to_le()
+    }
+    #[inline]
+    #[allow(clippy::wrong_self_convention)]
+    fn from_little_endian(v: i32) -> Self {
+        let b = i32::from_le(v);
+        Self(b)
+    }
+}
+
+impl<'a> flatbuffers::Verifiable for MqttQos {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        i32::run_verifier(v, pos)
+    }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for MqttQos {}
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MIN_SOURCE_ORDERING: i32 = 0;
 #[deprecated(
     since = "2.0.0",
@@ -814,17 +911,18 @@ pub const ENUM_MIN_FETCH_STEP: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_FETCH_STEP: u8 = 3;
+pub const ENUM_MAX_FETCH_STEP: u8 = 4;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_FETCH_STEP: [FetchStep; 4] = [
+pub const ENUM_VALUES_FETCH_STEP: [FetchStep; 5] = [
     FetchStep::NONE,
     FetchStep::FetchStepUrl,
     FetchStep::FetchStepFilesGlob,
     FetchStep::FetchStepContainer,
+    FetchStep::FetchStepMqtt,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -836,14 +934,16 @@ impl FetchStep {
     pub const FetchStepUrl: Self = Self(1);
     pub const FetchStepFilesGlob: Self = Self(2);
     pub const FetchStepContainer: Self = Self(3);
+    pub const FetchStepMqtt: Self = Self(4);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 3;
+    pub const ENUM_MAX: u8 = 4;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::FetchStepUrl,
         Self::FetchStepFilesGlob,
         Self::FetchStepContainer,
+        Self::FetchStepMqtt,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -852,6 +952,7 @@ impl FetchStep {
             Self::FetchStepUrl => Some("FetchStepUrl"),
             Self::FetchStepFilesGlob => Some("FetchStepFilesGlob"),
             Self::FetchStepContainer => Some("FetchStepContainer"),
+            Self::FetchStepMqtt => Some("FetchStepMqtt"),
             _ => None,
         }
     }
@@ -6737,6 +6838,136 @@ impl core::fmt::Debug for EnvVar<'_> {
         ds.finish()
     }
 }
+pub enum MqttTopicSubscriptionOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct MqttTopicSubscription<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for MqttTopicSubscription<'a> {
+    type Inner = MqttTopicSubscription<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> MqttTopicSubscription<'a> {
+    pub const VT_PATH: flatbuffers::VOffsetT = 4;
+    pub const VT_QOS: flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        MqttTopicSubscription { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args MqttTopicSubscriptionArgs<'args>,
+    ) -> flatbuffers::WIPOffset<MqttTopicSubscription<'bldr>> {
+        let mut builder = MqttTopicSubscriptionBuilder::new(_fbb);
+        if let Some(x) = args.qos {
+            builder.add_qos(x);
+        }
+        if let Some(x) = args.path {
+            builder.add_path(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn path(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(MqttTopicSubscription::VT_PATH, None)
+        }
+    }
+    #[inline]
+    pub fn qos(&self) -> Option<MqttQos> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<MqttQos>(MqttTopicSubscription::VT_QOS, None)
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for MqttTopicSubscription<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("path", Self::VT_PATH, false)?
+            .visit_field::<MqttQos>("qos", Self::VT_QOS, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct MqttTopicSubscriptionArgs<'a> {
+    pub path: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub qos: Option<MqttQos>,
+}
+impl<'a> Default for MqttTopicSubscriptionArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        MqttTopicSubscriptionArgs {
+            path: None,
+            qos: None,
+        }
+    }
+}
+
+pub struct MqttTopicSubscriptionBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> MqttTopicSubscriptionBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_path(&mut self, path: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(MqttTopicSubscription::VT_PATH, path);
+    }
+    #[inline]
+    pub fn add_qos(&mut self, qos: MqttQos) {
+        self.fbb_
+            .push_slot_always::<MqttQos>(MqttTopicSubscription::VT_QOS, qos);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> MqttTopicSubscriptionBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        MqttTopicSubscriptionBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<MqttTopicSubscription<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for MqttTopicSubscription<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("MqttTopicSubscription");
+        ds.field("path", &self.path());
+        ds.field("qos", &self.qos());
+        ds.finish()
+    }
+}
 pub enum FetchStepUrlOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -7680,6 +7911,224 @@ impl core::fmt::Debug for FetchStepContainer<'_> {
         ds.finish()
     }
 }
+pub enum FetchStepMqttOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct FetchStepMqtt<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for FetchStepMqtt<'a> {
+    type Inner = FetchStepMqtt<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> FetchStepMqtt<'a> {
+    pub const VT_HOST: flatbuffers::VOffsetT = 4;
+    pub const VT_PORT: flatbuffers::VOffsetT = 6;
+    pub const VT_USERNAME: flatbuffers::VOffsetT = 8;
+    pub const VT_PASSWORD: flatbuffers::VOffsetT = 10;
+    pub const VT_TOPICS: flatbuffers::VOffsetT = 12;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        FetchStepMqtt { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args FetchStepMqttArgs<'args>,
+    ) -> flatbuffers::WIPOffset<FetchStepMqtt<'bldr>> {
+        let mut builder = FetchStepMqttBuilder::new(_fbb);
+        if let Some(x) = args.topics {
+            builder.add_topics(x);
+        }
+        if let Some(x) = args.password {
+            builder.add_password(x);
+        }
+        if let Some(x) = args.username {
+            builder.add_username(x);
+        }
+        builder.add_port(args.port);
+        if let Some(x) = args.host {
+            builder.add_host(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn host(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(FetchStepMqtt::VT_HOST, None)
+        }
+    }
+    #[inline]
+    pub fn port(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(FetchStepMqtt::VT_PORT, Some(0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn username(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(FetchStepMqtt::VT_USERNAME, None)
+        }
+    }
+    #[inline]
+    pub fn password(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(FetchStepMqtt::VT_PASSWORD, None)
+        }
+    }
+    #[inline]
+    pub fn topics(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<MqttTopicSubscription<'a>>>>
+    {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab.get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<MqttTopicSubscription>>,
+            >>(FetchStepMqtt::VT_TOPICS, None)
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for FetchStepMqtt<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("host", Self::VT_HOST, false)?
+            .visit_field::<i32>("port", Self::VT_PORT, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "username",
+                Self::VT_USERNAME,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "password",
+                Self::VT_PASSWORD,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<MqttTopicSubscription>>,
+            >>("topics", Self::VT_TOPICS, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct FetchStepMqttArgs<'a> {
+    pub host: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub port: i32,
+    pub username: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub password: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub topics: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<MqttTopicSubscription<'a>>>,
+        >,
+    >,
+}
+impl<'a> Default for FetchStepMqttArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        FetchStepMqttArgs {
+            host: None,
+            port: 0,
+            username: None,
+            password: None,
+            topics: None,
+        }
+    }
+}
+
+pub struct FetchStepMqttBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> FetchStepMqttBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_host(&mut self, host: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(FetchStepMqtt::VT_HOST, host);
+    }
+    #[inline]
+    pub fn add_port(&mut self, port: i32) {
+        self.fbb_.push_slot::<i32>(FetchStepMqtt::VT_PORT, port, 0);
+    }
+    #[inline]
+    pub fn add_username(&mut self, username: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(FetchStepMqtt::VT_USERNAME, username);
+    }
+    #[inline]
+    pub fn add_password(&mut self, password: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(FetchStepMqtt::VT_PASSWORD, password);
+    }
+    #[inline]
+    pub fn add_topics(
+        &mut self,
+        topics: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<MqttTopicSubscription<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(FetchStepMqtt::VT_TOPICS, topics);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> FetchStepMqttBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        FetchStepMqttBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<FetchStepMqtt<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for FetchStepMqtt<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("FetchStepMqtt");
+        ds.field("host", &self.host());
+        ds.field("port", &self.port());
+        ds.field("username", &self.username());
+        ds.field("password", &self.password());
+        ds.field("topics", &self.topics());
+        ds.finish()
+    }
+}
 pub enum PrepStepDecompressOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -8355,6 +8804,21 @@ impl<'a> SetPollingSource<'a> {
 
     #[inline]
     #[allow(non_snake_case)]
+    pub fn fetch_as_fetch_step_mqtt(&self) -> Option<FetchStepMqtt<'a>> {
+        if self.fetch_type() == FetchStep::FetchStepMqtt {
+            self.fetch().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { FetchStepMqtt::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
     pub fn read_as_read_step_csv(&self) -> Option<ReadStepCsv<'a>> {
         if self.read_type() == ReadStep::ReadStepCsv {
             self.read().map(|t| {
@@ -8532,6 +8996,7 @@ impl flatbuffers::Verifiable for SetPollingSource<'_> {
           FetchStep::FetchStepUrl => v.verify_union_variant::<flatbuffers::ForwardsUOffset<FetchStepUrl>>("FetchStep::FetchStepUrl", pos),
           FetchStep::FetchStepFilesGlob => v.verify_union_variant::<flatbuffers::ForwardsUOffset<FetchStepFilesGlob>>("FetchStep::FetchStepFilesGlob", pos),
           FetchStep::FetchStepContainer => v.verify_union_variant::<flatbuffers::ForwardsUOffset<FetchStepContainer>>("FetchStep::FetchStepContainer", pos),
+          FetchStep::FetchStepMqtt => v.verify_union_variant::<flatbuffers::ForwardsUOffset<FetchStepMqtt>>("FetchStep::FetchStepMqtt", pos),
           _ => Ok(()),
         }
      })?
@@ -8711,6 +9176,16 @@ impl core::fmt::Debug for SetPollingSource<'_> {
             }
             FetchStep::FetchStepContainer => {
                 if let Some(x) = self.fetch_as_fetch_step_container() {
+                    ds.field("fetch", &x)
+                } else {
+                    ds.field(
+                        "fetch",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            FetchStep::FetchStepMqtt => {
+                if let Some(x) = self.fetch_as_fetch_step_mqtt() {
                     ds.field("fetch", &x)
                 } else {
                     ds.field(

--- a/src/domain/opendatafabric/src/serde/yaml/derivations_generated.rs
+++ b/src/domain/opendatafabric/src/serde/yaml/derivations_generated.rs
@@ -431,6 +431,8 @@ pub enum FetchStepDef {
     FilesGlob(#[serde_as(as = "FetchStepFilesGlobDef")] FetchStepFilesGlob),
     #[serde(alias = "container")]
     Container(#[serde_as(as = "FetchStepContainerDef")] FetchStepContainer),
+    #[serde(alias = "mqtt")]
+    Mqtt(#[serde_as(as = "FetchStepMqttDef")] FetchStepMqtt),
 }
 
 implement_serde_as!(FetchStep, FetchStepDef, "FetchStepDef");
@@ -445,6 +447,7 @@ implement_serde_as!(
     FetchStepContainerDef,
     "FetchStepContainerDef"
 );
+implement_serde_as!(FetchStepMqtt, FetchStepMqttDef, "FetchStepMqttDef");
 
 #[serde_as]
 #[skip_serializing_none]
@@ -494,6 +497,20 @@ pub struct FetchStepContainerDef {
     #[serde_as(as = "Option<Vec<EnvVarDef>>")]
     #[serde(default)]
     pub env: Option<Vec<EnvVar>>,
+}
+
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(remote = "FetchStepMqtt")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct FetchStepMqttDef {
+    pub host: String,
+    pub port: i32,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    #[serde_as(as = "Vec<MqttTopicSubscriptionDef>")]
+    pub topics: Vec<MqttTopicSubscription>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -629,6 +646,43 @@ pub enum MetadataEventDef {
 }
 
 implement_serde_as!(MetadataEvent, MetadataEventDef, "MetadataEventDef");
+
+////////////////////////////////////////////////////////////////////////////////
+// MqttTopicSubscription
+// https://github.com/kamu-data/open-data-fabric/blob/master/open-data-fabric.md#mqtttopicsubscription-schema
+////////////////////////////////////////////////////////////////////////////////
+
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(remote = "MqttTopicSubscription")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct MqttTopicSubscriptionDef {
+    pub path: String,
+    #[serde_as(as = "Option<MqttQosDef>")]
+    #[serde(default)]
+    pub qos: Option<MqttQos>,
+}
+
+implement_serde_as!(
+    MqttTopicSubscription,
+    MqttTopicSubscriptionDef,
+    "MqttTopicSubscriptionDef"
+);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(remote = "MqttQos")]
+#[serde(deny_unknown_fields)]
+pub enum MqttQosDef {
+    #[serde(alias = "atMostOnce", alias = "atmostonce")]
+    AtMostOnce,
+    #[serde(alias = "atLeastOnce", alias = "atleastonce")]
+    AtLeastOnce,
+    #[serde(alias = "exactlyOnce", alias = "exactlyonce")]
+    ExactlyOnce,
+}
+
+implement_serde_as!(MqttQos, MqttQosDef, "MqttQosDef");
 
 ////////////////////////////////////////////////////////////////////////////////
 // OffsetInterval

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -50,11 +50,22 @@ serde_yaml = "0.9"
 # Ingest
 # TODO: Using curl brings a lot of overhead including compiling and linking openssl
 # We should replace it with reqwest + a separate FTP client or drop FTP support in favor of container-based ingest.
-curl = { optional = true, version = "0.4", features = ["protocol-ftp", "static-curl", "static-ssl"] }
+curl = { optional = true, version = "0.4", features = [
+    "protocol-ftp",
+    "static-curl",
+    "static-ssl",
+] }
 curl-sys = { optional = true, version = "0.4" }
-flate2 = "1"  # GZip decoder
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "deflate"] }
+flate2 = "1" # GZip decoder
+reqwest = { version = "0.11", default-features = false, features = [
+    "rustls-tls",
+    "stream",
+    "gzip",
+    "brotli",
+    "deflate",
+] }
 ringbuf = "0.3"
+rumqttc = { version = "0.23" }
 zip = "0.6"
 
 # Data
@@ -69,7 +80,7 @@ aws-sdk-s3 = { version = "0.35" }
 aws-smithy-http = { version = "0.57", features = ["rt-tokio"] }
 aws-smithy-types = { version = "0.57" }
 aws-credential-types = { version = "0.57" }
-trust-dns-resolver = "0.23"  # TODO: Needed for DNSLink resolution with IPFS
+trust-dns-resolver = "0.23"                                     # TODO: Needed for DNSLink resolution with IPFS
 http = "0.2"
 
 # Utils
@@ -77,15 +88,15 @@ async-recursion = "1"
 async-stream = "0.3"
 async-trait = "0.1"
 bytes = "1"
-cfg-if = "1"  # Conditional compilation
+cfg-if = "1" # Conditional compilation
 chrono = { version = "0.4", features = ["serde"] }
 dashmap = "5"
 dill = "0.8"
 futures = "0.3"
-glob = "0.3"  # Used for glob fetch
+glob = "0.3" # Used for glob fetch
 hyper = "0.14"
 itertools = "0.11"
-libc = "0.2"  # Signal names
+libc = "0.2" # Signal names
 like = { version = "0.3", default-features = false }
 mockall = "0.11"
 pin-project = "1"
@@ -94,9 +105,16 @@ rand = "0.8"
 regex = "1"
 tempfile = "3"
 thiserror = { version = "1", default-features = false }
-tokio = { version = "1", default-features = false, features = ["fs", "process"] }
+tokio = { version = "1", default-features = false, features = [
+    "fs",
+    "process",
+] }
 tokio-stream = "0.1"
-tokio-util = { version = "0.7", default-features = false, features = ["codec", "compat", "io"] }
+tokio-util = { version = "0.7", default-features = false, features = [
+    "codec",
+    "compat",
+    "io",
+] }
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }
 walkdir = "2"
@@ -107,7 +125,7 @@ tower-http = { version = "0.4", features = ["fs", "trace"] }
 axum = "0.6"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"  # For getting uid:gid
+libc = "0.2" # For getting uid:gid
 
 
 [dev-dependencies]
@@ -115,7 +133,6 @@ criterion = { version = "0.5", features = ["async_tokio"] }
 filetime = "0.2"
 indoc = "2"
 tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
-
 test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/infra/core/src/utils/docker_images.rs
+++ b/src/infra/core/src/utils/docker_images.rs
@@ -18,6 +18,7 @@ pub const JUPYTER: &str = "ghcr.io/kamu-data/jupyter:0.6.1";
 // Test Images
 pub const HTTPD: &str = "docker.io/httpd:2.4";
 pub const MINIO: &str = "docker.io/minio/minio:RELEASE.2021-08-31T05-46-54Z";
+pub const RUMQTTD: &str = "docker.io/bytebeamio/rumqttd:0.19.0";
 pub const BUSYBOX: &str = "docker.io/busybox:latest";
 
 #[cfg(feature = "ftp")]

--- a/src/infra/core/tests/tests/test_setup.rs
+++ b/src/infra/core/tests/tests/test_setup.rs
@@ -44,6 +44,10 @@ async fn test_setup_pull_images() {
         .ensure_image(docker_images::MINIO, None)
         .await
         .unwrap();
+    container_runtime
+        .ensure_image(docker_images::RUMQTTD, None)
+        .await
+        .unwrap();
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "ftp")] {

--- a/src/infra/core/tests/utils/mod.rs
+++ b/src/infra/core/tests/utils/mod.rs
@@ -9,13 +9,14 @@
 
 #[cfg(feature = "ftp")]
 mod ftp_server;
-#[cfg(feature = "ftp")]
-pub use ftp_server::*;
-
 mod http_server;
-pub use http_server::*;
-
 mod ipfs_daemon;
-pub use ipfs_daemon::*;
+mod mqtt_broker;
 
 pub mod mock_engine_provisioner;
+
+#[cfg(feature = "ftp")]
+pub use ftp_server::*;
+pub use http_server::*;
+pub use ipfs_daemon::*;
+pub use mqtt_broker::*;


### PR DESCRIPTION
## Description

Relates to: #368 

This PR allows to define a dataset like this:
```yaml
kind: DatasetSnapshot
version: 1
content:
  name: temp
  kind: Root
  metadata:
    - kind: SetPollingSource
      fetch:
        kind: mqtt
        host: test.mosquitto.org
        port: 1883
        topics:
          - path: dev.kamu.example.mqtt.temp
            qos: AtMostOnce
      read:
        kind: NdJson
        ...
```
In this case `kamu-cli` will act as an MQTT **client**, subscribing to some topic(s).

Upon `kamu pull` it will connect to the MQTT broker and either:
- get nothing and exit after some configurable timeout
- get "retained" MQTT event - e.g. last temperature measurement that broker stores and sends upon subscription
- get a history of events it missed if MQTT QoS level is == `AtLeastOnce` or `ExactlyOnce` which makes broker buffer events for some time when subscriber is offline (the behavior is highly broker-specific)

Technical debt:
- MQTT breaks polling/push source separation as it's neither - related to https://github.com/kamu-data/kamu-node/issues/57 we will likely replace these metadata events with standalone `Source` manifest
- MQTT client will auto-acknowledge the events, so if ingest fails later those events will be lost - I will convert to manual ACKs in later PR
- Server / always listening mode for MQTT will be in a separate PR
- Making `kamu-node` into an MQTT broker can be done later if needed - for now it will act as a client, so user has to have their own broker and it needs to be accessible to kamu

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ❗
    - Relies on extended ODF schemas: https://github.com/open-data-fabric/open-data-fabric/pull/88 but change is backwards-compatible
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ❗
    - Added test dependency for `rumqttd` docker image, but it's very tiny and shouldn't impact builds
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
    - Documentation is part of the epic and will be done later
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌
    - More work is needed to add server mode