### PR TITLE
Add new allPaused method in AccountFlowConfigs API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a [configuration](/images/persistence-storage) of running a `kamu` API server along with a database,
   for persistent storage of data
 - New `listFlowInitiators` api to fetch all initiators of flows
+- New `allPaused` method in `AccountFlowConfigs` API
 
 ## [0.183.0] - 2024-05-22
 ### Added

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -62,7 +62,7 @@ type AccountEdge {
 
 type AccountFlowConfigs {
 	"""
-	Checks if all configs of this dataset are disabled
+	Checks if all configs of all datasets in account are disabled
 	"""
 	allPaused: Boolean!
 }

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -60,6 +60,13 @@ type AccountEdge {
 	node: Account!
 }
 
+type AccountFlowConfigs {
+	"""
+	Checks if all configs of this dataset are disabled
+	"""
+	allPaused: Boolean!
+}
+
 type AccountFlowConfigsMut {
 	resumeAccountDatasetFlows: Boolean!
 	pauseAccountDatasetFlows: Boolean!
@@ -82,6 +89,10 @@ type AccountFlows {
 	Returns interface for flow runs queries
 	"""
 	runs: AccountFlowRuns!
+	"""
+	Returns interface for flow configurations queries
+	"""
+	configs: AccountFlowConfigs!
 }
 
 type AccountFlowsMut {

--- a/src/adapter/graphql/src/mutations/flows_mut/account_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/account_flow_configs_mut.rs
@@ -9,9 +9,8 @@
 
 use chrono::Utc;
 use fs::FlowConfigurationService;
-use futures::TryStreamExt;
 use kamu_accounts::Account;
-use kamu_core::DatasetRepository;
+use kamu_core::DatasetOwnershipService;
 use kamu_flow_system as fs;
 use opendatafabric::DatasetID;
 
@@ -30,11 +29,9 @@ impl AccountFlowConfigsMut {
 
     #[graphql(skip)]
     async fn get_account_dataset_ids(&self, ctx: &Context<'_>) -> Result<Vec<DatasetID>> {
-        let datset_repo = from_catalog::<dyn DatasetRepository>(ctx).unwrap();
-        let datset_ids: Vec<_> = datset_repo
-            .get_datasets_by_owner(&self.account.account_name)
-            .map_ok(|dataset_handle| dataset_handle.id)
-            .try_collect()
+        let dataset_ownership_service = from_catalog::<dyn DatasetOwnershipService>(ctx).unwrap();
+        let datset_ids: Vec<_> = dataset_ownership_service
+            .get_owned_datasets(&self.account.id)
             .await?;
 
         Ok(datset_ids)

--- a/src/adapter/graphql/src/queries/accounts/account_flow_configs.rs
+++ b/src/adapter/graphql/src/queries/accounts/account_flow_configs.rs
@@ -27,7 +27,7 @@ impl AccountFlowConfigs {
         Self { account }
     }
 
-    /// Checks if all configs of this dataset are disabled
+    /// Checks if all configs of all datasets in account are disabled
     async fn all_paused(&self, ctx: &Context<'_>) -> Result<bool> {
         let dataset_ownership_service = from_catalog::<dyn DatasetOwnershipService>(ctx).unwrap();
         let owned_dataset_ids: Vec<_> = dataset_ownership_service

--- a/src/adapter/graphql/src/queries/accounts/account_flow_configs.rs
+++ b/src/adapter/graphql/src/queries/accounts/account_flow_configs.rs
@@ -1,0 +1,54 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use futures::StreamExt;
+use kamu_accounts::Account as AccountEntity;
+use kamu_core::DatasetOwnershipService;
+use kamu_flow_system::FlowConfigurationService;
+
+use crate::prelude::*;
+
+///////////////////////////////////////////////////////////////////////////////
+
+pub struct AccountFlowConfigs {
+    account: AccountEntity,
+}
+
+#[Object]
+impl AccountFlowConfigs {
+    #[graphql(skip)]
+    pub fn new(account: AccountEntity) -> Self {
+        Self { account }
+    }
+
+    /// Checks if all configs of this dataset are disabled
+    async fn all_paused(&self, ctx: &Context<'_>) -> Result<bool> {
+        let dataset_ownership_service = from_catalog::<dyn DatasetOwnershipService>(ctx).unwrap();
+        let owned_dataset_ids: Vec<_> = dataset_ownership_service
+            .get_owned_datasets(&self.account.id)
+            .await?;
+        let flow_config_service = from_catalog::<dyn FlowConfigurationService>(ctx).unwrap();
+
+        let mut all_configurations = flow_config_service
+            .find_configurations_by_datasets(owned_dataset_ids)
+            .await;
+
+        while let Some(configuration_result) = all_configurations.next().await {
+            if let Ok(configuration) = configuration_result
+                && configuration.is_active()
+            {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/queries/accounts/account_flows.rs
+++ b/src/adapter/graphql/src/queries/accounts/account_flows.rs
@@ -9,7 +9,7 @@
 
 use kamu_accounts::Account;
 
-use super::AccountFlowRuns;
+use super::{AccountFlowConfigs, AccountFlowRuns};
 use crate::prelude::*;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -28,6 +28,11 @@ impl AccountFlows {
     /// Returns interface for flow runs queries
     async fn runs(&self) -> AccountFlowRuns {
         AccountFlowRuns::new(self.account.clone())
+    }
+
+    /// Returns interface for flow configurations queries
+    async fn configs(&self) -> AccountFlowConfigs {
+        AccountFlowConfigs::new(self.account.clone())
     }
 }
 

--- a/src/adapter/graphql/src/queries/accounts/mod.rs
+++ b/src/adapter/graphql/src/queries/accounts/mod.rs
@@ -8,11 +8,13 @@
 // by the Apache License, Version 2.0.
 
 mod account;
+mod account_flow_configs;
 mod account_flow_runs;
 mod account_flows;
 mod accounts;
 
 pub(crate) use account::*;
+pub(crate) use account_flow_configs::*;
 pub(crate) use account_flow_runs::*;
 pub(crate) use account_flows::*;
 pub(crate) use accounts::*;

--- a/src/adapter/graphql/tests/tests/test_gql_account_flow_configs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_account_flow_configs.rs
@@ -970,7 +970,7 @@ impl FlowConfigHarness {
             }
             "#
         )
-        .replace("<account_name>", &account_name.to_string())
+        .replace("<account_name>", account_name)
     }
 
     fn set_config_time_delta_mutation(

--- a/src/adapter/graphql/tests/tests/test_gql_account_flow_configs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_account_flow_configs.rs
@@ -433,6 +433,185 @@ async fn test_pause_resume_account_flows() {
 
 ////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_log::test(tokio::test)]
+async fn test_account_configs_all_paused() {
+    let schema = kamu_adapter_graphql::schema_quiet();
+
+    let foo_dataset_alias = DatasetAlias::new(
+        Some(DEFAULT_ACCOUNT_NAME.clone()),
+        DatasetName::new_unchecked("foo"),
+    );
+    let bar_dataset_alias = DatasetAlias::new(
+        Some(DEFAULT_ACCOUNT_NAME.clone()),
+        DatasetName::new_unchecked("bar"),
+    );
+
+    let mock_dataset_action_authorizer = MockDatasetActionAuthorizer::allowing();
+    let harness = FlowConfigHarness::with_overrides(FlowRunsHarnessOverrides {
+        transform_service_mock: Some(MockTransformService::with_set_transform()),
+        polling_service_mock: Some(MockPollingIngestService::with_active_polling_source()),
+        mock_dataset_action_authorizer: Some(mock_dataset_action_authorizer),
+        ..Default::default()
+    });
+    let foo_create_result = harness.create_root_dataset(foo_dataset_alias).await;
+    let bar_create_result = harness.create_root_dataset(bar_dataset_alias).await;
+
+    let request_code =
+        FlowConfigHarness::trigger_flow_mutation(&foo_create_result.dataset_handle.id, "INGEST");
+    let response = schema
+        .execute(
+            async_graphql::Request::new(request_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+
+    let request_code = FlowConfigHarness::list_flows_query(&DEFAULT_ACCOUNT_NAME);
+    let response = schema
+        .execute(
+            async_graphql::Request::new(request_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "accounts": {
+                "byName": {
+                    "flows": {
+                        "runs": {
+                            "listFlows": {
+                                "nodes": [
+                                    {
+                                        "flowId": "0",
+                                        "description": {
+                                            "__typename": "FlowDescriptionDatasetPollingIngest",
+                                            "datasetId": foo_create_result.dataset_handle.id.to_string(),
+                                            "ingestResult": null,
+                                        },
+                                        "status": "WAITING",
+                                        "outcome": null,
+                                        "timing": {
+                                            "awaitingExecutorSince": null,
+                                            "runningSince": null,
+                                            "finishedAt": null,
+                                        },
+                                        "tasks": [],
+                                        "primaryTrigger": {
+                                            "__typename": "FlowTriggerManual",
+
+                                        },
+                                        "startCondition": null,
+                                    }
+                                ],
+                                "pageInfo": {
+                                    "hasPreviousPage": false,
+                                    "hasNextPage": false,
+                                    "currentPage": 0,
+                                    "totalPages": 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    let mutation_code = FlowConfigHarness::set_config_time_delta_mutation(
+        &bar_create_result.dataset_handle.id,
+        "INGEST",
+        false,
+        1,
+        "DAYS",
+    );
+    let response = schema
+        .execute(
+            async_graphql::Request::new(mutation_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+
+    let request_code = FlowConfigHarness::all_paused_account_configs_query(&DEFAULT_ACCOUNT_NAME);
+    let response = schema
+        .execute(
+            async_graphql::Request::new(request_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "accounts": {
+                "byName": {
+                    "flows": {
+                        "configs": {
+                            "allPaused": false
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    let mutation_code = FlowConfigHarness::pause_account_flows(&DEFAULT_ACCOUNT_NAME);
+    let response = schema
+        .execute(
+            async_graphql::Request::new(mutation_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "accounts": {
+                "byName": {
+                    "flows": {
+                        "configs": {
+                            "pauseAccountDatasetFlows": true
+                        }
+                    }
+                }
+            }
+        })
+    );
+
+    let request_code = FlowConfigHarness::all_paused_account_configs_query(&DEFAULT_ACCOUNT_NAME);
+    let response = schema
+        .execute(
+            async_graphql::Request::new(request_code.clone())
+                .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(response.is_ok(), "{response:?}");
+    assert_eq!(
+        response.data,
+        value!({
+            "accounts": {
+                "byName": {
+                    "flows": {
+                        "configs": {
+                            "allPaused": true
+                        }
+                    }
+                }
+            }
+        })
+    );
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+
 struct FlowConfigHarness {
     _tempdir: tempfile::TempDir,
     _catalog_base: dill::Catalog,
@@ -773,6 +952,25 @@ impl FlowConfigHarness {
             "#
         )
         .replace("<id>", &id.to_string())
+    }
+
+    fn all_paused_account_configs_query(account_name: &AccountName) -> String {
+        indoc!(
+            r#"
+            {
+                accounts {
+                    byName (name: "<account_name>") {
+                        flows {
+                            configs {
+                                allPaused
+                            }
+                        }
+                    }
+                }
+            }
+            "#
+        )
+        .replace("<account_name>", &account_name.to_string())
     }
 
     fn set_config_time_delta_mutation(

--- a/src/domain/flow-system/domain/src/services/flow_configuration/flow_configuration_service.rs
+++ b/src/domain/flow-system/domain/src/services/flow_configuration/flow_configuration_service.rs
@@ -31,7 +31,7 @@ pub trait FlowConfigurationService: Sync + Send {
         flow_key: FlowKey,
     ) -> Result<Option<FlowConfigurationState>, FindFlowConfigurationError>;
 
-    /// Find all configurations by flow keys
+    /// Find all configurations by dataset ids
     async fn find_configurations_by_datasets(
         &self,
         dataset_ids: Vec<DatasetID>,

--- a/src/domain/flow-system/domain/src/services/flow_configuration/flow_configuration_service.rs
+++ b/src/domain/flow-system/domain/src/services/flow_configuration/flow_configuration_service.rs
@@ -31,6 +31,12 @@ pub trait FlowConfigurationService: Sync + Send {
         flow_key: FlowKey,
     ) -> Result<Option<FlowConfigurationState>, FindFlowConfigurationError>;
 
+    /// Find all configurations by flow keys
+    async fn find_configurations_by_datasets(
+        &self,
+        dataset_ids: Vec<DatasetID>,
+    ) -> FlowConfigurationStateStream;
+
     /// Set or modify flow configuration
     async fn set_configuration(
         &self,

--- a/src/domain/flow-system/services/src/flow_configuration/flow_configuration_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow_configuration/flow_configuration_service_impl.rs
@@ -111,7 +111,7 @@ impl FlowConfigurationService for FlowConfigurationServiceImpl {
         Ok(maybe_flow_configuration.map(Into::into))
     }
 
-    /// Find all configurations by flow keys
+    /// Find all configurations by datasets
     #[tracing::instrument(level = "info", skip_all, fields(?dataset_ids))]
     async fn find_configurations_by_datasets(
         &self,


### PR DESCRIPTION
## Description

Closes: https://github.com/kamu-data/kamu-cli/issues/652

<!--- Describe your changes in detail and include your changelog entries -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅