### PR TITLE
661 smart protocol pulling diverged dataset fails even with force flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.185.1] - 2024-06-07
+### Fixed
+- Fixed support of `--force` mode for pull/push actions using Smart Transfer Protocol
+
 ## [0.185.0] - 2024-06-06
 ### Added
 - New `--reset-derivatives-on-diverged-input` flag to `kamu pull` command, which will trigger

--- a/src/adapter/http/src/smart_protocol/axum_server_pull_protocol.rs
+++ b/src/adapter/http/src/smart_protocol/axum_server_pull_protocol.rs
@@ -90,7 +90,8 @@ impl AxumServerPullProtocolInstance {
             })?;
 
         tracing::debug!(
-            "Pull client sent a pull request: beginAfter={:?} stopAt={:?} force={}",
+            "Pull client sent a pull request: beginAfter={:?} stopAt={:?} \
+             force_update_if_diverged={}",
             pull_request
                 .begin_after
                 .as_ref()
@@ -101,7 +102,7 @@ impl AxumServerPullProtocolInstance {
                 .as_ref()
                 .map(ToString::to_string)
                 .ok_or("None"),
-            pull_request.force,
+            pull_request.force_update_if_diverged,
         );
 
         let metadata_chain = self.dataset.as_metadata_chain();
@@ -114,7 +115,7 @@ impl AxumServerPullProtocolInstance {
             metadata_chain,
             pull_request.stop_at.as_ref().unwrap_or(&head),
             pull_request.begin_after.as_ref(),
-            pull_request.force,
+            pull_request.force_update_if_diverged,
         )
         .await;
 
@@ -173,7 +174,7 @@ impl AxumServerPullProtocolInstance {
                     metadata_chain,
                     pull_request.stop_at.as_ref().unwrap_or(&head),
                     pull_request.begin_after.as_ref(),
-                    pull_request.force,
+                    pull_request.force_update_if_diverged,
                 )
                 .await
                 .int_err()?;

--- a/src/adapter/http/src/smart_protocol/axum_server_pull_protocol.rs
+++ b/src/adapter/http/src/smart_protocol/axum_server_pull_protocol.rs
@@ -90,7 +90,7 @@ impl AxumServerPullProtocolInstance {
             })?;
 
         tracing::debug!(
-            "Pull client sent a pull request: beginAfter={:?} stopAt={:?}",
+            "Pull client sent a pull request: beginAfter={:?} stopAt={:?} force={}",
             pull_request
                 .begin_after
                 .as_ref()
@@ -100,7 +100,8 @@ impl AxumServerPullProtocolInstance {
                 .stop_at
                 .as_ref()
                 .map(ToString::to_string)
-                .ok_or("None")
+                .ok_or("None"),
+            pull_request.force,
         );
 
         let metadata_chain = self.dataset.as_metadata_chain();
@@ -113,6 +114,7 @@ impl AxumServerPullProtocolInstance {
             metadata_chain,
             pull_request.stop_at.as_ref().unwrap_or(&head),
             pull_request.begin_after.as_ref(),
+            pull_request.force,
         )
         .await;
 
@@ -171,6 +173,7 @@ impl AxumServerPullProtocolInstance {
                     metadata_chain,
                     pull_request.stop_at.as_ref().unwrap_or(&head),
                     pull_request.begin_after.as_ref(),
+                    pull_request.force,
                 )
                 .await
                 .int_err()?;

--- a/src/adapter/http/src/smart_protocol/axum_server_push_protocol.rs
+++ b/src/adapter/http/src/smart_protocol/axum_server_push_protocol.rs
@@ -82,7 +82,7 @@ impl AxumServerPushProtocolInstance {
 
     async fn push_main_flow(mut self) -> Result<(), PushServerError> {
         let push_request = self.handle_push_request_initiation().await?;
-        let force = push_request.force;
+        let force_update_if_diverged = push_request.force_update_if_diverged;
 
         let mut new_blocks = self.try_handle_push_metadata_request(push_request).await?;
         if !new_blocks.is_empty() {
@@ -126,7 +126,8 @@ impl AxumServerPushProtocolInstance {
             }
         }
 
-        self.try_handle_push_complete(new_blocks, force).await?;
+        self.try_handle_push_complete(new_blocks, force_update_if_diverged)
+            .await?;
 
         Ok(())
     }
@@ -313,7 +314,7 @@ impl AxumServerPushProtocolInstance {
     async fn try_handle_push_complete(
         &mut self,
         new_blocks: VecDeque<HashedMetadataBlock>,
-        force: bool,
+        force_update_if_diverged: bool,
     ) -> Result<(), PushServerError> {
         axum_read_payload::<DatasetPushComplete>(&mut self.socket)
             .await
@@ -325,7 +326,7 @@ impl AxumServerPushProtocolInstance {
 
         if !new_blocks.is_empty() {
             let dataset = self.dataset.as_ref().unwrap().as_ref();
-            let response = dataset_append_metadata(dataset, new_blocks, force)
+            let response = dataset_append_metadata(dataset, new_blocks, force_update_if_diverged)
                 .await
                 .map_err(|e| {
                     tracing::debug!("Appending dataset metadata failed with error: {}", e);

--- a/src/adapter/http/src/smart_protocol/messages.rs
+++ b/src/adapter/http/src/smart_protocol/messages.rs
@@ -19,6 +19,7 @@ use url::Url;
 pub struct DatasetPullRequest {
     pub begin_after: Option<Multihash>,
     pub stop_at: Option<Multihash>,
+    pub force: bool,
 }
 
 /// Response to initial dataset pull request message
@@ -85,6 +86,7 @@ pub enum ObjectPullStrategy {
 pub struct DatasetPushRequest {
     pub current_head: Option<Multihash>,
     pub transfer_plan: TransferPlan,
+    pub force: bool,
 }
 
 /// Response to initial dataset push request message

--- a/src/adapter/http/src/smart_protocol/messages.rs
+++ b/src/adapter/http/src/smart_protocol/messages.rs
@@ -19,7 +19,7 @@ use url::Url;
 pub struct DatasetPullRequest {
     pub begin_after: Option<Multihash>,
     pub stop_at: Option<Multihash>,
-    pub force: bool,
+    pub force_update_if_diverged: bool,
 }
 
 /// Response to initial dataset pull request message
@@ -86,7 +86,7 @@ pub enum ObjectPullStrategy {
 pub struct DatasetPushRequest {
     pub current_head: Option<Multihash>,
     pub transfer_plan: TransferPlan,
-    pub force: bool,
+    pub force_update_if_diverged: bool,
 }
 
 /// Response to initial dataset push request message

--- a/src/adapter/http/src/smart_protocol/protocol_dataset_helper.rs
+++ b/src/adapter/http/src/smart_protocol/protocol_dataset_helper.rs
@@ -61,8 +61,9 @@ pub async fn prepare_dataset_transfer_plan(
     metadata_chain: &dyn MetadataChain,
     stop_at: &Multihash,
     begin_after: Option<&Multihash>,
+    force: bool,
 ) -> Result<TransferPlan, PrepareDatasetTransferEstimateError> {
-    let mut block_stream = metadata_chain.iter_blocks_interval(stop_at, begin_after, false);
+    let mut block_stream = metadata_chain.iter_blocks_interval(stop_at, begin_after, force);
 
     let mut blocks_count: u32 = 0;
     let mut bytes_in_blocks: u64 = 0;
@@ -135,13 +136,14 @@ pub async fn prepare_dataset_metadata_batch(
     metadata_chain: &dyn MetadataChain,
     stop_at: &Multihash,
     begin_after: Option<&Multihash>,
+    force: bool,
 ) -> Result<MetadataBlocksBatch, InternalError> {
     let mut num_blocks: u32 = 0;
     let encoder = flate2::write::GzEncoder::new(Vec::new(), Compression::default());
     let mut tarball_builder = tar::Builder::new(encoder);
 
     let blocks_for_transfer: Vec<HashedMetadataBlock> = metadata_chain
-        .iter_blocks_interval(stop_at, begin_after, false)
+        .iter_blocks_interval(stop_at, begin_after, force)
         .try_collect()
         .await
         .int_err()?;
@@ -208,6 +210,7 @@ pub struct AppendMetadataResponse {
 pub async fn dataset_append_metadata(
     dataset: &dyn Dataset,
     metadata: VecDeque<HashedMetadataBlock>,
+    force: bool,
 ) -> Result<AppendMetadataResponse, AppendError> {
     if metadata.is_empty() {
         return Ok(AppendMetadataResponse {
@@ -257,7 +260,7 @@ pub async fn dataset_append_metadata(
             &new_head,
             SetRefOpts {
                 validate_block_present: false,
-                check_ref_is: Some(old_head.as_ref()),
+                check_ref_is: if force { None } else { Some(old_head.as_ref()) },
             },
         )
         .await?;
@@ -332,13 +335,14 @@ pub async fn collect_object_references_from_interval(
     dataset: &dyn Dataset,
     head: &Multihash,
     tail: Option<&Multihash>,
+    force: bool,
     missing_files_only: bool,
 ) -> Result<Vec<ObjectFileReference>, CollectMissingObjectReferencesFromIntervalError> {
     let mut res_references: Vec<ObjectFileReference> = Vec::new();
 
     let mut block_stream = dataset
         .as_metadata_chain()
-        .iter_blocks_interval(head, tail, false);
+        .iter_blocks_interval(head, tail, force);
     while let Some((_, block)) = block_stream.try_next().await? {
         collect_object_references_from_block(
             dataset,

--- a/src/adapter/http/src/smart_protocol/protocol_dataset_helper.rs
+++ b/src/adapter/http/src/smart_protocol/protocol_dataset_helper.rs
@@ -61,9 +61,10 @@ pub async fn prepare_dataset_transfer_plan(
     metadata_chain: &dyn MetadataChain,
     stop_at: &Multihash,
     begin_after: Option<&Multihash>,
-    force: bool,
+    ignore_missing_tail: bool,
 ) -> Result<TransferPlan, PrepareDatasetTransferEstimateError> {
-    let mut block_stream = metadata_chain.iter_blocks_interval(stop_at, begin_after, force);
+    let mut block_stream =
+        metadata_chain.iter_blocks_interval(stop_at, begin_after, ignore_missing_tail);
 
     let mut blocks_count: u32 = 0;
     let mut bytes_in_blocks: u64 = 0;
@@ -136,14 +137,14 @@ pub async fn prepare_dataset_metadata_batch(
     metadata_chain: &dyn MetadataChain,
     stop_at: &Multihash,
     begin_after: Option<&Multihash>,
-    force: bool,
+    ignore_missing_tail: bool,
 ) -> Result<MetadataBlocksBatch, InternalError> {
     let mut num_blocks: u32 = 0;
     let encoder = flate2::write::GzEncoder::new(Vec::new(), Compression::default());
     let mut tarball_builder = tar::Builder::new(encoder);
 
     let blocks_for_transfer: Vec<HashedMetadataBlock> = metadata_chain
-        .iter_blocks_interval(stop_at, begin_after, force)
+        .iter_blocks_interval(stop_at, begin_after, ignore_missing_tail)
         .try_collect()
         .await
         .int_err()?;
@@ -210,7 +211,7 @@ pub struct AppendMetadataResponse {
 pub async fn dataset_append_metadata(
     dataset: &dyn Dataset,
     metadata: VecDeque<HashedMetadataBlock>,
-    force: bool,
+    force_update_if_diverged: bool,
 ) -> Result<AppendMetadataResponse, AppendError> {
     if metadata.is_empty() {
         return Ok(AppendMetadataResponse {
@@ -260,7 +261,11 @@ pub async fn dataset_append_metadata(
             &new_head,
             SetRefOpts {
                 validate_block_present: false,
-                check_ref_is: if force { None } else { Some(old_head.as_ref()) },
+                check_ref_is: if force_update_if_diverged {
+                    None
+                } else {
+                    Some(old_head.as_ref())
+                },
             },
         )
         .await?;
@@ -335,14 +340,15 @@ pub async fn collect_object_references_from_interval(
     dataset: &dyn Dataset,
     head: &Multihash,
     tail: Option<&Multihash>,
-    force: bool,
+    ignore_missing_tail: bool,
     missing_files_only: bool,
 ) -> Result<Vec<ObjectFileReference>, CollectMissingObjectReferencesFromIntervalError> {
     let mut res_references: Vec<ObjectFileReference> = Vec::new();
 
-    let mut block_stream = dataset
-        .as_metadata_chain()
-        .iter_blocks_interval(head, tail, force);
+    let mut block_stream =
+        dataset
+            .as_metadata_chain()
+            .iter_blocks_interval(head, tail, ignore_missing_tail);
     while let Some((_, block)) = block_stream.try_next().await? {
         collect_object_references_from_block(
             dataset,

--- a/src/adapter/http/src/smart_protocol/protocol_dataset_helper.rs
+++ b/src/adapter/http/src/smart_protocol/protocol_dataset_helper.rs
@@ -542,7 +542,7 @@ fn get_simple_transfer_protocol_headers(
     if let Some(bearer) = maybe_bearer_header {
         vec![HeaderRow {
             name: http::header::AUTHORIZATION.to_string(),
-            value: bearer.0.token().to_string(),
+            value: format!("Bearer {}", bearer.0.token()),
         }]
     } else {
         vec![]

--- a/src/adapter/http/tests/harness/client_side_harness.rs
+++ b/src/adapter/http/tests/harness/client_side_harness.rs
@@ -164,13 +164,18 @@ impl ClientSideHarness {
         DatasetLayout::new(root_path.as_path())
     }
 
-    pub async fn pull_datasets(&self, dataset_ref: DatasetRefAny) -> Vec<PullResponse> {
+    pub async fn pull_datasets(
+        &self,
+        dataset_ref: DatasetRefAny,
+        force: bool,
+    ) -> Vec<PullResponse> {
         self.pull_service
             .pull_multi(
                 vec![dataset_ref],
                 PullMultiOptions {
                     sync_options: SyncOptions {
                         create_if_not_exists: true,
+                        force,
                         ..SyncOptions::default()
                     },
                     ..Default::default()
@@ -181,8 +186,8 @@ impl ClientSideHarness {
             .unwrap()
     }
 
-    pub async fn pull_dataset_result(&self, dataset_ref: DatasetRefAny) -> PullResult {
-        self.pull_datasets(dataset_ref)
+    pub async fn pull_dataset_result(&self, dataset_ref: DatasetRefAny, force: bool) -> PullResult {
+        self.pull_datasets(dataset_ref, force)
             .await
             .first()
             .unwrap()

--- a/src/adapter/http/tests/harness/common_harness.rs
+++ b/src/adapter/http/tests/harness/common_harness.rs
@@ -9,10 +9,13 @@
 
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::{fs, io};
 
+use datafusion::arrow::array::{Array, RecordBatch, UInt64Array};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use kamu::domain::*;
-use kamu::testing::{AddDataBuilder, MetadataFactory};
+use kamu::testing::{AddDataBuilder, MetadataFactory, ParquetWriterHelper};
 use kamu::{DatasetLayout, ObjectRepositoryLocalFSSha3};
 use opendatafabric::{AccountName, DatasetAlias, DatasetRef, MetadataEvent, Multihash};
 
@@ -62,10 +65,23 @@ pub(crate) async fn write_dataset_alias(dataset_layout: &DatasetLayout, alias: &
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-pub(crate) async fn create_random_data(dataset_layout: &DatasetLayout) -> AddDataBuilder {
-    let (d_hash, d_size) = create_random_file(&dataset_layout.data_dir).await;
+pub(crate) async fn create_random_data(
+    dataset_layout: &DatasetLayout,
+    prev_offset: Option<u64>,
+    prev_checkpoint: Option<Multihash>,
+) -> AddDataBuilder {
+    let (d_hash, d_size) = create_random_parquet_file(
+        &dataset_layout.data_dir,
+        10,
+        prev_offset.map_or(0, |offset| offset + 1),
+    )
+    .await;
+
     let (c_hash, c_size) = create_random_file(&dataset_layout.checkpoints_dir).await;
+
     MetadataFactory::add_data()
+        .prev_checkpoint(prev_checkpoint)
+        .prev_offset(prev_offset)
         .new_data_physical_hash(d_hash)
         .new_data_size(d_size as u64)
         .new_checkpoint_physical_hash(c_hash)
@@ -94,19 +110,80 @@ async fn create_random_file(root: &Path) -> (Multihash, usize) {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+async fn create_random_parquet_file(
+    root: &Path,
+    num_records: usize,
+    start_offset: u64,
+) -> (Multihash, usize) {
+    use rand::RngCore;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("offset", DataType::UInt64, false),
+        Field::new("a", DataType::UInt64, false),
+    ]));
+
+    let mut column_a: Vec<u64> = Vec::with_capacity(num_records);
+    let mut column_offset: Vec<u64> = Vec::with_capacity(num_records);
+    for index in 0..num_records {
+        column_a.push(rand::thread_rng().next_u64());
+        column_offset.push(start_offset + (index as u64));
+    }
+
+    let a: Arc<dyn Array> = Arc::new(UInt64Array::from(column_a));
+    let offset: Arc<dyn Array> = Arc::new(UInt64Array::from(column_offset));
+    let record_batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::clone(&a), Arc::clone(&offset)],
+    )
+    .unwrap();
+
+    std::fs::create_dir_all(root).unwrap();
+    let tmp_data_path = root.join("data");
+    ParquetWriterHelper::from_record_batch(&tmp_data_path, &record_batch).unwrap();
+
+    let repo = ObjectRepositoryLocalFSSha3::new(root);
+    let hash = repo
+        .insert_file_move(&tmp_data_path, InsertOpts::default())
+        .await
+        .unwrap()
+        .hash;
+
+    (hash, num_records)
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 pub(crate) async fn commit_add_data_event(
     dataset_repo: &dyn DatasetRepository,
     dataset_ref: &DatasetRef,
     dataset_layout: &DatasetLayout,
+    prev_data_block_hash: Option<Multihash>,
 ) -> CommitResult {
-    dataset_repo
-        .get_dataset(dataset_ref)
+    let dataset = dataset_repo.get_dataset(dataset_ref).await.unwrap();
+
+    let (prev_offset, prev_checkpoint) = if let Some(prev_data_block_hash) = prev_data_block_hash {
+        let prev_data_block = dataset
+            .as_metadata_chain()
+            .get_block(&prev_data_block_hash)
+            .await
+            .unwrap();
+        match prev_data_block.event {
+            opendatafabric::MetadataEvent::AddData(add_data) => (
+                Some(add_data.new_data.unwrap().offset_interval.end),
+                Some(add_data.new_checkpoint.unwrap().physical_hash),
+            ),
+            _ => panic!("unexpected data event type"),
+        }
+    } else {
+        (None, None)
+    };
+
+    let random_data = create_random_data(dataset_layout, prev_offset, prev_checkpoint)
         .await
-        .unwrap()
-        .commit_event(
-            MetadataEvent::AddData(create_random_data(dataset_layout).await.build()),
-            CommitOpts::default(),
-        )
+        .build();
+
+    dataset
+        .commit_event(MetadataEvent::AddData(random_data), CommitOpts::default())
         .await
         .unwrap()
 }

--- a/src/adapter/http/tests/harness/server_side_harness.rs
+++ b/src/adapter/http/tests/harness/server_side_harness.rs
@@ -17,7 +17,7 @@ use kamu::domain::auth::{
     DatasetAction,
     DatasetActionAuthorizer,
 };
-use kamu::domain::{DatasetRepository, InternalError, SystemTimeSourceStub};
+use kamu::domain::{CompactingService, DatasetRepository, InternalError, SystemTimeSourceStub};
 use kamu::testing::MockDatasetActionAuthorizer;
 use kamu::DatasetLayout;
 use kamu_accounts::{
@@ -41,6 +41,8 @@ pub(crate) trait ServerSideHarness {
     fn operating_account_name(&self) -> Option<AccountName>;
 
     fn cli_dataset_repository(&self) -> Arc<dyn DatasetRepository>;
+
+    fn cli_compacting_service(&self) -> Arc<dyn CompactingService>;
 
     fn dataset_layout(&self, dataset_handle: &DatasetHandle) -> DatasetLayout;
 

--- a/src/adapter/http/tests/harness/server_side_local_fs_harness.rs
+++ b/src/adapter/http/tests/harness/server_side_local_fs_harness.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use dill::Component;
 use event_bus::EventBus;
 use kamu::domain::{
+    CompactingService,
     DatasetRepository,
     InternalError,
     ResultIntoInternal,
@@ -22,7 +23,14 @@ use kamu::domain::{
     SystemTimeSource,
     SystemTimeSourceStub,
 };
-use kamu::{DatasetLayout, DatasetRepositoryLocalFs, DependencyGraphServiceInMemory};
+use kamu::{
+    CompactingServiceImpl,
+    DatasetLayout,
+    DatasetRepositoryLocalFs,
+    DependencyGraphServiceInMemory,
+    ObjectStoreBuilderLocalFs,
+    ObjectStoreRegistryImpl,
+};
 use kamu_accounts::{AuthenticationService, MockAuthenticationService};
 use opendatafabric::{AccountName, DatasetAlias, DatasetHandle};
 use tempfile::TempDir;
@@ -52,8 +60,12 @@ pub(crate) struct ServerSideLocalFsHarness {
 impl ServerSideLocalFsHarness {
     pub fn new(options: ServerSideHarnessOptions) -> Self {
         let tempdir = tempfile::tempdir().unwrap();
+
         let datasets_dir = tempdir.path().join("datasets");
         std::fs::create_dir(&datasets_dir).unwrap();
+
+        let run_info_dir = tempdir.path().join("run");
+        std::fs::create_dir(&run_info_dir).unwrap();
 
         let mut base_catalog_builder = match &options.base_catalog {
             None => dill::CatalogBuilder::new(),
@@ -79,7 +91,11 @@ impl ServerSideLocalFsHarness {
             .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
             .add_value(server_authentication_mock())
             .bind::<dyn AuthenticationService, MockAuthenticationService>()
-            .add_value(ServerUrlConfig::new_test(Some(&base_url_rest)));
+            .add_value(ServerUrlConfig::new_test(Some(&base_url_rest)))
+            .add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir.clone()))
+            .bind::<dyn CompactingService, CompactingServiceImpl>()
+            .add::<ObjectStoreRegistryImpl>()
+            .add::<ObjectStoreBuilderLocalFs>();
 
         let base_catalog = base_catalog_builder.build();
 
@@ -120,6 +136,11 @@ impl ServerSideHarness for ServerSideLocalFsHarness {
     fn cli_dataset_repository(&self) -> Arc<dyn DatasetRepository> {
         let cli_catalog = create_cli_user_catalog(&self.base_catalog);
         cli_catalog.get_one::<dyn DatasetRepository>().unwrap()
+    }
+
+    fn cli_compacting_service(&self) -> Arc<dyn CompactingService> {
+        let cli_catalog = create_cli_user_catalog(&self.base_catalog);
+        cli_catalog.get_one::<dyn CompactingService>().unwrap()
     }
 
     fn dataset_url_with_scheme(&self, dataset_alias: &DatasetAlias, scheme: &str) -> Url {

--- a/src/adapter/http/tests/tests/test_data_ingest.rs
+++ b/src/adapter/http/tests/tests/test_data_ingest.rs
@@ -524,8 +524,6 @@ impl DataIngestHarness {
             .add::<DataFormatRegistryImpl>()
             .add_builder(PushIngestServiceImpl::builder().with_run_info_dir(run_info_dir))
             .bind::<dyn PushIngestService, PushIngestServiceImpl>()
-            .add::<ObjectStoreRegistryImpl>()
-            .add::<ObjectStoreBuilderLocalFs>()
             .add::<EngineProvisionerNull>()
             .add_builder(UploadServiceLocal::builder().with_cache_dir(cache_dir.clone()))
             .bind::<dyn UploadService, UploadServiceLocal>()

--- a/src/adapter/http/tests/tests/test_data_query.rs
+++ b/src/adapter/http/tests/tests/test_data_query.rs
@@ -40,8 +40,6 @@ impl Harness {
                     .with_run_info_dir(run_info_dir.path().to_path_buf()),
             )
             .bind::<dyn PushIngestService, PushIngestServiceImpl>()
-            .add::<ObjectStoreRegistryImpl>()
-            .add::<ObjectStoreBuilderLocalFs>()
             .add::<EngineProvisionerNull>()
             .build();
 

--- a/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
+++ b/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
@@ -472,6 +472,7 @@ async fn create_test_case(server_harness: &dyn ServerSideHarness) -> TestCase {
         server_repo.as_ref(),
         &make_dataset_ref(&None, "foo"),
         &server_harness.dataset_layout(&create_result.dataset_handle),
+        None,
     )
     .await;
 

--- a/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
+++ b/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
@@ -122,7 +122,7 @@ async fn test_object_url_local_fs() {
             download_from_headers == vec![
                 messages::HeaderRow {
                     name: http::header::AUTHORIZATION.to_string(),
-                    value: DUMMY_ACCESS_TOKEN.to_string()
+                    value: format!("Bearer {DUMMY_ACCESS_TOKEN}")
                 }
             ]
     );
@@ -148,7 +148,7 @@ async fn test_object_url_local_fs() {
             download_from_headers == vec![
                 messages::HeaderRow {
                     name: http::header::AUTHORIZATION.to_string(),
-                    value: DUMMY_ACCESS_TOKEN.to_string()
+                    value: format!("Bearer {DUMMY_ACCESS_TOKEN}", )
                 }
             ]
     );
@@ -197,7 +197,7 @@ async fn test_object_url_local_fs() {
             upload_to_headers == vec![
                 messages::HeaderRow {
                     name: http::header::AUTHORIZATION.to_string(),
-                    value: DUMMY_ACCESS_TOKEN.to_string()
+                    value: format!("Bearer {DUMMY_ACCESS_TOKEN}", )
                 }
             ]
     );
@@ -222,7 +222,7 @@ async fn test_object_url_local_fs() {
             upload_to_headers == vec![
                 messages::HeaderRow {
                     name: http::header::AUTHORIZATION.to_string(),
-                    value: DUMMY_ACCESS_TOKEN.to_string()
+                    value: format!("Bearer {DUMMY_ACCESS_TOKEN}", )
                 }
             ]
     );

--- a/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
+++ b/src/adapter/http/tests/tests/test_protocol_dataset_helpers.rs
@@ -488,6 +488,7 @@ async fn create_test_case(server_harness: &dyn ServerSideHarness) -> TestCase {
         &commit_result.new_head,
         None,
         false,
+        false,
     )
     .await
     .unwrap();

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/mod.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/mod.rs
@@ -10,6 +10,7 @@
 mod scenario_aborted_read_of_existing_evolved_dataset_reread_succeeds;
 mod scenario_aborted_read_of_new_reread_succeeds;
 mod scenario_existing_advanced_dataset_fails;
+mod scenario_existing_diverged_dataset;
 mod scenario_existing_evolved_dataset;
 mod scenario_existing_up_to_date_dataset;
 mod scenario_new_dataset;
@@ -18,6 +19,7 @@ mod scenario_new_empty_dataset;
 pub(crate) use scenario_aborted_read_of_existing_evolved_dataset_reread_succeeds::*;
 pub(crate) use scenario_aborted_read_of_new_reread_succeeds::*;
 pub(crate) use scenario_existing_advanced_dataset_fails::*;
+pub(crate) use scenario_existing_diverged_dataset::*;
 pub(crate) use scenario_existing_evolved_dataset::*;
 pub(crate) use scenario_existing_up_to_date_dataset::*;
 pub(crate) use scenario_new_dataset::*;

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_aborted_read_of_existing_evolved_dataset_reread_succeeds.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_aborted_read_of_existing_evolved_dataset_reread_succeeds.rs
@@ -100,6 +100,7 @@ impl<TServerHarness: ServerSideHarness>
             server_repo.as_ref(),
             &server_dataset_ref,
             &server_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_aborted_read_of_new_reread_succeeds.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_aborted_read_of_new_reread_succeeds.rs
@@ -65,6 +65,7 @@ impl<TServerHarness: ServerSideHarness>
             server_repo.as_ref(),
             &make_dataset_ref(&server_account_name, "foo"),
             &server_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_evolved_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_evolved_dataset.rs
@@ -95,6 +95,7 @@ impl<TServerHarness: ServerSideHarness> SmartPullExistingEvolvedDatasetScenario<
             server_repo.as_ref(),
             &server_dataset_ref,
             &server_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_up_to_date_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_existing_up_to_date_dataset.rs
@@ -60,6 +60,7 @@ impl<TServerHarness: ServerSideHarness> SmartPullExistingUpToDateDatasetScenario
             server_repo.as_ref(),
             &make_dataset_ref(&server_account_name, "foo"),
             &server_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_new_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_pull/scenarios/scenario_new_dataset.rs
@@ -60,6 +60,7 @@ impl<TServerHarness: ServerSideHarness> SmartPullNewDatasetScenario<TServerHarne
             server_repo.as_ref(),
             &make_dataset_ref(&server_account_name, "foo"),
             &server_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_pull/test_smart_pull_local_fs.rs
+++ b/src/adapter/http/tests/tests/tests_pull/test_smart_pull_local_fs.rs
@@ -27,6 +27,13 @@ test_client_server_local_fs_harness_permutations!(
 
 test_client_server_local_fs_harness_permutations!(
     test_smart_pull_shared,
+    test_smart_pull_new_empty_dataset
+);
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+test_client_server_local_fs_harness_permutations!(
+    test_smart_pull_shared,
     test_smart_pull_existing_up_to_date_dataset
 );
 
@@ -35,6 +42,13 @@ test_client_server_local_fs_harness_permutations!(
 test_client_server_local_fs_harness_permutations!(
     test_smart_pull_shared,
     test_smart_pull_existing_evolved_dataset
+);
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+test_client_server_local_fs_harness_permutations!(
+    test_smart_pull_shared,
+    test_smart_pull_existing_diverged_dataset
 );
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -56,13 +70,6 @@ test_client_server_local_fs_harness_permutations!(
 test_client_server_local_fs_harness_permutations!(
     test_smart_pull_shared,
     test_smart_pull_aborted_read_of_existing_evolved_dataset_reread_succeeds
-);
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-test_client_server_local_fs_harness_permutations!(
-    test_smart_pull_shared,
-    test_smart_pull_new_empty_dataset
 );
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/tests/tests_pull/test_smart_pull_s3.rs
+++ b/src/adapter/http/tests/tests/tests_pull/test_smart_pull_s3.rs
@@ -24,6 +24,13 @@ test_client_server_s3_harness_permutations!(test_smart_pull_shared, test_smart_p
 
 test_client_server_s3_harness_permutations!(
     test_smart_pull_shared,
+    test_smart_pull_new_empty_dataset
+);
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+test_client_server_s3_harness_permutations!(
+    test_smart_pull_shared,
     test_smart_pull_existing_up_to_date_dataset
 );
 
@@ -32,6 +39,13 @@ test_client_server_s3_harness_permutations!(
 test_client_server_s3_harness_permutations!(
     test_smart_pull_shared,
     test_smart_pull_existing_evolved_dataset
+);
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+test_client_server_s3_harness_permutations!(
+    test_smart_pull_shared,
+    test_smart_pull_existing_diverged_dataset
 );
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -53,13 +67,6 @@ test_client_server_s3_harness_permutations!(
 test_client_server_s3_harness_permutations!(
     test_smart_pull_shared,
     test_smart_pull_aborted_read_of_existing_evolved_dataset_reread_succeeds
-);
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-test_client_server_s3_harness_permutations!(
-    test_smart_pull_shared,
-    test_smart_pull_new_empty_dataset
 );
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/tests/tests_pull/test_smart_pull_shared.rs
+++ b/src/adapter/http/tests/tests/tests_pull/test_smart_pull_shared.rs
@@ -26,13 +26,46 @@ pub(crate) async fn test_smart_pull_new_dataset<TServerHarness: ServerSideHarnes
     let client_handle = async {
         let pull_result = scenario
             .client_harness
-            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref))
+            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref), false)
             .await;
 
         assert_eq!(
             PullResult::Updated {
                 old_head: None,
                 new_head: scenario.server_commit_result.new_head,
+            },
+            pull_result
+        );
+
+        DatasetTestHelper::assert_datasets_in_sync(
+            &scenario.server_dataset_layout,
+            &scenario.client_dataset_layout,
+        );
+    };
+
+    await_client_server_flow!(api_server_handle, client_handle);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub(crate) async fn test_smart_pull_new_empty_dataset<TServerHarness: ServerSideHarness>(
+    a_client_harness: ClientSideHarness,
+    a_server_harness: TServerHarness,
+) {
+    let scenario =
+        SmartPullNewEmptyDatasetScenario::prepare(a_client_harness, a_server_harness).await;
+
+    let api_server_handle = scenario.server_harness.api_server_run();
+    let client_handle = async {
+        let pull_result = scenario
+            .client_harness
+            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref), false)
+            .await;
+
+        assert_eq!(
+            PullResult::Updated {
+                old_head: None,
+                new_head: scenario.server_create_result.head,
             },
             pull_result
         );
@@ -61,7 +94,7 @@ pub(crate) async fn test_smart_pull_existing_up_to_date_dataset<
     let client_handle = async {
         let pull_result = scenario
             .client_harness
-            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref))
+            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref), false)
             .await;
 
         assert_eq!(PullResult::UpToDate {}, pull_result);
@@ -88,13 +121,54 @@ pub(crate) async fn test_smart_pull_existing_evolved_dataset<TServerHarness: Ser
     let client_handle = async {
         let pull_result = scenario
             .client_harness
-            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref))
+            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref), false)
             .await;
 
         assert_eq!(
             PullResult::Updated {
                 old_head: Some(scenario.server_create_result.head),
                 new_head: scenario.server_commit_result.new_head,
+            },
+            pull_result
+        );
+
+        DatasetTestHelper::assert_datasets_in_sync(
+            &scenario.server_dataset_layout,
+            &scenario.client_dataset_layout,
+        );
+    };
+
+    await_client_server_flow!(api_server_handle, client_handle);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub(crate) async fn test_smart_pull_existing_diverged_dataset<TServerHarness: ServerSideHarness>(
+    a_client_harness: ClientSideHarness,
+    a_server_harness: TServerHarness,
+) {
+    let scenario =
+        SmartPullExistingDivergedDatasetScenario::prepare(a_client_harness, a_server_harness).await;
+
+    let api_server_handle = scenario.server_harness.api_server_run();
+    let client_handle = async {
+        let pull_result = scenario
+            .client_harness
+            .pull_dataset_result(
+                DatasetRefAny::from(scenario.server_dataset_ref),
+                true, /* diverged! */
+            )
+            .await;
+
+        let new_head = match scenario.server_compacting_result {
+            CompactingResult::NothingToDo => panic!("unexpected compacting result"),
+            CompactingResult::Success { new_head, .. } => new_head,
+        };
+
+        assert_eq!(
+            PullResult::Updated {
+                old_head: Some(scenario.server_precompacting_result.new_head),
+                new_head,
             },
             pull_result
         );
@@ -124,7 +198,7 @@ pub(crate) async fn test_smart_pull_existing_advanced_dataset_fails<
     let client_handle = async {
         let pull_responses = scenario
             .client_harness
-            .pull_datasets(DatasetRefAny::from(scenario.server_dataset_ref))
+            .pull_datasets(DatasetRefAny::from(scenario.server_dataset_ref), false)
             .await;
 
         // TODO: try expecting better error message
@@ -152,7 +226,7 @@ pub(crate) async fn test_smart_pull_aborted_read_of_new_reread_succeeds<
     let client_handle = async {
         let pull_result = scenario
             .client_harness
-            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref))
+            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref), false)
             .await;
 
         assert_eq!(
@@ -190,46 +264,13 @@ pub(crate) async fn test_smart_pull_aborted_read_of_existing_evolved_dataset_rer
     let client_handle = async {
         let pull_result = scenario
             .client_harness
-            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref))
+            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref), false)
             .await;
 
         assert_eq!(
             PullResult::Updated {
                 old_head: Some(scenario.server_create_result.head),
                 new_head: scenario.server_commit_result.new_head,
-            },
-            pull_result
-        );
-
-        DatasetTestHelper::assert_datasets_in_sync(
-            &scenario.server_dataset_layout,
-            &scenario.client_dataset_layout,
-        );
-    };
-
-    await_client_server_flow!(api_server_handle, client_handle);
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-pub(crate) async fn test_smart_pull_new_empty_dataset<TServerHarness: ServerSideHarness>(
-    a_client_harness: ClientSideHarness,
-    a_server_harness: TServerHarness,
-) {
-    let scenario =
-        SmartPullNewEmptyDatasetScenario::prepare(a_client_harness, a_server_harness).await;
-
-    let api_server_handle = scenario.server_harness.api_server_run();
-    let client_handle = async {
-        let pull_result = scenario
-            .client_harness
-            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref))
-            .await;
-
-        assert_eq!(
-            PullResult::Updated {
-                old_head: None,
-                new_head: scenario.server_create_result.head,
             },
             pull_result
         );

--- a/src/adapter/http/tests/tests/tests_pull/test_smart_pull_special.rs
+++ b/src/adapter/http/tests/tests/tests_pull/test_smart_pull_special.rs
@@ -55,7 +55,7 @@ async fn test_smart_pull_unauthenticated() {
     let client_handle = async {
         let pull_result = scenario
             .client_harness
-            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref))
+            .pull_dataset_result(DatasetRefAny::from(scenario.server_dataset_ref), false)
             .await;
 
         assert_eq!(

--- a/src/adapter/http/tests/tests/tests_push/scenarios/mod.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/mod.rs
@@ -10,6 +10,7 @@
 mod scenario_aborted_write_of_new_rewrite_succeeds;
 mod scenario_aborted_write_of_updated_rewrite_succeeds;
 mod scenario_existing_dataset_fails_as_server_advanced;
+mod scenario_existing_diverged_dataset;
 mod scenario_existing_evolved_dataset;
 mod scenario_existing_up_to_date_dataset;
 mod scenario_new_dataset;
@@ -18,6 +19,7 @@ mod scenario_new_empty_dataset;
 pub(crate) use scenario_aborted_write_of_new_rewrite_succeeds::*;
 pub(crate) use scenario_aborted_write_of_updated_rewrite_succeeds::*;
 pub(crate) use scenario_existing_dataset_fails_as_server_advanced::*;
+pub(crate) use scenario_existing_diverged_dataset::*;
 pub(crate) use scenario_existing_evolved_dataset::*;
 pub(crate) use scenario_existing_up_to_date_dataset::*;
 pub(crate) use scenario_new_dataset::*;

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_aborted_write_of_updated_rewrite_succeeds.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_aborted_write_of_updated_rewrite_succeeds.rs
@@ -102,6 +102,7 @@ impl<TServerHarness: ServerSideHarness>
             client_repo.as_ref(),
             &client_dataset_ref,
             &client_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_diverged_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_diverged_dataset.rs
@@ -1,0 +1,124 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use kamu::domain::*;
+use kamu::testing::MetadataFactory;
+use kamu::DatasetLayout;
+use opendatafabric::*;
+
+use crate::harness::{
+    commit_add_data_event,
+    copy_dataset_files,
+    make_dataset_ref,
+    write_dataset_alias,
+    ClientSideHarness,
+    ServerSideHarness,
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub(crate) struct SmartPushExistingDivergedDatasetScenario<TServerHarness: ServerSideHarness> {
+    pub client_harness: ClientSideHarness,
+    pub server_harness: TServerHarness,
+    pub server_dataset_layout: DatasetLayout,
+    pub client_dataset_layout: DatasetLayout,
+    pub server_dataset_ref: DatasetRefRemote,
+    pub client_dataset_ref: DatasetRef,
+    pub client_precompacting_result: CommitResult,
+    pub client_compacting_result: CompactingResult,
+}
+
+impl<TServerHarness: ServerSideHarness> SmartPushExistingDivergedDatasetScenario<TServerHarness> {
+    pub async fn prepare(
+        client_harness: ClientSideHarness,
+        server_harness: TServerHarness,
+    ) -> Self {
+        let client_account_name = client_harness.operating_account_name();
+        let server_account_name = server_harness.operating_account_name();
+
+        let client_repo = client_harness.dataset_repository();
+
+        let client_create_result = client_repo
+            .create_dataset_from_snapshot(
+                MetadataFactory::dataset_snapshot()
+                    .name(DatasetAlias::new(
+                        client_account_name.clone(),
+                        DatasetName::new_unchecked("foo"),
+                    ))
+                    .kind(DatasetKind::Root)
+                    .push_event(MetadataFactory::set_polling_source().build())
+                    .push_event(MetadataFactory::set_data_schema().build())
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        let client_dataset_layout =
+            client_harness.dataset_layout(&client_create_result.dataset_handle.id, "foo");
+
+        let client_dataset_ref = make_dataset_ref(&client_account_name, "foo");
+
+        // Generate a few blocks of random data
+        let mut commit_result: Option<CommitResult> = None;
+        for _ in 0..3 {
+            commit_result = Some(
+                commit_add_data_event(
+                    client_repo.as_ref(),
+                    &client_dataset_ref,
+                    &client_dataset_layout,
+                    commit_result.map(|r| r.new_head),
+                )
+                .await,
+            );
+        }
+        let foo_name = DatasetName::new_unchecked("foo");
+
+        let server_dataset_layout = server_harness.dataset_layout(&DatasetHandle::new(
+            client_create_result.dataset_handle.id.clone(),
+            DatasetAlias::new(server_account_name.clone(), foo_name.clone()),
+        ));
+
+        // Hard folder synchronization
+        copy_dataset_files(&client_dataset_layout, &server_dataset_layout).unwrap();
+
+        write_dataset_alias(
+            &server_dataset_layout,
+            &DatasetAlias::new(server_account_name.clone(), foo_name.clone()),
+        )
+        .await;
+
+        // Compact at client side
+        let compacting_service = client_harness.compacting_service();
+        let client_compacting_result = compacting_service
+            .compact_dataset(
+                &client_create_result.dataset_handle,
+                CompactingOptions::default(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let server_alias = DatasetAlias::new(server_account_name, foo_name);
+        let server_odf_url = server_harness.dataset_url(&server_alias);
+        let server_dataset_ref = DatasetRefRemote::from(&server_odf_url);
+
+        Self {
+            client_harness,
+            server_harness,
+            server_dataset_layout,
+            client_dataset_layout,
+            server_dataset_ref,
+            client_dataset_ref,
+            client_precompacting_result: commit_result.unwrap(),
+            client_compacting_result,
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_evolved_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_evolved_dataset.rs
@@ -99,6 +99,7 @@ impl<TServerHarness: ServerSideHarness> SmartPushExistingEvolvedDatasetScenario<
             client_repo.as_ref(),
             &client_dataset_ref,
             &client_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_up_to_date_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_existing_up_to_date_dataset.rs
@@ -71,6 +71,7 @@ impl<TServerHarness: ServerSideHarness> SmartPushExistingUpToDateDatasetScenario
             client_repo.as_ref(),
             &client_dataset_ref,
             &client_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_push/scenarios/scenario_new_dataset.rs
+++ b/src/adapter/http/tests/tests/tests_push/scenarios/scenario_new_dataset.rs
@@ -72,6 +72,7 @@ impl<TServerHarness: ServerSideHarness> SmartPushNewDatasetScenario<TServerHarne
             client_repo.as_ref(),
             &client_dataset_ref,
             &client_dataset_layout,
+            None,
         )
         .await;
 

--- a/src/adapter/http/tests/tests/tests_push/test_smart_push_local_fs.rs
+++ b/src/adapter/http/tests/tests/tests_push/test_smart_push_local_fs.rs
@@ -27,6 +27,13 @@ test_client_server_local_fs_harness_permutations!(
 
 test_client_server_local_fs_harness_permutations!(
     test_smart_push_shared,
+    test_smart_push_new_empty_dataset
+);
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+test_client_server_local_fs_harness_permutations!(
+    test_smart_push_shared,
     test_smart_push_existing_up_to_date_dataset
 );
 
@@ -35,6 +42,13 @@ test_client_server_local_fs_harness_permutations!(
 test_client_server_local_fs_harness_permutations!(
     test_smart_push_shared,
     test_smart_push_existing_evolved_dataset
+);
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+test_client_server_local_fs_harness_permutations!(
+    test_smart_push_shared,
+    test_smart_push_existing_diverged_dataset
 );
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -56,13 +70,6 @@ test_client_server_local_fs_harness_permutations!(
 test_client_server_local_fs_harness_permutations!(
     test_smart_push_shared,
     test_smart_push_aborted_write_of_updated_rewrite_succeeds
-);
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-test_client_server_local_fs_harness_permutations!(
-    test_smart_push_shared,
-    test_smart_push_new_empty_dataset
 );
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/tests/tests_push/test_smart_push_s3.rs
+++ b/src/adapter/http/tests/tests/tests_push/test_smart_push_s3.rs
@@ -24,6 +24,13 @@ test_client_server_s3_harness_permutations!(test_smart_push_shared, test_smart_p
 
 test_client_server_s3_harness_permutations!(
     test_smart_push_shared,
+    test_smart_push_new_empty_dataset
+);
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+test_client_server_s3_harness_permutations!(
+    test_smart_push_shared,
     test_smart_push_existing_up_to_date_dataset
 );
 
@@ -32,6 +39,13 @@ test_client_server_s3_harness_permutations!(
 test_client_server_s3_harness_permutations!(
     test_smart_push_shared,
     test_smart_push_existing_evolved_dataset
+);
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+test_client_server_s3_harness_permutations!(
+    test_smart_push_shared,
+    test_smart_push_existing_diverged_dataset
 );
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -53,13 +67,6 @@ test_client_server_s3_harness_permutations!(
 test_client_server_s3_harness_permutations!(
     test_smart_push_shared,
     test_smart_push_aborted_write_of_updated_rewrite_succeeds
-);
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
-test_client_server_s3_harness_permutations!(
-    test_smart_push_shared,
-    test_smart_push_new_empty_dataset
 );
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/tests/tests_push/test_smart_push_special.rs
+++ b/src/adapter/http/tests/tests/tests_push/test_smart_push_special.rs
@@ -46,7 +46,11 @@ async fn test_smart_push_new_dataset_unauthenticated() {
     let client_handle = async {
         let push_result = scenario
             .client_harness
-            .push_dataset(scenario.client_dataset_ref, scenario.server_dataset_ref)
+            .push_dataset(
+                scenario.client_dataset_ref,
+                scenario.server_dataset_ref,
+                false,
+            )
             .await;
 
         let dataset_result = &push_result.first().unwrap().result;
@@ -91,7 +95,7 @@ async fn test_smart_push_new_dataset_wrong_user() {
     let client_handle = async {
         let push_result = scenario
             .client_harness
-            .push_dataset(scenario.client_dataset_ref, wrong_server_dataset_ref)
+            .push_dataset(scenario.client_dataset_ref, wrong_server_dataset_ref, false)
             .await;
 
         let dataset_result = &push_result.first().unwrap().result;
@@ -129,7 +133,11 @@ async fn test_smart_push_existing_dataset_unauthenticated() {
     let client_handle = async {
         let push_result = scenario
             .client_harness
-            .push_dataset(scenario.client_dataset_ref, scenario.server_dataset_ref)
+            .push_dataset(
+                scenario.client_dataset_ref,
+                scenario.server_dataset_ref,
+                false,
+            )
             .await;
 
         let dataset_result = &push_result.first().unwrap().result;
@@ -167,7 +175,11 @@ async fn test_smart_push_existing_dataset_unauthorized() {
     let client_handle = async {
         let push_result = scenario
             .client_harness
-            .push_dataset(scenario.client_dataset_ref, scenario.server_dataset_ref)
+            .push_dataset(
+                scenario.client_dataset_ref,
+                scenario.server_dataset_ref,
+                false,
+            )
             .await;
 
         let dataset_result = &push_result.first().unwrap().result;

--- a/src/domain/core/src/services/sync_service.rs
+++ b/src/domain/core/src/services/sync_service.rs
@@ -220,14 +220,37 @@ impl DatasetNotFoundError {
 ///////////////////////////////////////////////////////////////////////////////
 
 #[derive(Error, Clone, Eq, PartialEq, Debug)]
-#[error(
-    "Source and destination datasets have diverged and have {uncommon_blocks_in_src} and \
-     {uncommon_blocks_in_dst} different blocks respectively, source head is {src_head}, \
-     destination head is {dst_head}"
-)]
 pub struct DatasetsDivergedError {
     pub src_head: Multihash,
     pub dst_head: Multihash,
+    pub detail: Option<DatasetsDivergedErrorDetail>,
+}
+
+impl std::fmt::Display for DatasetsDivergedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(detail) = &self.detail {
+            write!(
+                f,
+                "Source and destination datasets have diverged and have {} and {} different \
+                 blocks respectively, source head is {}, destination head is {}",
+                detail.uncommon_blocks_in_src,
+                detail.uncommon_blocks_in_dst,
+                self.src_head,
+                self.dst_head,
+            )
+        } else {
+            write!(
+                f,
+                "Source and destination datasets have diverged, source head is {}, destination \
+                 head is {}",
+                self.src_head, self.dst_head,
+            )
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct DatasetsDivergedErrorDetail {
     pub uncommon_blocks_in_src: u64,
     pub uncommon_blocks_in_dst: u64,
 }

--- a/src/infra/core/src/repos/dataset_impl.rs
+++ b/src/infra/core/src/repos/dataset_impl.rs
@@ -292,10 +292,12 @@ where
                 .int_err()?;
         }
 
-        if let Some(checkpoint_meta) = checkpoint_meta {
+        if let Some(checkpoint_meta) = checkpoint_meta
+            && let Some(checkpoint) = checkpoint
+        {
             self.as_checkpoint_repo()
                 .insert_file_move(
-                    &checkpoint.unwrap().into_inner(),
+                    &checkpoint.into_inner(),
                     InsertOpts {
                         precomputed_hash: Some(&checkpoint_meta.physical_hash),
                         expected_hash: None,

--- a/src/infra/core/src/sync_service_impl.rs
+++ b/src/infra/core/src/sync_service_impl.rs
@@ -236,7 +236,7 @@ impl SyncServiceImpl {
                 dst_factory,
                 listener,
                 TransferOptions {
-                    force: opts.force,
+                    force_update_if_diverged: opts.force,
                     ..Default::default()
                 },
             )
@@ -281,7 +281,7 @@ impl SyncServiceImpl {
                 maybe_dst_head.as_ref(),
                 listener,
                 TransferOptions {
-                    force,
+                    force_update_if_diverged: force,
                     ..Default::default()
                 },
             )

--- a/src/infra/core/src/testing/dummy_smart_transfer_protocol_client.rs
+++ b/src/infra/core/src/testing/dummy_smart_transfer_protocol_client.rs
@@ -14,7 +14,7 @@ use opendatafabric::Multihash;
 use url::Url;
 
 use crate::utils::simple_transfer_protocol::DatasetFactoryFn;
-use crate::utils::smart_transfer_protocol::{ObjectTransferOptions, SmartTransferProtocolClient};
+use crate::utils::smart_transfer_protocol::{SmartTransferProtocolClient, TransferOptions};
 
 #[dill::component]
 #[dill::interface(dyn SmartTransferProtocolClient)]
@@ -34,7 +34,7 @@ impl SmartTransferProtocolClient for DummySmartTransferProtocolClient {
         _dst: Option<Arc<dyn Dataset>>,
         _dst_factory: Option<DatasetFactoryFn>,
         _listener: Arc<dyn SyncListener>,
-        _transfer_options: ObjectTransferOptions,
+        _transfer_options: TransferOptions,
     ) -> Result<SyncResult, SyncError> {
         unimplemented!("Not supported yet")
     }
@@ -45,7 +45,7 @@ impl SmartTransferProtocolClient for DummySmartTransferProtocolClient {
         _http_dst_url: &Url,
         _dst_head: Option<&Multihash>,
         _listener: Arc<dyn SyncListener>,
-        _transfer_options: ObjectTransferOptions,
+        _transfer_options: TransferOptions,
     ) -> Result<SyncResult, SyncError> {
         unimplemented!("Not supported yet")
     }

--- a/src/infra/core/src/testing/metadata_factory.rs
+++ b/src/infra/core/src/testing/metadata_factory.rs
@@ -474,7 +474,8 @@ impl AddDataBuilder {
     }
 
     pub fn some_new_data(self) -> Self {
-        self.some_new_data_with_offset(0, 9)
+        let start_offset = self.v.prev_offset.map_or(0, |offset| offset + 1);
+        self.some_new_data_with_offset(start_offset, start_offset + 9)
     }
 
     pub fn some_new_data_with_offset(mut self, start: u64, end: u64) -> Self {
@@ -629,7 +630,8 @@ impl ExecuteTransformBuilder {
     }
 
     pub fn some_new_data(self) -> Self {
-        self.some_new_data_with_offset(0, 9)
+        let start_offset = self.v.prev_offset.map_or(0, |offset| offset + 1);
+        self.some_new_data_with_offset(start_offset, start_offset + 9)
     }
 
     pub fn some_new_data_with_offset(mut self, start: u64, end: u64) -> Self {

--- a/src/infra/core/src/utils/simple_transfer_protocol.rs
+++ b/src/infra/core/src/utils/simple_transfer_protocol.rs
@@ -125,8 +125,10 @@ impl SimpleTransferProtocol {
                     return Err(SyncError::DatasetsDiverged(DatasetsDivergedError {
                         src_head,
                         dst_head: dst_head.unwrap(),
-                        uncommon_blocks_in_dst,
-                        uncommon_blocks_in_src,
+                        detail: Some(DatasetsDivergedErrorDetail {
+                            uncommon_blocks_in_src,
+                            uncommon_blocks_in_dst,
+                        }),
                     }));
                 }
             }

--- a/src/infra/core/src/utils/smart_transfer_protocol.rs
+++ b/src/infra/core/src/utils/smart_transfer_protocol.rs
@@ -20,7 +20,7 @@ pub use super::simple_transfer_protocol::DatasetFactoryFn;
 #[derive(Debug, Eq, PartialEq)]
 pub struct TransferOptions {
     pub max_parallel_transfers: usize,
-    pub force: bool,
+    pub force_update_if_diverged: bool,
 }
 
 impl Default for TransferOptions {
@@ -34,7 +34,7 @@ impl Default for TransferOptions {
 
         Self {
             max_parallel_transfers,
-            force: false,
+            force_update_if_diverged: false,
         }
     }
 }

--- a/src/infra/core/src/utils/smart_transfer_protocol.rs
+++ b/src/infra/core/src/utils/smart_transfer_protocol.rs
@@ -18,11 +18,12 @@ pub use super::simple_transfer_protocol::DatasetFactoryFn;
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct ObjectTransferOptions {
+pub struct TransferOptions {
     pub max_parallel_transfers: usize,
+    pub force: bool,
 }
 
-impl Default for ObjectTransferOptions {
+impl Default for TransferOptions {
     fn default() -> Self {
         // Use number of allowed parallel threads on the target system.
         // Run single-threaded transfer as a fallback, if the parallelism grade cannot
@@ -33,6 +34,7 @@ impl Default for ObjectTransferOptions {
 
         Self {
             max_parallel_transfers,
+            force: false,
         }
     }
 }
@@ -47,7 +49,7 @@ pub trait SmartTransferProtocolClient: Sync + Send {
         dst: Option<Arc<dyn Dataset>>,
         dst_factory: Option<DatasetFactoryFn>,
         listener: Arc<dyn SyncListener>,
-        transfer_options: ObjectTransferOptions,
+        transfer_options: TransferOptions,
     ) -> Result<SyncResult, SyncError>;
 
     async fn push_protocol_client_flow(
@@ -56,7 +58,7 @@ pub trait SmartTransferProtocolClient: Sync + Send {
         http_dst_url: &Url,
         dst_head: Option<&Multihash>,
         listener: Arc<dyn SyncListener>,
-        transfer_options: ObjectTransferOptions,
+        transfer_options: TransferOptions,
     ) -> Result<SyncResult, SyncError>;
 }
 

--- a/src/infra/core/tests/tests/test_sync_service_impl.rs
+++ b/src/infra/core/tests/tests/test_sync_service_impl.rs
@@ -368,7 +368,14 @@ async fn do_test_sync(
 
     assert_matches!(
         sync_svc.sync(&dataset_alias_2.as_any_ref(), &push_ref.as_any_ref(), SyncOptions::default(), None).await,
-        Err(SyncError::DatasetsDiverged(DatasetsDivergedError { src_head, dst_head, uncommon_blocks_in_src, uncommon_blocks_in_dst }))
+        Err(SyncError::DatasetsDiverged(DatasetsDivergedError {
+            src_head,
+            dst_head,
+            detail: Some(DatasetsDivergedErrorDetail {
+                uncommon_blocks_in_src,
+                uncommon_blocks_in_dst
+            })
+        }))
         if src_head == b4_alt && dst_head == b5 && uncommon_blocks_in_src == 1 && uncommon_blocks_in_dst == 2
     );
 


### PR DESCRIPTION
## Description

Closes: #661 

<!--- Describe your changes in detail and include your changelog entries -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅