### PR TITLE
EthereumLogs data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+## Added
+- New `EthereumLogs` polling source allows to stream and decode log data directly from any ETH-compatible blockchain node
+  - See the updated `examples/reth-vs-snp500` example
+  - See the new [`datafusion-ethers`](https://github.com/kamu-data/datafusion-ethers) crate for implementation details
+## Changed
+- Upgraded to `arrow 52` and `datafusion 39`
+- Improved binary data formatting in CLI table output - instead of the `<binary>` placeholder it will display an abbreviated hex values e.g. `c47cf6…7e3755`
+- JSON and CSV formatters can now output binary data - it will be `hex`-encoded by default
+## Fixed
+- JSON formatter now properly supports `Decimal` types
+
 ## [0.185.1] - 2024-06-07
 ### Fixed
 - Fixed support of `--force` mode for pull/push actions using Smart Transfer Protocol

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "alloy"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ws",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fd095a9d70f4b1c5c102c84a4c782867a5c6416dbf6dcd42a63e7c7a89d3c8"
+dependencies = [
+ "num_enum",
+ "strum 0.26.2",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "c-kzg",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-types",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "thiserror",
+]
+
+[[package]]
 name = "alloy-core"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,7 +176,32 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.6.11",
+ "winnow 0.6.13",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "c-kzg",
+ "once_cell",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -127,6 +214,36 @@ dependencies = [
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "futures-utils-wasm",
+ "thiserror",
 ]
 
 [[package]]
@@ -152,13 +269,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-rpc-types-trace",
+ "alloy-transport",
+ "alloy-transport-ws",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures",
+ "futures-utils-wasm",
+ "lru",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "bimap",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b155716bab55763c95ba212806cf43d05bcc70e5f35b02bad20cf5ec7fe11fed"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8037e03c7f462a063f28daec9fda285a9a89da003c552f8637a80b9c8fd96241"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-pubsub",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ws",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve 0.13.8",
+ "k256",
+ "thiserror",
 ]
 
 [[package]]
@@ -217,7 +470,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fd4783b0a5840479013e9ce960d2eb7b3be381f722e0fe3d1f7c3bb6bd4ebd"
 dependencies = [
- "winnow 0.6.11",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -231,6 +484,49 @@ dependencies = [
  "alloy-sol-macro",
  "const-hex",
  "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-transport",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -973,7 +1269,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "ring 0.17.8",
+ "ring",
  "time",
  "tokio",
  "tracing",
@@ -1028,7 +1324,7 @@ dependencies = [
  "http",
  "percent-encoding",
  "tracing",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1148,7 +1444,7 @@ dependencies = [
  "p256",
  "percent-encoding",
  "regex",
- "ring 0.17.8",
+ "ring",
  "sha2",
  "time",
  "tracing",
@@ -1463,10 +1759,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bech32"
-version = "0.9.1"
+name = "bimap"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bit-set"
@@ -1542,6 +1838,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62dc83a094a71d43eeadd254b1ec2d24cb6a0bb6cadce00df51f0db594711a32"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "brotli"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,10 +1896,6 @@ name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "sha2",
- "tinyvec",
-]
 
 [[package]]
 name = "bstr"
@@ -1660,6 +1964,20 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "c-kzg"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf100c4cea8f207e883ff91ca886d621d8a166cb04971dfaa9bb8fd99ed95df"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "serde",
 ]
 
 [[package]]
@@ -1873,58 +2191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coins-bip32"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
-dependencies = [
- "bs58",
- "coins-core",
- "digest 0.10.7",
- "hmac",
- "k256",
- "serde",
- "sha2",
- "thiserror",
-]
-
-[[package]]
-name = "coins-bip39"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
-dependencies = [
- "bitvec",
- "coins-bip32",
- "hmac",
- "once_cell",
- "pbkdf2 0.12.2",
- "rand",
- "sha2",
- "thiserror",
-]
-
-[[package]]
-name = "coins-core"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
-dependencies = [
- "base64 0.21.7",
- "bech32",
- "bs58",
- "digest 0.10.7",
- "generic-array",
- "hex",
- "ripemd",
- "serde",
- "serde_derive",
- "sha2",
- "sha3",
- "thiserror",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,7 +2213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "strum 0.26.2",
- "strum_macros 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-width",
 ]
 
@@ -2288,15 +2554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,13 +2694,13 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
 name = "datafusion"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2480,6 +2737,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
+ "paste",
  "pin-project-lite",
  "rand",
  "sqlparser",
@@ -2487,7 +2745,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
- "uuid 1.8.0",
+ "uuid",
  "xz2",
  "zstd 0.13.1",
 ]
@@ -2495,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2516,32 +2774,31 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-ethers"
-version = "38.0.0"
+version = "38.2.0"
+source = "git+https://github.com/kamu-data/datafusion-ethers?branch=datafusion-39#aea38e51ca2bdb2b276361e07c9364e780edc52f"
 dependencies = [
- "alloy-core",
+ "alloy",
  "async-stream",
  "async-trait",
  "datafusion",
- "ethers",
  "futures",
  "serde_json",
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
 name = "datafusion-execution"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "chrono",
@@ -2561,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2572,13 +2829,13 @@ dependencies = [
  "serde_json",
  "sqlparser",
  "strum 0.26.2",
- "strum_macros 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "datafusion-functions"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2598,13 +2855,13 @@ dependencies = [
  "regex",
  "sha2",
  "unicode-segmentation",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2621,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2640,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-json"
 version = "0.1.3"
-source = "git+https://github.com/kamu-data/datafusion-functions-json.git?branch=datafusion-39#9fbda40b56f28d1b0b79af427565793d76543a4f"
+source = "git+https://github.com/kamu-data/datafusion-functions-json.git?branch=datafusion-39#51185421ae2b69cd45d14dc607b7689713de1eca"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2672,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2690,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2720,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2731,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2764,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
+source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3128,24 +3385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
-name = "enr"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "hex",
- "k256",
- "log",
- "rand",
- "rlp",
- "serde",
- "sha3",
- "zeroize",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,324 +3459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eth-keystore"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
-dependencies = [
- "aes",
- "ctr",
- "digest 0.10.7",
- "hex",
- "hmac",
- "pbkdf2 0.11.0",
- "rand",
- "scrypt",
- "serde",
- "serde_json",
- "sha2",
- "sha3",
- "thiserror",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3",
- "thiserror",
- "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "scale-info",
- "uint",
-]
-
-[[package]]
-name = "ethers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
-dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
-dependencies = [
- "const-hex",
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
- "futures-util",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
-dependencies = [
- "Inflector",
- "const-hex",
- "dunce",
- "ethers-core",
- "ethers-etherscan",
- "eyre",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "syn 2.0.66",
- "toml",
- "walkdir",
-]
-
-[[package]]
-name = "ethers-contract-derive"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
-dependencies = [
- "Inflector",
- "const-hex",
- "ethers-contract-abigen",
- "ethers-core",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
-dependencies = [
- "arrayvec",
- "bytes",
- "cargo_metadata",
- "chrono",
- "const-hex",
- "elliptic-curve 0.13.8",
- "ethabi",
- "generic-array",
- "k256",
- "num_enum",
- "once_cell",
- "open-fastrlp",
- "rand",
- "rlp",
- "serde",
- "serde_json",
- "strum 0.26.2",
- "syn 2.0.66",
- "tempfile",
- "thiserror",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "ethers-etherscan"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
-dependencies = [
- "chrono",
- "ethers-core",
- "reqwest",
- "semver 1.0.23",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethers-contract",
- "ethers-core",
- "ethers-providers",
- "ethers-signers",
- "futures-channel",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
-dependencies = [
- "async-trait",
- "auto_impl",
- "base64 0.21.7",
- "bytes",
- "const-hex",
- "enr",
- "ethers-core",
- "futures-channel",
- "futures-core",
- "futures-timer",
- "futures-util",
- "hashers",
- "http",
- "instant",
- "jsonwebtoken 8.3.0",
- "once_cell",
- "pin-project",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-tungstenite",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-signers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "const-hex",
- "elliptic-curve 0.13.8",
- "eth-keystore",
- "ethers-core",
- "rand",
- "sha2",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
-dependencies = [
- "cfg-if",
- "const-hex",
- "dirs 5.0.1",
- "dunce",
- "ethers-core",
- "glob",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.23",
- "serde",
- "serde_json",
- "solang-parser",
- "svm-rs",
- "thiserror",
- "tiny-keccak",
- "tokio",
- "tracing",
- "walkdir",
- "yansi",
-]
-
-[[package]]
 name = "event-bus"
 version = "0.185.1"
 dependencies = [
@@ -3578,16 +3499,6 @@ version = "0.185.1"
 dependencies = [
  "quote",
  "syn 2.0.66",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -3745,16 +3656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,16 +3727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
-name = "futures-locks"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
-dependencies = [
- "futures-channel",
- "futures-task",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3859,16 +3750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper 0.4.0",
-]
-
-[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,13 +3768,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
+name = "futures-utils-wasm"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generic-array"
@@ -3964,18 +3842,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "group"
@@ -4057,15 +3923,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
-]
-
-[[package]]
-name = "hashers"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
-dependencies = [
- "fxhash",
 ]
 
 [[package]]
@@ -4341,24 +4198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4402,12 +4241,6 @@ dependencies = [
  "include-flate-codegen",
  "proc-macro-hack",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -4614,28 +4447,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
-dependencies = [
- "base64 0.21.7",
- "pem 1.1.1",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
  "js-sys",
- "pem 3.0.4",
- "ring 0.17.8",
+ "pem",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -4652,13 +4471,13 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "once_cell",
  "sha2",
- "signature 2.2.0",
 ]
 
 [[package]]
 name = "kamu"
 version = "0.185.1"
 dependencies = [
+ "alloy",
  "async-recursion",
  "async-stream",
  "async-trait",
@@ -4681,7 +4500,6 @@ dependencies = [
  "datafusion-functions-json",
  "digest 0.10.7",
  "dill",
- "ethers",
  "event-bus",
  "filetime",
  "flatbuffers",
@@ -4753,7 +4571,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tracing",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4833,7 +4651,7 @@ dependencies = [
  "chrono",
  "dill",
  "internal-error",
- "jsonwebtoken 9.3.0",
+ "jsonwebtoken",
  "kamu-accounts",
  "kamu-accounts-inmem",
  "kamu-core",
@@ -4907,7 +4725,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -5556,7 +5374,7 @@ dependencies = [
  "ena",
  "is-terminal",
  "itertools 0.10.5",
- "lalrpop-util 0.19.12",
+ "lalrpop-util",
  "petgraph",
  "regex",
  "regex-syntax 0.6.29",
@@ -5567,40 +5385,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util 0.20.2",
- "petgraph",
- "regex",
- "regex-syntax 0.8.3",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
 name = "lalrpop-util"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata 0.4.6",
-]
 
 [[package]]
 name = "lazy_static"
@@ -5773,6 +5561,15 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "lru-cache"
@@ -6215,7 +6012,6 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -6274,7 +6070,7 @@ dependencies = [
  "quick-xml",
  "rand",
  "reqwest",
- "ring 0.17.8",
+ "ring",
  "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
@@ -6299,31 +6095,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "opendatafabric"
@@ -6568,12 +6339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6589,25 +6354,6 @@ dependencies = [
  "hmac",
  "password-hash 0.4.2",
  "sha2",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
-
-[[package]]
-name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
 ]
 
 [[package]]
@@ -6706,7 +6452,6 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros",
  "phf_shared 0.11.2",
 ]
 
@@ -6728,19 +6473,6 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
-dependencies = [
- "phf_generator",
- "phf_shared 0.11.2",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -6872,8 +6604,8 @@ checksum = "b3aa6f61d235de56ccffbca8627377ebe6ff0052a419f67b098f319a5f32e06d"
 dependencies = [
  "indoc 1.0.9",
  "js-sys",
- "lalrpop 0.19.12",
- "lalrpop-util 0.19.12",
+ "lalrpop",
+ "lalrpop-util",
  "serde",
  "serde_derive",
  "strum_macros 0.24.3",
@@ -6956,16 +6688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
-dependencies = [
- "proc-macro2",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "prettytable-rs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6987,9 +6709,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -7374,21 +7093,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -7398,7 +7102,7 @@ dependencies = [
  "getrandom",
  "libc",
  "spin 0.9.8",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -7409,15 +7113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79abed428d1fd2a128201cec72c5f6938e2da607c6f3745f769fabea399d950a"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "ripemd"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -7433,19 +7128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7602,7 +7285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -7650,8 +7333,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -7702,45 +7385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
-dependencies = [
- "cfg-if",
- "derive_more",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
-dependencies = [
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7759,25 +7409,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
-dependencies = [
- "hmac",
- "pbkdf2 0.11.0",
- "salsa20",
- "sha2",
-]
-
-[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -7866,12 +7504,6 @@ checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "send_wrapper"
@@ -8189,20 +7821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solang-parser"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
-dependencies = [
- "itertools 0.11.0",
- "lalrpop 0.20.2",
- "lalrpop-util 0.20.2",
- "phf",
- "thiserror",
- "unicode-xid",
-]
-
-[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8250,9 +7868,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bbffee862a796d67959a89859d6b1046bb5016d63e23835ad0da182777bbe0"
+checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -8322,7 +7940,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.8.0",
+ "uuid",
  "webpki-roots",
 ]
 
@@ -8405,7 +8023,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
- "uuid 1.8.0",
+ "uuid",
  "whoami",
 ]
 
@@ -8445,7 +8063,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
- "uuid 1.8.0",
+ "uuid",
  "whoami",
 ]
 
@@ -8471,7 +8089,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "uuid 1.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -8531,7 +8149,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -8562,9 +8180,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -8578,26 +8196,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "svm-rs"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
-dependencies = [
- "dirs 5.0.1",
- "fs2",
- "hex",
- "once_cell",
- "reqwest",
- "semver 1.0.23",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "url",
- "zip",
-]
 
 [[package]]
 name = "syn"
@@ -8781,6 +8379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "thrift"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8917,6 +8524,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -9002,7 +8610,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.11",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -9150,16 +8758,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -9400,12 +8998,6 @@ checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -9439,16 +9031,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
- "serde",
-]
 
 [[package]]
 name = "uuid"
@@ -9923,9 +9505,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c52728401e1dc672a56e81e593e912aa54c78f40246869f78359a2bf24d29d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -9952,7 +9534,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.0",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -10054,7 +9636,7 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "hmac",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha1",
  "time",
  "zstd 0.11.2+zstd.1.5.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "alloy"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -231,7 +231,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-transport",
  "url",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#0928b92000d1a56370531d5d3d825729b03dfed9"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "tokio",
 ]
@@ -2782,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-ethers"
 version = "38.2.0"
-source = "git+https://github.com/kamu-data/datafusion-ethers?branch=datafusion-39#aea38e51ca2bdb2b276361e07c9364e780edc52f"
+source = "git+https://github.com/kamu-data/datafusion-ethers?branch=datafusion-39#64073ee8ce86d08d391a728b1ed73d11725fe139"
 dependencies = [
  "alloy",
  "async-stream",
@@ -2798,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "chrono",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2835,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2861,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2929,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "ahash",
  "arrow",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?branch=main#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "alloy"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -231,7 +231,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-transport",
  "url",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#f6ebef272c5bd2783bae3fe7ef6ebc1dc3cee015"
+source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -2782,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-ethers"
 version = "38.2.0"
-source = "git+https://github.com/kamu-data/datafusion-ethers?branch=datafusion-39#64073ee8ce86d08d391a728b1ed73d11725fe139"
+source = "git+https://github.com/kamu-data/datafusion-ethers.git?branch=datafusion-39#64073ee8ce86d08d391a728b1ed73d11725fe139"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5012,6 +5012,8 @@ dependencies = [
  "async-trait",
  "datafusion",
  "digest 0.10.7",
+ "hex",
+ "indoc 2.0.5",
  "opendatafabric",
  "pretty_assertions",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,151 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "alloy-core"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b8b8d8c4e84449ce8f310ed48e09ce38b8290b163e3d0df68ea445a9ccce3a"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd2404399cb1b50572758e66e9b4bf088e5a3df9007be7126456c7e50af935f"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 0.6.11",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3abf6446a292e19853aaca43590eeb48bf435dfd2c74200259e8f4872f6ce3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277af0cbcc483ee6ad2c1e818090b5928d27f04fd6580680f31c1cf8068bcc2"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "proptest",
+ "rand",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b155716bab55763c95ba212806cf43d05bcc70e5f35b02bad20cf5ec7fe11fed"
+dependencies = [
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30708a79919b082f2692423c8cc72fc250477e4a2ecb0d4a7244cd3cdb299965"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a679ac01774ab7e00a567a918d4231ae692c5c8cedaf4e16956c3116d7896"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.2.6",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356da0c2228aa6675a5faaa08a3e4061b967f924753983d72b9a18d9a3fad44e"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.66",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fd4783b0a5840479013e9ce960d2eb7b3be381f722e0fe3d1f7c3bb6bd4ebd"
+dependencies = [
+ "winnow 0.6.11",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eb5e6234c0b62514992589fe1578f64d418dbc8ef5cd1ab2d7f2f568f599698"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +328,130 @@ dependencies = [
  "blake2",
  "cpufeatures",
  "password-hash 0.5.0",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -320,7 +589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f38255afda7c172893bdbd2e94d0f4260f99afc6978babca07aa57220769acc"
 dependencies = [
  "arrow",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -567,7 +836,7 @@ dependencies = [
  "Inflector",
  "async-graphql-parser",
  "darling",
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "strum 0.25.0",
@@ -644,12 +913,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -682,7 +973,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "ring",
+ "ring 0.17.8",
  "time",
  "tokio",
  "tracing",
@@ -737,7 +1028,7 @@ dependencies = [
  "http",
  "percent-encoding",
  "tracing",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -857,7 +1148,7 @@ dependencies = [
  "p256",
  "percent-encoding",
  "regex",
- "ring",
+ "ring 0.17.8",
  "sha2",
  "time",
  "tracing",
@@ -1030,7 +1321,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "http",
- "rustc_version",
+ "rustc_version 0.4.0",
  "tracing",
 ]
 
@@ -1132,6 +1423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,12 +1499,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1273,6 +1588,10 @@ name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2",
+ "tinyvec",
+]
 
 [[package]]
 name = "bstr"
@@ -1290,6 +1609,12 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -1363,7 +1688,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "thiserror",
@@ -1548,6 +1873,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "coins-bip32"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac",
+ "k256",
+ "serde",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac",
+ "once_cell",
+ "pbkdf2 0.12.2",
+ "rand",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58",
+ "digest 0.10.7",
+ "generic-array",
+ "hex",
+ "ripemd",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,7 +1947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "strum 0.26.2",
- "strum_macros 0.26.4",
+ "strum_macros 0.26.3",
  "unicode-width",
 ]
 
@@ -1585,6 +1962,19 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
 ]
 
 [[package]]
@@ -1656,6 +2046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,7 +2097,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0227b9f93e535d49bc7ce914c066243424ce85ed90864cebd0874b184e9b6947"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -1849,6 +2245,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +2285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1928,10 +2345,10 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "platforms",
- "rustc_version",
+ "rustc_version 0.4.0",
  "subtle",
  "zeroize",
 ]
@@ -2020,14 +2437,13 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
 name = "datafusion"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fb4eeeb7109393a0739ac5b8fd892f95ccef691421491c85544f7997366f68"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "ahash",
  "arrow",
@@ -2049,6 +2465,7 @@ dependencies = [
  "datafusion-functions-array",
  "datafusion-optimizer",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-sql",
  "flate2",
@@ -2070,7 +2487,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
- "uuid",
+ "uuid 1.8.0",
  "xz2",
  "zstd 0.13.1",
 ]
@@ -2078,8 +2495,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741aeac15c82f239f2fc17deccaab19873abbd62987be20023689b15fa72fa09"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "ahash",
  "arrow",
@@ -2088,6 +2504,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
+ "hashbrown 0.14.5",
  "instant",
  "libc",
  "num_cpus",
@@ -2099,17 +2516,32 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8ddfb8d8cb51646a30da0122ecfffb81ca16919ae9a3495a9e7468bdcd52b8"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
+name = "datafusion-ethers"
+version = "38.0.0"
+dependencies = [
+ "alloy-core",
+ "async-stream",
+ "async-trait",
+ "datafusion",
+ "ethers",
+ "futures",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "datafusion-execution"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282122f90b20e8f98ebfa101e4bf20e718fd2684cf81bef4e8c6366571c64404"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "arrow",
  "chrono",
@@ -2129,8 +2561,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5478588f733df0dfd87a62671c7478f590952c95fa2fa5c137e3ff2929491e22"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "ahash",
  "arrow",
@@ -2141,14 +2572,13 @@ dependencies = [
  "serde_json",
  "sqlparser",
  "strum 0.26.2",
- "strum_macros 0.26.4",
+ "strum_macros 0.26.3",
 ]
 
 [[package]]
 name = "datafusion-functions"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4afd261cea6ac9c3ca1192fd5e9f940596d8e9208c5b1333f4961405db53185"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2168,16 +2598,17 @@ dependencies = [
  "regex",
  "sha2",
  "unicode-segmentation",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b36a6c4838ab94b5bf8f7a96ce6ce059d805c5d1dcaa6ace49e034eb65cd999"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
+ "ahash",
  "arrow",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -2190,8 +2621,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fdd200a6233f48d3362e7ccb784f926f759100e44ae2137a5e2dcb986a59c4"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2203,6 +2633,21 @@ dependencies = [
  "datafusion-expr",
  "datafusion-functions",
  "itertools 0.12.1",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-json"
+version = "0.1.3"
+source = "git+https://github.com/kamu-data/datafusion-functions-json.git?branch=datafusion-39#9fbda40b56f28d1b0b79af427565793d76543a4f"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "jiter",
  "log",
  "paste",
 ]
@@ -2227,8 +2672,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f2820938810e8a2d71228fd6f59f33396aebc5f5f687fcbf14de5aab6a7e1a"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2246,8 +2690,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adf8eb12716f52ddf01e09eb6c94d3c9b291e062c05c91b839a448bddba2ff8"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "ahash",
  "arrow",
@@ -2277,19 +2720,18 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5472c3230584c150197b3f2c23f2392b9dc54dbfb62ad41e7e36447cfce4be"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-expr",
+ "rand",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ae750c38389685a8b62e5b899bbbec488950755ad6d218f3662d35b800c4fe"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "ahash",
  "arrow",
@@ -2322,8 +2764,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befc67a3cdfbfa76853f43b10ac27337821bb98e519ab6baf431fcc0bcfcafdb"
+source = "git+https://github.com/apache/datafusion.git?branch=main#66ef9b92e523d2c484a5c724e5b1afd66705dd04"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2331,6 +2772,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "log",
+ "regex",
  "sqlparser",
  "strum 0.26.2",
 ]
@@ -2377,6 +2819,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2853,15 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "digest"
@@ -2503,6 +2978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "duration-string"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,9 +2999,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
  "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.9",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2563,16 +3058,35 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest",
- "ff",
+ "digest 0.10.7",
+ "ff 0.12.1",
  "generic-array",
- "group",
+ "group 0.12.1",
  "pkcs8 0.9.0",
  "rand_core",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2612,6 +3126,24 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enr"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "hex",
+ "k256",
+ "log",
+ "rand",
+ "rlp",
+ "serde",
+ "sha3",
+ "zeroize",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -2688,6 +3220,324 @@ dependencies = [
 ]
 
 [[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex",
+ "hmac",
+ "pbkdf2 0.11.0",
+ "rand",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sha3",
+ "thiserror",
+ "uuid 0.8.2",
+]
+
+[[package]]
+name = "ethabi"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+dependencies = [
+ "ethereum-types",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "ethers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
+dependencies = [
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
+ "ethers-solc",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
+dependencies = [
+ "const-hex",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
+ "ethers-core",
+ "ethers-providers",
+ "futures-util",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "dunce",
+ "ethers-core",
+ "ethers-etherscan",
+ "eyre",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn 2.0.66",
+ "toml",
+ "walkdir",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "ethers-contract-abigen",
+ "ethers-core",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "ethers-core"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
+dependencies = [
+ "arrayvec",
+ "bytes",
+ "cargo_metadata",
+ "chrono",
+ "const-hex",
+ "elliptic-curve 0.13.8",
+ "ethabi",
+ "generic-array",
+ "k256",
+ "num_enum",
+ "once_cell",
+ "open-fastrlp",
+ "rand",
+ "rlp",
+ "serde",
+ "serde_json",
+ "strum 0.26.2",
+ "syn 2.0.66",
+ "tempfile",
+ "thiserror",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ethers-etherscan"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
+dependencies = [
+ "chrono",
+ "ethers-core",
+ "reqwest",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-providers",
+ "ethers-signers",
+ "futures-channel",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-providers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.7",
+ "bytes",
+ "const-hex",
+ "enr",
+ "ethers-core",
+ "futures-channel",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "http",
+ "instant",
+ "jsonwebtoken 8.3.0",
+ "once_cell",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "const-hex",
+ "elliptic-curve 0.13.8",
+ "eth-keystore",
+ "ethers-core",
+ "rand",
+ "sha2",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-solc"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
+dependencies = [
+ "cfg-if",
+ "const-hex",
+ "dirs 5.0.1",
+ "dunce",
+ "ethers-core",
+ "glob",
+ "home",
+ "md-5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "solang-parser",
+ "svm-rs",
+ "thiserror",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
 name = "event-bus"
 version = "0.185.1"
 dependencies = [
@@ -2731,6 +3581,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fast_chemail"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +3604,17 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
 
 [[package]]
 name = "fd-lock"
@@ -2761,6 +3632,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
@@ -2785,6 +3666,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,7 +3690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
 dependencies = [
  "bitflags 1.3.2",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -2852,10 +3745,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2917,6 +3826,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-locks"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
+dependencies = [
+ "futures-channel",
+ "futures-task",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2940,6 +3859,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,6 +3887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +3903,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3027,12 +3966,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -3098,6 +4060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
+dependencies = [
+ "fxhash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,6 +4127,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
@@ -3172,7 +4152,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3352,6 +4332,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +4402,12 @@ dependencies = [
  "include-flate-codegen",
  "proc-macro-hack",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -3546,6 +4559,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jiter"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abbbbe1bad457e3cd5503af716aedc735e849505a0d2172c55a753ae1b127458"
+dependencies = [
+ "ahash",
+ "bitvec",
+ "lexical-parse-float",
+ "num-bigint",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,17 +4614,45 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.7",
+ "pem 1.1.1",
+ "ring 0.16.20",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
+name = "jsonwebtoken"
 version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
  "js-sys",
- "pem",
- "ring",
+ "pem 3.0.4",
+ "ring 0.17.8",
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "once_cell",
+ "sha2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3622,8 +4677,11 @@ dependencies = [
  "curl-sys",
  "dashmap",
  "datafusion",
- "digest",
+ "datafusion-ethers",
+ "datafusion-functions-json",
+ "digest 0.10.7",
  "dill",
+ "ethers",
  "event-bus",
  "filetime",
  "flatbuffers",
@@ -3695,7 +4753,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tracing",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -3775,7 +4833,7 @@ dependencies = [
  "chrono",
  "dill",
  "internal-error",
- "jsonwebtoken",
+ "jsonwebtoken 9.3.0",
  "kamu-accounts",
  "kamu-accounts-inmem",
  "kamu-core",
@@ -3849,7 +4907,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -4024,6 +5082,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "glob",
+ "hex",
  "http",
  "humansize",
  "hyper",
@@ -4061,6 +5120,7 @@ dependencies = [
  "minus",
  "num-format",
  "opendatafabric",
+ "pretty_assertions",
  "prettytable-rs",
  "random-names",
  "read_input",
@@ -4133,7 +5193,7 @@ dependencies = [
  "arrow-json",
  "async-trait",
  "datafusion",
- "digest",
+ "digest 0.10.7",
  "opendatafabric",
  "pretty_assertions",
  "serde",
@@ -4321,7 +5381,7 @@ dependencies = [
  "chrono",
  "criterion",
  "datafusion",
- "digest",
+ "digest 0.10.7",
  "futures",
  "geo-types",
  "geojson",
@@ -4359,7 +5419,7 @@ dependencies = [
  "glob",
  "indoc 2.0.5",
  "regex",
- "semver",
+ "semver 1.0.23",
  "toml",
 ]
 
@@ -4475,6 +5535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak-asm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a3633291834c4fbebf8673acbc1b04ec9d151418ff9b8e26dcd79129928758"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,7 +5556,7 @@ dependencies = [
  "ena",
  "is-terminal",
  "itertools 0.10.5",
- "lalrpop-util",
+ "lalrpop-util 0.19.12",
  "petgraph",
  "regex",
  "regex-syntax 0.6.29",
@@ -4497,10 +5567,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util 0.20.2",
+ "petgraph",
+ "regex",
+ "regex-syntax 0.8.3",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
 name = "lalrpop-util"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata 0.4.6",
+]
 
 [[package]]
 name = "lazy_static"
@@ -4746,7 +5846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4885,7 +5985,7 @@ name = "multiformats"
 version = "0.185.1"
 dependencies = [
  "bs58",
- "digest",
+ "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "rand",
@@ -5101,6 +6201,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5153,7 +6274,7 @@ dependencies = [
  "quick-xml",
  "rand",
  "reqwest",
- "ring",
+ "ring 0.17.8",
  "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
@@ -5180,6 +6301,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "open-fastrlp"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+ "ethereum-types",
+ "open-fastrlp-derive",
+]
+
+[[package]]
+name = "open-fastrlp-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
+dependencies = [
+ "bytes",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "opendatafabric"
 version = "0.185.1"
 dependencies = [
@@ -5187,7 +6333,7 @@ dependencies = [
  "base64 0.21.7",
  "bitflags 2.5.0",
  "chrono",
- "digest",
+ "digest 0.10.7",
  "ed25519-dalek",
  "enum-variants",
  "flatbuffers",
@@ -5295,9 +6441,35 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
  "sha2",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5396,6 +6568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5407,10 +6585,29 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
  "password-hash 0.4.2",
  "sha2",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -5494,11 +6691,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
+ "phf_macros",
  "phf_shared 0.11.2",
 ]
 
@@ -5520,6 +6728,19 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5651,8 +6872,8 @@ checksum = "b3aa6f61d235de56ccffbca8627377ebe6ff0052a419f67b098f319a5f32e06d"
 dependencies = [
  "indoc 1.0.9",
  "js-sys",
- "lalrpop",
- "lalrpop-util",
+ "lalrpop 0.19.12",
+ "lalrpop-util 0.19.12",
  "serde",
  "serde_derive",
  "strum_macros 0.24.3",
@@ -5735,6 +6956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "prettytable-rs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5749,6 +6980,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5756,6 +7001,15 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -5795,6 +7049,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.5.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.3",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -5855,6 +7129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5892,6 +7172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -6068,9 +7357,34 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -6084,7 +7398,7 @@ dependencies = [
  "getrandom",
  "libc",
  "spin 0.9.8",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6098,10 +7412,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rlp-derive",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "rsa"
@@ -6110,7 +7455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -6122,6 +7467,36 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rumqttc"
@@ -6184,12 +7559,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -6212,7 +7602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.8",
  "rustls-webpki",
  "sct",
 ]
@@ -6260,8 +7650,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6269,6 +7659,18 @@ name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -6300,12 +7702,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+dependencies = [
+ "cfg-if",
+ "derive_more",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6324,13 +7759,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2 0.11.0",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6339,10 +7786,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array",
  "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.9",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6381,12 +7842,42 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "seq-macro"
@@ -6507,7 +7998,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6518,7 +8009,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6527,8 +8018,18 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b57fd861253bff08bb1919e995f90ba8f4889de2726091c8876f3a4e823b40"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -6602,7 +8103,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -6612,7 +8113,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -6685,6 +8186,20 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "solang-parser"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
+dependencies = [
+ "itertools 0.11.0",
+ "lalrpop 0.20.2",
+ "lalrpop-util 0.20.2",
+ "phf",
+ "thiserror",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -6807,7 +8322,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.8.0",
  "webpki-roots",
 ]
 
@@ -6863,7 +8378,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -6890,7 +8405,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
- "uuid",
+ "uuid 1.8.0",
  "whoami",
 ]
 
@@ -6930,7 +8445,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
- "uuid",
+ "uuid 1.8.0",
  "whoami",
 ]
 
@@ -6956,7 +8471,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "uuid",
+ "uuid 1.8.0",
 ]
 
 [[package]]
@@ -7016,7 +8531,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.4",
+ "strum_macros 0.26.3",
 ]
 
 [[package]]
@@ -7047,9 +8562,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -7063,6 +8578,26 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "svm-rs"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
+dependencies = [
+ "dirs 5.0.1",
+ "fs2",
+ "hex",
+ "once_cell",
+ "reqwest",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "url",
+ "zip",
+]
 
 [[package]]
 name = "syn"
@@ -7084,6 +8619,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6fe08d08d84f2c0a77f1e7c46518789d745c2e87a2721791ed7c3c9bc78df28"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -7112,6 +8659,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -7379,6 +8932,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -7429,6 +8983,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.6",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
@@ -7437,7 +9002,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.13",
+ "winnow 0.6.11",
 ]
 
 [[package]]
@@ -7588,6 +9153,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7734,6 +9309,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7807,6 +9400,12 @@ checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -7843,6 +9442,16 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
@@ -7872,7 +9481,7 @@ dependencies = [
  "cargo_metadata",
  "cfg-if",
  "regex",
- "rustc_version",
+ "rustc_version 0.4.0",
  "rustversion",
  "time",
 ]
@@ -8314,9 +9923,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "56c52728401e1dc672a56e81e593e912aa54c78f40246869f78359a2bf24d29d"
 dependencies = [
  "memchr",
 ]
@@ -8329,6 +9938,34 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.0",
+ "send_wrapper 0.6.0",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]
@@ -8388,6 +10025,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "zip"
@@ -8403,7 +10054,7 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "sha1",
  "time",
  "zstd 0.11.2+zstd.1.5.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "alloy"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b8b8d8c4e84449ce8f310ed48e09ce38b8290b163e3d0df68ea445a9ccce3a"
+checksum = "5af3faff14c12c8b11037e0a093dd157c3702becb8435577a2408534d0758315"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd2404399cb1b50572758e66e9b4bf088e5a3df9007be7126456c7e50af935f"
+checksum = "cb6e6436a9530f25010d13653e206fab4c9feddacf21a54de8d7311b275bc56b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3abf6446a292e19853aaca43590eeb48bf435dfd2c74200259e8f4872f6ce3"
+checksum = "aaeaccd50238126e3a0ff9387c7c568837726ad4f4e399b528ca88104d6c25ef"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -231,7 +231,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277af0cbcc483ee6ad2c1e818090b5928d27f04fd6580680f31c1cf8068bcc2"
+checksum = "f783611babedbbe90db3478c120fb5f5daacceffc210b39adc0af4fe0da70bad"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30708a79919b082f2692423c8cc72fc250477e4a2ecb0d4a7244cd3cdb299965"
+checksum = "4bad41a7c19498e3f6079f7744656328699f8ea3e783bdd10d85788cd439f572"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a679ac01774ab7e00a567a918d4231ae692c5c8cedaf4e16956c3116d7896"
+checksum = "fd9899da7d011b4fe4c406a524ed3e3f963797dbc93b45479d60341d3a27b252"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356da0c2228aa6675a5faaa08a3e4061b967f924753983d72b9a18d9a3fad44e"
+checksum = "d32d595768fdc61331a132b6f65db41afae41b9b97d36c21eb1b955c422a7e60"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -466,18 +466,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fd4783b0a5840479013e9ce960d2eb7b3be381f722e0fe3d1f7c3bb6bd4ebd"
+checksum = "baa2fbd22d353d8685bd9fee11ba2d8b5c3b1d11e56adb3265fcf1f32bfdf404"
 dependencies = [
  "winnow 0.6.13",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb5e6234c0b62514992589fe1578f64d418dbc8ef5cd1ab2d7f2f568f599698"
+checksum = "a49042c6d3b66a9fe6b2b5a8bf0d39fc2ae1ee0310a2a26ffedd79fb097878dd"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -489,7 +489,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-transport",
  "url",
@@ -516,12 +516,12 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=main#506edee985b7b3786759d2d834e426738f21161a"
+source = "git+https://github.com/alloy-rs/alloy?rev=a81f9e1e80e677a8f78b592657ffba607a0098b9#a81f9e1e80e677a8f78b592657ffba607a0098b9"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http",
+ "http 0.2.12",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
@@ -764,9 +764,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
+checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
+checksum = "a7029a5b3efbeafbf4a12d12dc16b8f9e9bff20a410b8c25c5d28acc089e1043"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
+checksum = "d33238427c60271710695f17742f45b1a5dc5bcfc5c15331c25ddfe7abf70d97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0a2432f0cba5692bf4cb757469c66791394bac9ec7ce63c1afe74744c37b27"
+checksum = "fe9b95e825ae838efaf77e366c00d3fc8cca78134c9db497d6bda425f2e7b7c1"
 dependencies = [
  "bytes",
  "half",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
+checksum = "87cf8385a9d5b5fcde771661dd07652b79b9139fea66193eda6a88664400ccab"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
+checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2742ac1f6650696ab08c88f6dd3f0eb68ce10f8c253958a18c943a68cd04aec5"
+checksum = "cb29be98f987bcf217b070512bb7afba2f65180858bca462edf4a39d84a23e10"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-digest"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f38255afda7c172893bdbd2e94d0f4260f99afc6978babca07aa57220769acc"
+checksum = "565ca1b27d65d78eccb0189820aa64fbe3fb1492de4b74a8741ab2285966b934"
 dependencies = [
  "arrow",
  "digest 0.10.7",
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3241ce691192d789b7b94f56a10e166ee608bdc3932c759eb0b85f09235352bb"
+checksum = "cdd624aafd1f34710a1d6ed44ea0e9b06f7b75adc4277c53bac4a2d23229030b"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
+checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
+checksum = "2041380f94bd6437ab648e6c2085a045e45a0c44f91a1b9a4fe3fed3d379bfb1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -953,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e6b61e3dc468f503181dccc2fc705bdcc5f2f146755fa5b56d0a6c5943f412"
+checksum = "fcb56ed1547004e12203652f12fe12e824161ff9d1e5cf2a7dc4ff02ba94f413"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848ee52bb92eb459b811fb471175ea3afcf620157674c8794f539838920f9228"
+checksum = "575b42f1fc588f2da6977b94a5ca565459f5ab07b60545e17243fb9a7ed6d43e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -983,18 +983,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d9483aaabe910c4781153ae1b6ae0393f72d9ef757d38d09d450070cf2e528"
+checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
+checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1006,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
+checksum = "e435ada8409bcafc910bc3e0077f532a4daa20e99060a496685c0e3e53cc2597"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1018,7 +1018,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1057,7 +1057,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
 dependencies = [
- "brotli 6.0.0",
+ "brotli",
  "bzip2",
  "flate2",
  "futures-core",
@@ -1066,8 +1066,8 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "xz2",
- "zstd 0.13.1",
- "zstd-safe 7.1.0",
+ "zstd 0.13.0",
+ "zstd-safe 7.0.0",
 ]
 
 [[package]]
@@ -1088,7 +1088,7 @@ dependencies = [
  "fnv",
  "futures-util",
  "handlebars",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.6",
  "mime",
  "multer",
@@ -1229,6 +1229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,8 +1273,8 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "ring",
  "time",
  "tokio",
@@ -1299,8 +1305,8 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "pin-project-lite",
  "tracing",
 ]
@@ -1321,7 +1327,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "fastrand",
- "http",
+ "http 0.2.12",
  "percent-encoding",
  "tracing",
  "uuid",
@@ -1348,8 +1354,8 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
  "regex",
@@ -1374,7 +1380,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http",
+ "http 0.2.12",
  "regex",
  "tracing",
 ]
@@ -1396,7 +1402,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "http",
+ "http 0.2.12",
  "regex",
  "tracing",
 ]
@@ -1419,7 +1425,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "http",
+ "http 0.2.12",
  "regex",
  "tracing",
 ]
@@ -1438,7 +1444,7 @@ dependencies = [
  "form_urlencoded",
  "hex",
  "hmac",
- "http",
+ "http 0.2.12",
  "num-bigint",
  "once_cell",
  "p256",
@@ -1474,8 +1480,8 @@ dependencies = [
  "crc32c",
  "crc32fast",
  "hex",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "md-5",
  "pin-project-lite",
  "sha1",
@@ -1506,8 +1512,8 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1546,14 +1552,14 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -1567,7 +1573,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1584,8 +1590,8 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "itoa",
  "num-integer",
  "pin-project-lite",
@@ -1616,7 +1622,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http",
+ "http 0.2.12",
  "rustc_version 0.4.0",
  "tracing",
 ]
@@ -1634,9 +1640,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -1667,8 +1673,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1685,8 +1691,8 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "pin-project-lite",
  "serde",
@@ -1851,34 +1857,13 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 2.5.1",
-]
-
-[[package]]
-name = "brotli"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 4.0.1",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -1904,7 +1889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata 0.4.6",
+ "regex-automata 0.4.7",
  "serde",
 ]
 
@@ -2073,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -2084,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -2132,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.6"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2142,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.6"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2154,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84733fe9ab28bdce67389f0300221a5c4cd29f6def6417636d7b7ca5e5f3e3b2"
+checksum = "d2020fa13af48afc65a9a87335bda648309ab3d154cd03c7ff95b378c7ed39c4"
 dependencies = [
  "clap",
 ]
@@ -2359,9 +2344,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0227b9f93e535d49bc7ce914c066243424ce85ed90864cebd0874b184e9b6947"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version 0.4.0",
 ]
@@ -2699,8 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f92d2d7a9cba4580900b32b009848d9eb35f1028ac84cdd6ddcf97612cd0068"
 dependencies = [
  "ahash",
  "arrow",
@@ -2747,13 +2733,14 @@ dependencies = [
  "url",
  "uuid",
  "xz2",
- "zstd 0.13.1",
+ "zstd 0.13.0",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effed030d2c1667eb1e11df5372d4981eaf5d11a521be32220b3985ae5ba6971"
 dependencies = [
  "ahash",
  "arrow",
@@ -2773,16 +2760,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0091318129dad1359f08e4c6c71f855163c35bba05d1dbf983196f727857894"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-ethers"
-version = "38.2.0"
-source = "git+https://github.com/kamu-data/datafusion-ethers.git?branch=datafusion-39#64073ee8ce86d08d391a728b1ed73d11725fe139"
+version = "39.0.0"
+source = "git+https://github.com/kamu-data/datafusion-ethers.git?tag=v39.0.0#90c09b8cd02461f284387682ac6dd6103b21c812"
 dependencies = [
  "alloy",
  "async-stream",
@@ -2797,8 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8385aba84fc4a06d3ebccfbcbf9b4f985e80c762fac634b49079f7cc14933fb1"
 dependencies = [
  "arrow",
  "chrono",
@@ -2817,12 +2806,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb192f0055d2ce64e38ac100abc18e4e6ae9734d3c28eee522bbbd6a32108a3"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-array",
+ "arrow-buffer",
  "chrono",
  "datafusion-common",
  "paste",
@@ -2834,8 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c081ae5b7edd712b92767fb8ed5c0e32755682f8075707666cd70835807c0b"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2860,8 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb28a4ea52c28a26990646986a27c4052829a2a2572386258679e19263f8b78"
 dependencies = [
  "ahash",
  "arrow",
@@ -2877,8 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-array"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b17c02a74cdc87380a56758ec27e7d417356bf806f33062700908929aedb8a"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2897,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-json"
 version = "0.1.3"
-source = "git+https://github.com/kamu-data/datafusion-functions-json.git?branch=datafusion-39#51185421ae2b69cd45d14dc607b7689713de1eca"
+source = "git+https://github.com/kamu-data/datafusion-functions-json.git?branch=datafusion-39#d76be91dcb171538531f8e7d9589f4b7de00e04c"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2911,15 +2905,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-odata"
-version = "38.0.0"
-source = "git+https://github.com/kamu-data/datafusion-odata.git?branch=axum-0.6#ed5d9a7f6995267638355544bd565df92afc1f63"
+version = "39.0.0"
+source = "git+https://github.com/kamu-data/datafusion-odata.git?branch=axum-0.6#21f7b230515cb33de1a1929db59b924d0cb26ad1"
 dependencies = [
  "async-trait",
  "axum",
  "chrono",
  "datafusion",
- "http",
- "quick-xml",
+ "http 0.2.12",
+ "quick-xml 0.32.0",
  "regex",
  "serde",
  "thiserror",
@@ -2928,8 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12172f2a6c9eb4992a51e62d709eeba5dedaa3b5369cce37ff6c2260e100ba76"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2941,13 +2936,14 @@ dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "log",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3fce531b623e94180f6cd33d620ef01530405751b6ddd2fd96250cdbd78e2e"
 dependencies = [
  "ahash",
  "arrow",
@@ -2976,8 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046400b6a2cc3ed57a7c576f5ae6aecc77804ac8e0186926b278b189305b2a77"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2987,8 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aed47f5a2ad8766260befb375b201592e86a08b260256e168ae4311426a2bff"
 dependencies = [
  "ahash",
  "arrow",
@@ -3020,8 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639#8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa92bb1fd15e46ce5fb6f1c85f3ac054592560f294429a28e392b5f9cd4255e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3214,6 +3213,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3596,9 +3606,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version 0.4.0",
@@ -3876,7 +3886,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -3943,7 +3972,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.12",
  "httpdate",
  "mime",
  "sha1",
@@ -3955,7 +3984,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.12",
 ]
 
 [[package]]
@@ -4044,13 +4073,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -4062,9 +4125,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "9f3935c160d00ac752e09787e6e6bfc26494c2183cc922f1bc678a60d4733bc2"
 
 [[package]]
 name = "httpdate"
@@ -4097,9 +4160,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -4112,19 +4175,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -4133,10 +4233,30 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4163,6 +4283,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,12 +4418,14 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -4332,7 +4572,7 @@ dependencies = [
  "socket2",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -4507,8 +4747,8 @@ dependencies = [
  "futures",
  "glob",
  "hex",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "indoc 2.0.5",
  "internal-error",
  "itertools 0.11.0",
@@ -4529,7 +4769,7 @@ dependencies = [
  "rand",
  "random-names",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "ringbuf",
  "rumqttc",
  "serde",
@@ -4789,8 +5029,8 @@ dependencies = [
  "flate2",
  "fs_extra",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "indoc 2.0.5",
  "kamu",
  "kamu-accounts",
@@ -4801,7 +5041,7 @@ dependencies = [
  "opendatafabric",
  "paste",
  "rand",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "sha3",
@@ -4829,11 +5069,11 @@ dependencies = [
  "async-trait",
  "chrono",
  "dill",
- "http",
+ "http 0.2.12",
  "kamu-accounts",
  "kamu-core",
  "opendatafabric",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tempfile",
@@ -4853,15 +5093,15 @@ dependencies = [
  "dill",
  "event-bus",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.29",
  "indoc 2.0.5",
  "kamu",
  "kamu-accounts",
  "kamu-core",
  "opendatafabric",
- "quick-xml",
- "reqwest",
+ "quick-xml 0.31.0",
+ "reqwest 0.11.27",
  "serde",
  "tempfile",
  "test-group",
@@ -4901,9 +5141,9 @@ dependencies = [
  "futures",
  "glob",
  "hex",
- "http",
+ "http 0.2.12",
  "humansize",
- "hyper",
+ "hyper 0.14.29",
  "indicatif",
  "indoc 2.0.5",
  "internal-error",
@@ -4943,7 +5183,7 @@ dependencies = [
  "random-names",
  "read_input",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "rust-embed",
  "serde",
  "serde_json",
@@ -4986,7 +5226,7 @@ dependencies = [
  "datafusion",
  "dill",
  "futures",
- "http",
+ "http 0.2.12",
  "internal-error",
  "kamu-accounts",
  "object_store",
@@ -5549,6 +5789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5770,7 +6016,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "memchr",
@@ -6054,24 +6300,24 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
+checksum = "fbebfd32c213ba1907fa7a9c9138015a8de2b43e30c5aa45b18f7deb46786ad6"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "hyper",
+ "hyper 1.3.1",
  "itertools 0.12.1",
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.31.0",
  "rand",
- "reqwest",
+ "reqwest 0.12.4",
  "ring",
  "rustls-pemfile 2.1.2",
  "serde",
@@ -6270,9 +6516,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "096795d4f47f65fd3ee1ec5a98b77ab26d602f2cc785b0e4be5443add17ecc32"
+checksum = "29c3b5322cc1bbf67f11c079c42be41a55949099b78732f7dba9e15edde40eab"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -6283,7 +6529,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64 0.22.1",
- "brotli 3.5.0",
+ "brotli",
  "bytes",
  "chrono",
  "flate2",
@@ -6300,7 +6546,8 @@ dependencies = [
  "thrift",
  "tokio",
  "twox-hash",
- "zstd 0.13.1",
+ "zstd 0.13.0",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -6786,7 +7033,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6835,6 +7082,16 @@ name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
  "serde",
@@ -6974,14 +7231,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -6995,13 +7252,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -7012,9 +7269,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -7028,11 +7285,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -7041,8 +7298,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -7050,7 +7306,7 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -7059,7 +7315,51 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.22.4",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -7193,12 +7493,12 @@ dependencies = [
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -7288,8 +7588,22 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -7300,6 +7614,19 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -7336,6 +7663,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -7930,7 +8268,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -8095,6 +8433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8223,9 +8567,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fe08d08d84f2c0a77f1e7c46518789d745c2e87a2721791ed7c3c9bc78df28"
+checksum = "8d71e19bca02c807c9faa67b5a47673ff231b6e7449b251695188522f1dc44b2"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -8238,6 +8582,17 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "system-configuration"
@@ -8443,6 +8798,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8513,7 +8878,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -8537,10 +8913,10 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite",
  "webpki-roots",
 ]
@@ -8626,10 +9002,10 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -8672,8 +9048,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "http-range-header",
  "httpdate",
  "mime",
@@ -8875,11 +9251,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.21.12",
  "sha1",
  "thiserror",
  "url",
@@ -9006,12 +9382,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna 1.0.0",
  "percent-encoding",
  "serde",
 ]
@@ -9029,10 +9405,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "utf16_iter"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -9525,6 +9913,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9585,6 +9995,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9605,6 +10039,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9618,6 +10073,28 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9655,11 +10132,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe 7.1.0",
+ "zstd-safe 7.0.0",
 ]
 
 [[package]]
@@ -9674,18 +10151,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,10 +197,10 @@ debug = 1
 # Use this section to test or apply emergency ovverides to dependencies
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 [patch.crates-io]
-datafusion = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
-datafusion-common = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
-datafusion-execution = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
-datafusion-expr = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
+datafusion = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
+datafusion-common = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
+datafusion-execution = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
+datafusion-expr = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
 datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = 'axum-0.6' }
 # datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", branch = "datafusion-39" }
 datafusion-functions-json = { git = 'https://github.com/kamu-data/datafusion-functions-json.git', branch = "datafusion-39" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,10 @@ debug = 1
 # Use this section to test or apply emergency ovverides to dependencies
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 [patch.crates-io]
-# datafusion = { git = 'https://github.com/apache/arrow-datafusion.git', tag = '37.1.0-rc2' }
-# datafusion-common = { git = 'https://github.com/apache/arrow-datafusion.git', tag = '37.1.0-rc2' }
+datafusion = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
+datafusion-common = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
+datafusion-execution = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
+datafusion-expr = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
 datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = 'axum-0.6' }
+datafusion-ethers = { path = '../datafusion-ethers' }
+datafusion-functions-json = { git = 'https://github.com/kamu-data/datafusion-functions-json.git', branch = "datafusion-39" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,5 +202,5 @@ datafusion-common = { git = 'https://github.com/apache/datafusion.git', branch =
 datafusion-execution = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
 datafusion-expr = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
 datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = 'axum-0.6' }
-datafusion-ethers = { path = '../datafusion-ethers' }
+# datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", branch = "datafusion-39" }
 datafusion-functions-json = { git = 'https://github.com/kamu-data/datafusion-functions-json.git', branch = "datafusion-39" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,10 +197,12 @@ debug = 1
 # Use this section to test or apply emergency ovverides to dependencies
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 [patch.crates-io]
+# Alloy is not yet regularly released on crates.io
+alloy = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
 datafusion = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
 datafusion-common = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
 datafusion-execution = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
 datafusion-expr = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
 datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = 'axum-0.6' }
-# datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", branch = "datafusion-39" }
+datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", branch = "datafusion-39" }
 datafusion-functions-json = { git = 'https://github.com/kamu-data/datafusion-functions-json.git', branch = "datafusion-39" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,12 +197,9 @@ debug = 1
 # Use this section to test or apply emergency ovverides to dependencies
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 [patch.crates-io]
-# Alloy is not yet regularly released on crates.io
-alloy = { git = "https://github.com/alloy-rs/alloy", branch = "main" }
-datafusion = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
-datafusion-common = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
-datafusion-execution = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
-datafusion-expr = { git = 'https://github.com/apache/datafusion.git', rev = '8fcb3e4b8a8fe6c4c7f83922dd860c9fa78c0639' }
+# datafusion = { git = 'https://github.com/apache/datafusion.git', tag = '39.0.0-rc1' }
+# datafusion-common = { git = 'https://github.com/apache/datafusion.git', tag = '39.0.0-rc1' }
+# datafusion-execution = { git = 'https://github.com/apache/datafusion.git', tag = '39.0.0-rc1' }
+# datafusion-expr = { git = 'https://github.com/apache/datafusion.git', tag = '39.0.0-rc1' }
 datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = 'axum-0.6' }
-datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", branch = "datafusion-39" }
-datafusion-functions-json = { git = 'https://github.com/kamu-data/datafusion-functions-json.git', branch = "datafusion-39" }
+# datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", tag = "v39.0.0" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,11 +1,11 @@
 [bans]
 # Forbid multiple versions of same dependency (with some exceptions)
 # TODO: Change to "deny" once we crack down on duplication
-multiple-versions = "warn"
+multiple-versions = "allow"
+
 # Avoid adding dependencies to this list as this slows down compilation.
 # Find another ways to avoid duplication.
-skip-tree = [
-]
+skip-tree = []
 
 # We should always specify version ranges
 wildcards = "deny"
@@ -13,9 +13,16 @@ wildcards = "deny"
 # We specify features explicitly to avoid bloat
 workspace-default-features = "deny"
 features = [
-    { name = "opendatafabric", allow = ["default", "sqlx"] },
-    { name = "kamu", allow = ["default"] },
-    { name = "kamu-cli", allow = ["default"] },
+    { name = "opendatafabric", allow = [
+        "default",
+        "sqlx",
+    ] },
+    { name = "kamu", allow = [
+        "default",
+    ] },
+    { name = "kamu-cli", allow = [
+        "default",
+    ] },
 ]
 
 deny = [
@@ -53,8 +60,8 @@ allow = [
     "MPL-2.0",
     "Zlib",
     "OpenSSL",
+    "Unlicense",
 ]
-copyleft = "deny"
 private = { ignore = true }
 
 [[licenses.exceptions]]
@@ -65,26 +72,15 @@ name = "unicode-ident"
 [[licenses.clarify]]
 name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-allow-git = [
-    "https://github.com/apache/arrow-datafusion",
-    "https://github.com/kamu-data/datafusion-odata"
-]
+allow-org = { github = ["kamu-data", "apache", "alloy-rs"] }
 
 
 [advisories]
-vulnerability = "warn"
-unmaintained = "warn"
-unsound = "warn"
 yanked = "deny"
-notice = "warn"
-ignore = [
-]
-
+ignore = ["RUSTSEC-2023-0071"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 [bans]
 # Forbid multiple versions of same dependency (with some exceptions)
 # TODO: Change to "deny" once we crack down on duplication
-multiple-versions = "allow"
+multiple-versions = "warn"
 
 # Avoid adding dependencies to this list as this slows down compilation.
 # Find another ways to avoid duplication.
@@ -33,14 +33,17 @@ deny = [
 
     ### Creates we deny multiple versions of ###
     # This is a temporary approach until we deny by default with some exceptions
+    { name = "alloy", deny-multiple-versions = true },
     { name = "arrow", deny-multiple-versions = true },
     { name = "axum", deny-multiple-versions = true },
     { name = "aws-config", deny-multiple-versions = true },
     { name = "clap", deny-multiple-versions = true },
     { name = "datafusion", deny-multiple-versions = true },
+    # { name = "hyper", deny-multiple-versions = true },
     { name = "object_store", deny-multiple-versions = true },
     { name = "parquet", deny-multiple-versions = true },
     { name = "prost", deny-multiple-versions = true },
+    # { name = "reqwest", deny-multiple-versions = true },
     # { name = "rustls", deny-multiple-versions = true },
     { name = "tokio", deny-multiple-versions = true },
     { name = "tonic", deny-multiple-versions = true },
@@ -58,9 +61,10 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
-    "Zlib",
     "OpenSSL",
+    "Unicode-3.0",
     "Unlicense",
+    "Zlib",
 ]
 private = { ignore = true }
 

--- a/examples/reth-vs-snp500/init-s3-all.sh
+++ b/examples/reth-vs-snp500/init-s3-all.sh
@@ -7,7 +7,8 @@ S3_EXAMPLE_URL="https://s3.us-west-2.amazonaws.com/datasets.kamu.dev/odf/v2/exam
 kamu init || true
 
 # Root
-kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.mint-burn"
+kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.tokens-minted"
+kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.tokens-burned"
 kamu pull "${S3_CONTRIB_URL}com.cryptocompare.ohlcv.eth-usd"
 kamu pull "${S3_CONTRIB_URL}co.alphavantage.tickers.daily.spy"
 
@@ -15,6 +16,7 @@ kamu pull "${S3_EXAMPLE_URL}account.transactions"
 kamu pull "${S3_EXAMPLE_URL}account.tokens.transfers"
 
 # Deriv
+kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.mint-burn"
 kamu pull "${S3_EXAMPLE_URL}account.tokens.portfolio"
 kamu pull "${S3_EXAMPLE_URL}account.tokens.portfolio.market-value"
 kamu pull "${S3_EXAMPLE_URL}account.tokens.portfolio.usd"

--- a/examples/reth-vs-snp500/init-s3-ipfs.sh
+++ b/examples/reth-vs-snp500/init-s3-ipfs.sh
@@ -7,8 +7,11 @@ S3_EXAMPLE_URL="https://s3.us-west-2.amazonaws.com/datasets.kamu.dev/odf/v2/exam
 kamu init || true
 
 # Pull from S3 for speed but then alias to IPFS
-kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.mint-burn" --no-alias
-kamu repo alias add --pull net.rocketpool.reth.mint-burn "ipns://net.rocketpool.reth.mint-burn.ipns.kamu.dev"
+kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.tokens-minted" --no-alias
+kamu repo alias add --pull net.rocketpool.reth.tokens-minted "ipns://net.rocketpool.reth.tokens-minted.ipns.kamu.dev"
+
+kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.tokens-burned" --no-alias
+kamu repo alias add --pull net.rocketpool.reth.tokens-burned "ipns://net.rocketpool.reth.tokens-burned.ipns.kamu.dev"
 
 kamu pull "${S3_CONTRIB_URL}com.cryptocompare.ohlcv.eth-usd" --no-alias
 kamu repo alias add --pull com.cryptocompare.ohlcv.eth-usd "ipns://com.cryptocompare.ohlcv.eth-usd.ipns.kamu.dev"

--- a/examples/reth-vs-snp500/init-s3.sh
+++ b/examples/reth-vs-snp500/init-s3.sh
@@ -7,7 +7,8 @@ S3_EXAMPLE_URL="https://s3.us-west-2.amazonaws.com/datasets.kamu.dev/odf/v2/exam
 kamu init || true
 
 # Root
-kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.mint-burn"
+kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.tokens-minted"
+kamu pull "${S3_CONTRIB_URL}net.rocketpool.reth.tokens-burned"
 kamu pull "${S3_CONTRIB_URL}com.cryptocompare.ohlcv.eth-usd"
 kamu pull "${S3_CONTRIB_URL}co.alphavantage.tickers.daily.spy"
 

--- a/examples/reth-vs-snp500/net.rocketpool.reth.mint-burn.yaml
+++ b/examples/reth-vs-snp500/net.rocketpool.reth.mint-burn.yaml
@@ -3,38 +3,42 @@ kind: DatasetSnapshot
 version: 1
 content:
   name: net.rocketpool.reth.mint-burn
-  kind: Root
+  kind: Derivative
   metadata:
-    - kind: SetPollingSource
-      fetch:
-        kind: Container
-        # Image src: https://github.com/kamu-data/kamu-contrib/tree/5009e5d75b4f1fb903e5745fa35ea67a4815fbe7/net.rocketpool
-        image: "ghcr.io/kamu-data/fetch-net.rocketpool.reth.mint-burn:0.2.0"
-        env:
-          - name: ETH_NODE_PROVIDER_URL
-          - name: BLOCK_BATCH_SIZE
-            value: "100000"
-          - name: ODF_BATCH_SIZE
-            value: "10000"
-      read:
-        kind: NdJson
-      preprocess:
+    - kind: SetTransform
+      inputs:
+        - datasetRef: net.rocketpool.reth.tokens-minted
+          alias: tokens_minted
+        - datasetRef: net.rocketpool.reth.tokens-burned
+          alias: tokens_burned
+      transform:
         kind: Sql
         engine: datafusion
         query: |
-          SELECT
-            to_timestamp_seconds("eventTime") as event_time,
-            'rETH' as token_symbol,
-            "eventName" as event_name,
-            cast("amount" as double) / pow(10.0, 18) as amount,
-            cast("ethAmount" as double) / pow(10.0, 18) as eth_amount,
-            "blockNumber" as block_number,
-            "blockHash" as block_hash,
-            "transactionIndex" as transaction_index,
-            "transactionHash" as transaction_hash,
-            "logIndex" as log_index
-          FROM input
-      merge:
-        kind: Ledger
-        primaryKey:
-          - transaction_hash
+          select
+            event_time,
+            block_number,
+            block_hash,
+            transaction_index,
+            transaction_hash,
+            log_index,
+            token_symbol,
+            event_name,
+            to as holder_address,
+            amount,
+            eth_amount
+          from tokens_minted
+          union all
+          select
+            event_time,
+            block_number,
+            block_hash,
+            transaction_index,
+            transaction_hash,
+            log_index,
+            token_symbol,
+            event_name,
+            from as holder_address,
+            amount,
+            eth_amount
+          from tokens_burned

--- a/examples/reth-vs-snp500/net.rocketpool.reth.tokens-burned.yaml
+++ b/examples/reth-vs-snp500/net.rocketpool.reth.tokens-burned.yaml
@@ -1,0 +1,50 @@
+---
+kind: DatasetSnapshot
+version: 1
+content:
+  name: net.rocketpool.reth.tokens-burned
+  kind: Root
+  metadata:
+    - kind: SetPollingSource
+      fetch:
+        kind: EthereumLogs
+        chainId: 1 # Ethereum Mainnet
+        signature: |
+          TokensBurned(
+            address indexed from,
+            uint256 amount,
+            uint256 ethAmount,
+            uint256 time
+          )
+        # Using contract deployment block to limit scanning
+        filter: |
+          address = X'ae78736cd615f374d3085123a210448e74fc6393'
+          and
+          block_number > 13325304
+      read:
+        kind: Parquet
+      preprocess:
+        kind: Sql
+        engine: datafusion
+        # Note many providers don't yet return `blockTimestamp` from `eth_getLogs`
+        # so we fallback to the time contained within the event
+        # See: https://github.com/ethereum/execution-apis/issues/295
+        query: |
+          select
+            coalesce(
+              block_timestamp,
+              to_timestamp_seconds(cast(event.time as bigint))
+            ) as event_time,
+            block_number,
+            block_hash,
+            transaction_index,
+            transaction_hash,
+            log_index,
+            'rETH' as token_symbol,
+            'TokensBurned' as event_name,
+            event.from as from,
+            cast(event.amount as double) / pow(10.0, 18) as amount,
+            cast(event."ethAmount" as double) / pow(10.0, 18) as eth_amount
+          from input
+      merge:
+        kind: Append

--- a/examples/reth-vs-snp500/net.rocketpool.reth.tokens-minted.yaml
+++ b/examples/reth-vs-snp500/net.rocketpool.reth.tokens-minted.yaml
@@ -1,0 +1,50 @@
+---
+kind: DatasetSnapshot
+version: 1
+content:
+  name: net.rocketpool.reth.tokens-minted
+  kind: Root
+  metadata:
+    - kind: SetPollingSource
+      fetch:
+        kind: EthereumLogs
+        chainId: 1 # Ethereum Mainnet
+        signature: |
+          TokensMinted(
+            address indexed to,
+            uint256 amount,
+            uint256 ethAmount,
+            uint256 time
+          )
+        # Using contract deployment block to limit scanning
+        filter: |
+          address = X'ae78736cd615f374d3085123a210448e74fc6393'
+          and
+          block_number > 13325304
+      read:
+        kind: Parquet
+      preprocess:
+        kind: Sql
+        engine: datafusion
+        # Note many providers don't yet return `blockTimestamp` from `eth_getLogs`
+        # so we fallback to the time contained within the event
+        # See: https://github.com/ethereum/execution-apis/issues/295
+        query: |
+          select
+            coalesce(
+              block_timestamp,
+              to_timestamp_seconds(cast(event.time as bigint))
+            ) as event_time,
+            block_number,
+            block_hash,
+            transaction_index,
+            transaction_hash,
+            log_index,
+            'rETH' as token_symbol,
+            'TokensMinted' as event_name,
+            event.to as to,
+            cast(event.amount as double) / pow(10.0, 18) as amount,
+            cast(event."ethAmount" as double) / pow(10.0, 18) as eth_amount
+          from input
+      merge:
+        kind: Append

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -747,13 +747,20 @@ type ExecuteTransformInput {
 	newOffset: Int
 }
 
-union FetchStep = FetchStepUrl | FetchStepFilesGlob | FetchStepContainer | FetchStepMqtt
+union FetchStep = FetchStepUrl | FetchStepFilesGlob | FetchStepContainer | FetchStepMqtt | FetchStepEthereumLogs
 
 type FetchStepContainer {
 	image: String!
 	command: [String!]
 	args: [String!]
 	env: [EnvVar!]
+}
+
+type FetchStepEthereumLogs {
+	chainId: Int
+	nodeUrl: String
+	filter: String
+	signature: String
 }
 
 type FetchStepFilesGlob {

--- a/src/adapter/flight-sql/Cargo.toml
+++ b/src/adapter/flight-sql/Cargo.toml
@@ -22,11 +22,11 @@ doctest = false
 
 
 [dependencies]
-arrow-flight = { version = "51", features = ["flight-sql-experimental"] }
+arrow-flight = { version = "52", features = ["flight-sql-experimental"] }
 async-trait = { version = "0.1", default-features = false }
 base64 = { version = "0.21", default-features = false }
 dashmap = { version = "5", default-features = false }
-datafusion = { version = "38", default-features = false }
+datafusion = { version = "39", default-features = false }
 futures = "0.3"
 like = { version = "0.3", default-features = false }
 prost = { version = "0.12", default-features = false }

--- a/src/adapter/flight-sql/src/service.rs
+++ b/src/adapter/flight-sql/src/service.rs
@@ -45,6 +45,7 @@ use arrow_flight::sql::{
     CommandStatementQuery,
     CommandStatementSubstraitPlan,
     CommandStatementUpdate,
+    DoPutPreparedStatementResult,
     ProstMessageExt,
     SqlInfo,
     TicketStatementQuery,
@@ -1054,7 +1055,7 @@ impl FlightSqlService for KamuFlightSqlService {
         &self,
         query: CommandPreparedStatementQuery,
         _request: Request<PeekableFlightDataStream>,
-    ) -> Result<Response<<Self as FlightService>::DoPutStream>, Status> {
+    ) -> Result<DoPutPreparedStatementResult, Status> {
         Err(Status::unimplemented(
             "Implement do_put_prepared_statement_query",
         ))

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -35,11 +35,17 @@ kamu-flow-system-services = { workspace = true }
 event-sourcing = { workspace = true }
 
 
-async-graphql = { version = "6", features = ["chrono", "url", "apollo_tracing"] }
+async-graphql = { version = "6", features = [
+    "chrono",
+    "url",
+    "apollo_tracing",
+] }
 async-trait = { version = "0.1", default-features = false }
 cron = { version = "0.12", default-features = false }
 chrono = "0.4"
-datafusion = { version = "38", default-features = false, features = ["serde"] } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
+datafusion = { version = "39", default-features = false, features = [
+    "serde",
+] } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.8"
 futures = "0.3"
 serde = { version = "1", default-features = false }

--- a/src/adapter/graphql/src/scalars/data_batch.rs
+++ b/src/adapter/graphql/src/scalars/data_batch.rs
@@ -70,9 +70,13 @@ impl DataBatch {
         let mut buf = Vec::new();
         {
             let mut writer: Box<dyn RecordsWriter> = match format {
-                DataBatchFormat::Csv => {
-                    Box::new(CsvWriterBuilder::new().with_header(true).build(&mut buf))
-                }
+                DataBatchFormat::Csv => Box::new(CsvWriter::new(
+                    &mut buf,
+                    CsvWriterOptions {
+                        header: true,
+                        ..Default::default()
+                    },
+                )),
                 DataBatchFormat::Json => Box::new(JsonArrayOfStructsWriter::new(&mut buf)),
                 DataBatchFormat::JsonSOA => {
                     Box::new(JsonStructOfArraysWriter::new(&mut buf, MAX_SOA_BUFFER_SIZE))

--- a/src/adapter/graphql/src/scalars/odf_generated.rs
+++ b/src/adapter/graphql/src/scalars/odf_generated.rs
@@ -422,6 +422,7 @@ pub enum FetchStep {
     FilesGlob(FetchStepFilesGlob),
     Container(FetchStepContainer),
     Mqtt(FetchStepMqtt),
+    EthereumLogs(FetchStepEthereumLogs),
 }
 
 impl From<odf::FetchStep> for FetchStep {
@@ -431,6 +432,7 @@ impl From<odf::FetchStep> for FetchStep {
             odf::FetchStep::FilesGlob(v) => Self::FilesGlob(v.into()),
             odf::FetchStep::Container(v) => Self::Container(v.into()),
             odf::FetchStep::Mqtt(v) => Self::Mqtt(v.into()),
+            odf::FetchStep::EthereumLogs(v) => Self::EthereumLogs(v.into()),
         }
     }
 }
@@ -509,6 +511,25 @@ impl From<odf::FetchStepMqtt> for FetchStepMqtt {
             username: v.username.map(Into::into),
             password: v.password.map(Into::into),
             topics: v.topics.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(SimpleObject, Debug, Clone, PartialEq, Eq)]
+pub struct FetchStepEthereumLogs {
+    pub chain_id: Option<u64>,
+    pub node_url: Option<String>,
+    pub filter: Option<String>,
+    pub signature: Option<String>,
+}
+
+impl From<odf::FetchStepEthereumLogs> for FetchStepEthereumLogs {
+    fn from(v: odf::FetchStepEthereumLogs) -> Self {
+        Self {
+            chain_id: v.chain_id.map(Into::into),
+            node_url: v.node_url.map(Into::into),
+            filter: v.filter.map(Into::into),
+            signature: v.signature.map(Into::into),
         }
     }
 }

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -37,20 +37,32 @@ async-trait = "0.1"
 base64 = "0.21"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
-datafusion = { version = "38", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
+datafusion = { version = "39", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.8"
-flate2 = "1"                                                           # GZip decoder
+flate2 = "1" # GZip decoder
 futures = "0.3"
 http = "0.2"
 hyper = "0.14"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "multipart", "json", "stream", "gzip", "brotli", "deflate"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "rustls-tls",
+    "multipart",
+    "json",
+    "stream",
+    "gzip",
+    "brotli",
+    "deflate",
+] }
 serde = "1"
 serde_json = "1"
 tar = "0.4"
 thiserror = { version = "1", default-features = false }
 tokio = { version = "1", default-features = false, features = [] }
 tokio-stream = "0.1"
-tokio-util = { version = "0.7", default-features = false, features = ["codec", "compat", "io"] }
+tokio-util = { version = "0.7", default-features = false, features = [
+    "codec",
+    "compat",
+    "io",
+] }
 tokio-tungstenite = { version = "0.20", features = ["rustls-tls-native-roots"] }
 tower = "0.4"
 tracing = "0.1"

--- a/src/adapter/http/tests/harness/client_side_harness.rs
+++ b/src/adapter/http/tests/harness/client_side_harness.rs
@@ -101,6 +101,8 @@ impl ClientSideHarness {
 
         b.add::<DataFormatRegistryImpl>();
 
+        b.add_builder(FetchService::builder().with_run_info_dir(run_info_dir.clone()));
+
         b.add_builder(
             PollingIngestServiceImpl::builder()
                 .with_run_info_dir(run_info_dir.clone())

--- a/src/adapter/odata/Cargo.toml
+++ b/src/adapter/odata/Cargo.toml
@@ -28,9 +28,9 @@ kamu-core = { workspace = true }
 
 axum = { version = "0.6", features = ["headers"] }
 chrono = { version = "0.4", default-features = false }
-datafusion = { version = "38", default-features = false }
+datafusion = { version = "39", default-features = false }
 # ToDo remove version pin after we will migrate axum to new major version
-datafusion-odata = { version = "38", default-features = false }
+datafusion-odata = { version = "39", default-features = false }
 dill = { version = "0.8" }
 futures = { version = "0.3", default-features = false }
 http = "0.2"

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -72,22 +72,26 @@ kamu-flow-system-postgres = { workspace = true }
 kamu-flow-system-sqlite = { workspace = true }
 
 # CLI
-chrono-humanize = "0.2"  # Human readable durations
+chrono-humanize = "0.2"                                           # Human readable durations
 clap = "4"
 clap_complete = "4"
-console = "0.15"  # Terminal colors
-ctrlc = "3" # Ctrl+C handler
-humansize = "2"  # Human readable data sizes
-indicatif = "0.17"  # Progress bars and spinners
+console = "0.15"                                                  # Terminal colors
+ctrlc = "3"                                                       # Ctrl+C handler
+humansize = "2"                                                   # Human readable data sizes
+indicatif = "0.17"                                                # Progress bars and spinners
 minus = { version = "5", features = ["static_output", "search"] }
-num-format = "0.4"  # Human-readable number formatting
-prettytable-rs = "0.10"  # ASCII table formatting
-read_input = "0.8"  # Basic user input
-webbrowser = "0.8"  # For opening URLs in default system browser
+num-format = "0.4"                                                # Human-readable number formatting
+prettytable-rs = "0.10"                                           # ASCII table formatting
+read_input = "0.8"                                                # Basic user input
+webbrowser = "0.8"                                                # For opening URLs in default system browser
 
 # APIs
 arrow-flight = { version = "51", features = ["flight-sql-experimental"] }
-async-graphql = { version = "6", features = ["chrono", "url", "apollo_tracing"] }
+async-graphql = { version = "6", features = [
+    "chrono",
+    "url",
+    "apollo_tracing",
+] }
 async-graphql-axum = "6"
 axum = { version = "0.6", features = ["ws"] }
 axum-extra = { version = "0.8", features = ["async-read-body"] }
@@ -100,7 +104,10 @@ tower = "0.4"
 tower-http = { version = "0.4", features = ["trace", "cors"] }
 
 # Web UI
-rust-embed = { optional = true, version = "8", features = ["interpolate-folder-path", "compression"] }
+rust-embed = { optional = true, version = "8", features = [
+    "interpolate-folder-path",
+    "compression",
+] }
 mime = "0.3"
 mime_guess = "2"
 
@@ -115,26 +122,39 @@ serde_yaml = "0.9"
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-perfetto = { workspace = true }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt", "ansi", "env-filter"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "std",
+    "fmt",
+    "ansi",
+    "env-filter",
+] }
 tracing-log = "0.2"
 tracing-bunyan-formatter = "0.3"
 
 # Utils
 async-trait = "0.1"
 chrono = "0.4"
-cfg-if = "1"  # Conditional compilation
-datafusion = { version = "38", default-features = false, features = ["crypto_expressions", "encoding_expressions", "parquet", "regex_expressions", "unicode_expressions", "compression"] }
+cfg-if = "1" # Conditional compilation
+datafusion = { version = "38", default-features = false, features = [
+    "crypto_expressions",
+    "encoding_expressions",
+    "parquet",
+    "regex_expressions",
+    "unicode_expressions",
+    "compression",
+] }
 dill = "0.8"
 dirs = "5"
 fs_extra = "1.3"
 futures = "0.3"
-glob = "0.3"  # Used for path completions
+glob = "0.3" # Used for path completions
+hex = { version = "0.4", default-features = false, features = [] }
 indoc = "2"
 itertools = "0.11"
-libc = "0.2"  # Signal names
+libc = "0.2" # Signal names
 regex = "1"
-shlex = "1"  # Parsing partial input for custom completions
-signal-hook = "0.3"  # Signal handling
+shlex = "1" # Parsing partial input for custom completions
+signal-hook = "0.3" # Signal handling
 tokio = { version = "1", default-features = false, features = ["io-util"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tokio-util = { version = "0.7", default-features = false, features = ["io"] }
@@ -146,14 +166,21 @@ whoami = "1.5"
 
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"  # For getting uid:gid
+libc = "0.2" # For getting uid:gid
 
 
 [dev-dependencies]
 assert_cmd = "2"
+pretty_assertions = { version = "1" }
 test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 
 
 [build-dependencies]
-vergen = { version = "8", features = ["build", "cargo", "git", "gitcl", "rustc"] }
+vergen = { version = "8", features = [
+    "build",
+    "cargo",
+    "git",
+    "gitcl",
+    "rustc",
+] }

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -86,7 +86,7 @@ read_input = "0.8"                                                # Basic user i
 webbrowser = "0.8"                                                # For opening URLs in default system browser
 
 # APIs
-arrow-flight = { version = "51", features = ["flight-sql-experimental"] }
+arrow-flight = { version = "52", features = ["flight-sql-experimental"] }
 async-graphql = { version = "6", features = [
     "chrono",
     "url",
@@ -135,7 +135,7 @@ tracing-bunyan-formatter = "0.3"
 async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1" # Conditional compilation
-datafusion = { version = "38", default-features = false, features = [
+datafusion = { version = "39", default-features = false, features = [
     "crypto_expressions",
     "encoding_expressions",
     "parquet",

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -492,6 +492,28 @@ pub fn register_config_in_catalog(
             .unwrap(),
     });
 
+    catalog_builder.add_value(config.source.as_ref().unwrap().to_infra_cfg());
+    catalog_builder.add_value(
+        config
+            .source
+            .as_ref()
+            .unwrap()
+            .mqtt
+            .as_ref()
+            .unwrap()
+            .to_infra_cfg(),
+    );
+    catalog_builder.add_value(
+        config
+            .source
+            .as_ref()
+            .unwrap()
+            .ethereum
+            .as_ref()
+            .unwrap()
+            .to_infra_cfg(),
+    );
+
     let ipfs_conf = config.protocol.as_ref().unwrap().ipfs.as_ref().unwrap();
 
     catalog_builder.add_value(IpfsGateway {

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -254,6 +254,8 @@ pub fn configure_base_catalog(
 
     b.add::<DataFormatRegistryImpl>();
 
+    b.add_builder(FetchService::builder().with_run_info_dir(workspace_layout.run_info_dir.clone()));
+
     b.add_builder(
         PollingIngestServiceImpl::builder()
             .with_run_info_dir(workspace_layout.run_info_dir.clone())

--- a/src/app/cli/src/commands/tail_command.rs
+++ b/src/app/cli/src/commands/tail_command.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, Int32Array, UInt8Array};
+use datafusion::arrow::array::{Int32Array, UInt8Array};
 use datafusion::arrow::datatypes::DataType;
 use kamu::domain::QueryService;
 use opendatafabric::*;
@@ -60,7 +60,7 @@ impl Command for TailCommand {
                     // TODO: `RecordsFormat` should allow specifying column formats by name, not
                     // only positionally
                     ColumnFormat::default(),
-                    ColumnFormat::default().with_value_fmt(|array: &ArrayRef, row: usize| {
+                    ColumnFormat::default().with_value_fmt(|array, row, _| {
                         let err = Err(InvalidOperationType(0));
                         let op = match array.data_type() {
                             DataType::UInt8 => array

--- a/src/app/cli/src/output/output_config.rs
+++ b/src/app/cli/src/output/output_config.rs
@@ -27,11 +27,13 @@ pub struct OutputConfig {
 impl OutputConfig {
     pub fn get_records_writer(&self, fmt: RecordsFormat) -> Box<dyn RecordsWriter> {
         match self.format {
-            OutputFormat::Csv => Box::new(
-                CsvWriterBuilder::new()
-                    .with_header(true)
-                    .build(std::io::stdout()),
-            ),
+            OutputFormat::Csv => Box::new(CsvWriter::new(
+                std::io::stdout(),
+                CsvWriterOptions {
+                    header: true,
+                    ..Default::default()
+                },
+            )),
             OutputFormat::Json => Box::new(JsonArrayOfStructsWriter::new(std::io::stdout())),
             OutputFormat::JsonSoA => {
                 Box::new(JsonStructOfArraysWriter::new(std::io::stdout(), usize::MAX))

--- a/src/app/cli/src/output/records_writers.rs
+++ b/src/app/cli/src/output/records_writers.rs
@@ -17,7 +17,7 @@ use datafusion::arrow::util::display::array_value_to_string;
 use kamu_data_utils::data::format::WriterError;
 pub use kamu_data_utils::data::format::{
     CsvWriter,
-    CsvWriterBuilder,
+    CsvWriterOptions,
     JsonArrayOfArraysWriter,
     JsonArrayOfStructsWriter,
     JsonLineDelimitedWriter,

--- a/src/app/cli/src/output/records_writers.rs
+++ b/src/app/cli/src/output/records_writers.rs
@@ -70,60 +70,61 @@ impl RecordsFormat {
         }
     }
 
-    pub fn get_style_spec(&self, _row: usize, column: usize, _array: &ArrayRef) -> &str {
-        self.column_formats
-            .get(column)
-            .and_then(|cf| cf.style_spec.as_ref())
-            .or(self.default_column_format.style_spec.as_ref())
-            .map(String::as_str)
-            .unwrap()
+    pub fn get_column_format(&self, col: usize) -> ColumnFormatRef {
+        let cfmt = self.column_formats.get(col);
+
+        ColumnFormatRef {
+            style_spec: cfmt
+                .and_then(|f| f.style_spec.as_ref())
+                .or(self.default_column_format.style_spec.as_ref()),
+            null_value: cfmt
+                .and_then(|f| f.null_value.as_ref())
+                .or(self.default_column_format.null_value.as_ref()),
+            max_len: cfmt
+                .and_then(|f| f.max_len)
+                .or(self.default_column_format.max_len),
+            max_bin_len: cfmt
+                .and_then(|f| f.max_bin_len)
+                .or(self.default_column_format.max_bin_len),
+            value_fmt: cfmt
+                .and_then(|f| f.value_fmt.as_ref())
+                .or(self.default_column_format.value_fmt.as_ref()),
+        }
     }
 
     // TODO: PERF: Rethink into a columnar approach
     pub fn format(&self, row: usize, col: usize, array: &ArrayRef) -> String {
         use datafusion::arrow::array::*;
 
+        let column_fmt = self.get_column_format(col);
+
         // Check for null
-        let null_value = self
-            .column_formats
-            .get(col)
-            .and_then(|cf| cf.null_value.as_ref())
-            .or(self.default_column_format.null_value.as_ref())
-            .unwrap();
-
         if array.is_null(row) {
-            return null_value.clone();
-        }
-
-        // Check for binary data
-        match array.data_type() {
-            DataType::Binary
-            | DataType::LargeBinary
-            | DataType::List(_)
-            | DataType::LargeList(_) => {
-                let binary_placeholder = self
-                    .column_formats
-                    .get(col)
-                    .and_then(|cf| cf.binary_placeholder.as_ref())
-                    .or(self.default_column_format.binary_placeholder.as_ref());
-
-                if let Some(binary_placeholder) = binary_placeholder {
-                    return binary_placeholder.clone();
-                }
-            }
-            _ => (),
+            return column_fmt.null_value.unwrap().clone();
         }
 
         // Format value
-        let mut value = if let Some(value_fmt) = self
-            .column_formats
-            .get(col)
-            .and_then(|cf| cf.value_fmt.as_ref())
-            .or(self.default_column_format.value_fmt.as_ref())
-        {
-            value_fmt(array, row)
+        let mut value = if let Some(value_fmt) = column_fmt.value_fmt {
+            (*value_fmt)(array, row, &column_fmt)
         } else {
-            array_value_to_string(array, row).unwrap()
+            match array.data_type() {
+                DataType::Utf8 => {
+                    Self::format_str(downcast_array::<StringArray>(array).value(row), &column_fmt)
+                }
+                DataType::LargeUtf8 => Self::format_str(
+                    downcast_array::<LargeStringArray>(array).value(row),
+                    &column_fmt,
+                ),
+                DataType::Binary => Self::format_binary(
+                    downcast_array::<BinaryArray>(array).value(row),
+                    &column_fmt,
+                ),
+                DataType::LargeBinary => Self::format_binary(
+                    downcast_array::<LargeBinaryArray>(array).value(row),
+                    &column_fmt,
+                ),
+                _ => array_value_to_string(array, row).unwrap(),
+            }
         };
 
         // Truncate to limit
@@ -138,12 +139,39 @@ impl RecordsFormat {
             if value.len() > max_len {
                 if let Some((byte_index, _)) = value.char_indices().nth(max_len) {
                     value.truncate(byte_index);
-                    value.push_str("...");
+                    value.push('…');
                 }
             }
         }
 
         value
+    }
+
+    fn format_str(v: &str, fmt: &ColumnFormatRef) -> String {
+        let max_len = fmt.max_len.unwrap_or(usize::MAX);
+
+        if v.len() <= max_len {
+            v.to_string()
+        } else {
+            // TODO: Account for UTF
+            let half_len = max_len / 2;
+            let head = &v[..half_len];
+            let tail = &v[usize::max(half_len, v.len() - half_len)..];
+            format!("{head}…{tail}")
+        }
+    }
+
+    fn format_binary(v: &[u8], fmt: &ColumnFormatRef) -> String {
+        let max_len = fmt.max_bin_len.or(fmt.max_len).unwrap_or(usize::MAX);
+        let max_len_bin = max_len / 2;
+        if v.len() <= max_len_bin {
+            hex::encode(v)
+        } else {
+            let half_len_bin = max_len_bin / 2;
+            let head = &v[..half_len_bin];
+            let tail = &v[usize::max(half_len_bin, v.len() - half_len_bin)..];
+            format!("{}…{}", hex::encode(head), hex::encode(tail))
+        }
     }
 }
 
@@ -154,22 +182,22 @@ impl Default for RecordsFormat {
             default_column_format: ColumnFormat::new()
                 .with_style_spec("r")
                 .with_null_value("")
-                .with_binary_placeholder("<binary>")
-                .with_max_len(90),
+                .with_max_len(90)
+                .with_max_binary_len(13),
         }
     }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-type ValueFormatterCallback = Box<dyn Fn(&ArrayRef, usize) -> String>;
+type ValueFormatterCallback = Box<dyn Fn(&ArrayRef, usize, &ColumnFormatRef) -> String>;
 
 #[derive(Default)]
 pub struct ColumnFormat {
     style_spec: Option<String>,
     null_value: Option<String>,
-    binary_placeholder: Option<String>,
     max_len: Option<usize>,
+    max_bin_len: Option<usize>,
     value_fmt: Option<ValueFormatterCallback>,
 }
 
@@ -192,13 +220,8 @@ impl ColumnFormat {
         }
     }
 
-    pub fn with_binary_placeholder(self, binary_placeholder: impl Into<String>) -> Self {
-        Self {
-            binary_placeholder: Some(binary_placeholder.into()),
-            ..self
-        }
-    }
-
+    /// Determines maximum length of the formatted value in its textual
+    /// representation
     pub fn with_max_len(self, max_len: usize) -> Self {
         Self {
             max_len: Some(max_len),
@@ -206,9 +229,18 @@ impl ColumnFormat {
         }
     }
 
+    /// Specialization of max length for binary fields (length given is still in
+    /// textual hex representation)
+    pub fn with_max_binary_len(self, max_bin_len: usize) -> Self {
+        Self {
+            max_bin_len: Some(max_bin_len),
+            ..self
+        }
+    }
+
     pub fn with_value_fmt<F>(self, value_fmt: F) -> Self
     where
-        F: Fn(&ArrayRef, usize) -> String + 'static,
+        F: Fn(&ArrayRef, usize, &ColumnFormatRef) -> String + 'static,
     {
         Self {
             value_fmt: Some(Box::new(value_fmt)),
@@ -219,15 +251,11 @@ impl ColumnFormat {
     pub fn with_value_fmt_t<T: 'static>(self, value_fmt_t: fn(T) -> String) -> Self {
         let value_fmt_t: Box<dyn Any> = Box::new(value_fmt_t);
         Self {
-            value_fmt: Some(Box::new(move |array, row| {
+            value_fmt: Some(Box::new(move |array, row, _| {
                 Self::value_fmt_t(array, row, value_fmt_t.as_ref(), std::any::type_name::<T>())
             })),
             ..self
         }
-    }
-
-    pub fn get_style_spec(&self) -> Option<&str> {
-        self.style_spec.as_deref()
     }
 
     fn value_fmt_t(
@@ -270,9 +298,25 @@ impl ColumnFormat {
                 }
                 _ => unimplemented!(),
             },
+            DataType::Utf8 => format_typed!(StringArray, &str, type_name, array, value_fmt, row),
+            DataType::LargeUtf8 => {
+                format_typed!(LargeStringArray, &str, type_name, array, value_fmt, row)
+            }
+            DataType::Binary => format_typed!(BinaryArray, &[u8], type_name, array, value_fmt, row),
+            DataType::LargeBinary => {
+                format_typed!(BinaryArray, &[u8], type_name, array, value_fmt, row)
+            }
             _ => unimplemented!(),
         }
     }
+}
+
+pub struct ColumnFormatRef<'a> {
+    style_spec: Option<&'a String>,
+    null_value: Option<&'a String>,
+    max_len: Option<usize>,
+    max_bin_len: Option<usize>,
+    value_fmt: Option<&'a ValueFormatterCallback>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -343,7 +387,7 @@ where
             for col in 0..records.num_columns() {
                 let array = records.column(col);
 
-                let style_spec = self.format.get_style_spec(row, col, array);
+                let style_spec = self.format.get_column_format(col).style_spec.unwrap();
                 let value = self.format.format(row, col, array);
                 cells.push(Cell::new(&value).style_spec(style_spec));
             }

--- a/src/app/cli/src/services/config/models.rs
+++ b/src/app/cli/src/services/config/models.rs
@@ -26,15 +26,23 @@ pub struct CLIConfig {
     /// Engine configuration
     #[merge(strategy = merge_recursive)]
     pub engine: Option<EngineConfig>,
+
+    /// Source configuration
+    #[merge(strategy = merge_recursive)]
+    pub source: Option<SourceConfig>,
+
     /// Network protocols configuration
     #[merge(strategy = merge_recursive)]
     pub protocol: Option<ProtocolConfig>,
+
     /// Data access and visualization configuration
     #[merge(strategy = merge_recursive)]
     pub frontend: Option<FrontendConfig>,
+
     /// Users configuration
     #[merge(strategy = merge_recursive)]
     pub users: Option<PredefinedAccountsConfig>,
+
     /// Database connection configuration
     pub database: Option<DatabaseConfig>,
     /// Uploads configuration
@@ -46,6 +54,7 @@ impl CLIConfig {
     pub fn new() -> Self {
         Self {
             engine: None,
+            source: None,
             protocol: None,
             frontend: None,
             users: None,
@@ -61,6 +70,7 @@ impl CLIConfig {
     pub fn sample() -> Self {
         Self {
             engine: Some(EngineConfig::sample()),
+            source: Some(SourceConfig::sample()),
             protocol: Some(ProtocolConfig::sample()),
             frontend: Some(FrontendConfig::sample()),
             users: Some(PredefinedAccountsConfig::sample()),
@@ -74,6 +84,7 @@ impl Default for CLIConfig {
     fn default() -> Self {
         Self {
             engine: Some(EngineConfig::default()),
+            source: Some(SourceConfig::default()),
             protocol: Some(ProtocolConfig::default()),
             frontend: Some(FrontendConfig::default()),
             users: Some(PredefinedAccountsConfig::default()),
@@ -83,6 +94,8 @@ impl Default for CLIConfig {
     }
 }
 
+////////////////////////////////////////////////////////////////////////////////////////
+// Engine
 ////////////////////////////////////////////////////////////////////////////////////////
 
 #[skip_serializing_none]
@@ -182,6 +195,176 @@ impl Default for EngineImagesConfig {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
+// Source
+////////////////////////////////////////////////////////////////////////////////////////
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Merge, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct SourceConfig {
+    /// Target number of records after which we will stop consuming from the
+    /// resumable source and commit data, leaving the rest for the next
+    /// iteration. This ensures that one data slice doesn't become too big.
+    pub target_records_per_slice: Option<u64>,
+    /// MQTT-specific configuration
+    #[merge(strategy = merge_recursive)]
+    pub mqtt: Option<MqttSourceConfig>,
+    /// Ethereum-specific configuration
+    #[merge(strategy = merge_recursive)]
+    pub ethereum: Option<EthereumSourceConfig>,
+}
+
+impl SourceConfig {
+    pub fn new() -> Self {
+        Self {
+            target_records_per_slice: None,
+            mqtt: None,
+            ethereum: None,
+        }
+    }
+
+    fn sample() -> Self {
+        Self {
+            mqtt: Some(MqttSourceConfig::sample()),
+            ethereum: Some(EthereumSourceConfig::sample()),
+            ..Self::default()
+        }
+    }
+
+    pub fn to_infra_cfg(&self) -> kamu::ingest::SourceConfig {
+        kamu::ingest::SourceConfig {
+            target_records_per_slice: self.target_records_per_slice.unwrap(),
+        }
+    }
+}
+
+impl Default for SourceConfig {
+    fn default() -> Self {
+        let infra_cfg = kamu::ingest::SourceConfig::default();
+        Self {
+            target_records_per_slice: Some(infra_cfg.target_records_per_slice),
+            mqtt: Some(MqttSourceConfig::default()),
+            ethereum: Some(EthereumSourceConfig::default()),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Merge, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct MqttSourceConfig {
+    /// Time in milliseconds to wait for MQTT broker to send us some data after
+    /// which we will consider that we have "caught up" and end the polling
+    /// loop.
+    pub broker_idle_timeout_ms: Option<u64>,
+}
+
+impl MqttSourceConfig {
+    pub fn new() -> Self {
+        Self {
+            broker_idle_timeout_ms: None,
+        }
+    }
+
+    fn sample() -> Self {
+        Self { ..Self::default() }
+    }
+
+    pub fn to_infra_cfg(&self) -> kamu::ingest::MqttSourceConfig {
+        kamu::ingest::MqttSourceConfig {
+            broker_idle_timeout_ms: self.broker_idle_timeout_ms.unwrap(),
+        }
+    }
+}
+
+impl Default for MqttSourceConfig {
+    fn default() -> Self {
+        let infra_cfg = kamu::ingest::MqttSourceConfig::default();
+        Self {
+            broker_idle_timeout_ms: Some(infra_cfg.broker_idle_timeout_ms),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Merge, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct EthereumSourceConfig {
+    /// Default RPC endpoints to use if source does not specify one explicitly.
+    #[merge(strategy = merge::vec::append)]
+    pub rpc_endpoints: Vec<EthRpcEndpoint>,
+    /// Default number of blocks to scan within one query to `eth_getLogs` RPC
+    /// endpoint.
+    pub get_logs_block_stride: Option<u64>,
+    /// Forces iteration to stop after the specified number of blocks were
+    /// scanned even if we didn't reach the target record number. This is useful
+    /// to not lose a lot of scanning progress in case of an RPC error.
+    pub commit_after_blocks_scanned: Option<u64>,
+}
+
+impl EthereumSourceConfig {
+    pub fn new() -> Self {
+        Self {
+            rpc_endpoints: Vec::new(),
+            get_logs_block_stride: None,
+            commit_after_blocks_scanned: None,
+        }
+    }
+
+    fn sample() -> Self {
+        Self { ..Self::default() }
+    }
+
+    pub fn to_infra_cfg(&self) -> kamu::ingest::EthereumSourceConfig {
+        kamu::ingest::EthereumSourceConfig {
+            rpc_endpoints: self
+                .rpc_endpoints
+                .iter()
+                .map(EthRpcEndpoint::to_infra_cfg)
+                .collect(),
+            get_logs_block_stride: self.get_logs_block_stride.unwrap(),
+            commit_after_blocks_scanned: self.commit_after_blocks_scanned.unwrap(),
+        }
+    }
+}
+
+impl Default for EthereumSourceConfig {
+    fn default() -> Self {
+        let infra_cfg = kamu::ingest::EthereumSourceConfig::default();
+        Self {
+            rpc_endpoints: Vec::new(),
+            get_logs_block_stride: Some(infra_cfg.get_logs_block_stride),
+            commit_after_blocks_scanned: Some(infra_cfg.commit_after_blocks_scanned),
+        }
+    }
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct EthRpcEndpoint {
+    pub chain_id: u64,
+    pub chain_name: String,
+    pub node_url: Url,
+}
+
+impl EthRpcEndpoint {
+    pub fn to_infra_cfg(&self) -> kamu::ingest::EthRpcEndpoint {
+        kamu::ingest::EthRpcEndpoint {
+            chain_id: self.chain_id,
+            chain_name: self.chain_name.clone(),
+            node_url: self.node_url.clone(),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Protocol
+////////////////////////////////////////////////////////////////////////////////////////
 
 #[skip_serializing_none]
 #[derive(Debug, Clone, Merge, Serialize, Deserialize)]
@@ -253,6 +436,8 @@ impl Default for IpfsConfig {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
+// Frontend
+////////////////////////////////////////////////////////////////////////////////////////
 
 #[skip_serializing_none]
 #[derive(Debug, Clone, Merge, Serialize, Deserialize)]
@@ -320,6 +505,8 @@ impl Default for JupyterConfig {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
+// Database
+////////////////////////////////////////////////////////////////////////////////////////
 
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -365,6 +552,8 @@ pub struct RemoteDatabaseConfig {
     pub port: Option<u32>,
 }
 
+////////////////////////////////////////////////////////////////////////////////////////
+// Misc
 ////////////////////////////////////////////////////////////////////////////////////////
 
 #[skip_serializing_none]

--- a/src/app/cli/tests/tests/test_output.rs
+++ b/src/app/cli/tests/tests/test_output.rs
@@ -66,7 +66,7 @@ async fn test_records_format() {
             .with_style_spec("r")
             .with_value_fmt_t(humanize_quantity),
         ColumnFormat::new().with_style_spec("l").with_max_len(5),
-        ColumnFormat::default().with_max_len(5),
+        ColumnFormat::default().with_max_binary_len(5),
     ]);
 
     let mut buf = Vec::new();

--- a/src/domain/core/Cargo.toml
+++ b/src/domain/core/Cargo.toml
@@ -43,8 +43,10 @@ tracing = { version = "0.1", default-features = false }
 url = { version = "2", default-features = false, features = ["serde"] }
 
 # TODO: Avoid this dependency or depend on sub-crates
-datafusion = { version = "38", default-features = false, features = ["parquet"] }
-object_store = { version = "0.9", default-features = false }
+datafusion = { version = "39", default-features = false, features = [
+    "parquet",
+] }
+object_store = { version = "0.10", default-features = false }
 
 # TODO: Make serde optional
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/src/domain/flow-system/domain/Cargo.toml
+++ b/src/domain/flow-system/domain/Cargo.toml
@@ -42,7 +42,9 @@ url = { version = "2", default-features = false }
 
 # TODO: Make serde optional
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde_with = { version = "3", default-features = false, features = ["chrono_0_4"] }
+serde_with = { version = "3", default-features = false, features = [
+    "chrono_0_4",
+] }
 
 [dev-dependencies]
-datafusion = { version = "38", default-features = false }
+datafusion = { version = "39", default-features = false }

--- a/src/domain/opendatafabric/Cargo.toml
+++ b/src/domain/opendatafabric/Cargo.toml
@@ -44,12 +44,16 @@ sha3 = "0.10"
 url = "2"
 
 # Crypto
-ed25519-dalek = { version = "2", default-features = false, features = ["std", "fast", "rand_core"] }
+ed25519-dalek = { version = "2", default-features = false, features = [
+    "std",
+    "fast",
+    "rand_core",
+] }
 rand = "0.8"
 
 # Serialization
 base64 = "0.21"
-flatbuffers = "23"
+flatbuffers = "24"
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_with = "3"
@@ -60,8 +64,10 @@ prost = "0.12"
 tonic = "0.11"
 
 # Optional
-arrow = { optional = true, version = "51", default-features = false, features = ["ipc"] }
-sqlx = { optional = true, version = "0.7", default_features = false}
+arrow = { optional = true, version = "52", default-features = false, features = [
+    "ipc",
+] }
+sqlx = { optional = true, version = "0.7", default_features = false }
 
 [dev-dependencies]
 indoc = "2"

--- a/src/domain/opendatafabric/schemas/odf.fbs
+++ b/src/domain/opendatafabric/schemas/odf.fbs
@@ -383,11 +383,19 @@ table FetchStepMqtt {
   topics: [MqttTopicSubscription];
 }
 
+table FetchStepEthereumLogs {
+  chain_id: uint64 = null;
+  node_url: string;
+  filter: string;
+  signature: string;
+}
+
 union FetchStep {
   FetchStepUrl,
   FetchStepFilesGlob,
   FetchStepContainer,
   FetchStepMqtt,
+  FetchStepEthereumLogs,
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/opendatafabric/src/dtos/dtos_generated.rs
+++ b/src/domain/opendatafabric/src/dtos/dtos_generated.rs
@@ -340,6 +340,7 @@ pub enum FetchStep {
     FilesGlob(FetchStepFilesGlob),
     Container(FetchStepContainer),
     Mqtt(FetchStepMqtt),
+    EthereumLogs(FetchStepEthereumLogs),
 }
 
 impl_enum_with_variants!(FetchStep);
@@ -409,6 +410,25 @@ pub struct FetchStepMqtt {
 }
 
 impl_enum_variant!(FetchStep::Mqtt(FetchStepMqtt));
+
+/// Connects to an Ethereum node to stream transaction logs.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FetchStepEthereumLogs {
+    /// Identifier of the chain to scan logs from. This parameter may be used
+    /// for RPC endpoint lookup as well as asserting that provided `nodeUrl`
+    /// corresponds to the expected chain.
+    pub chain_id: Option<u64>,
+    /// Url of the node.
+    pub node_url: Option<String>,
+    /// An SQL WHERE clause that can be used to pre-filter the logs before
+    /// fetching them from the ETH node.
+    pub filter: Option<String>,
+    /// Solidity log event signature to use for decoding. Using this field adds
+    /// `event` to the output containing decoded log as JSON.
+    pub signature: Option<String>,
+}
+
+impl_enum_variant!(FetchStep::EthereumLogs(FetchStepEthereumLogs));
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SourceOrdering {

--- a/src/domain/opendatafabric/src/engine/grpc_generated/engine.tonic.rs
+++ b/src/domain/opendatafabric/src/engine/grpc_generated/engine.tonic.rs
@@ -143,15 +143,16 @@ pub mod engine_server {
     #[async_trait]
     pub trait Engine: Send + Sync + 'static {
         /// Server streaming response type for the ExecuteRawQuery method.
-        type ExecuteRawQueryStream: futures_core::Stream<Item = std::result::Result<super::RawQueryResponse, tonic::Status>>
-            + Send
+        type ExecuteRawQueryStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::RawQueryResponse, tonic::Status>,
+            > + Send
             + 'static;
         async fn execute_raw_query(
             &self,
             request: tonic::Request<super::RawQueryRequest>,
         ) -> std::result::Result<tonic::Response<Self::ExecuteRawQueryStream>, tonic::Status>;
         /// Server streaming response type for the ExecuteTransform method.
-        type ExecuteTransformStream: futures_core::Stream<
+        type ExecuteTransformStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::TransformResponse, tonic::Status>,
             > + Send
             + 'static;
@@ -252,7 +253,9 @@ pub mod engine_server {
                             request: tonic::Request<super::RawQueryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).execute_raw_query(request).await };
+                            let fut = async move {
+                                <T as Engine>::execute_raw_query(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -294,7 +297,9 @@ pub mod engine_server {
                             request: tonic::Request<super::TransformRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { (*inner).execute_transform(request).await };
+                            let fut = async move {
+                                <T as Engine>::execute_transform(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }

--- a/src/domain/opendatafabric/src/serde/flatbuffers/convertors_generated.rs
+++ b/src/domain/opendatafabric/src/serde/flatbuffers/convertors_generated.rs
@@ -666,6 +666,10 @@ impl<'fb> FlatbuffersEnumSerializable<'fb, fb::FetchStep> for odf::FetchStep {
                 fb::FetchStep::FetchStepMqtt,
                 v.serialize(fb).as_union_value(),
             ),
+            odf::FetchStep::EthereumLogs(v) => (
+                fb::FetchStep::FetchStepEthereumLogs,
+                v.serialize(fb).as_union_value(),
+            ),
         }
     }
 }
@@ -691,6 +695,11 @@ impl<'fb> FlatbuffersEnumDeserializable<'fb, fb::FetchStep> for odf::FetchStep {
             fb::FetchStep::FetchStepMqtt => {
                 odf::FetchStep::Mqtt(odf::FetchStepMqtt::deserialize(unsafe {
                     fb::FetchStepMqtt::init_from_table(table)
+                }))
+            }
+            fb::FetchStep::FetchStepEthereumLogs => {
+                odf::FetchStep::EthereumLogs(odf::FetchStepEthereumLogs::deserialize(unsafe {
+                    fb::FetchStepEthereumLogs::init_from_table(table)
                 }))
             }
             _ => panic!("Invalid enum value: {}", t.0),
@@ -859,6 +868,33 @@ impl<'fb> FlatbuffersDeserializable<fb::FetchStepMqtt<'fb>> for odf::FetchStepMq
                         .collect()
                 })
                 .unwrap(),
+        }
+    }
+}
+
+impl<'fb> FlatbuffersSerializable<'fb> for odf::FetchStepEthereumLogs {
+    type OffsetT = WIPOffset<fb::FetchStepEthereumLogs<'fb>>;
+
+    fn serialize(&self, fb: &mut FlatBufferBuilder<'fb>) -> Self::OffsetT {
+        let node_url_offset = self.node_url.as_ref().map(|v| fb.create_string(&v));
+        let filter_offset = self.filter.as_ref().map(|v| fb.create_string(&v));
+        let signature_offset = self.signature.as_ref().map(|v| fb.create_string(&v));
+        let mut builder = fb::FetchStepEthereumLogsBuilder::new(fb);
+        self.chain_id.map(|v| builder.add_chain_id(v));
+        node_url_offset.map(|off| builder.add_node_url(off));
+        filter_offset.map(|off| builder.add_filter(off));
+        signature_offset.map(|off| builder.add_signature(off));
+        builder.finish()
+    }
+}
+
+impl<'fb> FlatbuffersDeserializable<fb::FetchStepEthereumLogs<'fb>> for odf::FetchStepEthereumLogs {
+    fn deserialize(proxy: fb::FetchStepEthereumLogs<'fb>) -> Self {
+        odf::FetchStepEthereumLogs {
+            chain_id: proxy.chain_id().map(|v| v),
+            node_url: proxy.node_url().map(|v| v.to_owned()),
+            filter: proxy.filter().map(|v| v.to_owned()),
+            signature: proxy.signature().map(|v| v.to_owned()),
         }
     }
 }

--- a/src/domain/opendatafabric/src/serde/flatbuffers/proxies_generated.rs
+++ b/src/domain/opendatafabric/src/serde/flatbuffers/proxies_generated.rs
@@ -911,18 +911,19 @@ pub const ENUM_MIN_FETCH_STEP: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_FETCH_STEP: u8 = 4;
+pub const ENUM_MAX_FETCH_STEP: u8 = 5;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_FETCH_STEP: [FetchStep; 5] = [
+pub const ENUM_VALUES_FETCH_STEP: [FetchStep; 6] = [
     FetchStep::NONE,
     FetchStep::FetchStepUrl,
     FetchStep::FetchStepFilesGlob,
     FetchStep::FetchStepContainer,
     FetchStep::FetchStepMqtt,
+    FetchStep::FetchStepEthereumLogs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -935,15 +936,17 @@ impl FetchStep {
     pub const FetchStepFilesGlob: Self = Self(2);
     pub const FetchStepContainer: Self = Self(3);
     pub const FetchStepMqtt: Self = Self(4);
+    pub const FetchStepEthereumLogs: Self = Self(5);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 4;
+    pub const ENUM_MAX: u8 = 5;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::FetchStepUrl,
         Self::FetchStepFilesGlob,
         Self::FetchStepContainer,
         Self::FetchStepMqtt,
+        Self::FetchStepEthereumLogs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -953,6 +956,7 @@ impl FetchStep {
             Self::FetchStepFilesGlob => Some("FetchStepFilesGlob"),
             Self::FetchStepContainer => Some("FetchStepContainer"),
             Self::FetchStepMqtt => Some("FetchStepMqtt"),
+            Self::FetchStepEthereumLogs => Some("FetchStepEthereumLogs"),
             _ => None,
         }
     }
@@ -8130,6 +8134,198 @@ impl core::fmt::Debug for FetchStepMqtt<'_> {
         ds.finish()
     }
 }
+pub enum FetchStepEthereumLogsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct FetchStepEthereumLogs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for FetchStepEthereumLogs<'a> {
+    type Inner = FetchStepEthereumLogs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> FetchStepEthereumLogs<'a> {
+    pub const VT_CHAIN_ID: flatbuffers::VOffsetT = 4;
+    pub const VT_NODE_URL: flatbuffers::VOffsetT = 6;
+    pub const VT_FILTER: flatbuffers::VOffsetT = 8;
+    pub const VT_SIGNATURE: flatbuffers::VOffsetT = 10;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        FetchStepEthereumLogs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args FetchStepEthereumLogsArgs<'args>,
+    ) -> flatbuffers::WIPOffset<FetchStepEthereumLogs<'bldr>> {
+        let mut builder = FetchStepEthereumLogsBuilder::new(_fbb);
+        if let Some(x) = args.chain_id {
+            builder.add_chain_id(x);
+        }
+        if let Some(x) = args.signature {
+            builder.add_signature(x);
+        }
+        if let Some(x) = args.filter {
+            builder.add_filter(x);
+        }
+        if let Some(x) = args.node_url {
+            builder.add_node_url(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn chain_id(&self) -> Option<u64> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<u64>(FetchStepEthereumLogs::VT_CHAIN_ID, None)
+        }
+    }
+    #[inline]
+    pub fn node_url(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(FetchStepEthereumLogs::VT_NODE_URL, None)
+        }
+    }
+    #[inline]
+    pub fn filter(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(FetchStepEthereumLogs::VT_FILTER, None)
+        }
+    }
+    #[inline]
+    pub fn signature(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(
+                FetchStepEthereumLogs::VT_SIGNATURE,
+                None,
+            )
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for FetchStepEthereumLogs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<u64>("chain_id", Self::VT_CHAIN_ID, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "node_url",
+                Self::VT_NODE_URL,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("filter", Self::VT_FILTER, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "signature",
+                Self::VT_SIGNATURE,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
+}
+pub struct FetchStepEthereumLogsArgs<'a> {
+    pub chain_id: Option<u64>,
+    pub node_url: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub filter: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub signature: Option<flatbuffers::WIPOffset<&'a str>>,
+}
+impl<'a> Default for FetchStepEthereumLogsArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        FetchStepEthereumLogsArgs {
+            chain_id: None,
+            node_url: None,
+            filter: None,
+            signature: None,
+        }
+    }
+}
+
+pub struct FetchStepEthereumLogsBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> FetchStepEthereumLogsBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_chain_id(&mut self, chain_id: u64) {
+        self.fbb_
+            .push_slot_always::<u64>(FetchStepEthereumLogs::VT_CHAIN_ID, chain_id);
+    }
+    #[inline]
+    pub fn add_node_url(&mut self, node_url: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            FetchStepEthereumLogs::VT_NODE_URL,
+            node_url,
+        );
+    }
+    #[inline]
+    pub fn add_filter(&mut self, filter: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            FetchStepEthereumLogs::VT_FILTER,
+            filter,
+        );
+    }
+    #[inline]
+    pub fn add_signature(&mut self, signature: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            FetchStepEthereumLogs::VT_SIGNATURE,
+            signature,
+        );
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> FetchStepEthereumLogsBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        FetchStepEthereumLogsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<FetchStepEthereumLogs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for FetchStepEthereumLogs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("FetchStepEthereumLogs");
+        ds.field("chain_id", &self.chain_id());
+        ds.field("node_url", &self.node_url());
+        ds.field("filter", &self.filter());
+        ds.field("signature", &self.signature());
+        ds.finish()
+    }
+}
 pub enum PrepStepDecompressOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -8820,6 +9016,21 @@ impl<'a> SetPollingSource<'a> {
 
     #[inline]
     #[allow(non_snake_case)]
+    pub fn fetch_as_fetch_step_ethereum_logs(&self) -> Option<FetchStepEthereumLogs<'a>> {
+        if self.fetch_type() == FetchStep::FetchStepEthereumLogs {
+            self.fetch().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { FetchStepEthereumLogs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
     pub fn read_as_read_step_csv(&self) -> Option<ReadStepCsv<'a>> {
         if self.read_type() == ReadStep::ReadStepCsv {
             self.read().map(|t| {
@@ -8998,6 +9209,7 @@ impl flatbuffers::Verifiable for SetPollingSource<'_> {
           FetchStep::FetchStepFilesGlob => v.verify_union_variant::<flatbuffers::ForwardsUOffset<FetchStepFilesGlob>>("FetchStep::FetchStepFilesGlob", pos),
           FetchStep::FetchStepContainer => v.verify_union_variant::<flatbuffers::ForwardsUOffset<FetchStepContainer>>("FetchStep::FetchStepContainer", pos),
           FetchStep::FetchStepMqtt => v.verify_union_variant::<flatbuffers::ForwardsUOffset<FetchStepMqtt>>("FetchStep::FetchStepMqtt", pos),
+          FetchStep::FetchStepEthereumLogs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<FetchStepEthereumLogs>>("FetchStep::FetchStepEthereumLogs", pos),
           _ => Ok(()),
         }
      })?
@@ -9187,6 +9399,16 @@ impl core::fmt::Debug for SetPollingSource<'_> {
             }
             FetchStep::FetchStepMqtt => {
                 if let Some(x) = self.fetch_as_fetch_step_mqtt() {
+                    ds.field("fetch", &x)
+                } else {
+                    ds.field(
+                        "fetch",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            FetchStep::FetchStepEthereumLogs => {
+                if let Some(x) = self.fetch_as_fetch_step_ethereum_logs() {
                     ds.field("fetch", &x)
                 } else {
                     ds.field(

--- a/src/domain/opendatafabric/src/serde/yaml/derivations_generated.rs
+++ b/src/domain/opendatafabric/src/serde/yaml/derivations_generated.rs
@@ -433,6 +433,8 @@ pub enum FetchStepDef {
     Container(#[serde_as(as = "FetchStepContainerDef")] FetchStepContainer),
     #[serde(alias = "mqtt")]
     Mqtt(#[serde_as(as = "FetchStepMqttDef")] FetchStepMqtt),
+    #[serde(alias = "ethereumLogs", alias = "ethereumlogs")]
+    EthereumLogs(#[serde_as(as = "FetchStepEthereumLogsDef")] FetchStepEthereumLogs),
 }
 
 implement_serde_as!(FetchStep, FetchStepDef, "FetchStepDef");
@@ -448,6 +450,11 @@ implement_serde_as!(
     "FetchStepContainerDef"
 );
 implement_serde_as!(FetchStepMqtt, FetchStepMqttDef, "FetchStepMqttDef");
+implement_serde_as!(
+    FetchStepEthereumLogs,
+    FetchStepEthereumLogsDef,
+    "FetchStepEthereumLogsDef"
+);
 
 #[serde_as]
 #[skip_serializing_none]
@@ -511,6 +518,18 @@ pub struct FetchStepMqttDef {
     pub password: Option<String>,
     #[serde_as(as = "Vec<MqttTopicSubscriptionDef>")]
     pub topics: Vec<MqttTopicSubscription>,
+}
+
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(remote = "FetchStepEthereumLogs")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct FetchStepEthereumLogsDef {
+    pub chain_id: Option<u64>,
+    pub node_url: Option<String>,
+    pub filter: Option<String>,
+    pub signature: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -48,7 +48,7 @@ serde_with = "3"
 serde_yaml = "0.9"
 
 # Ingest
-alloy = { version = "0.1", git = "https://github.com/alloy-rs/alloy", branch = "main", default-features = false, features = [
+alloy = { version = "0.1", default-features = false, features = [
     "std",
     "provider-http",
     "provider-ws",
@@ -61,7 +61,7 @@ curl = { optional = true, version = "0.4", features = [
     "static-ssl",
 ] }
 curl-sys = { optional = true, version = "0.4" }
-datafusion-ethers = { version = "38", git = "https://github.com/kamu-data/datafusion-ethers", branch = "datafusion-39" }
+datafusion-ethers = { version = "38", default-features = false }
 datafusion-functions-json = { version = "0.1" }
 flate2 = "1" # GZip decoder
 reqwest = { version = "0.11", default-features = false, features = [

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -48,6 +48,11 @@ serde_with = "3"
 serde_yaml = "0.9"
 
 # Ingest
+alloy = { version = "0.1", git = "https://github.com/alloy-rs/alloy", branch = "main", default-features = false, features = [
+    "std",
+    "provider-http",
+    "provider-ws",
+] }
 # TODO: Using curl brings a lot of overhead including compiling and linking openssl
 # We should replace it with reqwest + a separate FTP client or drop FTP support in favor of container-based ingest.
 curl = { optional = true, version = "0.4", features = [
@@ -56,12 +61,8 @@ curl = { optional = true, version = "0.4", features = [
     "static-ssl",
 ] }
 curl-sys = { optional = true, version = "0.4" }
-datafusion-ethers = { version = "38" }
+datafusion-ethers = { version = "38", git = "https://github.com/kamu-data/datafusion-ethers", branch = "datafusion-39" }
 datafusion-functions-json = { version = "0.1" }
-ethers = { version = "2", default-features = false, features = [
-    "ws",
-    "rustls",
-] }
 flate2 = "1" # GZip decoder
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -56,6 +56,12 @@ curl = { optional = true, version = "0.4", features = [
     "static-ssl",
 ] }
 curl-sys = { optional = true, version = "0.4" }
+datafusion-ethers = { version = "38" }
+datafusion-functions-json = { version = "0.1" }
+ethers = { version = "2", default-features = false, features = [
+    "ws",
+    "rustls",
+] }
 flate2 = "1" # GZip decoder
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
@@ -80,7 +86,7 @@ aws-sdk-s3 = { version = "0.35" }
 aws-smithy-http = { version = "0.57", features = ["rt-tokio"] }
 aws-smithy-types = { version = "0.57" }
 aws-credential-types = { version = "0.57" }
-trust-dns-resolver = "0.23"  # TODO: Needed for DNSLink resolution with IPFS
+trust-dns-resolver = "0.23"                                     # TODO: Needed for DNSLink resolution with IPFS
 http = "0.2"
 
 # Utils

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -40,7 +40,7 @@ kamu-ingest-datafusion = { workspace = true }
 random-names = { workspace = true }
 
 # Serialization
-flatbuffers = "23"
+flatbuffers = "24"
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -48,7 +48,8 @@ serde_with = "3"
 serde_yaml = "0.9"
 
 # Ingest
-alloy = { version = "0.1", default-features = false, features = [
+# TODO: Alloy is not yet regularly released on crates.io
+alloy = { version = "0.1", git = "https://github.com/alloy-rs/alloy", rev = "a81f9e1e80e677a8f78b592657ffba607a0098b9", default-features = false, features = [
     "std",
     "provider-http",
     "provider-ws",
@@ -61,8 +62,8 @@ curl = { optional = true, version = "0.4", features = [
     "static-ssl",
 ] }
 curl-sys = { optional = true, version = "0.4" }
-datafusion-ethers = { version = "38", default-features = false }
-datafusion-functions-json = { version = "0.1" }
+datafusion-ethers = { version = "39", git = 'https://github.com/kamu-data/datafusion-ethers.git', tag = "v39.0.0" }
+datafusion-functions-json = { version = "0.1", git = 'https://github.com/kamu-data/datafusion-functions-json.git', branch = "datafusion-39" }
 flate2 = "1" # GZip decoder
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
@@ -76,8 +77,8 @@ rumqttc = { version = "0.23" }
 zip = "0.6"
 
 # Data
-datafusion = { version = "38", default-features = false }
-object_store = { version = "0.9", features = ["aws"] }
+datafusion = { version = "39", default-features = false }
+object_store = { version = "0.10", features = ["aws"] }
 digest = "0.10"
 sha3 = "0.10"
 

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -951,7 +951,7 @@ impl FetchService {
 
         // Alloy does not support newlines in log signatures, but it's nice for
         // formatting
-        let signature = fetch.signature.as_ref().map(|s| s.replace("\n", " "));
+        let signature = fetch.signature.as_ref().map(|s| s.replace('\n', " "));
 
         let mut coder: Box<dyn Transcoder + Send> = if let Some(sig) = &signature {
             Box::new(EthRawAndDecodedLogsToArrow::new_from_signature(sig).int_err()?)
@@ -964,7 +964,7 @@ impl FetchService {
             None => None,
             Some(PollingSourceState::ETag(s)) => {
                 let Some((num, _hash)) = s.split_once('@') else {
-                    panic!("Malformed ETag: {}", s);
+                    panic!("Malformed ETag: {s}");
                 };
                 Some(StreamState {
                     last_seen_block: num.parse().unwrap(),
@@ -1003,7 +1003,7 @@ impl FetchService {
             Err(EthereumRpcError::new(format!(
                 "Expected to connect to chain ID {expected_chain_id} but got {chain_id} instead"
             ))
-            .int_err())?
+            .int_err())?;
         }
 
         // Setup Datafusion context
@@ -1063,8 +1063,7 @@ impl FetchService {
         let block_range_unprocessed = (
             resume_from_state
                 .as_ref()
-                .map(|s| s.last_seen_block + 1)
-                .unwrap_or(block_range_all.0),
+                .map_or(block_range_all.0, |s| s.last_seen_block + 1),
             block_range_all.1,
         );
 

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, SubsecRound, TimeZone, Utc};
 use container_runtime::*;
+use futures::TryStreamExt;
 use kamu_core::engine::ProcessError;
 use kamu_core::*;
 use opendatafabric::*;
@@ -24,29 +25,113 @@ use super::*;
 ////////////////////////////////////////////////////////////////////////////////
 
 pub const ODF_BATCH_SIZE: &str = "ODF_BATCH_SIZE";
-pub const ODF_BATCH_SIZE_DEFAULT: u64 = 10_000;
 
-pub const ODF_POLL_TIMEOUT_MS: &str = "ODF_POLL_TIMEOUT_MS";
-pub const ODF_POLL_TIMEOUT_MS_DEFAULT: u64 = 1000;
+////////////////////////////////////////////////////////////////////////////////
+// Configs
+////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct SourceConfig {
+    /// Target number of records after which we will stop consuming from the
+    /// resumable source and commit data, leaving the rest for the next
+    /// iteration. This ensures that one data slice doesn't become too big.
+    pub target_records_per_slice: u64,
+}
+
+impl Default for SourceConfig {
+    fn default() -> Self {
+        Self {
+            target_records_per_slice: 10_000,
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct MqttSourceConfig {
+    /// Time in milliseconds to wait for MQTT broker to send us some data after
+    /// which we will consider that we have "caught up" and end the polling
+    /// loop.
+    pub broker_idle_timeout_ms: u64,
+}
+
+impl Default for MqttSourceConfig {
+    fn default() -> Self {
+        Self {
+            broker_idle_timeout_ms: 1_000,
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct EthereumSourceConfig {
+    /// Default RPC endpoints to use if source does not specify one explicitly.
+    pub rpc_endpoints: Vec<EthRpcEndpoint>,
+    /// Default number of blocks to scan within one query to `eth_getLogs` RPC
+    /// endpoint.
+    pub get_logs_block_stride: u64,
+    // TODO: Consider replacing this with logic that upon encountering an error still commits the
+    // progress made before it
+    /// Forces iteration to stop after the specified number of blocks were
+    /// scanned even if we didn't reach the target record number. This is useful
+    /// to not lose a lot of scanning progress in case of an RPC error.
+    pub commit_after_blocks_scanned: u64,
+}
+
+impl Default for EthereumSourceConfig {
+    fn default() -> Self {
+        Self {
+            rpc_endpoints: Vec::new(),
+            get_logs_block_stride: 100_000,
+            commit_after_blocks_scanned: 1_000_000,
+        }
+    }
+}
+
+impl EthereumSourceConfig {
+    pub fn get_endpoint_by_chain_id(&self, chain_id: u64) -> Option<&EthRpcEndpoint> {
+        self.rpc_endpoints.iter().find(|e| e.chain_id == chain_id)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EthRpcEndpoint {
+    pub chain_id: u64,
+    pub chain_name: String,
+    pub node_url: Url,
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct FetchService {
     container_runtime: Arc<ContainerRuntime>,
-    container_log_dir: PathBuf,
+    run_info_dir: PathBuf,
+    source_config: Arc<SourceConfig>,
+    mqtt_source_config: Arc<MqttSourceConfig>,
+    eth_source_config: Arc<EthereumSourceConfig>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
+#[dill::component(pub)]
 // TODO: Split this service apart into pluggable protocol implementations
 impl FetchService {
     pub fn new(
         container_runtime: Arc<ContainerRuntime>,
-        container_log_dir: impl Into<PathBuf>,
+        run_info_dir: PathBuf,
+        source_config: Option<Arc<SourceConfig>>,
+        mqtt_source_config: Option<Arc<MqttSourceConfig>>,
+        eth_source_config: Option<Arc<EthereumSourceConfig>>,
     ) -> Self {
         Self {
             container_runtime,
-            container_log_dir: container_log_dir.into(),
+            run_info_dir,
+            source_config: source_config.unwrap_or_default(),
+            mqtt_source_config: mqtt_source_config.unwrap_or_default(),
+            eth_source_config: eth_source_config.unwrap_or_default(),
         }
     }
 
@@ -114,7 +199,12 @@ impl FetchService {
                 &listener,
             ),
             FetchStep::Mqtt(fetch) => {
-                Self::fetch_mqtt(dataset_handle, fetch, target_path, &listener).await
+                self.fetch_mqtt(dataset_handle, fetch, target_path, &listener)
+                    .await
+            }
+            FetchStep::EthereumLogs(fetch) => {
+                self.fetch_ethereum_logs(fetch, prev_source_state, target_path, &listener)
+                    .await
             }
         }
     }
@@ -202,10 +292,10 @@ impl FetchService {
         });
 
         // Setup logging
-        let out_dir = self.container_log_dir.join(format!("fetch-{operation_id}"));
+        let out_dir = self.run_info_dir.join(format!("fetch-{operation_id}"));
         std::fs::create_dir_all(&out_dir).int_err()?;
 
-        let stderr_path = self.container_log_dir.join("fetch.err.txt");
+        let stderr_path = out_dir.join("fetch.err.txt");
 
         let mut target_file = tokio::fs::File::create(target_path).await.int_err()?;
         let stderr_file = std::fs::File::create(&stderr_path).int_err()?;
@@ -236,7 +326,7 @@ impl FetchService {
             container_builder = container_builder.entry_point(command.join(" "));
         }
 
-        let mut batch_size = ODF_BATCH_SIZE_DEFAULT;
+        let mut batch_size = self.source_config.target_records_per_slice;
 
         if let Some(env_vars) = &fetch.env {
             for EnvVar { name, value } in env_vars {
@@ -568,9 +658,11 @@ impl FetchService {
                 return Err(PollingIngestError::not_found(url.as_str(), None));
             }
             code => {
+                let body = response.text().await.ok();
+
                 return Err(PollingIngestError::unreachable(
                     url.as_str(),
-                    Some(HttpStatusError::new(u32::from(code.as_u16())).into()),
+                    Some(HttpStatusError::new(u32::from(code.as_u16()), body).into()),
                 ));
             }
         }
@@ -730,6 +822,7 @@ impl FetchService {
     }
 
     async fn fetch_mqtt(
+        &self,
         dataset_handle: &DatasetHandle,
         fetch: &FetchStepMqtt,
         target_path: &Path,
@@ -773,22 +866,9 @@ impl FetchService {
         let mut fetched_records = 0;
         let mut file = std::fs::File::create(target_path).int_err()?;
 
-        // TODO: Reading from env vars is temporary - should be replaced by vars
-        // provider
-        let max_records: u64 = std::env::var(ODF_BATCH_SIZE)
-            .ok()
-            .map(|s| s.parse())
-            .transpose()
-            .int_err()?
-            .unwrap_or(ODF_BATCH_SIZE_DEFAULT);
-
-        let poll_timeout: u64 = std::env::var(ODF_POLL_TIMEOUT_MS)
-            .ok()
-            .map(|s| s.parse())
-            .transpose()
-            .int_err()?
-            .unwrap_or(ODF_POLL_TIMEOUT_MS_DEFAULT);
-        let poll_timeout = std::time::Duration::from_millis(poll_timeout);
+        let max_records = self.source_config.target_records_per_slice;
+        let poll_timeout =
+            std::time::Duration::from_millis(self.mqtt_source_config.broker_idle_timeout_ms);
 
         loop {
             // Limit number of records read if they keep flowing faster that we timeout
@@ -841,6 +921,236 @@ impl FetchService {
                 zero_copy_path: None,
             }))
         }
+    }
+
+    // TODO: FIXME: This implementation is overly complex due to DataFusion's poor
+    // support of streaming / unbounded sources.
+    //
+    // In future datafusion-ethers should implement queries as unbounded source and
+    // `DataFrame::execute_stream()` should not only yield data batches, but also
+    // provide access to the state of the underlying stream for us to know how
+    // far in the block range we have scanned. Since currently we can't access
+    // the state of streaming - we can't interrupt the stream to resume later.
+    // The implementation therefore uses DataFusion only to analyze SQL and
+    // convert the WHERE clause into a filter, and then calls ETH RPC directly
+    // to scan through block ranges.
+    //
+    // TODO: Account for re-orgs
+    async fn fetch_ethereum_logs(
+        &self,
+        fetch: &FetchStepEthereumLogs,
+        prev_source_state: Option<&PollingSourceState>,
+        target_path: &Path,
+        listener: &Arc<dyn FetchProgressListener>,
+    ) -> Result<FetchResult, PollingIngestError> {
+        use datafusion::prelude::*;
+        use datafusion_ethers::convert::*;
+        use datafusion_ethers::stream::*;
+        use ethers::prelude::*;
+
+        let mut coder: Box<dyn Transcoder + Send> = if let Some(signature) = &fetch.signature {
+            Box::new(EthRawAndDecodedLogsToArrow::new_from_signature(&signature).int_err()?)
+        } else {
+            Box::new(EthRawLogsToArrow::new())
+        };
+
+        // Get last state
+        let resume_from_state = match prev_source_state {
+            None => None,
+            Some(PollingSourceState::ETag(s)) => {
+                let Some((num, _hash)) = s.split_once('@') else {
+                    panic!("Malformed ETag: {}", s);
+                };
+                Some(StreamState {
+                    last_seen_block: num.parse().unwrap(),
+                })
+            }
+            _ => panic!("EthereumLogs should only use ETag state"),
+        };
+
+        // Setup node RPC client
+        let node_url = if let Some(url) = &fetch.node_url {
+            Self::template_url(url)?
+        } else if let Some(ep) = self
+            .eth_source_config
+            .get_endpoint_by_chain_id(fetch.chain_id.unwrap())
+        {
+            ep.node_url.clone()
+        } else {
+            Err(EthereumRpcError::new(format!(
+                "Ethereum node RPC URL is not provided in the source manifest and no default node \
+                 configured for chain ID {}",
+                fetch.chain_id.unwrap()
+            ))
+            .int_err())?
+        };
+
+        let rpc_client = Arc::new(Provider::<Http>::connect(&node_url.to_string()).await);
+        let chain_id = rpc_client.get_chainid().await.int_err()?;
+        tracing::info!(%node_url, %chain_id, "Connected to ETH node");
+        if let Some(expected_chain_id) = fetch.chain_id
+            && expected_chain_id != chain_id.as_u64()
+        {
+            Err(EthereumRpcError::new(format!(
+                "Expected to connect to chain ID {expected_chain_id} but got {chain_id} instead"
+            ))
+            .int_err())?
+        }
+
+        // Setup Datafusion context
+        let mut ctx = SessionContext::new();
+        datafusion_ethers::udf::register_all(&mut ctx).unwrap();
+        ctx.register_catalog(
+            "eth",
+            Arc::new(datafusion_ethers::provider::EthCatalog::new(
+                rpc_client.clone(),
+            )),
+        );
+
+        // Prepare the query according to filters
+        let sql = if let Some(filter) = &fetch.filter {
+            let filter = if let Some(signature) = &fetch.signature {
+                format!("({filter}) and topic0 = eth_event_selector('{signature}')")
+            } else {
+                filter.clone()
+            };
+            format!("select * from eth.eth.logs where {filter}")
+        } else {
+            "select * from eth.eth.logs".to_string()
+        };
+
+        // Extract the filter out of the plan
+        let df = ctx.sql(&sql).await.int_err()?;
+        let plan = df.create_physical_plan().await.int_err()?;
+
+        let plan_str = datafusion::physical_plan::get_plan_string(&plan).join("\n");
+        tracing::info!(sql, plan = plan_str, "Original plan");
+
+        let Some(filter) = plan
+            .as_any()
+            .downcast_ref::<datafusion_ethers::provider::EthGetLogs<Http>>()
+            .map(|i| i.filter().clone())
+        else {
+            panic!("Could not downcast the plan to EthGetLogs");
+        };
+
+        // Resolve filter into a numeric block range
+        let block_range_all = datafusion_ethers::stream::RawLogsStream::filter_to_block_range(
+            &rpc_client,
+            &filter.block_option,
+        )
+        .await
+        .int_err()?;
+
+        // Block interval that will be considered during this iteration
+        let block_range_unprocessed = (
+            resume_from_state
+                .as_ref()
+                .map(|s| s.last_seen_block + 1)
+                .unwrap_or(block_range_all.0),
+            block_range_all.1,
+        );
+
+        let mut state = resume_from_state.clone();
+
+        let stream = datafusion_ethers::stream::RawLogsStream::paginate(
+            rpc_client.clone(),
+            filter,
+            StreamOptions {
+                block_stride: self.eth_source_config.get_logs_block_stride,
+            },
+            resume_from_state.clone(),
+        );
+        futures::pin_mut!(stream);
+
+        while let Some(batch) = stream.try_next().await.int_err()? {
+            let blocks_processed = batch.state.last_seen_block + 1 - block_range_unprocessed.0;
+
+            // TODO: Design a better listener API that can reflect scanned input range,
+            // number of records, and data volume transferred
+            listener.on_progress(&FetchProgress {
+                fetched_bytes: blocks_processed,
+                total_bytes: TotalBytes::Exact(
+                    block_range_unprocessed.1 + 1 - block_range_unprocessed.0,
+                ),
+            });
+
+            if !batch.logs.is_empty() {
+                coder.append(&batch.logs).int_err()?;
+            }
+
+            state = Some(batch.state);
+
+            if coder.len() as u64 >= self.source_config.target_records_per_slice {
+                tracing::info!(
+                    target_records_per_slice = self.source_config.target_records_per_slice,
+                    num_logs = coder.len(),
+                    "Interrupting the stream after reaching the target batch size",
+                );
+                break;
+            }
+            if blocks_processed >= self.eth_source_config.commit_after_blocks_scanned {
+                tracing::info!(
+                    commit_after_blocks_scanned =
+                        self.eth_source_config.commit_after_blocks_scanned,
+                    blocks_processed,
+                    "Interrupting the stream to commit progress",
+                );
+                break;
+            }
+        }
+
+        // Have we made any progress?
+        if resume_from_state == state {
+            return Ok(FetchResult::UpToDate);
+        }
+
+        let state = state.unwrap();
+
+        // Record scanning state
+        // TODO: Reorg tolerance
+        let last_seen_block = rpc_client
+            .get_block(state.last_seen_block)
+            .await
+            .int_err()?
+            .unwrap();
+
+        tracing::info!(
+            blocks_scanned = state.last_seen_block - block_range_unprocessed.0 + 1,
+            block_range_scanned = ?(block_range_unprocessed.0, state.last_seen_block),
+            block_range_ramaining = ?(state.last_seen_block + 1, block_range_unprocessed.1),
+            num_logs = coder.len(),
+            "Finished block scan cycle",
+        );
+
+        // Did we exhaust the source? (not accounting for new transactions)
+        let has_more = state.last_seen_block < block_range_unprocessed.1;
+
+        // Write data, if any, to parquet file
+        if coder.len() > 0 {
+            let batch = coder.finish();
+            {
+                let mut writer = datafusion::parquet::arrow::ArrowWriter::try_new(
+                    std::fs::File::create_new(target_path).int_err()?,
+                    batch.schema(),
+                    None,
+                )
+                .int_err()?;
+                writer.write(&batch).int_err()?;
+                writer.finish().int_err()?;
+            }
+        }
+
+        Ok(FetchResult::Updated(FetchResultUpdated {
+            source_state: Some(PollingSourceState::ETag(format!(
+                "{}@{:x}",
+                last_seen_block.number.unwrap(),
+                last_seen_block.hash.unwrap(),
+            ))),
+            source_event_time: None,
+            has_more,
+            zero_copy_path: None,
+        }))
     }
 
     fn parse_http_date_time(val: &str) -> DateTime<Utc> {
@@ -936,14 +1246,24 @@ impl FetchProgressListener for NullFetchProgressListener {}
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-#[error("HTTP request failed with status code {code}")]
 struct HttpStatusError {
     pub code: u32,
+    pub body: Option<String>,
 }
 
 impl HttpStatusError {
-    fn new(code: u32) -> Self {
-        Self { code }
+    fn new(code: u32, body: Option<String>) -> Self {
+        Self { code, body }
+    }
+}
+
+impl std::fmt::Display for HttpStatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HTTP request failed with status code {}", self.code)?;
+        if let Some(body) = &self.body {
+            write!(f, ", message: {body}")?;
+        }
+        Ok(())
     }
 }
 
@@ -998,6 +1318,20 @@ struct EventTimeSourceExtractError {
 impl std::convert::From<EventTimeSourceError> for PollingIngestError {
     fn from(e: EventTimeSourceError) -> Self {
         Self::Internal(e.int_err())
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("Ethereum RPC error: {message}")]
+struct EthereumRpcError {
+    pub message: String,
+}
+
+impl EthereumRpcError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
     }
 }
 

--- a/src/infra/core/src/ingest/ingest_common.rs
+++ b/src/infra/core/src/ingest/ingest_common.rs
@@ -62,5 +62,12 @@ pub fn new_session_context(object_store_registry: Arc<dyn ObjectStoreRegistry>) 
 
     let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
 
-    SessionContext::new_with_config_rt(config, runtime)
+    let mut ctx = SessionContext::new_with_config_rt(config, runtime);
+
+    // TODO: As part of the ODF spec we should let people opt-in into various
+    // SQL extensions on per-transform basis
+    datafusion_ethers::udf::register_all(&mut ctx).unwrap();
+    datafusion_functions_json::register_all(&mut ctx).unwrap();
+
+    ctx
 }

--- a/src/infra/core/src/repos/metadata_chain_impl.rs
+++ b/src/infra/core/src/repos/metadata_chain_impl.rs
@@ -19,7 +19,7 @@ macro_rules! invalid_event {
     ($e:expr, $msg:expr $(,)?) => {
         return Err(kamu_core::AppendValidationError::InvalidEvent(
             kamu_core::InvalidEventError::new($e, $msg),
-        ));
+        ))
     };
 }
 

--- a/src/infra/core/src/repos/metadata_chain_validators.rs
+++ b/src/infra/core/src/repos/metadata_chain_validators.rs
@@ -19,6 +19,7 @@ use kamu_core::{
 use opendatafabric::{
     AddData,
     ExecuteTransform,
+    FetchStep,
     IntoDataStreamBlock,
     IntoDataStreamEvent,
     MetadataBlock,
@@ -396,6 +397,13 @@ impl ValidateSetPollingSourceVisitor {
                 // Queries must be normalized
                 if let Some(transform) = &e.preprocess {
                     validate_transform(&block.event, transform)?;
+                }
+
+                // Eth source must identify the chain
+                if let FetchStep::EthereumLogs(f) = &e.fetch {
+                    if f.chain_id.is_none() && f.node_url.is_none() {
+                        invalid_event!(e.clone(), "Eth source must specify chainId or nodeUrl")
+                    }
                 }
 
                 true

--- a/src/infra/core/tests/tests/engine/test_engine_io.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_io.rs
@@ -42,10 +42,16 @@ async fn test_engine_io_common(
     let ingest_svc = PollingIngestServiceImpl::new(
         dataset_repo.clone(),
         dataset_action_authorizer.clone(),
+        Arc::new(FetchService::new(
+            Arc::new(ContainerRuntime::default()),
+            run_info_dir.to_path_buf(),
+            None,
+            None,
+            None,
+        )),
         engine_provisioner.clone(),
         object_store_registry.clone(),
         Arc::new(DataFormatRegistryImpl::new()),
-        Arc::new(ContainerRuntime::default()),
         run_info_dir.to_path_buf(),
         cache_dir.to_path_buf(),
         time_source.clone(),

--- a/src/infra/core/tests/tests/engine/test_engine_transform.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_transform.rs
@@ -243,6 +243,7 @@ async fn test_transform_common(transform: Transform, test_retractions: bool) {
         )]))
         .bind::<dyn ObjectStoreRegistry, ObjectStoreRegistryImpl>()
         .add::<DataFormatRegistryImpl>()
+        .add_builder(FetchService::builder().with_run_info_dir(run_info_dir.clone()))
         .add_builder(
             PollingIngestServiceImpl::builder()
                 .with_cache_dir(cache_dir)

--- a/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
@@ -1118,6 +1118,7 @@ impl IngestTestHarness {
             ))
             .bind::<dyn SystemTimeSource, SystemTimeSourceStub>()
             .add::<DataFormatRegistryImpl>()
+            .add_builder(FetchService::builder().with_run_info_dir(run_info_dir.clone()))
             .add_builder(
                 PollingIngestServiceImpl::builder()
                     .with_cache_dir(cache_dir)

--- a/src/infra/core/tests/tests/repos/test_object_store_s3.rs
+++ b/src/infra/core/tests/tests/repos/test_object_store_s3.rs
@@ -9,7 +9,6 @@
 
 use std::sync::Arc;
 
-use bytes::Bytes;
 use datafusion::execution::object_store::ObjectStoreRegistry;
 use kamu::testing::LocalS3Server;
 use kamu::utils::s3_context::S3Context;
@@ -27,7 +26,10 @@ async fn test_auth_explicit_endpoint() {
     let store = reg.get_store(&store_url).unwrap();
 
     let path = object_store::path::Path::parse("asdf").unwrap();
-    store.put(&path, Bytes::from_static(b"test")).await.unwrap();
+    store
+        .put(&path, object_store::PutPayload::from_static(b"test"))
+        .await
+        .unwrap();
 
     let store = reg.get_store(&store_url).unwrap();
     let res = store.get(&path).await.unwrap();

--- a/src/infra/ingest-datafusion/Cargo.toml
+++ b/src/infra/ingest-datafusion/Cargo.toml
@@ -27,25 +27,34 @@ opendatafabric = { workspace = true, features = ["arrow"] }
 kamu-core = { workspace = true }
 kamu-data-utils = { workspace = true }
 
-datafusion = { version = "38", default-features = false }
+datafusion = { version = "39", default-features = false }
 digest = "0.10"
 geo-types = { version = "0.7", default-features = false, features = [] }
-geojson ={ version = "0.24", default-features = false, features = ["geo-types"] }
+geojson = { version = "0.24", default-features = false, features = [
+    "geo-types",
+] }
 glob = "0.3"
-object_store = { version = "0.9", features = ["aws"] }
+object_store = { version = "0.10", features = ["aws"] }
 serde = { version = "1" }
 serde_json = "1"
 sha3 = "0.10"
 shapefile = { version = "0.5", features = ["geo-types"] }
 walkdir = "2"
-zip = { version = "0.6", default-features = false, features = ["deflate", "bzip2", "zstd"]}
+zip = { version = "0.6", default-features = false, features = [
+    "deflate",
+    "bzip2",
+    "zstd",
+] }
 
 # Utils
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 thiserror = "1"
-tokio = { version = "1", default-features = false, features=["fs", "process"] }
+tokio = { version = "1", default-features = false, features = [
+    "fs",
+    "process",
+] }
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }
 
@@ -58,7 +67,7 @@ rand = "0.8"
 test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tempfile = "3"
-tokio = { version = "1", default-features = false, features=["rt", "macros"] }
+tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 
@@ -73,4 +82,3 @@ harness = false
 [[bench]]
 name = "snapshot"
 harness = false
-

--- a/src/utils/data-utils/Cargo.toml
+++ b/src/utils/data-utils/Cargo.toml
@@ -33,7 +33,7 @@ datafusion = { version = "38", default-features = false, features = [
     "serde",
 ] }
 digest = "0.10"
-hex = "*"
+hex = "0.4"
 pretty_assertions = { version = "1" }
 sha3 = "0.10"
 tracing = { version = "0.1", default-features = false }

--- a/src/utils/data-utils/Cargo.toml
+++ b/src/utils/data-utils/Cargo.toml
@@ -24,22 +24,27 @@ doctest = false
 [dependencies]
 opendatafabric = { workspace = true }
 
+async-trait = "0.1"
 arrow = { version = "51", default-features = false }
 arrow-json = { version = "51", default-features = false }
 arrow-digest = { version = "51", default-features = false }
-datafusion = { version = "38", default-features = false, features = ["parquet", "serde"] }
-tracing = { version = "0.1", default-features = false }
-
-async-trait = "0.1"
+datafusion = { version = "38", default-features = false, features = [
+    "parquet",
+    "serde",
+] }
 digest = "0.10"
+hex = "*"
 pretty_assertions = { version = "1" }
 sha3 = "0.10"
+tracing = { version = "0.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 url = "2"
-serde = {version = "1", default-features = false }
-serde_json = {version = "1"}
+serde = { version = "1", default-features = false }
+serde_json = { version = "1" }
+
 
 [dev-dependencies]
+indoc = "2"
 test-log = { version = "0.2", features = ["trace"] }
-tokio = { version = "1", default-features = false, features=["rt", "macros"] }
+tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/utils/data-utils/Cargo.toml
+++ b/src/utils/data-utils/Cargo.toml
@@ -25,10 +25,10 @@ doctest = false
 opendatafabric = { workspace = true }
 
 async-trait = "0.1"
-arrow = { version = "51", default-features = false }
-arrow-json = { version = "51", default-features = false }
-arrow-digest = { version = "51", default-features = false }
-datafusion = { version = "38", default-features = false, features = [
+arrow = { version = "52", default-features = false }
+arrow-json = { version = "52", default-features = false }
+arrow-digest = { version = "52", default-features = false }
+datafusion = { version = "39", default-features = false, features = [
     "parquet",
     "serde",
 ] }

--- a/src/utils/data-utils/src/data/format.rs
+++ b/src/utils/data-utils/src/data/format.rs
@@ -12,12 +12,12 @@ use std::io::{BufWriter, ErrorKind, Write};
 use arrow::array::{AsArray, OffsetSizeTrait};
 use arrow::datatypes::{ArrowPrimitiveType, DataType, SchemaRef};
 use arrow::error::ArrowError;
-pub use datafusion::arrow::csv::{Writer as CsvWriter, WriterBuilder as CsvWriterBuilder};
-use datafusion::arrow::json::ArrayWriter;
-pub use datafusion::arrow::json::LineDelimitedWriter as JsonLineDelimitedWriter;
 use datafusion::arrow::record_batch::RecordBatch;
+use serde::ser::Serializer;
 use thiserror::Error;
 
+/////////////////////////////////////////////////////////////////////////////////////////
+// RecordsWriter
 /////////////////////////////////////////////////////////////////////////////////////////
 
 pub trait RecordsWriter {
@@ -51,75 +51,6 @@ pub trait RecordsWriter {
     }
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////
-// CSV
-/////////////////////////////////////////////////////////////////////////////////////////
-
-impl<W: Write> RecordsWriter for CsvWriter<W> {
-    fn write_batch(&mut self, records: &RecordBatch) -> Result<(), WriterError> {
-        let writer_result = CsvWriter::write(self, records);
-        self.handle_writer_result(writer_result)
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-// JSON Array-of-Structures
-/////////////////////////////////////////////////////////////////////////////////////////
-
-/// This type exists purely as a workaround to an issue where empty batches
-/// produce no output (which is an invalid JSON) instead of an empty array `[]`.
-pub struct JsonArrayOfStructsWriter<W: std::io::Write> {
-    inner: Option<ArrayWriter<W>>,
-    empty: bool,
-}
-
-impl<W: std::io::Write> JsonArrayOfStructsWriter<W> {
-    pub fn new(writer: W) -> Self {
-        Self {
-            inner: Some(ArrayWriter::new(writer)),
-            empty: true,
-        }
-    }
-}
-
-impl<W: Write> RecordsWriter for JsonArrayOfStructsWriter<W> {
-    fn write_batch(&mut self, records: &RecordBatch) -> Result<(), WriterError> {
-        if self.empty && records.num_rows() != 0 {
-            self.empty = false;
-        }
-        let writer_result = self.inner.as_mut().unwrap().write(records);
-        self.handle_writer_result(writer_result)
-    }
-
-    fn finish(&mut self) -> Result<(), WriterError> {
-        let mut inner = self.inner.take().unwrap();
-        inner.finish()?;
-
-        // FIXME: Workaround for upstream bug
-        if self.empty {
-            write!(inner.into_inner(), "[]")?;
-        }
-
-        Ok(())
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-// JSON Line-Delimited
-/////////////////////////////////////////////////////////////////////////////////////////
-
-impl<W: Write> RecordsWriter for JsonLineDelimitedWriter<W> {
-    fn write_batch(&mut self, records: &RecordBatch) -> Result<(), WriterError> {
-        let writer_result = JsonLineDelimitedWriter::write(self, records);
-        self.handle_writer_result(writer_result)
-    }
-
-    fn finish(&mut self) -> Result<(), WriterError> {
-        JsonLineDelimitedWriter::finish(self).unwrap();
-        Ok(())
-    }
-}
-
 #[derive(Debug, Error)]
 pub enum WriterError {
     #[error(transparent)]
@@ -133,6 +64,211 @@ pub enum WriterError {
 #[derive(Debug, Error)]
 #[error("Data is too large to fit in the defined serialization buffer")]
 pub struct DataTooLarge;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// CSV
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug)]
+pub struct CsvWriterOptions {
+    /// Whether to write column names as file headers. Defaults to `true`
+    pub header: bool,
+    /// Optional column delimiter. Defaults to `b','`
+    pub delimiter: u8,
+    /// Optional quote character. Defaults to `b'"'`
+    pub quote: u8,
+}
+
+impl Default for CsvWriterOptions {
+    fn default() -> Self {
+        Self {
+            header: true,
+            delimiter: b',',
+            quote: b'"',
+        }
+    }
+}
+
+pub struct CsvWriter<W> {
+    writer: W,
+    options: CsvWriterOptions,
+    rows_written: usize,
+}
+
+impl<W> CsvWriter<W> {
+    pub fn new(writer: W, options: CsvWriterOptions) -> Self {
+        Self {
+            writer,
+            options,
+            rows_written: 0,
+        }
+    }
+}
+
+impl<W: Write> RecordsWriter for CsvWriter<W> {
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), WriterError> {
+        if self.rows_written == 0 && self.options.header {
+            for (i, field) in batch.schema_ref().fields().iter().enumerate() {
+                if i != 0 {
+                    self.writer.write_all(&[self.options.delimiter])?;
+                }
+                // TODO: quote / escape
+                CsvEscapeStringEncoder::write_escaped(
+                    &mut self.writer,
+                    field.name(),
+                    &self.options,
+                )?;
+            }
+            self.rows_written += 1;
+        }
+
+        let mut encoders = Vec::new();
+        for (f, c) in batch.schema_ref().fields().iter().zip(batch.columns()) {
+            encoders.push(encoder_for_csv(f.data_type(), c, &self.options));
+        }
+
+        for idx in 0..batch.num_rows() {
+            if self.rows_written != 0 {
+                self.writer.write_all(b"\n")?;
+            }
+
+            for (i, e) in encoders.iter_mut().enumerate() {
+                if i != 0 {
+                    self.writer.write_all(&[self.options.delimiter])?;
+                }
+                e.encode(idx, &mut self.writer)?;
+            }
+
+            self.rows_written += 1;
+        }
+
+        Ok(())
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// JSON Array-of-Structures
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct JsonArrayOfStructsWriter<W> {
+    writer: W,
+    empty: bool,
+}
+
+impl<W: std::io::Write> JsonArrayOfStructsWriter<W> {
+    pub fn new(mut writer: W) -> Self {
+        writer.write_all(b"[").unwrap();
+        Self {
+            writer,
+            empty: true,
+        }
+    }
+}
+
+impl<W: Write> RecordsWriter for JsonArrayOfStructsWriter<W> {
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), WriterError> {
+        let mut encoders = Vec::new();
+        for (f, c) in batch.schema_ref().fields().iter().zip(batch.columns()) {
+            encoders.push(encoder_for_json(f.data_type(), c));
+        }
+
+        for idx in 0..batch.num_rows() {
+            if !self.empty {
+                self.writer.write_all(b",")?;
+            }
+
+            self.writer.write_all(b"{")?;
+
+            for (i, (e, f)) in encoders
+                .iter_mut()
+                .zip(batch.schema_ref().fields().iter())
+                .enumerate()
+            {
+                if i != 0 {
+                    self.writer.write_all(b",")?;
+                }
+
+                {
+                    let mut serializer = serde_json::Serializer::new(&mut self.writer);
+                    serializer.serialize_str(f.name()).unwrap();
+                }
+                self.writer.write_all(b":")?;
+                e.encode(idx, &mut self.writer)?;
+            }
+
+            self.writer.write_all(b"}")?;
+            self.empty = false;
+        }
+
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<(), WriterError> {
+        self.writer.write_all(b"]")?;
+        Ok(())
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// JSON Line-Delimited
+/////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct JsonLineDelimitedWriter<W> {
+    writer: W,
+    empty: bool,
+}
+
+impl<W: std::io::Write> JsonLineDelimitedWriter<W> {
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer,
+            empty: true,
+        }
+    }
+}
+
+impl<W: Write> RecordsWriter for JsonLineDelimitedWriter<W> {
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), WriterError> {
+        let mut encoders = Vec::new();
+        for (f, c) in batch.schema_ref().fields().iter().zip(batch.columns()) {
+            encoders.push(encoder_for_json(f.data_type(), c));
+        }
+
+        for idx in 0..batch.num_rows() {
+            if !self.empty {
+                self.writer.write_all(b"\n")?;
+            }
+
+            self.writer.write_all(b"{")?;
+
+            for (i, (e, f)) in encoders
+                .iter_mut()
+                .zip(batch.schema_ref().fields().iter())
+                .enumerate()
+            {
+                if i != 0 {
+                    self.writer.write_all(b",")?;
+                }
+
+                {
+                    let mut serializer = serde_json::Serializer::new(&mut self.writer);
+                    serializer.serialize_str(f.name()).unwrap();
+                }
+                self.writer.write_all(b":")?;
+                e.encode(idx, &mut self.writer)?;
+            }
+
+            self.writer.write_all(b"}")?;
+            self.empty = false;
+        }
+
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<(), WriterError> {
+        Ok(())
+    }
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////
 // JSON Array-of-Arrays
@@ -151,6 +287,10 @@ impl<W: std::io::Write> JsonArrayOfArraysWriter<W> {
             started: false,
         }
     }
+
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
 }
 
 impl<W: std::io::Write> RecordsWriter for JsonArrayOfArraysWriter<W> {
@@ -164,7 +304,7 @@ impl<W: std::io::Write> RecordsWriter for JsonArrayOfArraysWriter<W> {
 
         let mut encoders = Vec::new();
         for (f, c) in batch.schema().fields().iter().zip(batch.columns()) {
-            encoders.push(encoder_for(f.data_type(), c));
+            encoders.push(encoder_for_json(f.data_type(), c));
         }
 
         for idx in 0..batch.num_rows() {
@@ -191,211 +331,6 @@ impl<W: std::io::Write> RecordsWriter for JsonArrayOfArraysWriter<W> {
     fn finish(&mut self) -> Result<(), WriterError> {
         self.writer.write_all(b"]")?;
         Ok(())
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-// Row-wise encoders
-/////////////////////////////////////////////////////////////////////////////////////////
-
-trait Encoder {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError>;
-}
-
-struct NullEncoder;
-impl Encoder for NullEncoder {
-    fn encode(&mut self, _idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        write!(buf, "null")?;
-        Ok(())
-    }
-}
-
-struct NullableEncoder<'a, E: Encoder + 'a>(&'a dyn arrow::array::Array, E);
-impl<'a, E: Encoder + 'a> Encoder for NullableEncoder<'a, E> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        if self.0.is_null(idx) {
-            NullEncoder.encode(idx, buf)
-        } else {
-            self.1.encode(idx, buf)
-        }
-    }
-}
-
-struct BooleanEncoder<'a>(&'a arrow::array::BooleanArray);
-impl<'a> Encoder for BooleanEncoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        if self.0.value(idx) {
-            write!(buf, "true")?;
-        } else {
-            write!(buf, "false")?;
-        }
-        Ok(())
-    }
-}
-
-struct IntegerEncoder<'a, T: ArrowPrimitiveType>(&'a arrow::array::PrimitiveArray<T>);
-impl<'a, T: ArrowPrimitiveType> Encoder for IntegerEncoder<'a, T>
-where
-    <T as ArrowPrimitiveType>::Native: std::fmt::Display,
-{
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        write!(buf, "{}", self.0.value(idx))?;
-        Ok(())
-    }
-}
-
-struct Float16Encoder<'a>(&'a arrow::array::Float16Array);
-impl<'a> Encoder for Float16Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        use serde::ser::Serializer;
-        let mut serializer = serde_json::Serializer::new(buf);
-        serializer
-            .serialize_f32(self.0.value(idx).to_f32())
-            .unwrap();
-        Ok(())
-    }
-}
-
-struct Float32Encoder<'a>(&'a arrow::array::Float32Array);
-impl<'a> Encoder for Float32Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        use serde::ser::Serializer;
-        let mut serializer = serde_json::Serializer::new(buf);
-        serializer.serialize_f32(self.0.value(idx)).unwrap();
-        Ok(())
-    }
-}
-
-struct Float64Encoder<'a>(&'a arrow::array::Float64Array);
-impl<'a> Encoder for Float64Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        use serde::ser::Serializer;
-        let mut serializer = serde_json::Serializer::new(buf);
-        serializer.serialize_f64(self.0.value(idx)).unwrap();
-        Ok(())
-    }
-}
-
-struct Decimal128Encoder<'a>(&'a arrow::array::Decimal128Array);
-impl<'a> Encoder for Decimal128Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        // TODO: PERF: Avoid allocation
-        // TODO: Support decimal-as-string setting?
-        write!(buf, "{}", self.0.value_as_string(idx))?;
-        Ok(())
-    }
-}
-
-struct Decimal256Encoder<'a>(&'a arrow::array::Decimal256Array);
-impl<'a> Encoder for Decimal256Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        // TODO: PERF: Avoid allocation
-        // TODO: Support decimal-as-string setting?
-        write!(buf, "{}", self.0.value_as_string(idx))?;
-        Ok(())
-    }
-}
-
-struct StringEncoder<'a, OffsetSize: OffsetSizeTrait>(
-    &'a arrow::array::GenericStringArray<OffsetSize>,
-);
-impl<'a, OffsetSize: OffsetSizeTrait> Encoder for StringEncoder<'a, OffsetSize> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        use serde::ser::Serializer;
-        let mut serializer = serde_json::Serializer::new(buf);
-        serializer.serialize_str(self.0.value(idx)).unwrap();
-        Ok(())
-    }
-}
-
-/// This encoder uses default arrow representation as determined by
-/// [`arrow::util::display::ArrayFormatter`]. When using this encoder you have
-/// to be absolutely sure that result does not include symbols that have special
-/// meaning within a JSON string.
-struct ArrowEncoder<'a>(arrow::util::display::ArrayFormatter<'a>);
-impl<'a> Encoder for ArrowEncoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        write!(buf, "\"{}\"", self.0.value(idx))?;
-        Ok(())
-    }
-}
-
-fn encoder_for<'a>(dt: &DataType, c: &'a dyn arrow::array::Array) -> Box<dyn Encoder + 'a> {
-    use arrow::datatypes as dts;
-    match dt {
-        DataType::Null => Box::new(NullEncoder),
-        DataType::Boolean => Box::new(NullableEncoder(c, BooleanEncoder(c.as_boolean()))),
-        DataType::Int8 => Box::new(NullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::Int8Type>()),
-        )),
-        DataType::Int16 => Box::new(NullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::Int16Type>()),
-        )),
-        DataType::Int32 => Box::new(NullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::Int32Type>()),
-        )),
-        DataType::Int64 => Box::new(NullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::Int64Type>()),
-        )),
-        DataType::UInt8 => Box::new(NullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::UInt8Type>()),
-        )),
-        DataType::UInt16 => Box::new(NullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::UInt16Type>()),
-        )),
-        DataType::UInt32 => Box::new(NullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::UInt32Type>()),
-        )),
-        DataType::UInt64 => Box::new(NullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::UInt64Type>()),
-        )),
-        DataType::Float16 => Box::new(NullableEncoder(c, Float16Encoder(c.as_primitive()))),
-        DataType::Float32 => Box::new(NullableEncoder(c, Float32Encoder(c.as_primitive()))),
-        DataType::Float64 => Box::new(NullableEncoder(c, Float64Encoder(c.as_primitive()))),
-        DataType::Decimal128(_, _) => {
-            Box::new(NullableEncoder(c, Decimal128Encoder(c.as_primitive())))
-        }
-        DataType::Decimal256(_, _) => {
-            Box::new(NullableEncoder(c, Decimal256Encoder(c.as_primitive())))
-        }
-        DataType::Utf8 => Box::new(NullableEncoder(c, StringEncoder(c.as_string::<i32>()))),
-        DataType::LargeUtf8 => Box::new(NullableEncoder(c, StringEncoder(c.as_string::<i64>()))),
-        DataType::Timestamp(_, _)
-        | DataType::Date32
-        | DataType::Date64
-        | DataType::Time32(_)
-        | DataType::Time64(_)
-        | DataType::Duration(_)
-        | DataType::Interval(_) => {
-            let options = arrow::util::display::FormatOptions::new().with_display_error(true);
-            let formatter = arrow::util::display::ArrayFormatter::try_new(c, &options).unwrap();
-            Box::new(NullableEncoder(c, ArrowEncoder(formatter)))
-        }
-        DataType::Binary
-        | DataType::FixedSizeBinary(_)
-        | DataType::LargeBinary
-        | DataType::BinaryView
-        | DataType::Utf8View
-        | DataType::List(_)
-        | DataType::ListView(_)
-        | DataType::FixedSizeList(_, _)
-        | DataType::LargeList(_)
-        | DataType::LargeListView(_)
-        | DataType::Struct(_)
-        | DataType::Union(_, _)
-        | DataType::Dictionary(_, _)
-        | DataType::Map(_, _)
-        | DataType::RunEndEncoded(_, _) => {
-            unimplemented!("Array-of-Arrays encoding is not yet supported for {}", dt)
-        }
     }
 }
 
@@ -447,7 +382,7 @@ impl<W: std::io::Write> RecordsWriter for JsonStructOfArraysWriter<W> {
         {
             let buf_start_len = buf.len();
 
-            let mut encoder = encoder_for(f.data_type(), c);
+            let mut encoder = encoder_for_json(f.data_type(), c);
             for idx in 0..c.len() {
                 if buf.len() > 1 {
                     buf.push(b',');
@@ -466,8 +401,6 @@ impl<W: std::io::Write> RecordsWriter for JsonStructOfArraysWriter<W> {
     }
 
     fn finish(&mut self) -> Result<(), WriterError> {
-        use serde::ser::Serializer;
-
         let mut first = true;
         if let Some(schema) = &self.schema {
             for (f, buf) in schema.fields().iter().zip(&mut self.column_buffers) {
@@ -486,6 +419,438 @@ impl<W: std::io::Write> RecordsWriter for JsonStructOfArraysWriter<W> {
             }
         }
         self.writer.write_all(b"}")?;
+        Ok(())
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// Row-wise encoders
+/////////////////////////////////////////////////////////////////////////////////////////
+
+trait Encoder {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError>;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+fn encoder_for_json<'a>(dt: &DataType, c: &'a dyn arrow::array::Array) -> Box<dyn Encoder + 'a> {
+    use arrow::datatypes as dts;
+    match dt {
+        DataType::Null => Box::new(JsonNullEncoder),
+        DataType::Boolean => Box::new(JsonNullableEncoder(c, BooleanEncoder(c.as_boolean()))),
+        DataType::Int8 => Box::new(JsonNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int8Type>()),
+        )),
+        DataType::Int16 => Box::new(JsonNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int16Type>()),
+        )),
+        DataType::Int32 => Box::new(JsonNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int32Type>()),
+        )),
+        DataType::Int64 => Box::new(JsonNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int64Type>()),
+        )),
+        DataType::UInt8 => Box::new(JsonNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt8Type>()),
+        )),
+        DataType::UInt16 => Box::new(JsonNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt16Type>()),
+        )),
+        DataType::UInt32 => Box::new(JsonNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt32Type>()),
+        )),
+        DataType::UInt64 => Box::new(JsonNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt64Type>()),
+        )),
+        DataType::Float16 => Box::new(JsonNullableEncoder(c, Float16Encoder(c.as_primitive()))),
+        DataType::Float32 => Box::new(JsonNullableEncoder(c, Float32Encoder(c.as_primitive()))),
+        DataType::Float64 => Box::new(JsonNullableEncoder(c, Float64Encoder(c.as_primitive()))),
+        DataType::Decimal128(_, _) => Box::new(JsonNullableEncoder(
+            c,
+            JsonSafeStringEncoder(Decimal128Encoder(c.as_primitive())),
+        )),
+        DataType::Decimal256(_, _) => Box::new(JsonNullableEncoder(
+            c,
+            JsonSafeStringEncoder(Decimal256Encoder(c.as_primitive())),
+        )),
+        DataType::Utf8 => Box::new(JsonNullableEncoder(
+            c,
+            JsonEscapeStringEncoder::new(StringEncoder(c.as_string::<i32>())),
+        )),
+        DataType::LargeUtf8 => Box::new(JsonNullableEncoder(
+            c,
+            JsonEscapeStringEncoder::new(StringEncoder(c.as_string::<i64>())),
+        )),
+        DataType::Timestamp(_, _)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Duration(_)
+        | DataType::Interval(_) => {
+            let options = arrow::util::display::FormatOptions::new().with_display_error(true);
+            let formatter = arrow::util::display::ArrayFormatter::try_new(c, &options).unwrap();
+            Box::new(JsonNullableEncoder(
+                c,
+                JsonSafeStringEncoder(ArrowEncoder(formatter)),
+            ))
+        }
+        DataType::Binary => Box::new(JsonNullableEncoder(
+            c,
+            JsonSafeStringEncoder(BinaryHexEncoder(c.as_binary::<i32>())),
+        )),
+        DataType::LargeBinary => Box::new(JsonNullableEncoder(
+            c,
+            JsonSafeStringEncoder(BinaryHexEncoder(c.as_binary::<i64>())),
+        )),
+        DataType::FixedSizeBinary(_) => Box::new(JsonNullableEncoder(
+            c,
+            JsonSafeStringEncoder(BinaryFixedHexEncoder(c.as_fixed_size_binary())),
+        )),
+        DataType::BinaryView
+        | DataType::Utf8View
+        | DataType::List(_)
+        | DataType::ListView(_)
+        | DataType::FixedSizeList(_, _)
+        | DataType::LargeList(_)
+        | DataType::LargeListView(_)
+        | DataType::Struct(_)
+        | DataType::Union(_, _)
+        | DataType::Dictionary(_, _)
+        | DataType::Map(_, _)
+        | DataType::RunEndEncoded(_, _) => {
+            unimplemented!("Array-of-Arrays encoding is not yet supported for {}", dt)
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+fn encoder_for_csv<'a>(
+    dt: &DataType,
+    c: &'a dyn arrow::array::Array,
+    opts: &'a CsvWriterOptions,
+) -> Box<dyn Encoder + 'a> {
+    use arrow::datatypes as dts;
+    match dt {
+        DataType::Null => Box::new(CsvNullEncoder),
+        DataType::Boolean => Box::new(CsvNullableEncoder(c, BooleanEncoder(c.as_boolean()))),
+        DataType::Int8 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int8Type>()),
+        )),
+        DataType::Int16 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int16Type>()),
+        )),
+        DataType::Int32 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int32Type>()),
+        )),
+        DataType::Int64 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int64Type>()),
+        )),
+        DataType::UInt8 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt8Type>()),
+        )),
+        DataType::UInt16 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt16Type>()),
+        )),
+        DataType::UInt32 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt32Type>()),
+        )),
+        DataType::UInt64 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt64Type>()),
+        )),
+        DataType::Float16 => Box::new(CsvNullableEncoder(c, Float16Encoder(c.as_primitive()))),
+        DataType::Float32 => Box::new(CsvNullableEncoder(c, Float32Encoder(c.as_primitive()))),
+        DataType::Float64 => Box::new(CsvNullableEncoder(c, Float64Encoder(c.as_primitive()))),
+        DataType::Decimal128(_, _) => {
+            Box::new(CsvNullableEncoder(c, Decimal128Encoder(c.as_primitive())))
+        }
+        DataType::Decimal256(_, _) => {
+            Box::new(CsvNullableEncoder(c, Decimal256Encoder(c.as_primitive())))
+        }
+        DataType::Utf8 => Box::new(CsvNullableEncoder(
+            c,
+            CsvEscapeStringEncoder::new(StringEncoder(c.as_string::<i32>()), opts),
+        )),
+        DataType::LargeUtf8 => Box::new(CsvNullableEncoder(
+            c,
+            CsvEscapeStringEncoder::new(StringEncoder(c.as_string::<i64>()), opts),
+        )),
+        DataType::Timestamp(_, _)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Duration(_)
+        | DataType::Interval(_) => {
+            let options = arrow::util::display::FormatOptions::new().with_display_error(true);
+            let formatter = arrow::util::display::ArrayFormatter::try_new(c, &options).unwrap();
+            Box::new(CsvNullableEncoder(c, ArrowEncoder(formatter)))
+        }
+        DataType::Binary => Box::new(CsvNullableEncoder(
+            c,
+            BinaryHexEncoder(c.as_binary::<i32>()),
+        )),
+        DataType::LargeBinary => Box::new(CsvNullableEncoder(
+            c,
+            BinaryHexEncoder(c.as_binary::<i64>()),
+        )),
+        DataType::FixedSizeBinary(_) => Box::new(CsvNullableEncoder(
+            c,
+            BinaryFixedHexEncoder(c.as_fixed_size_binary()),
+        )),
+        DataType::BinaryView
+        | DataType::Utf8View
+        | DataType::List(_)
+        | DataType::ListView(_)
+        | DataType::FixedSizeList(_, _)
+        | DataType::LargeList(_)
+        | DataType::LargeListView(_)
+        | DataType::Struct(_)
+        | DataType::Union(_, _)
+        | DataType::Dictionary(_, _)
+        | DataType::Map(_, _)
+        | DataType::RunEndEncoded(_, _) => {
+            unimplemented!("Array-of-Arrays encoding is not yet supported for {}", dt)
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+struct JsonEscapeStringEncoder<E: Encoder>(E, Vec<u8>);
+impl<E: Encoder> JsonEscapeStringEncoder<E> {
+    fn new(e: E) -> Self {
+        Self(e, Vec::new())
+    }
+}
+impl<E: Encoder> Encoder for JsonEscapeStringEncoder<E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        self.0.encode(idx, &mut self.1)?;
+        let mut serializer = serde_json::Serializer::new(buf);
+        serializer
+            .serialize_str(std::str::from_utf8(&self.1).unwrap())
+            .unwrap();
+
+        self.1.clear();
+        Ok(())
+    }
+}
+
+struct JsonSafeStringEncoder<E: Encoder>(E);
+impl<E: Encoder> Encoder for JsonSafeStringEncoder<E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "\"")?;
+        self.0.encode(idx, buf)?;
+        write!(buf, "\"")?;
+        Ok(())
+    }
+}
+
+struct CsvEscapeStringEncoder<'a, E: Encoder>(E, &'a CsvWriterOptions, Vec<u8>);
+impl<'a, E: Encoder> CsvEscapeStringEncoder<'a, E> {
+    fn new(e: E, opts: &'a CsvWriterOptions) -> Self {
+        Self(e, opts, Vec::new())
+    }
+}
+
+impl CsvEscapeStringEncoder<'static, CsvNullEncoder> {
+    fn write_escaped<'a, 'b>(
+        buf: &mut dyn std::io::Write,
+        s: &str,
+        opts: &CsvWriterOptions,
+    ) -> Result<(), WriterError> {
+        if !s.contains(&[
+            char::from(opts.delimiter),
+            char::from(opts.quote),
+            '\n',
+            '\r',
+        ]) {
+            buf.write_all(s.as_bytes())?;
+        } else {
+            buf.write_all(&[opts.quote])?;
+            let double_quote = [opts.quote, opts.quote];
+            let s = s.replace(
+                char::from(opts.quote),
+                std::str::from_utf8(&double_quote).unwrap(),
+            );
+            buf.write_all(s.as_bytes())?;
+            buf.write_all(&[opts.quote])?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a, E: Encoder> Encoder for CsvEscapeStringEncoder<'a, E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        self.0.encode(idx, &mut self.2)?;
+        CsvEscapeStringEncoder::write_escaped(buf, std::str::from_utf8(&self.2).unwrap(), self.1)?;
+        self.2.clear();
+        Ok(())
+    }
+}
+
+struct JsonNullEncoder;
+impl Encoder for JsonNullEncoder {
+    fn encode(&mut self, _idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "null")?;
+        Ok(())
+    }
+}
+
+struct JsonNullableEncoder<'a, E: Encoder + 'a>(&'a dyn arrow::array::Array, E);
+impl<'a, E: Encoder + 'a> Encoder for JsonNullableEncoder<'a, E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        if self.0.is_null(idx) {
+            JsonNullEncoder.encode(idx, buf)
+        } else {
+            self.1.encode(idx, buf)
+        }
+    }
+}
+
+struct CsvNullEncoder;
+impl Encoder for CsvNullEncoder {
+    fn encode(&mut self, _idx: usize, _buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        Ok(())
+    }
+}
+
+struct CsvNullableEncoder<'a, E: Encoder + 'a>(&'a dyn arrow::array::Array, E);
+impl<'a, E: Encoder + 'a> Encoder for CsvNullableEncoder<'a, E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        if self.0.is_null(idx) {
+            CsvNullEncoder.encode(idx, buf)
+        } else {
+            self.1.encode(idx, buf)
+        }
+    }
+}
+
+struct BooleanEncoder<'a>(&'a arrow::array::BooleanArray);
+impl<'a> Encoder for BooleanEncoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        if self.0.value(idx) {
+            write!(buf, "true")?;
+        } else {
+            write!(buf, "false")?;
+        }
+        Ok(())
+    }
+}
+
+struct IntegerEncoder<'a, T: ArrowPrimitiveType>(&'a arrow::array::PrimitiveArray<T>);
+impl<'a, T: ArrowPrimitiveType> Encoder for IntegerEncoder<'a, T>
+where
+    <T as ArrowPrimitiveType>::Native: std::fmt::Display,
+{
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "{}", self.0.value(idx))?;
+        Ok(())
+    }
+}
+
+struct Float16Encoder<'a>(&'a arrow::array::Float16Array);
+impl<'a> Encoder for Float16Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let mut serializer = serde_json::Serializer::new(buf);
+        serializer
+            .serialize_f32(self.0.value(idx).to_f32())
+            .unwrap();
+        Ok(())
+    }
+}
+
+struct Float32Encoder<'a>(&'a arrow::array::Float32Array);
+impl<'a> Encoder for Float32Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let mut serializer = serde_json::Serializer::new(buf);
+        serializer.serialize_f32(self.0.value(idx)).unwrap();
+        Ok(())
+    }
+}
+
+struct Float64Encoder<'a>(&'a arrow::array::Float64Array);
+impl<'a> Encoder for Float64Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let mut serializer = serde_json::Serializer::new(buf);
+        serializer.serialize_f64(self.0.value(idx)).unwrap();
+        Ok(())
+    }
+}
+
+struct Decimal128Encoder<'a>(&'a arrow::array::Decimal128Array);
+impl<'a> Encoder for Decimal128Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        // TODO: PERF: Avoid allocation
+        write!(buf, "{}", self.0.value_as_string(idx))?;
+        Ok(())
+    }
+}
+
+struct Decimal256Encoder<'a>(&'a arrow::array::Decimal256Array);
+impl<'a> Encoder for Decimal256Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        // TODO: PERF: Avoid allocation
+        write!(buf, "{}", self.0.value_as_string(idx))?;
+        Ok(())
+    }
+}
+
+struct StringEncoder<'a, OffsetSize: OffsetSizeTrait>(
+    &'a arrow::array::GenericStringArray<OffsetSize>,
+);
+impl<'a, OffsetSize: OffsetSizeTrait> Encoder for StringEncoder<'a, OffsetSize> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "{}", self.0.value(idx))?;
+        Ok(())
+    }
+}
+
+struct BinaryHexEncoder<'a, OffsetSize: OffsetSizeTrait>(
+    &'a arrow::array::GenericBinaryArray<OffsetSize>,
+);
+impl<'a, OffsetSize: OffsetSizeTrait> Encoder for BinaryHexEncoder<'a, OffsetSize> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let hex_str = hex::encode(self.0.value(idx));
+        write!(buf, "{hex_str}")?;
+        Ok(())
+    }
+}
+
+struct BinaryFixedHexEncoder<'a>(&'a arrow::array::FixedSizeBinaryArray);
+impl<'a> Encoder for BinaryFixedHexEncoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let hex_str = hex::encode(self.0.value(idx));
+        write!(buf, "{hex_str}")?;
+        Ok(())
+    }
+}
+
+/// This encoder uses default arrow representation as determined by
+/// [`arrow::util::display::ArrayFormatter`]. When using this encoder you have
+/// to be absolutely sure that result does not include symbols that have special
+/// meaning within a JSON string.
+struct ArrowEncoder<'a>(arrow::util::display::ArrayFormatter<'a>);
+impl<'a> Encoder for ArrowEncoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "{}", self.0.value(idx))?;
         Ok(())
     }
 }
@@ -510,7 +875,7 @@ mod tests {
     /// writer does not produce any output while it should produce empty array.
     /// If this test fails - it's a good thing, meaning we can remove workaround
     /// on our side.
-    #[test]
+    #[test_log::test]
     fn test_arrow_writer_empty_batch_issue() {
         let batch = get_empty_batch();
 
@@ -524,77 +889,121 @@ mod tests {
         assert_eq!(std::str::from_utf8(&buf).unwrap(), "");
     }
 
-    #[test]
-    fn test_arrow_writer_empty_batch_fix() {
+    // AoS
+    #[test_log::test]
+    fn test_json_aos_empty() {
         let batch = get_empty_batch();
         assert_aos_output(batch, json!([]));
     }
 
-    #[test]
+    #[test_log::test]
+    fn test_json_aos_simple() {
+        let batch = get_sample_batch();
+        assert_aos_output(
+            batch,
+            json!([
+                {
+                    "bin": "666f6f",
+                    "bin_fixed": "0102",
+                    "decimal": "5789604461865809771178549250434395392663499233282028201972879200395656481996",
+                    "nullable": 1,
+                    "ts_milli": "2020-01-01T12:00:00Z",
+                    "uint64": 100,
+                    "utf8": "foo",
+                    "utf8_special": "sep,quotes'\",newline\nfin",
+                },
+                {
+                    "bin": "626172",
+                    "bin_fixed": "0304",
+                    "decimal": "-5789604461865809771178549250434395392663499233282028201972879200395656481996",
+                    "nullable": null,
+                    "ts_milli": "2020-01-01T12:01:00Z",
+                    "uint64": 200,
+                    "utf8": "bar",
+                    "utf8_special": null,
+                }
+            ]),
+        );
+    }
+
+    // AoA
+    #[test_log::test]
     fn test_json_aoa_empty() {
         let batch = get_empty_batch();
         assert_aoa_output(batch, json!([]));
     }
 
-    #[test]
+    #[test_log::test]
     fn test_json_aoa_simple() {
         let batch = get_sample_batch();
         assert_aoa_output(
             batch,
-            json!([[1, "a"], [2, "b"], [3, "c"], [null, "d"], [5, null]]),
+            json!([
+                [
+                    1,
+                    100,
+                    "5789604461865809771178549250434395392663499233282028201972879200395656481996",
+                    "foo",
+                    "sep,quotes'\",newline\nfin",
+                    "666f6f",
+                    "0102",
+                    "2020-01-01T12:00:00Z",
+                ],
+                [
+                    null,
+                    200,
+                    "-5789604461865809771178549250434395392663499233282028201972879200395656481996",
+                    "bar",
+                    null,
+                    "626172",
+                    "0304",
+                    "2020-01-01T12:01:00Z",
+                ],
+            ]),
         );
     }
 
+    // SoA
     #[test_log::test]
-    fn test_json_aoa_temporal() {
-        let schema = Schema::new(vec![Field::new(
-            "t",
-            DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("UTC"))),
-            true,
-        )]);
-
-        let a = TimestampMillisecondArray::from(vec![
-            // 2020-01-01T12:00:00Z
-            Some(1_577_880_000_000),
-            // 2020-01-01T12:01:00Z
-            Some(1_577_880_060_000),
-            None,
-        ])
-        .with_timezone("UTC");
-
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a)]).unwrap();
-
-        assert_aoa_output(
-            batch,
-            serde_json::json!([["2020-01-01T12:00:00Z"], ["2020-01-01T12:01:00Z"], [null]]),
-        );
-    }
-
-    #[test]
     fn test_json_soa_empty() {
         let batch = get_empty_batch();
         assert_soa_output(
             batch,
             json!({
-                "c1": [],
-                "c2": [],
+                "bin": [],
+                "bin_fixed": [],
+                "decimal": [],
+                "nullable": [],
+                "ts_milli": [],
+                "uint64": [],
+                "utf8": [],
+                "utf8_special": [],
             }),
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn test_json_soa_simple() {
         let batch = get_sample_batch();
         assert_soa_output(
             batch,
             json!({
-                "c1": [1, 2, 3, null, 5],
-                "c2": ["a", "b", "c", "d", null],
+                "bin": ["666f6f", "626172"],
+                "bin_fixed": ["0102", "0304"],
+                "decimal": [
+                    "5789604461865809771178549250434395392663499233282028201972879200395656481996",
+                    "-5789604461865809771178549250434395392663499233282028201972879200395656481996",
+                ],
+                "nullable": [1, null],
+                "ts_milli": ["2020-01-01T12:00:00Z", "2020-01-01T12:01:00Z"],
+                "uint64": [100, 200],
+                "utf8": ["foo", "bar"],
+                "utf8_special": ["sep,quotes'\",newline\nfin", null],
             }),
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn test_json_soa_max_size() {
         let batch = get_sample_batch();
 
@@ -606,28 +1015,133 @@ mod tests {
         );
     }
 
-    fn get_sample_batch() -> RecordBatch {
-        let schema = Schema::new(vec![
-            Field::new("c1", DataType::Int32, true),
-            Field::new("c2", DataType::Utf8, true),
-        ]);
+    // LD
+    #[test_log::test]
+    fn test_json_ld_empty() {
+        let batch = get_empty_batch();
+        assert_ld_output(batch, vec![]);
+    }
 
-        let a = Int32Array::from(vec![Some(1), Some(2), Some(3), None, Some(5)]);
-        let b = StringArray::from(vec![Some("a"), Some("b"), Some("c"), Some("d"), None]);
+    #[test_log::test]
+    fn test_json_ld_simple() {
+        let batch = get_sample_batch();
+        assert_ld_output(
+            batch,
+            vec![
+                json!({
+                    "bin": "666f6f",
+                    "bin_fixed": "0102",
+                    "decimal": "5789604461865809771178549250434395392663499233282028201972879200395656481996",
+                    "nullable": 1,
+                    "ts_milli": "2020-01-01T12:00:00Z",
+                    "uint64": 100,
+                    "utf8": "foo",
+                    "utf8_special": "sep,quotes'\",newline\nfin",
+                }),
+                json!({
+                    "bin": "626172",
+                    "bin_fixed": "0304",
+                    "decimal": "-5789604461865809771178549250434395392663499233282028201972879200395656481996",
+                    "nullable": null,
+                    "ts_milli": "2020-01-01T12:01:00Z",
+                    "uint64": 200,
+                    "utf8": "bar",
+                    "utf8_special": null,
+                }),
+            ],
+        );
+    }
 
-        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]).unwrap()
+    // CSV
+    #[test_log::test]
+    fn test_csv_empty() {
+        let batch = get_empty_batch();
+        assert_csv_output(
+            batch.clone(),
+            CsvWriterOptions::default(),
+            "nullable,uint64,decimal,utf8,utf8_special,bin,bin_fixed,ts_milli",
+        );
+        assert_csv_output(
+            batch,
+            CsvWriterOptions {
+                header: false,
+                ..Default::default()
+            },
+            "",
+        );
+    }
+
+    #[test_log::test]
+    fn test_csv_simple() {
+        let batch = get_sample_batch();
+        assert_csv_output(
+            batch,
+            CsvWriterOptions::default(),
+            indoc::indoc!(
+                r#"
+                nullable,uint64,decimal,utf8,utf8_special,bin,bin_fixed,ts_milli
+                1,100,5789604461865809771178549250434395392663499233282028201972879200395656481996,foo,"sep,quotes'"",newline
+                fin",666f6f,0102,2020-01-01T12:00:00Z
+                ,200,-5789604461865809771178549250434395392663499233282028201972879200395656481996,bar,,626172,0304,2020-01-01T12:01:00Z
+                "#
+            )
+            .trim(),
+        );
     }
 
     fn get_empty_batch() -> RecordBatch {
-        let schema = Schema::new(vec![
-            Field::new("c1", DataType::Int32, true),
-            Field::new("c2", DataType::Utf8, true),
-        ]);
+        RecordBatch::new_empty(Arc::new(Schema::new(vec![
+            Field::new("nullable", DataType::UInt64, true),
+            Field::new("uint64", DataType::UInt64, false),
+            Field::new("decimal", DataType::Decimal256(76, 0), false),
+            Field::new("utf8", DataType::Utf8, false),
+            Field::new("utf8_special", DataType::Utf8, true),
+            Field::new("bin", DataType::Binary, false),
+            Field::new("bin_fixed", DataType::FixedSizeBinary(2), false),
+            Field::new(
+                "ts_milli",
+                DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("UTC"))),
+                false,
+            ),
+        ])))
+    }
 
-        let a = Int32Array::new_null(0);
-        let b = StringArray::new_null(0);
-
-        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]).unwrap()
+    fn get_sample_batch() -> RecordBatch {
+        RecordBatch::try_new(
+            get_empty_batch().schema(),
+            vec![
+                Arc::new(UInt64Array::from(vec![Some(1), None])),
+                Arc::new(UInt64Array::from(vec![100, 200])),
+                Arc::new(
+                    Decimal256Array::from(vec![i256::MAX, i256::MIN])
+                        .with_precision_and_scale(76, 0)
+                        .unwrap(),
+                ),
+                Arc::new(StringArray::from(vec![
+                    "foo".to_string(),
+                    "bar".to_string(),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("sep,quotes'\",newline\nfin".to_string()),
+                    None,
+                ])),
+                Arc::new(BinaryArray::from(vec![&b"foo"[..], &b"bar"[..]])),
+                Arc::new({
+                    let v = vec![vec![1, 2], vec![3, 4]];
+                    FixedSizeBinaryArray::try_from_iter(v.into_iter()).unwrap()
+                }),
+                Arc::new(
+                    TimestampMillisecondArray::from(vec![
+                        // 2020-01-01T12:00:00Z
+                        1_577_880_000_000,
+                        // 2020-01-01T12:01:00Z
+                        1_577_880_060_000,
+                    ])
+                    .with_timezone(Arc::from("UTC")),
+                ),
+            ],
+        )
+        .unwrap()
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -670,5 +1184,39 @@ mod tests {
 
         let actual: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         assert_eq!(actual, expected);
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn assert_ld_output(batch: RecordBatch, expected: Vec<serde_json::Value>) {
+        let mut buf = Vec::new();
+        {
+            let mut writer = JsonLineDelimitedWriter::new(&mut buf);
+            writer.write_batch(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+        let actual_str = std::str::from_utf8(&buf).unwrap();
+        tracing::debug!("Raw result:\n{actual_str}");
+        let actual: Vec<serde_json::Value> = if actual_str.is_empty() {
+            Vec::new()
+        } else {
+            actual_str
+                .split('\n')
+                .map(|s| serde_json::from_slice(s.as_bytes()).unwrap())
+                .collect()
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn assert_csv_output(batch: RecordBatch, opts: CsvWriterOptions, expected: &str) {
+        let mut buf = Vec::new();
+        {
+            let mut writer = CsvWriter::new(&mut buf, opts);
+            writer.write_batch(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+        let actual = std::str::from_utf8(&buf).unwrap();
+        pretty_assertions::assert_eq!(actual, expected);
     }
 }

--- a/src/utils/data-utils/src/data/format.rs
+++ b/src/utils/data-utils/src/data/format.rs
@@ -671,12 +671,12 @@ impl<'a, E: Encoder> CsvEscapeStringEncoder<'a, E> {
 }
 
 impl CsvEscapeStringEncoder<'static, CsvNullEncoder> {
-    fn write_escaped<'a, 'b>(
+    fn write_escaped(
         buf: &mut dyn std::io::Write,
         s: &str,
         opts: &CsvWriterOptions,
     ) -> Result<(), WriterError> {
-        if !s.contains(&[
+        if !s.contains([
             char::from(opts.delimiter),
             char::from(opts.quote),
             '\n',

--- a/src/utils/datafusion-cli/Cargo.toml
+++ b/src/utils/datafusion-cli/Cargo.toml
@@ -30,12 +30,12 @@ edition = { workspace = true }
 publish = { workspace = true }
 
 [dependencies]
-arrow = "51.0.0"
+arrow = { version = "52.0.0" }
 async-trait = "0.1"
 aws-config = "0.57"
 aws-credential-types = "0.57"
 clap = { version = "4", features = ["derive"] }
-datafusion = { version = "38", features = [
+datafusion = { version = "39", features = [
     "crypto_expressions",
     "datetime_expressions",
     "encoding_expressions",
@@ -44,14 +44,20 @@ datafusion = { version = "38", features = [
     "unicode_expressions",
     "compression",
 ] }
-datafusion-common = { version = "38", default-features = false }
+datafusion-common = { version = "39", default-features = false }
 dirs = "4"
 futures = "0.3"
-object_store = { version = "0.9", features = ["aws", "gcp", "http"] }
+object_store = { version = "0.10.1", features = ["aws", "gcp", "http"] }
 parking_lot = { version = "0.12" }
-parquet = { version = "51", default-features = false }
+parquet = { version = "52", default-features = false }
 regex = "1"
 rustyline = "11"
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot", "signal"] }
+tokio = { version = "1", features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "parking_lot",
+    "signal",
+] }
 url = { version = "2" }
-

--- a/src/utils/datafusion-cli/README.md
+++ b/src/utils/datafusion-cli/README.md
@@ -12,7 +12,7 @@ We decided to copy the code instead of using the existing `datafusion-cli` crate
 ## Upgrade procedure
 1. Clone or sync the upstream repo:
   
-  `git clone https://github.com/apache/arrow-datafusion.git`
+  `git clone https://github.com/apache/datafusion.git`
 
 2. Checkout the appropriate release tag:
     
@@ -22,10 +22,10 @@ We decided to copy the code instead of using the existing `datafusion-cli` crate
 
   ```
   rm -rf src/utils/datafusion-cli/src
-  cp ../arrow-datafusion/datafusion-cli/src src/utils/datafusion-cli/
+  cp -r ../datafusion/datafusion-cli/src src/utils/datafusion-cli/
   rm src/utils/datafusion-cli/src/main.rs
   ```
 
 4. Compare `Cargo.toml` files:
 
-  `diff ../arrow-datafusion/datafusion-cli/Cargo.toml src/utils/datafusion-cli/Cargo.toml`
+  `diff ../datafusion/datafusion-cli/Cargo.toml src/utils/datafusion-cli/Cargo.toml`

--- a/src/utils/datafusion-cli/src/catalog.rs
+++ b/src/utils/datafusion-cli/src/catalog.rs
@@ -289,6 +289,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "kamu: we don't care about this test and it take too long"]
     async fn query_gs_location_test() -> Result<()> {
         let bucket = "examplegsbucket";
         let location = format!("gs://{bucket}/file.parquet");

--- a/src/utils/datafusion-cli/src/catalog.rs
+++ b/src/utils/datafusion-cli/src/catalog.rs
@@ -333,9 +333,9 @@ mod tests {
             if cfg!(windows) { "USERPROFILE" } else { "HOME" },
             test_home_path,
         );
-        let input = "~/Code/arrow-datafusion/benchmarks/data/tpch_sf1/part/part-0.parquet";
+        let input = "~/Code/datafusion/benchmarks/data/tpch_sf1/part/part-0.parquet";
         let expected = format!(
-            "{}{}Code{}arrow-datafusion{}benchmarks{}data{}tpch_sf1{}part{}part-0.parquet",
+            "{}{}Code{}datafusion{}benchmarks{}data{}tpch_sf1{}part{}part-0.parquet",
             test_home_path,
             MAIN_SEPARATOR,
             MAIN_SEPARATOR,

--- a/src/utils/datafusion-cli/src/command.rs
+++ b/src/utils/datafusion-cli/src/command.rs
@@ -27,11 +27,11 @@ use datafusion::arrow::array::{ArrayRef, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::exec_err;
+use datafusion::common::instant::Instant;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::prelude::SessionContext;
-use datafusion_common::instant::Instant;
 
-use crate::exec::exec_from_lines;
+use crate::exec::{exec_and_print, exec_from_lines};
 use crate::functions::{display_all_functions, Function};
 use crate::print_format::PrintFormat;
 use crate::print_options::PrintOptions;
@@ -60,18 +60,15 @@ impl Command {
         ctx: &mut SessionContext,
         print_options: &mut PrintOptions,
     ) -> Result<()> {
-        let now = Instant::now();
         match self {
-            Self::Help => print_options.print_batches(&[all_commands_info()], now),
-            Self::ListTables => {
-                let df = ctx.sql("SHOW TABLES").await?;
-                let batches = df.collect().await?;
-                print_options.print_batches(&batches, now)
+            Self::Help => {
+                let now = Instant::now();
+                let command_batch = all_commands_info();
+                print_options.print_batches(command_batch.schema(), &[command_batch], now)
             }
+            Self::ListTables => exec_and_print(ctx, print_options, "SHOW TABLES".into()).await,
             Self::DescribeTableStmt(name) => {
-                let df = ctx.sql(&format!("SHOW COLUMNS FROM {}", name)).await?;
-                let batches = df.collect().await?;
-                print_options.print_batches(&batches, now)
+                exec_and_print(ctx, print_options, format!("SHOW COLUMNS FROM {}", name)).await
             }
             Self::Include(filename) => {
                 if let Some(filename) = filename {

--- a/src/utils/datafusion-cli/src/object_storage.rs
+++ b/src/utils/datafusion-cli/src/object_storage.rs
@@ -21,11 +21,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use aws_credential_types::provider::ProvideCredentials;
-use datafusion::common::{exec_datafusion_err, exec_err, internal_err};
-use datafusion::error::{DataFusionError, Result};
-use datafusion::execution::context::SessionState;
-use datafusion::prelude::SessionContext;
-use datafusion_common::config::{
+use datafusion::common::config::{
     ConfigEntry,
     ConfigExtension,
     ConfigField,
@@ -33,6 +29,10 @@ use datafusion_common::config::{
     TableOptions,
     Visit,
 };
+use datafusion::common::{config_err, exec_datafusion_err, exec_err};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::context::SessionState;
+use datafusion::prelude::SessionContext;
 use object_store::aws::{AmazonS3Builder, AwsCredential};
 use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::http::HttpBuilder;
@@ -43,17 +43,24 @@ pub async fn get_s3_object_store_builder(
     url: &Url,
     aws_options: &AwsOptions,
 ) -> Result<AmazonS3Builder> {
+    let AwsOptions {
+        access_key_id,
+        secret_access_key,
+        session_token,
+        region,
+        endpoint,
+        allow_http,
+    } = aws_options;
+
     let bucket_name = get_bucket_name(url)?;
     let mut builder = AmazonS3Builder::from_env().with_bucket_name(bucket_name);
 
-    if let (Some(access_key_id), Some(secret_access_key)) =
-        (&aws_options.access_key_id, &aws_options.secret_access_key)
-    {
+    if let (Some(access_key_id), Some(secret_access_key)) = (access_key_id, secret_access_key) {
         builder = builder
             .with_access_key_id(access_key_id)
             .with_secret_access_key(secret_access_key);
 
-        if let Some(session_token) = &aws_options.session_token {
+        if let Some(session_token) = session_token {
             builder = builder.with_token(session_token);
         }
     } else {
@@ -76,8 +83,27 @@ pub async fn get_s3_object_store_builder(
         builder = builder.with_credentials(credentials);
     }
 
-    if let Some(region) = &aws_options.region {
+    if let Some(region) = region {
         builder = builder.with_region(region);
+    }
+
+    if let Some(endpoint) = endpoint {
+        // Make a nicer error if the user hasn't allowed http and the endpoint
+        // is http as the default message is "URL scheme is not allowed"
+        if let Ok(endpoint_url) = Url::try_from(endpoint.as_str()) {
+            if !matches!(allow_http, Some(true)) && endpoint_url.scheme() == "http" {
+                return config_err!(
+                    "Invalid endpoint: {endpoint}. HTTP is not allowed for S3 endpoints. To allow \
+                     HTTP, set 'aws.allow_http' to true"
+                );
+            }
+        }
+
+        builder = builder.with_endpoint(endpoint);
+    }
+
+    if let Some(allow_http) = allow_http {
+        builder = builder.with_allow_http(*allow_http);
     }
 
     Ok(builder)
@@ -193,6 +219,8 @@ pub struct AwsOptions {
     pub region: Option<String>,
     /// OSS or COS Endpoint
     pub endpoint: Option<String>,
+    /// Allow HTTP (otherwise will always use https)
+    pub allow_http: Option<bool>,
 }
 
 impl ExtensionOptions for AwsOptions {
@@ -224,11 +252,14 @@ impl ExtensionOptions for AwsOptions {
             "region" => {
                 self.region.set(rem, value)?;
             }
-            "oss" | "cos" => {
+            "oss" | "cos" | "endpoint" => {
                 self.endpoint.set(rem, value)?;
             }
+            "allow_http" => {
+                self.allow_http.set(rem, value)?;
+            }
             _ => {
-                return internal_err!("Config value \"{}\" not found on AwsOptions", rem);
+                return config_err!("Config value \"{}\" not found on AwsOptions", rem);
             }
         }
         Ok(())
@@ -262,6 +293,7 @@ impl ExtensionOptions for AwsOptions {
         self.session_token.visit(&mut v, "session_token", "");
         self.region.visit(&mut v, "region", "");
         self.endpoint.visit(&mut v, "endpoint", "");
+        self.allow_http.visit(&mut v, "allow_http", "");
         v.0
     }
 }
@@ -308,7 +340,7 @@ impl ExtensionOptions for GcpOptions {
                 self.application_credentials_path.set(rem, value)?;
             }
             _ => {
-                return internal_err!("Config value \"{}\" not found on GcpOptions", rem);
+                return config_err!("Config value \"{}\" not found on GcpOptions", rem);
             }
         }
         Ok(())
@@ -461,6 +493,7 @@ mod tests {
         let access_key_id = "fake_access_key_id";
         let secret_access_key = "fake_secret_access_key";
         let region = "fake_us-east-2";
+        let endpoint = "endpoint33";
         let session_token = "fake_session_token";
         let location = "s3://bucket/path/file.parquet";
 
@@ -469,7 +502,8 @@ mod tests {
         let sql = format!(
             "CREATE EXTERNAL TABLE test STORED AS PARQUET OPTIONS('aws.access_key_id' \
              '{access_key_id}', 'aws.secret_access_key' '{secret_access_key}', 'aws.region' \
-             '{region}', 'aws.session_token' {session_token}) LOCATION '{location}'"
+             '{region}', 'aws.session_token' {session_token}, 'aws.endpoint' '{endpoint}') \
+             LOCATION '{location}'"
         );
 
         let ctx = SessionContext::new();
@@ -486,11 +520,71 @@ mod tests {
                 (AmazonS3ConfigKey::AccessKeyId, access_key_id),
                 (AmazonS3ConfigKey::SecretAccessKey, secret_access_key),
                 (AmazonS3ConfigKey::Region, region),
+                (AmazonS3ConfigKey::Endpoint, endpoint),
                 (AmazonS3ConfigKey::Token, session_token),
             ];
             for (key, value) in config {
                 assert_eq!(value, builder.get_config_value(&key).unwrap());
             }
+        } else {
+            return plan_err!("LogicalPlan is not a CreateExternalTable");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn s3_object_store_builder_allow_http_error() -> Result<()> {
+        let access_key_id = "fake_access_key_id";
+        let secret_access_key = "fake_secret_access_key";
+        let endpoint = "http://endpoint33";
+        let location = "s3://bucket/path/file.parquet";
+
+        let table_url = ListingTableUrl::parse(location)?;
+        let scheme = table_url.scheme();
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET OPTIONS('aws.access_key_id' \
+             '{access_key_id}', 'aws.secret_access_key' '{secret_access_key}', 'aws.endpoint' \
+             '{endpoint}') LOCATION '{location}'"
+        );
+
+        let ctx = SessionContext::new();
+        let mut plan = ctx.state().create_logical_plan(&sql).await?;
+
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
+            register_options(&ctx, scheme);
+            let mut table_options = ctx.state().default_table_options().clone();
+            table_options.alter_with_string_hash_map(&cmd.options)?;
+            let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
+            let err = get_s3_object_store_builder(table_url.as_ref(), aws_options)
+                .await
+                .unwrap_err();
+
+            assert_eq!(
+                err.to_string(),
+                "Invalid or Unsupported Configuration: Invalid endpoint: http://endpoint33. HTTP \
+                 is not allowed for S3 endpoints. To allow HTTP, set 'aws.allow_http' to true"
+            );
+        } else {
+            return plan_err!("LogicalPlan is not a CreateExternalTable");
+        }
+
+        // Now add `allow_http` to the options and check if it works
+        let sql = format!(
+            "CREATE EXTERNAL TABLE test STORED AS PARQUET OPTIONS('aws.access_key_id' \
+             '{access_key_id}', 'aws.secret_access_key' '{secret_access_key}', 'aws.endpoint' \
+             '{endpoint}','aws.allow_http' 'true') LOCATION '{location}'"
+        );
+
+        let mut plan = ctx.state().create_logical_plan(&sql).await?;
+
+        if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
+            register_options(&ctx, scheme);
+            let mut table_options = ctx.state().default_table_options().clone();
+            table_options.alter_with_string_hash_map(&cmd.options)?;
+            let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
+            // ensure this isn't an error
+            get_s3_object_store_builder(table_url.as_ref(), aws_options).await?;
         } else {
             return plan_err!("LogicalPlan is not a CreateExternalTable");
         }

--- a/src/utils/datafusion-cli/src/print_format.rs
+++ b/src/utils/datafusion-cli/src/print_format.rs
@@ -20,6 +20,7 @@
 use std::str::FromStr;
 
 use arrow::csv::writer::WriterBuilder;
+use arrow::datatypes::SchemaRef;
 use arrow::json::{ArrayWriter, LineDelimitedWriter};
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::pretty_format_batches_with_options;
@@ -93,7 +94,7 @@ fn keep_only_maxrows(s: &str, maxrows: usize) -> String {
 
     assert!(lines.len() >= maxrows + 4); // 4 lines for top and bottom border
 
-    let last_line = &lines[lines.len() - 1]; // bottom borderline
+    let last_line = &lines[lines.len() - 1]; // bottom border line
 
     let spaces = last_line.len().saturating_sub(4);
     let dotted_line = format!("| .{:<spaces$}|", "", spaces = spaces);
@@ -154,6 +155,7 @@ impl PrintFormat {
     pub fn print_batches<W: std::io::Write>(
         &self,
         writer: &mut W,
+        schema: SchemaRef,
         batches: &[RecordBatch],
         maxrows: MaxRows,
         with_header: bool,
@@ -165,7 +167,7 @@ impl PrintFormat {
             .cloned()
             .collect();
         if batches.is_empty() {
-            return Ok(());
+            return self.print_empty(writer, schema);
         }
 
         match self {
@@ -183,13 +185,28 @@ impl PrintFormat {
             Self::NdJson => batches_to_json!(LineDelimitedWriter, writer, &batches),
         }
     }
+
+    /// Print when the result batches contain no rows
+    fn print_empty<W: std::io::Write>(&self, writer: &mut W, schema: SchemaRef) -> Result<()> {
+        match self {
+            // Print column headers for Table format
+            Self::Table if !schema.fields().is_empty() => {
+                let empty_batch = RecordBatch::new_empty(schema);
+                let formatted =
+                    pretty_format_batches_with_options(&[empty_batch], &DEFAULT_FORMAT_OPTIONS)?;
+                writeln!(writer, "{}", formatted)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::{ArrayRef, Int32Array};
+    use arrow::array::Int32Array;
     use arrow::datatypes::{DataType, Field, Schema};
 
     use super::*;
@@ -199,7 +216,6 @@ mod tests {
         for format in [
             PrintFormat::Csv,
             PrintFormat::Tsv,
-            PrintFormat::Table,
             PrintFormat::Json,
             PrintFormat::NdJson,
             PrintFormat::Automatic,
@@ -207,10 +223,26 @@ mod tests {
             // no output for empty batches, even with header set
             PrintBatchesTest::new()
                 .with_format(format)
+                .with_schema(three_column_schema())
                 .with_batches(vec![])
                 .with_expected(&[""])
                 .run();
         }
+
+        // output column headers for empty batches when format is Table
+        #[rustfmt::skip]
+        let expected = &[
+            "+---+---+---+",
+            "| a | b | c |",
+            "+---+---+---+",
+            "+---+---+---+",
+        ];
+        PrintBatchesTest::new()
+            .with_format(PrintFormat::Table)
+            .with_schema(three_column_schema())
+            .with_batches(vec![])
+            .with_expected(expected)
+            .run();
     }
 
     #[test]
@@ -382,6 +414,7 @@ mod tests {
         for max_rows in [MaxRows::Unlimited, MaxRows::Limited(5), MaxRows::Limited(3)] {
             PrintBatchesTest::new()
                 .with_format(PrintFormat::Table)
+                .with_schema(one_column_schema())
                 .with_batches(vec![one_column_batch()])
                 .with_maxrows(max_rows)
                 .with_expected(expected)
@@ -447,15 +480,15 @@ mod tests {
         let empty_batch = RecordBatch::new_empty(batch.schema());
 
         #[rustfmt::skip]
-            let expected =&[
-                "+---+",
-                "| a |",
-                "+---+",
-                "| 1 |",
-                "| 2 |",
-                "| 3 |",
-                "+---+",
-            ];
+        let expected =&[
+            "+---+",
+            "| a |",
+            "+---+",
+            "| 1 |",
+            "| 2 |",
+            "| 3 |",
+            "+---+",
+        ];
 
         PrintBatchesTest::new()
             .with_format(PrintFormat::Table)
@@ -465,14 +498,32 @@ mod tests {
     }
 
     #[test]
-    fn test_print_batches_empty_batches_no_header() {
+    fn test_print_batches_empty_batch() {
         let empty_batch = RecordBatch::new_empty(one_column_batch().schema());
 
-        // empty batches should not print a header
-        let expected = &[""];
+        // Print column headers for empty batch when format is Table
+        #[rustfmt::skip]
+        let expected =&[
+            "+---+",
+            "| a |",
+            "+---+",
+            "+---+",
+        ];
 
         PrintBatchesTest::new()
             .with_format(PrintFormat::Table)
+            .with_schema(one_column_schema())
+            .with_batches(vec![empty_batch])
+            .with_header(WithHeader::Yes)
+            .with_expected(expected)
+            .run();
+
+        // No output for empty batch when schema contains no columns
+        let empty_batch = RecordBatch::new_empty(Arc::new(Schema::empty()));
+        let expected = &[""];
+        PrintBatchesTest::new()
+            .with_format(PrintFormat::Table)
+            .with_schema(Arc::new(Schema::empty()))
             .with_batches(vec![empty_batch])
             .with_header(WithHeader::Yes)
             .with_expected(expected)
@@ -482,6 +533,7 @@ mod tests {
     #[derive(Debug)]
     struct PrintBatchesTest {
         format: PrintFormat,
+        schema: SchemaRef,
         batches: Vec<RecordBatch>,
         maxrows: MaxRows,
         with_header: WithHeader,
@@ -501,6 +553,7 @@ mod tests {
         fn new() -> Self {
             Self {
                 format: PrintFormat::Table,
+                schema: Arc::new(Schema::empty()),
                 batches: vec![],
                 maxrows: MaxRows::Unlimited,
                 with_header: WithHeader::Ignored,
@@ -511,6 +564,12 @@ mod tests {
         /// set the format
         fn with_format(mut self, format: PrintFormat) -> Self {
             self.format = format;
+            self
+        }
+
+        // set the schema
+        fn with_schema(mut self, schema: SchemaRef) -> Self {
+            self.schema = schema;
             self
         }
 
@@ -570,21 +629,31 @@ mod tests {
         fn output_with_header(&self, with_header: bool) -> String {
             let mut buffer: Vec<u8> = vec![];
             self.format
-                .print_batches(&mut buffer, &self.batches, self.maxrows, with_header)
+                .print_batches(
+                    &mut buffer,
+                    self.schema.clone(),
+                    &self.batches,
+                    self.maxrows,
+                    with_header,
+                )
                 .unwrap();
             String::from_utf8(buffer).unwrap()
         }
     }
 
-    /// Return a batch with three columns and three rows
-    fn three_column_batch() -> RecordBatch {
-        let schema = Arc::new(Schema::new(vec![
+    /// Return a schema with three columns
+    fn three_column_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Int32, false),
             Field::new("c", DataType::Int32, false),
-        ]));
+        ]))
+    }
+
+    /// Return a batch with three columns and three rows
+    fn three_column_batch() -> RecordBatch {
         RecordBatch::try_new(
-            schema,
+            three_column_schema(),
             vec![
                 Arc::new(Int32Array::from(vec![1, 2, 3])),
                 Arc::new(Int32Array::from(vec![4, 5, 6])),
@@ -594,12 +663,17 @@ mod tests {
         .unwrap()
     }
 
+    /// Return a schema with one column
+    fn one_column_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
     /// return a batch with one column and three rows
     fn one_column_batch() -> RecordBatch {
-        RecordBatch::try_from_iter(vec![(
-            "a",
-            Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef,
-        )])
+        RecordBatch::try_new(
+            one_column_schema(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
         .unwrap()
     }
 

--- a/src/utils/datafusion-cli/src/print_options.rs
+++ b/src/utils/datafusion-cli/src/print_options.rs
@@ -20,11 +20,12 @@ use std::io::Write;
 use std::pin::Pin;
 use std::str::FromStr;
 
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
+use datafusion::common::instant::Instant;
 use datafusion::common::DataFusionError;
 use datafusion::error::Result;
 use datafusion::physical_plan::RecordBatchStream;
-use datafusion_common::instant::Instant;
 use futures::StreamExt;
 
 use crate::print_format::PrintFormat;
@@ -99,12 +100,17 @@ fn get_execution_details_formatted(
 
 impl PrintOptions {
     /// Print the batches to stdout using the specified format
-    pub fn print_batches(&self, batches: &[RecordBatch], query_start_time: Instant) -> Result<()> {
+    pub fn print_batches(
+        &self,
+        schema: SchemaRef,
+        batches: &[RecordBatch],
+        query_start_time: Instant,
+    ) -> Result<()> {
         let stdout = std::io::stdout();
         let mut writer = stdout.lock();
 
         self.format
-            .print_batches(&mut writer, batches, self.maxrows, true)?;
+            .print_batches(&mut writer, schema, batches, self.maxrows, true)?;
 
         let row_count: usize = batches.iter().map(|b| b.num_rows()).sum();
         let formatted_exec_details = get_execution_details_formatted(
@@ -145,8 +151,13 @@ impl PrintOptions {
         while let Some(maybe_batch) = stream.next().await {
             let batch = maybe_batch?;
             row_count += batch.num_rows();
-            self.format
-                .print_batches(&mut writer, &[batch], MaxRows::Unlimited, with_header)?;
+            self.format.print_batches(
+                &mut writer,
+                batch.schema(),
+                &[batch],
+                MaxRows::Unlimited,
+                with_header,
+            )?;
             with_header = false;
         }
 


### PR DESCRIPTION
## Description

Closes: #554 
Closes: #323 

### Core Functionality

Introduces new `EthereumLogs` polling source (see https://github.com/open-data-fabric/open-data-fabric/pull/90):
```yaml
kind: SetPollingSource
fetch:
  kind: EthereumLogs
  chainId: 1 # Ethereum Mainnet
  signature: |
    TokensMinted(
      address indexed to,
      uint256 amount,
      uint256 ethAmount,
      uint256 time
    )
  # Using contract deployment block to limit scanning
  filter: |
    address = X'ae78736cd615f374d3085123a210448e74fc6393'
    and
    block_number > 13325304
```

It supports:
- SQL WHERE-like filter push-down into RPC calls
- optional event signature decoding (into a nested struct)

Most logic lives in our new [`datafusion-ethers`](https://github.com/kamu-data/datafusion-ethers) crate.

Ethereum node endpoint can be specified in the source or in kamu config. Multiple chains can be supported simultaneously.

### Other Changes
- Better binary formatting in CLI output - instead of `<binary>` placeholder you will see abbreviated hex values like `c47cf6…7e3755`
- Custom CSV and JSON writers to allow outputting (hex-encoded) binary data and decimals
- Because of the show-stopper bug in `datafusion 38` with nested struct field access I had to include an upgrade to `v39`
  - Currently it points to `rc1` tag, but will be switched to the release as soon as it's out
  - `datafusion-ethers`, `datafusion-odata` and our fork of `datafusion-functions-json` will be updated accordingly

> Note: `datafusion v39` upgrade brings in new `object_store` version which depends on new `reqwest`. This causes a duplication of `http`, `hyper`, `rustls` and some other small crates in HTTP stack. I propose to accept this and remove duplication by upgrading the rest of the crates once new `tonic` is released.

## Checklist before requesting a review

- [x] Unit and integration tests added: ❌
  - Extensive tests exist in `datafusion-ethers` repository
  - Not adding tests to kamu yet because of complexity of setup requiring `foundry` and also some flakyness associated with `anvil` contract deployments
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌
    - Will be updated separately with demos and guides
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌
    - DI changed slightly needing to register `FetchService` explicitly
    - Ethereum node configuration will need to be exposed in the node too
  - [x] Dataset pipelines: ❌
    - Will need to be updated to new `reth-vs-snp500` demo layout
  - Demo deployment will need to be updated