### PR TITLE
Add reset derivative flag to pull command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- New `--reset-derivatives-on-diverged-input` flag to `kamu pull` command, which will trigger
+  compaction for derived dataset if transformation fails due to root dataset compaction and retry transformation
+
+## [0.184.0] - 2024-05-28
 ### Changed
 - `InitiatorFilterInput` now accept `[AccountID]` instead of `AccountName`
   `AccountFlowFilters` now filter by `DatasetId` instead of `DatasetName`.

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -638,6 +638,7 @@ Pull new data into the datasets
 * `--no-alias` — Don't automatically add a remote push alias for this destination
 * `--set-watermark <TIME>` — Injects a manual watermark into the dataset to signify that no data is expected to arrive with event time that precedes it
 * `-f`, `--force` — Overwrite local version with remote, even if revisions have diverged
+* `--reset-derivatives-on-fail` — Run hard compacting of derivative dataset if transformation failed
 
 Pull is a multi-functional command that lets you update a local dataset. Depending on the parameters and the types of datasets involved it can be used to:
 - Run polling ingest to pull data into a root dataset from an external source

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -638,7 +638,7 @@ Pull new data into the datasets
 * `--no-alias` — Don't automatically add a remote push alias for this destination
 * `--set-watermark <TIME>` — Injects a manual watermark into the dataset to signify that no data is expected to arrive with event time that precedes it
 * `-f`, `--force` — Overwrite local version with remote, even if revisions have diverged
-* `--reset-derivatives-on-diverged-input` — Run hard compacting of derivative dataset if transformation failed
+* `--reset-derivatives-on-diverged-input` — Run hard compacting of derivative dataset if transformation failed due to root dataset compaction
 
 Pull is a multi-functional command that lets you update a local dataset. Depending on the parameters and the types of datasets involved it can be used to:
 - Run polling ingest to pull data into a root dataset from an external source

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -638,7 +638,7 @@ Pull new data into the datasets
 * `--no-alias` — Don't automatically add a remote push alias for this destination
 * `--set-watermark <TIME>` — Injects a manual watermark into the dataset to signify that no data is expected to arrive with event time that precedes it
 * `-f`, `--force` — Overwrite local version with remote, even if revisions have diverged
-* `--reset-derivatives-on-fail` — Run hard compacting of derivative dataset if transformation failed
+* `--reset-derivatives-on-diverged-input` — Run hard compacting of derivative dataset if transformation failed
 
 Pull is a multi-functional command that lets you update a local dataset. Depending on the parameters and the types of datasets involved it can be used to:
 - Run polling ingest to pull data into a root dataset from an external source

--- a/src/adapter/http/tests/harness/client_side_harness.rs
+++ b/src/adapter/http/tests/harness/client_side_harness.rs
@@ -115,9 +115,6 @@ impl ClientSideHarness {
 
         b.add::<TransformServiceImpl>();
 
-        b.add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir))
-            .bind::<dyn CompactingService, CompactingServiceImpl>();
-
         b.add::<PullServiceImpl>();
 
         b.add::<PushServiceImpl>();

--- a/src/adapter/http/tests/harness/client_side_harness.rs
+++ b/src/adapter/http/tests/harness/client_side_harness.rs
@@ -115,6 +115,9 @@ impl ClientSideHarness {
 
         b.add::<TransformServiceImpl>();
 
+        b.add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir))
+            .bind::<dyn CompactingService, CompactingServiceImpl>();
+
         b.add::<PullServiceImpl>();
 
         b.add::<PushServiceImpl>();

--- a/src/adapter/http/tests/harness/client_side_harness.rs
+++ b/src/adapter/http/tests/harness/client_side_harness.rs
@@ -102,7 +102,7 @@ impl ClientSideHarness {
 
         b.add_builder(
             PollingIngestServiceImpl::builder()
-                .with_run_info_dir(run_info_dir)
+                .with_run_info_dir(run_info_dir.clone())
                 .with_cache_dir(cache_dir),
         )
         .bind::<dyn PollingIngestService, PollingIngestServiceImpl>();
@@ -114,6 +114,9 @@ impl ClientSideHarness {
         b.add::<SyncServiceImpl>();
 
         b.add::<TransformServiceImpl>();
+
+        b.add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir))
+            .bind::<dyn CompactingService, CompactingServiceImpl>();
 
         b.add::<PullServiceImpl>();
 

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -303,7 +303,7 @@ pub fn get_command(
                     submatches.get_one("as").cloned(),
                     !submatches.get_flag("no-alias"),
                     submatches.get_flag("force"),
-                    submatches.get_flag("reset-derivatives-on-fail"),
+                    submatches.get_flag("reset-derivatives-on-diverged-input"),
                 ))
             }
         }

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -303,6 +303,7 @@ pub fn get_command(
                     submatches.get_one("as").cloned(),
                     !submatches.get_flag("no-alias"),
                     submatches.get_flag("force"),
+                    submatches.get_flag("reset-derivatives-on-fail"),
                 ))
             }
         }

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -774,6 +774,10 @@ pub fn cli() -> Command {
                             .long("force")
                             .action(ArgAction::SetTrue)
                             .help("Overwrite local version with remote, even if revisions have diverged"),
+                        Arg::new("reset-derivatives-on-fail")
+                            .long("reset-derivatives-on-fail")
+                            .action(ArgAction::SetTrue)
+                            .help("Run hard compacting of derivative dataset if transformation failed"),
                     ])
                     .after_help(indoc::indoc!(
                         r#"

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -777,7 +777,7 @@ pub fn cli() -> Command {
                         Arg::new("reset-derivatives-on-diverged-input")
                             .long("reset-derivatives-on-diverged-input")
                             .action(ArgAction::SetTrue)
-                            .help("Run hard compacting of derivative dataset if transformation failed"),
+                            .help("Run hard compacting of derivative dataset if transformation failed due to root dataset compaction"),
                     ])
                     .after_help(indoc::indoc!(
                         r#"

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -774,8 +774,8 @@ pub fn cli() -> Command {
                             .long("force")
                             .action(ArgAction::SetTrue)
                             .help("Overwrite local version with remote, even if revisions have diverged"),
-                        Arg::new("reset-derivatives-on-fail")
-                            .long("reset-derivatives-on-fail")
+                        Arg::new("reset-derivatives-on-diverged-input")
+                            .long("reset-derivatives-on-diverged-input")
                             .action(ArgAction::SetTrue)
                             .help("Run hard compacting of derivative dataset if transformation failed"),
                     ])

--- a/src/app/cli/src/commands/compact_command.rs
+++ b/src/app/cli/src/commands/compact_command.rs
@@ -150,7 +150,10 @@ impl Command for CompactCommand {
             Ok(())
         } else {
             Err(BatchError::new(
-                format!("Failed to compact {} dataset(s)", errors.len()),
+                format!(
+                    "Failed to compact {}/{total_results} dataset(s)",
+                    errors.len()
+                ),
                 errors,
             )
             .into())

--- a/src/app/cli/src/commands/compact_command.rs
+++ b/src/app/cli/src/commands/compact_command.rs
@@ -19,7 +19,7 @@ use kamu::domain::{
 };
 use opendatafabric::{DatasetHandle, DatasetRef};
 
-use crate::{CLIError, Command, CompactingMultiProgress, VerificationMultiProgress};
+use crate::{BatchError, CLIError, Command, CompactingMultiProgress, VerificationMultiProgress};
 
 pub struct CompactCommand {
     dataset_repo: Arc<dyn DatasetRepository>,
@@ -114,9 +114,10 @@ impl Command for CompactCommand {
             progress.draw();
         });
 
-        self.compacting_svc
-            .compact_dataset(
-                &dataset_handle,
+        let compacting_results = self
+            .compacting_svc
+            .compact_multi(
+                vec![dataset_handle.as_local_ref()],
                 CompactingOptions {
                     max_slice_size: Some(self.max_slice_size),
                     max_slice_records: Some(self.max_slice_records),
@@ -124,12 +125,35 @@ impl Command for CompactCommand {
                 },
                 Some(listener.clone()),
             )
-            .await
-            .map_err(CLIError::failure)?;
+            .await;
+
+        let total_results = compacting_results.len();
 
         listener.finish();
         draw_thread.join().unwrap();
 
-        Ok(())
+        let errors: Vec<_> = compacting_results
+            .into_iter()
+            .filter_map(|response| match response.result {
+                Ok(_) => None,
+                Err(e) => Some((e, format!("Failed to compact {}", response.dataset_ref))),
+            })
+            .collect();
+
+        if errors.is_empty() {
+            eprintln!(
+                "{}",
+                console::style(format!("{total_results} dataset(s) were compacted"))
+                    .green()
+                    .bold()
+            );
+            Ok(())
+        } else {
+            Err(BatchError::new(
+                format!("Failed to compact {} dataset(s)", errors.len()),
+                errors,
+            )
+            .into())
+        }
     }
 }

--- a/src/domain/core/src/services/compacting_service.rs
+++ b/src/domain/core/src/services/compacting_service.rs
@@ -24,8 +24,15 @@ pub trait CompactingService: Send + Sync {
         &self,
         dataset_handle: &DatasetHandle,
         options: CompactingOptions,
-        listener: Option<Arc<dyn CompactingMultiListener>>,
+        listener: Option<Arc<dyn CompactingListener>>,
     ) -> Result<CompactingResult, CompactingError>;
+
+    async fn compact_multi(
+        &self,
+        dataset_refs: Vec<DatasetRef>,
+        options: CompactingOptions,
+        listener: Option<Arc<dyn CompactingMultiListener>>,
+    ) -> Vec<CompactingResponse>;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -157,6 +164,12 @@ pub enum CompactingResult {
         old_num_blocks: usize,
         new_num_blocks: usize,
     },
+}
+
+#[derive(Debug)]
+pub struct CompactingResponse {
+    pub dataset_ref: DatasetRef,
+    pub result: Result<CompactingResult, CompactingError>,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/domain/core/src/services/pull_service.rs
+++ b/src/domain/core/src/services/pull_service.rs
@@ -107,12 +107,16 @@ pub struct PullOptions {
     pub ingest_options: PollingIngestOptions,
     /// Sync-specific options,
     pub sync_options: SyncOptions,
+    /// Run compacting of derivative dataset without saving data
+    /// if transformation failed
+    pub reset_derivatives: bool,
 }
 
 impl Default for PullOptions {
     fn default() -> Self {
         Self {
             add_aliases: true,
+            reset_derivatives: false,
             ingest_options: PollingIngestOptions::default(),
             sync_options: SyncOptions::default(),
         }
@@ -132,6 +136,9 @@ pub struct PullMultiOptions {
     pub ingest_options: PollingIngestOptions,
     /// Sync-specific options,
     pub sync_options: SyncOptions,
+    /// Run compacting of all derivative datasets without saving data
+    /// if transformation fails
+    pub reset_derivatives: bool,
 }
 
 impl Default for PullMultiOptions {
@@ -142,6 +149,7 @@ impl Default for PullMultiOptions {
             add_aliases: true,
             ingest_options: PollingIngestOptions::default(),
             sync_options: SyncOptions::default(),
+            reset_derivatives: false,
         }
     }
 }
@@ -152,12 +160,14 @@ pub trait PullListener: Send + Sync {
     fn get_ingest_listener(self: Arc<Self>) -> Option<Arc<dyn PollingIngestListener>>;
     fn get_transform_listener(self: Arc<Self>) -> Option<Arc<dyn TransformListener>>;
     fn get_sync_listener(self: Arc<Self>) -> Option<Arc<dyn SyncListener>>;
+    fn get_compacting_listener(self: Arc<Self>) -> Option<Arc<dyn CompactingListener>>;
 }
 
 pub trait PullMultiListener: Send + Sync {
     fn get_ingest_listener(self: Arc<Self>) -> Option<Arc<dyn PollingIngestMultiListener>>;
     fn get_transform_listener(self: Arc<Self>) -> Option<Arc<dyn TransformMultiListener>>;
     fn get_sync_listener(self: Arc<Self>) -> Option<Arc<dyn SyncMultiListener>>;
+    fn get_compacting_listener(self: Arc<Self>) -> Option<Arc<dyn CompactingMultiListener>>;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/domain/core/src/services/pull_service.rs
+++ b/src/domain/core/src/services/pull_service.rs
@@ -108,15 +108,15 @@ pub struct PullOptions {
     /// Sync-specific options,
     pub sync_options: SyncOptions,
     /// Run compacting of derivative dataset without saving data
-    /// if transformation failed
-    pub reset_derivatives: bool,
+    /// if transformation failed due to root dataset compaction
+    pub reset_derivatives_on_diverged_input: bool,
 }
 
 impl Default for PullOptions {
     fn default() -> Self {
         Self {
             add_aliases: true,
-            reset_derivatives: false,
+            reset_derivatives_on_diverged_input: false,
             ingest_options: PollingIngestOptions::default(),
             sync_options: SyncOptions::default(),
         }
@@ -137,8 +137,8 @@ pub struct PullMultiOptions {
     /// Sync-specific options,
     pub sync_options: SyncOptions,
     /// Run compacting of all derivative datasets without saving data
-    /// if transformation fails
-    pub reset_derivatives: bool,
+    /// if transformation fails due to root dataset compaction
+    pub reset_derivatives_on_diverged_input: bool,
 }
 
 impl Default for PullMultiOptions {
@@ -149,7 +149,7 @@ impl Default for PullMultiOptions {
             add_aliases: true,
             ingest_options: PollingIngestOptions::default(),
             sync_options: SyncOptions::default(),
-            reset_derivatives: false,
+            reset_derivatives_on_diverged_input: false,
         }
     }
 }
@@ -160,14 +160,12 @@ pub trait PullListener: Send + Sync {
     fn get_ingest_listener(self: Arc<Self>) -> Option<Arc<dyn PollingIngestListener>>;
     fn get_transform_listener(self: Arc<Self>) -> Option<Arc<dyn TransformListener>>;
     fn get_sync_listener(self: Arc<Self>) -> Option<Arc<dyn SyncListener>>;
-    fn get_compacting_listener(self: Arc<Self>) -> Option<Arc<dyn CompactingListener>>;
 }
 
 pub trait PullMultiListener: Send + Sync {
     fn get_ingest_listener(self: Arc<Self>) -> Option<Arc<dyn PollingIngestMultiListener>>;
     fn get_transform_listener(self: Arc<Self>) -> Option<Arc<dyn TransformMultiListener>>;
     fn get_sync_listener(self: Arc<Self>) -> Option<Arc<dyn SyncMultiListener>>;
-    fn get_compacting_listener(self: Arc<Self>) -> Option<Arc<dyn CompactingMultiListener>>;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/domain/core/src/services/transform_service.rs
+++ b/src/domain/core/src/services/transform_service.rs
@@ -62,7 +62,7 @@ pub enum TransformResult {
     },
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TransformOptions {
     /// Run compacting of derivative datasets without saving data
     /// if transformation fails due to root dataset compaction

--- a/src/domain/core/src/services/transform_service.rs
+++ b/src/domain/core/src/services/transform_service.rs
@@ -30,12 +30,14 @@ pub trait TransformService: Send + Sync {
     async fn transform(
         &self,
         dataset_ref: &DatasetRef,
+        transfrom_options: TransformOptions,
         listener: Option<Arc<dyn TransformListener>>,
     ) -> Result<TransformResult, TransformError>;
 
     async fn transform_multi(
         &self,
         dataset_refs: Vec<DatasetRef>,
+        transfrom_options: TransformOptions,
         listener: Option<Arc<dyn TransformMultiListener>>,
     ) -> Vec<(DatasetRef, Result<TransformResult, TransformError>)>;
 
@@ -58,6 +60,13 @@ pub enum TransformResult {
         old_head: Multihash,
         new_head: Multihash,
     },
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TransformOptions {
+    /// Run compacting of derivative datasets without saving data
+    /// if transformation fails due to root dataset compaction
+    pub reset_derivatives_on_diverged_input: bool,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/domain/core/src/services/transform_service.rs
+++ b/src/domain/core/src/services/transform_service.rs
@@ -133,6 +133,12 @@ pub enum TransformError {
         AccessError,
     ),
     #[error(transparent)]
+    InvalidInterval(
+        #[from]
+        #[backtrace]
+        InvalidIntervalError,
+    ),
+    #[error(transparent)]
     Internal(
         #[from]
         #[backtrace]

--- a/src/infra/core/src/compacting_service_impl.rs
+++ b/src/infra/core/src/compacting_service_impl.rs
@@ -34,6 +34,8 @@ use opendatafabric::{
     Checkpoint,
     DatasetHandle,
     DatasetKind,
+    DatasetRef,
+    DatasetRefPattern,
     DatasetVocabulary,
     MetadataEvent,
     Multihash,
@@ -44,6 +46,7 @@ use opendatafabric::{
 use random_names::get_random_name;
 use url::Url;
 
+use crate::utils::datasets_filtering::filter_datasets_by_local_pattern;
 use crate::*;
 
 pub struct CompactingServiceImpl {
@@ -461,7 +464,7 @@ impl CompactingService for CompactingServiceImpl {
         &self,
         dataset_handle: &DatasetHandle,
         options: CompactingOptions,
-        multi_listener: Option<Arc<dyn CompactingMultiListener>>,
+        maybe_listener: Option<Arc<dyn CompactingListener>>,
     ) -> Result<CompactingResult, CompactingError> {
         self.dataset_authorizer
             .check_action_allowed(dataset_handle, domain::auth::DatasetAction::Write)
@@ -486,9 +489,7 @@ impl CompactingService for CompactingServiceImpl {
             ));
         }
 
-        let listener = multi_listener
-            .and_then(|l| l.begin_compact(dataset_handle))
-            .unwrap_or(Arc::new(NullCompactingListener {}));
+        let listener = maybe_listener.unwrap_or(Arc::new(NullCompactingListener {}));
 
         let max_slice_size = options.max_slice_size.unwrap_or(DEFAULT_MAX_SLICE_SIZE);
         let max_slice_records = options
@@ -514,5 +515,43 @@ impl CompactingService for CompactingServiceImpl {
                 Err(err)
             }
         }
+    }
+
+    async fn compact_multi(
+        &self,
+        dataset_refs: Vec<DatasetRef>,
+        options: CompactingOptions,
+        multi_listener: Option<Arc<dyn CompactingMultiListener>>,
+    ) -> Vec<CompactingResponse> {
+        let dataset_handles: Vec<_> = match filter_datasets_by_local_pattern(
+            self.dataset_repo.as_ref(),
+            dataset_refs
+                .into_iter()
+                .map(DatasetRefPattern::Ref)
+                .collect(),
+        )
+        .try_collect()
+        .await
+        {
+            Ok(matched_datasets) => matched_datasets,
+            Err(_) => return vec![],
+        };
+
+        let listener = multi_listener.unwrap_or(Arc::new(NullCompactingMultiListener {}));
+
+        let mut result = vec![];
+        for dataset_handle in &dataset_handles {
+            result.push(CompactingResponse {
+                dataset_ref: dataset_handle.as_local_ref(),
+                result: self
+                    .compact_dataset(
+                        dataset_handle,
+                        options.clone(),
+                        listener.begin_compact(dataset_handle),
+                    )
+                    .await,
+            });
+        }
+        result
     }
 }

--- a/src/infra/core/src/pull_service_impl.rs
+++ b/src/infra/core/src/pull_service_impl.rs
@@ -25,7 +25,6 @@ pub struct PullServiceImpl {
     ingest_svc: Arc<dyn PollingIngestService>,
     transform_svc: Arc<dyn TransformService>,
     sync_svc: Arc<dyn SyncService>,
-    compacting_svc: Arc<dyn CompactingService>,
     system_time_source: Arc<dyn SystemTimeSource>,
     current_account_subject: Arc<CurrentAccountSubject>,
     dataset_action_authorizer: Arc<dyn auth::DatasetActionAuthorizer>,
@@ -40,7 +39,6 @@ impl PullServiceImpl {
         ingest_svc: Arc<dyn PollingIngestService>,
         transform_svc: Arc<dyn TransformService>,
         sync_svc: Arc<dyn SyncService>,
-        compacting_svc: Arc<dyn CompactingService>,
         system_time_source: Arc<dyn SystemTimeSource>,
         current_account_subject: Arc<CurrentAccountSubject>,
         dataset_action_authorizer: Arc<dyn auth::DatasetActionAuthorizer>,
@@ -51,7 +49,6 @@ impl PullServiceImpl {
             ingest_svc,
             transform_svc,
             sync_svc,
-            compacting_svc,
             system_time_source,
             current_account_subject,
             dataset_action_authorizer,
@@ -422,63 +419,26 @@ impl PullServiceImpl {
         Ok(results)
     }
 
-    #[async_recursion::async_recursion]
     async fn transform_multi(
         &self,
         batch: &[PullItem], // TODO: Move to avoid cloning
         transform_listener: Option<Arc<dyn TransformMultiListener>>,
-        compacting_listener: Option<Arc<dyn CompactingMultiListener>>,
-        retry_with_compaction: bool,
+        reset_derivatives_on_diverged_input: bool,
     ) -> Result<Vec<PullResponse>, InternalError> {
         let transform_requests = batch.iter().map(|pi| pi.local_ref.clone()).collect();
 
         let transform_results = self
             .transform_svc
-            .transform_multi(transform_requests, transform_listener.clone())
+            .transform_multi(
+                transform_requests,
+                TransformOptions {
+                    reset_derivatives_on_diverged_input,
+                },
+                transform_listener,
+            )
             .await;
 
         assert_eq!(batch.len(), transform_results.len());
-
-        if retry_with_compaction {
-            let mut compacting_target_refs = vec![];
-            for (dataset_ref, transform_result) in &transform_results {
-                if let Err(transform_err) = transform_result
-                    && let TransformError::InvalidInterval(_) = transform_err
-                {
-                    compacting_target_refs.push(dataset_ref.clone());
-                }
-            }
-
-            if !compacting_target_refs.is_empty() {
-                let compacting_results = self
-                    .compacting_svc
-                    .compact_multi(
-                        compacting_target_refs,
-                        CompactingOptions {
-                            keep_metadata_only: true,
-                            ..Default::default()
-                        },
-                        compacting_listener,
-                    )
-                    .await;
-
-                let retry_items: Vec<_> = std::iter::zip(batch, compacting_results)
-                    .filter_map(|(pi, response)| {
-                        assert_eq!(pi.local_ref, response.dataset_ref);
-                        if let Ok(result) = response.result
-                            && let CompactingResult::Success { .. } = result
-                        {
-                            return Some(pi.clone());
-                        }
-                        None
-                    })
-                    .collect();
-
-                return self
-                    .transform_multi(&retry_items, transform_listener, None, false)
-                    .await;
-            }
-        }
 
         Ok(std::iter::zip(batch, transform_results)
             .map(|(pi, res)| {
@@ -522,7 +482,8 @@ impl PullService for PullServiceImpl {
                 PullMultiOptions {
                     recursive: false,
                     all: false,
-                    reset_derivatives: options.reset_derivatives,
+                    reset_derivatives_on_diverged_input: options
+                        .reset_derivatives_on_diverged_input,
                     add_aliases: options.add_aliases,
                     ingest_options: options.ingest_options,
                     sync_options: options.sync_options,
@@ -631,10 +592,7 @@ impl PullService for PullServiceImpl {
                     listener
                         .as_ref()
                         .and_then(|l| l.clone().get_transform_listener()),
-                    listener
-                        .as_ref()
-                        .and_then(|l| l.clone().get_compacting_listener()),
-                    options.reset_derivatives,
+                    options.reset_derivatives_on_diverged_input,
                 )
                 .await?
             };
@@ -808,10 +766,6 @@ impl PullMultiListener for ListenerMultiAdapter {
     fn get_sync_listener(self: Arc<Self>) -> Option<Arc<dyn SyncMultiListener>> {
         Some(self)
     }
-
-    fn get_compacting_listener(self: Arc<Self>) -> Option<Arc<dyn CompactingMultiListener>> {
-        Some(self)
-    }
 }
 
 impl PollingIngestMultiListener for ListenerMultiAdapter {
@@ -833,11 +787,5 @@ impl SyncMultiListener for ListenerMultiAdapter {
         _dst: &DatasetRefAny,
     ) -> Option<Arc<dyn SyncListener>> {
         self.0.clone().get_sync_listener()
-    }
-}
-
-impl CompactingMultiListener for ListenerMultiAdapter {
-    fn begin_compact(&self, _dataset: &DatasetHandle) -> Option<Arc<dyn CompactingListener>> {
-        self.0.clone().get_compacting_listener()
     }
 }

--- a/src/infra/core/src/testing/mock_transform_service.rs
+++ b/src/infra/core/src/testing/mock_transform_service.rs
@@ -15,6 +15,7 @@ use kamu_core::{
     TransformError,
     TransformListener,
     TransformMultiListener,
+    TransformOptions,
     TransformResult,
     TransformService,
     VerificationError,
@@ -43,12 +44,14 @@ mockall::mock! {
       async fn transform(
           &self,
           dataset_ref: &DatasetRef,
+          options: TransformOptions,
           listener: Option<Arc<dyn TransformListener>>,
       ) -> Result<TransformResult, TransformError>;
 
       async fn transform_multi(
           &self,
           dataset_refs: Vec<DatasetRef>,
+          options: TransformOptions,
           listener: Option<Arc<dyn TransformMultiListener>>,
       ) -> Vec<(DatasetRef, Result<TransformResult, TransformError>)>;
 

--- a/src/infra/core/src/transform_service_impl.rs
+++ b/src/infra/core/src/transform_service_impl.rs
@@ -405,7 +405,10 @@ impl TransformServiceImpl {
                 .iter_blocks_interval(new_block_hash, query_input.prev_block_hash.as_ref(), false)
                 .try_collect()
                 .await
-                .int_err()?
+                .map_err(|chain_err| match chain_err {
+                    IterBlocksError::InvalidInterval(err) => TransformError::InvalidInterval(err),
+                    _ => TransformError::Internal(chain_err.int_err()),
+                })?
         } else {
             Vec::new()
         };

--- a/src/infra/core/src/transform_service_impl.rs
+++ b/src/infra/core/src/transform_service_impl.rs
@@ -803,10 +803,10 @@ impl TransformService for TransformServiceImpl {
             let f = match self.dataset_repo.resolve_dataset_ref(dataset_ref).await {
                 Ok(hdl) => {
                     let maybe_listener = multi_listener.begin_transform(&hdl);
-                    self.transform_impl(hdl.into(), options.clone(), maybe_listener)
+                    self.transform_impl(hdl.into(), options, maybe_listener)
                 }
                 // Relying on this call to fail to avoid boxing the futures
-                Err(_) => self.transform_impl(dataset_ref.clone(), options.clone(), None),
+                Err(_) => self.transform_impl(dataset_ref.clone(), options, None),
             };
             futures.push(f);
         }

--- a/src/infra/core/tests/tests/engine/test_engine_io.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_io.rs
@@ -36,17 +36,19 @@ async fn test_engine_io_common(
     ));
 
     let dataset_action_authorizer = Arc::new(auth::AlwaysHappyDatasetActionAuthorizer::new());
+    let object_store_registry = Arc::new(ObjectStoreRegistryImpl::new(object_stores));
+    let time_source = Arc::new(SystemTimeSourceDefault);
 
     let ingest_svc = PollingIngestServiceImpl::new(
         dataset_repo.clone(),
         dataset_action_authorizer.clone(),
         engine_provisioner.clone(),
-        Arc::new(ObjectStoreRegistryImpl::new(object_stores)),
+        object_store_registry.clone(),
         Arc::new(DataFormatRegistryImpl::new()),
         Arc::new(ContainerRuntime::default()),
         run_info_dir.to_path_buf(),
         cache_dir.to_path_buf(),
-        Arc::new(SystemTimeSourceDefault),
+        time_source.clone(),
     );
 
     let transform_svc = TransformServiceImpl::new(
@@ -54,6 +56,13 @@ async fn test_engine_io_common(
         dataset_action_authorizer.clone(),
         engine_provisioner.clone(),
         Arc::new(SystemTimeSourceDefault),
+        Arc::new(CompactingServiceImpl::new(
+            dataset_action_authorizer.clone(),
+            dataset_repo.clone(),
+            object_store_registry.clone(),
+            time_source.clone(),
+            run_info_dir.to_path_buf(),
+        )),
     );
 
     ///////////////////////////////////////////////////////////////////////////
@@ -136,7 +145,11 @@ async fn test_engine_io_common(
         .dataset;
 
     let block_hash = match transform_svc
-        .transform(&deriv_alias.as_local_ref(), None)
+        .transform(
+            &deriv_alias.as_local_ref(),
+            TransformOptions::default(),
+            None,
+        )
         .await
         .unwrap()
     {
@@ -186,7 +199,11 @@ async fn test_engine_io_common(
         .unwrap();
 
     let block_hash = match transform_svc
-        .transform(&deriv_alias.as_local_ref(), None)
+        .transform(
+            &deriv_alias.as_local_ref(),
+            TransformOptions::default(),
+            None,
+        )
         .await
         .unwrap()
     {

--- a/src/infra/core/tests/tests/engine/test_engine_transform.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_transform.rs
@@ -246,10 +246,12 @@ async fn test_transform_common(transform: Transform, test_retractions: bool) {
         .add_builder(
             PollingIngestServiceImpl::builder()
                 .with_cache_dir(cache_dir)
-                .with_run_info_dir(run_info_dir),
+                .with_run_info_dir(run_info_dir.clone()),
         )
         .bind::<dyn PollingIngestService, PollingIngestServiceImpl>()
         .add::<TransformServiceImpl>()
+        .add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir))
+        .bind::<dyn CompactingService, CompactingServiceImpl>()
         .add_value(SystemTimeSourceStub::new_set(
             Utc.with_ymd_and_hms(2050, 1, 1, 12, 0, 0).unwrap(),
         ))

--- a/src/infra/core/tests/tests/engine/test_engine_transform.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_transform.rs
@@ -347,7 +347,11 @@ async fn test_transform_common(transform: Transform, test_retractions: bool) {
     time_source.set(Utc.with_ymd_and_hms(2050, 1, 2, 12, 0, 0).unwrap());
 
     let res = transform_svc
-        .transform(&deriv_alias.as_local_ref(), None)
+        .transform(
+            &deriv_alias.as_local_ref(),
+            TransformOptions::default(),
+            None,
+        )
         .await
         .unwrap();
     assert_matches!(res, TransformResult::Updated { .. });
@@ -421,7 +425,11 @@ async fn test_transform_common(transform: Transform, test_retractions: bool) {
     time_source.set(Utc.with_ymd_and_hms(2050, 1, 3, 12, 0, 0).unwrap());
 
     let res = transform_svc
-        .transform(&deriv_alias.as_local_ref(), None)
+        .transform(
+            &deriv_alias.as_local_ref(),
+            TransformOptions::default(),
+            None,
+        )
         .await
         .unwrap();
     assert_matches!(res, TransformResult::Updated { .. });

--- a/src/infra/core/tests/tests/test_compact_service_impl.rs
+++ b/src/infra/core/tests/tests/test_compact_service_impl.rs
@@ -26,7 +26,7 @@ use kamu_accounts::CurrentAccountSubject;
 use kamu_core::auth;
 use opendatafabric::*;
 
-use super::test_pull_service_impl::{TestTransformService, TestTransfromResult};
+use super::test_pull_service_impl::TestTransformService;
 use crate::mock_engine_provisioner;
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -973,7 +973,7 @@ async fn test_dataset_keep_metadata_only_compact() {
     // After: seed <- set_transform
     let res = harness
         .transform_svc
-        .transform(&derived_dataset_ref, None)
+        .transform(&derived_dataset_ref, TransformOptions::default(), None)
         .await
         .unwrap();
     assert_matches!(res, TransformResult::Updated { .. });
@@ -1155,10 +1155,7 @@ impl CompactTestHarness {
             .add::<ObjectStoreBuilderLocalFs>()
             .add_value(ObjectStoreBuilderS3::new(s3_context.clone(), true))
             .bind::<dyn ObjectStoreBuilder, ObjectStoreBuilderS3>()
-            .add_value(TestTransformService::new(
-                Arc::new(Mutex::new(Vec::new())),
-                TestTransfromResult::Success,
-            ))
+            .add_value(TestTransformService::new(Arc::new(Mutex::new(Vec::new()))))
             .bind::<dyn TransformService, TestTransformService>()
             .add::<VerificationServiceImpl>()
             .add_value(CurrentAccountSubject::new_test())

--- a/src/infra/core/tests/tests/test_compact_service_impl.rs
+++ b/src/infra/core/tests/tests/test_compact_service_impl.rs
@@ -14,13 +14,7 @@ use chrono::{DateTime, NaiveDate, TimeDelta, TimeZone, Utc};
 use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use dill::Component;
-use domain::{
-    CompactingError,
-    CompactingOptions,
-    CompactingResult,
-    CompactingService,
-    NullCompactingMultiListener,
-};
+use domain::{CompactingError, CompactingOptions, CompactingResult, CompactingService};
 use event_bus::EventBus;
 use futures::TryStreamExt;
 use indoc::{formatdoc, indoc};
@@ -32,7 +26,7 @@ use kamu_accounts::CurrentAccountSubject;
 use kamu_core::auth;
 use opendatafabric::*;
 
-use super::test_pull_service_impl::TestTransformService;
+use super::test_pull_service_impl::{TestTransformService, TestTransfromResult};
 use crate::mock_engine_provisioner;
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -77,7 +71,7 @@ async fn test_dataset_compact() {
             .compact_dataset(
                 &created.dataset_handle,
                 CompactingOptions::default(),
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::NothingToDo)
@@ -121,7 +115,7 @@ async fn test_dataset_compact() {
             .compact_dataset(
                 &created.dataset_handle,
                 CompactingOptions::default(),
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::Success {
@@ -219,7 +213,7 @@ async fn test_dataset_compact_s3() {
             .compact_dataset(
                 &created.dataset_handle,
                 CompactingOptions::default(),
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::NothingToDo)
@@ -263,7 +257,7 @@ async fn test_dataset_compact_s3() {
             .compact_dataset(
                 &created.dataset_handle,
                 CompactingOptions::default(),
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::Success {
@@ -381,7 +375,7 @@ async fn test_dataset_compacting_watermark_only_blocks() {
         .compact_dataset(
             &created.dataset_handle,
             CompactingOptions::default(),
-            Some(Arc::new(NullCompactingMultiListener {})),
+            Some(Arc::new(NullCompactingListener {})),
         )
         .await
         .unwrap();
@@ -552,7 +546,7 @@ async fn test_dataset_compacting_limits() {
                     max_slice_size: None,
                     ..CompactingOptions::default()
                 },
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::Success {
@@ -709,7 +703,7 @@ async fn test_dataset_compacting_keep_all_non_data_blocks() {
             .compact_dataset(
                 &created.dataset_handle,
                 CompactingOptions::default(),
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::Success {
@@ -796,7 +790,7 @@ async fn test_dataset_compacting_derive_error() {
             .compact_dataset(
                 &created.dataset_handle,
                 CompactingOptions::default(),
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Err(CompactingError::InvalidDatasetKind(_)),
@@ -859,7 +853,7 @@ async fn test_large_dataset_compact() {
                     max_slice_size: None,
                     ..CompactingOptions::default()
                 },
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::Success {
@@ -956,7 +950,7 @@ async fn test_dataset_keep_metadata_only_compact() {
                     keep_metadata_only: true,
                     ..CompactingOptions::default()
                 },
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::NothingToDo)
@@ -993,7 +987,7 @@ async fn test_dataset_keep_metadata_only_compact() {
                     keep_metadata_only: true,
                     ..CompactingOptions::default()
                 },
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::Success {
@@ -1040,7 +1034,7 @@ async fn test_dataset_keep_metadata_only_compact() {
                     keep_metadata_only: true,
                     ..CompactingOptions::default()
                 },
-                Some(Arc::new(NullCompactingMultiListener {}))
+                Some(Arc::new(NullCompactingListener {}))
             )
             .await,
         Ok(CompactingResult::Success {
@@ -1161,7 +1155,10 @@ impl CompactTestHarness {
             .add::<ObjectStoreBuilderLocalFs>()
             .add_value(ObjectStoreBuilderS3::new(s3_context.clone(), true))
             .bind::<dyn ObjectStoreBuilder, ObjectStoreBuilderS3>()
-            .add_value(TestTransformService::new(Arc::new(Mutex::new(Vec::new()))))
+            .add_value(TestTransformService::new(
+                Arc::new(Mutex::new(Vec::new())),
+                TestTransfromResult::Success,
+            ))
             .bind::<dyn TransformService, TestTransformService>()
             .add::<VerificationServiceImpl>()
             .add_value(CurrentAccountSubject::new_test())

--- a/src/infra/core/tests/tests/test_pull_service_impl.rs
+++ b/src/infra/core/tests/tests/test_pull_service_impl.rs
@@ -723,6 +723,7 @@ async fn test_set_watermark() {
             4,
         ),
         false,
+        PullTestHarnessResultOwerrides::default(),
     );
 
     let dataset_alias = n!("foo");
@@ -786,6 +787,7 @@ async fn test_set_watermark_unauthorized() {
         tmp_dir.path(),
         MockDatasetActionAuthorizer::denying(),
         true,
+        PullTestHarnessResultOwerrides::default(),
     );
 
     let dataset_alias = n!("foo");
@@ -812,6 +814,7 @@ async fn test_set_watermark_rejects_on_derivative() {
         tmp_dir.path(),
         AlwaysHappyDatasetActionAuthorizer::new(),
         true,
+        PullTestHarnessResultOwerrides::default(),
     );
 
     let dataset_alias = n!("foo");
@@ -840,6 +843,43 @@ async fn test_set_watermark_rejects_on_derivative() {
     assert_eq!(harness.num_blocks(&dataset_alias).await, 1);
 }
 
+#[tokio::test]
+async fn test_compactin_on_transform_faile() {
+    let harnes_owerrides = PullTestHarnessResultOwerrides {
+        transfrom_test_service_result: Some(TestTransfromResult::Failed),
+    };
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let harness =
+        PullTestHarness::new_with_result_owerrides(tmp_dir.path(), false, harnes_owerrides);
+
+    create_graph(
+        harness.dataset_repo.as_ref(),
+        vec![(n!("a"), names![]), (n!("b"), names!["a"])],
+    )
+    .await;
+
+    // Pulling b results in a sync
+    assert_eq!(
+        harness
+            .pull_failed(
+                refs!["b"],
+                PullMultiOptions {
+                    recursive: true,
+                    reset_derivatives: true,
+                    ..PullMultiOptions::default()
+                }
+            )
+            .await,
+        vec![
+            PullBatch::Ingest(refs!("a")),
+            PullBatch::Transform(refs!("b")),
+            PullBatch::Compact(refs!("b")),
+            PullBatch::Transform(refs!("b")),
+        ],
+    );
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
 
 struct PullTestHarness {
@@ -852,11 +892,25 @@ struct PullTestHarness {
 }
 
 impl PullTestHarness {
+    fn new_with_result_owerrides(
+        tmp_path: &Path,
+        multi_tenant: bool,
+        result_owerrides: PullTestHarnessResultOwerrides,
+    ) -> Self {
+        Self::new_with_authorizer(
+            tmp_path,
+            auth::AlwaysHappyDatasetActionAuthorizer::new(),
+            multi_tenant,
+            result_owerrides,
+        )
+    }
+
     fn new(tmp_path: &Path, multi_tenant: bool) -> Self {
         Self::new_with_authorizer(
             tmp_path,
             auth::AlwaysHappyDatasetActionAuthorizer::new(),
             multi_tenant,
+            PullTestHarnessResultOwerrides::default(),
         )
     }
 
@@ -864,11 +918,15 @@ impl PullTestHarness {
         tmp_path: &Path,
         dataset_action_authorizer: TDatasetAuthorizer,
         multi_tenant: bool,
+        result_owerrides: PullTestHarnessResultOwerrides,
     ) -> Self {
         let calls = Arc::new(Mutex::new(Vec::new()));
 
         let datasets_dir_path = tmp_path.join("datasets");
         std::fs::create_dir(&datasets_dir_path).unwrap();
+        let test_transform_service_result = result_owerrides
+            .transfrom_test_service_result
+            .unwrap_or(TestTransfromResult::Success);
 
         let catalog = dill::CatalogBuilder::new()
             .add::<SystemTimeSourceDefault>()
@@ -888,8 +946,13 @@ impl PullTestHarness {
             .add::<RemoteAliasesRegistryImpl>()
             .add_value(TestIngestService::new(calls.clone()))
             .bind::<dyn PollingIngestService, TestIngestService>()
-            .add_value(TestTransformService::new(calls.clone()))
+            .add_value(TestTransformService::new(
+                calls.clone(),
+                test_transform_service_result,
+            ))
             .bind::<dyn TransformService, TestTransformService>()
+            .add_value(TestCompactingService::new(calls.clone()))
+            .bind::<dyn CompactingService, TestCompactingService>()
             .add_builder(TestSyncService::builder().with_calls(calls.clone()))
             .bind::<dyn SyncService, TestSyncService>()
             .add::<PullServiceImpl>()
@@ -948,6 +1011,23 @@ impl PullTestHarness {
 
         self.collect_calls()
     }
+
+    async fn pull_failed(
+        &self,
+        refs: Vec<DatasetRefAny>,
+        options: PullMultiOptions,
+    ) -> Vec<PullBatch> {
+        self.pull_svc
+            .pull_multi(refs.clone(), options, None)
+            .await
+            .unwrap();
+        self.collect_calls()
+    }
+}
+
+#[derive(Default)]
+struct PullTestHarnessResultOwerrides {
+    pub transfrom_test_service_result: Option<TestTransfromResult>,
 }
 
 #[derive(Debug, Clone, Eq)]
@@ -955,6 +1035,7 @@ pub enum PullBatch {
     Ingest(Vec<DatasetRefAny>),
     Transform(Vec<DatasetRefAny>),
     Sync(Vec<(DatasetRefAny, DatasetRefAny)>),
+    Compact(Vec<DatasetRefAny>),
 }
 
 impl PullBatch {
@@ -1016,6 +1097,13 @@ impl std::cmp::PartialEq for PullBatch {
                 l.len() == r.len() && std::iter::zip(&l, &r).all(|(li, ri)| Self::cmp_ref(li, ri))
             }
             (Self::Transform(l), Self::Transform(r)) => {
+                let mut l = l.clone();
+                l.sort();
+                let mut r = r.clone();
+                r.sort();
+                l.len() == r.len() && std::iter::zip(&l, &r).all(|(li, ri)| Self::cmp_ref(li, ri))
+            }
+            (Self::Compact(l), Self::Compact(r)) => {
                 let mut l = l.clone();
                 l.sort();
                 let mut r = r.clone();
@@ -1092,13 +1180,19 @@ impl PollingIngestService for TestIngestService {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+pub enum TestTransfromResult {
+    Success,
+    Failed,
+}
+
 pub struct TestTransformService {
     calls: Arc<Mutex<Vec<PullBatch>>>,
+    mock_result: TestTransfromResult,
 }
 
 impl TestTransformService {
-    pub fn new(calls: Arc<Mutex<Vec<PullBatch>>>) -> Self {
-        Self { calls }
+    pub fn new(calls: Arc<Mutex<Vec<PullBatch>>>, mock_result: TestTransfromResult) -> Self {
+        Self { calls, mock_result }
     }
 }
 
@@ -1126,7 +1220,16 @@ impl TransformService for TestTransformService {
     ) -> Vec<(DatasetRef, Result<TransformResult, TransformError>)> {
         let results = dataset_refs
             .iter()
-            .map(|r| (r.clone(), Ok(TransformResult::UpToDate)))
+            .map(|r| match &self.mock_result {
+                TestTransfromResult::Success => (r.clone(), Ok(TransformResult::UpToDate)),
+                TestTransfromResult::Failed => (
+                    r.clone(),
+                    Err(TransformError::InvalidInterval(InvalidIntervalError {
+                        head: Multihash::from_digest_sha3_256(b"foo"),
+                        tail: Multihash::from_digest_sha3_256(b"bar"),
+                    })),
+                ),
+            })
             .collect();
         self.calls.lock().unwrap().push(PullBatch::Transform(
             dataset_refs.into_iter().map(Into::into).collect(),
@@ -1221,5 +1324,53 @@ impl SyncService for TestSyncService {
 
     async fn ipfs_add(&self, _src: &DatasetRef) -> Result<String, SyncError> {
         unimplemented!()
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct TestCompactingService {
+    calls: Arc<Mutex<Vec<PullBatch>>>,
+}
+
+impl TestCompactingService {
+    pub fn new(calls: Arc<Mutex<Vec<PullBatch>>>) -> Self {
+        Self { calls }
+    }
+}
+
+#[async_trait::async_trait]
+impl CompactingService for TestCompactingService {
+    async fn compact_dataset(
+        &self,
+        _dataset_handle: &DatasetHandle,
+        _options: CompactingOptions,
+        _listener: Option<Arc<dyn CompactingListener>>,
+    ) -> Result<CompactingResult, CompactingError> {
+        unimplemented!()
+    }
+
+    async fn compact_multi(
+        &self,
+        dataset_refs: Vec<DatasetRef>,
+        _options: CompactingOptions,
+        _listener: Option<Arc<dyn CompactingMultiListener>>,
+    ) -> Vec<CompactingResponse> {
+        let results = dataset_refs
+            .iter()
+            .map(|r| CompactingResponse {
+                dataset_ref: r.clone(),
+                result: Ok(CompactingResult::Success {
+                    old_head: Multihash::from_digest_sha3_256(b"old_head"),
+                    new_head: Multihash::from_digest_sha3_256(b"new_head"),
+                    old_num_blocks: 5,
+                    new_num_blocks: 4,
+                }),
+            })
+            .collect();
+        self.calls.lock().unwrap().push(PullBatch::Compact(
+            dataset_refs.into_iter().map(Into::into).collect(),
+        ));
+        results
     }
 }

--- a/src/infra/core/tests/tests/test_transform_service_impl.rs
+++ b/src/infra/core/tests/tests/test_transform_service_impl.rs
@@ -14,6 +14,7 @@ use chrono::{TimeZone, Utc};
 use dill::Component;
 use event_bus::EventBus;
 use futures::TryStreamExt;
+use indoc::indoc;
 use kamu::domain::engine::*;
 use kamu::domain::*;
 use kamu::testing::*;
@@ -30,6 +31,8 @@ struct TransformTestHarness {
     _tempdir: TempDir,
     dataset_repo: Arc<dyn DatasetRepository>,
     transform_service: Arc<TransformServiceImpl>,
+    compacting_service: Arc<dyn CompactingService>,
+    push_ingest_svc: Arc<PushIngestServiceImpl>,
 }
 
 impl TransformTestHarness {
@@ -42,33 +45,53 @@ impl TransformTestHarness {
     ) -> Self {
         let tempdir = tempfile::tempdir().unwrap();
         let datasets_dir = tempdir.path().join("datasets");
+        let run_info_dir = tempdir.path().join("run");
         std::fs::create_dir(&datasets_dir).unwrap();
+        std::fs::create_dir(&run_info_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_value(CurrentAccountSubject::new_test())
-            .add_value(dataset_action_authorizer)
-            .bind::<dyn auth::DatasetActionAuthorizer, TAuthorizer>()
-            .add_value(engine_provisioner)
-            .bind::<dyn EngineProvisioner, TEngineProvisioner>()
             .add_builder(
                 DatasetRepositoryLocalFs::builder()
                     .with_root(datasets_dir)
                     .with_multi_tenant(false),
             )
-            .add::<SystemTimeSourceDefault>()
             .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
+            .add_value(dataset_action_authorizer)
+            .bind::<dyn auth::DatasetActionAuthorizer, TAuthorizer>()
+            .add::<SystemTimeSourceDefault>()
+            .add::<ObjectStoreRegistryImpl>()
+            .add::<ObjectStoreBuilderLocalFs>()
+            .add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir.clone()))
+            .bind::<dyn CompactingService, CompactingServiceImpl>()
+            .add_builder(
+                PushIngestServiceImpl::builder()
+                    .with_object_store_registry(Arc::new(ObjectStoreRegistryImpl::new(vec![
+                        Arc::new(ObjectStoreBuilderLocalFs::new()),
+                    ])))
+                    .with_data_format_registry(Arc::new(DataFormatRegistryImpl::new()))
+                    .with_run_info_dir(run_info_dir),
+            )
+            .bind::<dyn PushIngestService, PushIngestServiceImpl>()
+            .add_value(engine_provisioner)
+            .bind::<dyn EngineProvisioner, TEngineProvisioner>()
             .add::<TransformServiceImpl>()
+            .add::<VerificationServiceImpl>()
             .build();
 
-        let transform_service = catalog.get_one::<TransformServiceImpl>().unwrap();
         let dataset_repo = catalog.get_one::<dyn DatasetRepository>().unwrap();
+        let compacting_service = catalog.get_one::<dyn CompactingService>().unwrap();
+        let push_ingest_svc = catalog.get_one::<PushIngestServiceImpl>().unwrap();
+        let transform_service = catalog.get_one::<TransformServiceImpl>().unwrap();
 
         Self {
             _tempdir: tempdir,
             dataset_repo,
             transform_service,
+            compacting_service,
+            push_ingest_svc,
         }
     }
 
@@ -171,6 +194,21 @@ impl TransformTestHarness {
             .unwrap();
         (block_hash, block.into_typed::<AddData>().unwrap())
     }
+
+    async fn ingest_data(&self, data_str: String, dataset_ref: &DatasetRef) {
+        let data = std::io::Cursor::new(data_str);
+
+        self.push_ingest_svc
+            .ingest_from_file_stream(
+                dataset_ref,
+                None,
+                Box::new(data),
+                PushIngestOpts::default(),
+                None,
+            )
+            .await
+            .unwrap();
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -243,7 +281,7 @@ async fn test_transform_enforces_authorization() {
 
     let transform_result = harness
         .transform_service
-        .transform(&bar.as_local_ref(), None)
+        .transform(&bar.as_local_ref(), TransformOptions::default(), None)
         .await;
 
     assert_matches!(transform_result, Ok(_));
@@ -263,7 +301,7 @@ async fn test_transform_unauthorized() {
 
     let transform_result = harness
         .transform_service
-        .transform(&bar.as_local_ref(), None)
+        .transform(&bar.as_local_ref(), TransformOptions::default(), None)
         .await;
 
     assert_matches!(
@@ -601,7 +639,122 @@ async fn test_get_verification_plan_one_to_one() {
     assert_requests_equivalent(&plan[2].request, deriv_req_t6);
 }
 
+#[test_log::test(tokio::test)]
+async fn test_transform_with_compacting_retry() {
+    let harness = TransformTestHarness::new_custom(
+        auth::AlwaysHappyDatasetActionAuthorizer::new(),
+        mock_engine_provisioner::MockEngineProvisioner::new().always_provision_engine(),
+    );
+    let root_alias = DatasetAlias::new(None, DatasetName::new_unchecked("foo"));
+
+    let foo_created_result = harness
+        .dataset_repo
+        .create_dataset_from_snapshot(
+            MetadataFactory::dataset_snapshot()
+                .name(root_alias)
+                .kind(DatasetKind::Root)
+                .push_event(
+                    MetadataFactory::add_push_source()
+                        .read(ReadStepCsv {
+                            header: Some(true),
+                            schema: Some(
+                                ["date TIMESTAMP", "city STRING", "population BIGINT"]
+                                    .iter()
+                                    .map(|s| (*s).to_string())
+                                    .collect(),
+                            ),
+                            ..ReadStepCsv::default()
+                        })
+                        .merge(MergeStrategyLedger {
+                            primary_key: vec!["date".to_string(), "city".to_string()],
+                        })
+                        .build(),
+                )
+                .push_event(SetVocab {
+                    event_time_column: Some("date".to_string()),
+                    ..Default::default()
+                })
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    let data_str = indoc!(
+        "
+            date,city,population
+            2020-01-01,A,1000
+            2020-01-02,B,2000
+            2020-01-03,C,3000
+            "
+    );
+    harness
+        .ingest_data(
+            data_str.to_string(),
+            &foo_created_result.dataset_handle.as_local_ref(),
+        )
+        .await;
+    let data_str = indoc!(
+        "
+            date,city,population
+            2020-01-04,A,4000
+            2020-01-05,B,5000
+            2020-01-06,C,6000
+            "
+    );
+    harness
+        .ingest_data(
+            data_str.to_string(),
+            &foo_created_result.dataset_handle.as_local_ref(),
+        )
+        .await;
+
+    let (bar, _) = harness
+        .new_deriv("bar", &[foo_created_result.dataset_handle.alias.clone()])
+        .await;
+
+    let transform_result = harness
+        .transform_service
+        .transform(&bar.as_local_ref(), TransformOptions::default(), None)
+        .await;
+
+    assert_matches!(transform_result, Ok(TransformResult::Updated { .. }));
+
+    harness
+        .compacting_service
+        .compact_dataset(
+            &foo_created_result.dataset_handle,
+            CompactingOptions::default(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let transform_result = harness
+        .transform_service
+        .transform(&bar.as_local_ref(), TransformOptions::default(), None)
+        .await;
+
+    assert_matches!(
+        transform_result,
+        Err(TransformError::InvalidInterval(InvalidIntervalError { .. }))
+    );
+
+    let transform_result = harness
+        .transform_service
+        .transform(
+            &bar.as_local_ref(),
+            TransformOptions {
+                reset_derivatives_on_diverged_input: true,
+            },
+            None,
+        )
+        .await;
+
+    assert_matches!(transform_result, Ok(TransformResult::Updated { .. }));
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
+
 fn assert_requests_equivalent(lhs: &TransformRequestExt, mut rhs: TransformRequestExt) {
     // Operation IDs are randomly generated, so ignoring them for this check
     rhs.operation_id = lhs.operation_id.clone();

--- a/src/infra/core/tests/tests/test_verification_service_impl.rs
+++ b/src/infra/core/tests/tests/test_verification_service_impl.rs
@@ -21,7 +21,7 @@ use kamu::*;
 use kamu_accounts::CurrentAccountSubject;
 use opendatafabric::*;
 
-use super::test_pull_service_impl::{TestTransformService, TestTransfromResult};
+use super::test_pull_service_impl::TestTransformService;
 
 #[tokio::test]
 async fn test_verify_data_consistency() {
@@ -48,7 +48,6 @@ async fn test_verify_data_consistency() {
         .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
         .add_value(TestTransformService::new(
             Arc::new(Mutex::new(Vec::new())),
-            TestTransfromResult::Success,
         ))
         .bind::<dyn TransformService, TestTransformService>()
         .add::<VerificationServiceImpl>()

--- a/src/infra/core/tests/tests/test_verification_service_impl.rs
+++ b/src/infra/core/tests/tests/test_verification_service_impl.rs
@@ -46,9 +46,7 @@ async fn test_verify_data_consistency() {
                 .with_multi_tenant(false),
         )
         .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
-        .add_value(TestTransformService::new(
-            Arc::new(Mutex::new(Vec::new())),
-        ))
+        .add_value(TestTransformService::new(Arc::new(Mutex::new(Vec::new()))))
         .bind::<dyn TransformService, TestTransformService>()
         .add::<VerificationServiceImpl>()
         .build();
@@ -144,7 +142,7 @@ async fn test_verify_data_consistency() {
         .new_head;
 
     assert_matches!(
-        dataset.as_metadata_chain().get_block(&head).await.unwrap(), 
+        dataset.as_metadata_chain().get_block(&head).await.unwrap(),
         MetadataBlock {
             event: MetadataEvent::AddData(AddData {
                 new_data: Some(DataSlice {

--- a/src/infra/core/tests/tests/test_verification_service_impl.rs
+++ b/src/infra/core/tests/tests/test_verification_service_impl.rs
@@ -21,7 +21,7 @@ use kamu::*;
 use kamu_accounts::CurrentAccountSubject;
 use opendatafabric::*;
 
-use super::test_pull_service_impl::TestTransformService;
+use super::test_pull_service_impl::{TestTransformService, TestTransfromResult};
 
 #[tokio::test]
 async fn test_verify_data_consistency() {
@@ -46,7 +46,10 @@ async fn test_verify_data_consistency() {
                 .with_multi_tenant(false),
         )
         .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
-        .add_value(TestTransformService::new(Arc::new(Mutex::new(Vec::new()))))
+        .add_value(TestTransformService::new(
+            Arc::new(Mutex::new(Vec::new())),
+            TestTransfromResult::Success,
+        ))
         .bind::<dyn TransformService, TestTransformService>()
         .add::<VerificationServiceImpl>()
         .build();

--- a/src/infra/core/tests/utils/mock_engine_provisioner.rs
+++ b/src/infra/core/tests/utils/mock_engine_provisioner.rs
@@ -33,6 +33,12 @@ impl MockEngineProvisioner {
             .return_once(|_, _| Ok(Arc::new(EngineStub {})));
         self
     }
+
+    pub fn always_provision_engine(mut self) -> Self {
+        self.expect_provision_engine()
+            .returning(|_, _| Ok(Arc::new(EngineStub {})));
+        self
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Closes: https://github.com/kamu-data/kamu-cli/issues/644

<!--- Describe your changes in detail and include your changelog entries -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅