### PR TITLE
Extend compacting config with recursive flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Added support of `--all` flag to the `kamu delete` command
 - Made recursive deletion dataset with provided `%` pattern
+### Changed
+- `HardCompacting` configuration now is one of `Full` or `KeepMetadataOnly` variants. In case of 
+  `KeepMetadataOnly` variant required to provide `recursive` value which will trigger downstream
+  dependecnies compacting
 
 ## [0.182.0] - 2024-05-20
 ### Added

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -189,10 +189,27 @@ type CommitResultSuccess implements CommitResult & UpdateReadmeResult {
 	message: String!
 }
 
-input CompactingConditionInput {
+input CompactingConditionFull {
 	maxSliceSize: Int!
 	maxSliceRecords: Int!
-	keepMetadataOnly: Boolean!
+}
+
+input CompactingConditionInput @oneOf {
+	full: CompactingConditionFull
+	metadataOnly: CompactingConditionMetadataOnly
+}
+
+input CompactingConditionMetadataOnly {
+	recursive: Boolean!
+}
+
+type CompactingFull {
+	maxSliceSize: Int!
+	maxSliceRecords: Int!
+}
+
+type CompactingMetadataOnly {
+	recursive: Boolean!
 }
 
 enum CompressionFormat {
@@ -796,10 +813,10 @@ type FlowConfigurationBatching {
 	maxBatchingInterval: TimeDelta!
 }
 
-type FlowConfigurationCompacting {
-	maxSliceSize: Int!
-	maxSliceRecords: Int!
-	keepMetadataOnly: Boolean!
+union FlowConfigurationCompacting = CompactingFull | CompactingMetadataOnly
+
+type FlowConfigurationCompactingRule {
+	compactingRule: FlowConfigurationCompacting!
 }
 
 union FlowConfigurationSchedule = TimeDelta | Cron5ComponentExpression
@@ -808,7 +825,7 @@ type FlowConfigurationScheduleRule {
 	scheduleRule: FlowConfigurationSchedule!
 }
 
-union FlowConfigurationSnapshot = FlowConfigurationBatching | FlowConfigurationScheduleRule | FlowConfigurationCompacting
+union FlowConfigurationSnapshot = FlowConfigurationBatching | FlowConfigurationScheduleRule | FlowConfigurationCompactingRule
 
 type FlowConnection {
 	"""

--- a/src/adapter/graphql/src/queries/flows/flow_config_snapshot.rs
+++ b/src/adapter/graphql/src/queries/flows/flow_config_snapshot.rs
@@ -17,12 +17,17 @@ use crate::prelude::*;
 pub enum FlowConfigurationSnapshot {
     Batching(FlowConfigurationBatching),
     Schedule(FlowConfigurationScheduleRule),
-    Compacting(FlowConfigurationCompacting),
+    Compacting(FlowConfigurationCompactingRule),
 }
 
 #[derive(SimpleObject)]
 pub struct FlowConfigurationScheduleRule {
     schedule_rule: FlowConfigurationSchedule,
+}
+
+#[derive(SimpleObject)]
+pub struct FlowConfigurationCompactingRule {
+    compacting_rule: FlowConfigurationCompacting,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -46,7 +51,18 @@ impl From<fs::FlowConfigurationSnapshot> for FlowConfigurationSnapshot {
                 })
             }
             fs::FlowConfigurationSnapshot::Compacting(compacting_rule) => {
-                Self::Compacting(compacting_rule.into())
+                Self::Compacting(FlowConfigurationCompactingRule {
+                    compacting_rule: match compacting_rule {
+                        fs::CompactingRule::Full(compacting_full_rule) => {
+                            FlowConfigurationCompacting::Full(compacting_full_rule.into())
+                        }
+                        fs::CompactingRule::MetadataOnly(compacting_metadata_only_rule) => {
+                            FlowConfigurationCompacting::MetadataOnly(
+                                compacting_metadata_only_rule.into(),
+                            )
+                        }
+                    },
+                })
             }
         }
     }

--- a/src/domain/flow-system/services/src/flow/flow_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow/flow_service_impl.rs
@@ -871,7 +871,7 @@ impl FlowServiceImpl {
                 }
             }
 
-            _ => {}
+            DownstreamDependencyTriggerType::Empty => {}
         }
 
         Ok(plans)


### PR DESCRIPTION
## Description

Closes: https://github.com/kamu-data/kamu-cli/issues/643

<!--- Describe your changes in detail and include your changelog entries -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅