### PR TITLE
Add query reproducibility and aliases support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+## Added
+- The `/query` REST API endpoint now supports:
+  - POST requests with all parameters being passed via body
+  - Specifying schema format
+  - Specifying `aliases` to associate table names with specific dataset IDs
+  - Returning and providing state information to achieve full reproducibility of queries
+
 ## [0.186.0] - 2024-06-13
 ## Added
 - New `EthereumLogs` polling source allows to stream and decode log data directly from any ETH-compatible blockchain node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,6 +5041,7 @@ dependencies = [
  "kamu-accounts-inmem",
  "kamu-accounts-services",
  "kamu-data-utils",
+ "kamu-ingest-datafusion",
  "mockall",
  "opendatafabric",
  "paste",

--- a/src/adapter/graphql/src/queries/data.rs
+++ b/src/adapter/graphql/src/queries/data.rs
@@ -44,7 +44,7 @@ impl DataQueries {
                     .sql_statement(&query, domain::QueryOptions::default())
                     .await;
                 match sql_result {
-                    Ok(r) => r,
+                    Ok(r) => r.df,
                     Err(e) => return Ok(e.into()),
                 }
             }

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -75,6 +75,7 @@ uuid = { version = "1", default-features = false, features = ["v4"] }
 container-runtime = { workspace = true }
 kamu-accounts-services = { workspace = true }
 kamu-accounts-inmem = { workspace = true }
+kamu-ingest-datafusion = { workspace = true }
 
 fs_extra = "1.3"                                                    # Recursive folder copy
 indoc = "2"

--- a/src/adapter/http/src/data/query_handler.rs
+++ b/src/adapter/http/src/data/query_handler.rs
@@ -18,11 +18,13 @@
 
 use std::fmt::Debug;
 
-use axum::extract::{Extension, Query};
+use axum::extract::{self, Extension, Query};
 use axum::response::Json;
-use datafusion::dataframe::DataFrame;
+use datafusion::arrow::array::RecordBatch;
+use datafusion::common::DFSchema;
 use kamu::domain::*;
 use kamu_data_utils::data::format::*;
+use opendatafabric::{DatasetID, Multihash};
 
 use crate::api_error::*;
 
@@ -33,107 +35,339 @@ const MAX_SOA_BUFFER_SIZE: usize = 100_000_000;
 
 /////////////////////////////////////////////////////////////////////////////////
 
-#[allow(clippy::enum_variant_names)]
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum SubFormat {
-    #[default]
-    JsonAos,
-    JsonSoa,
-    JsonAoa,
-}
-
-// TODO: Sanity limits
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct QueryParams {
-    query: String,
-    #[serde(default)]
-    skip: u64,
-    #[serde(default = "QueryParams::default_limit")]
-    limit: u64,
-    #[serde(default)]
-    format: SubFormat,
-    #[serde(default = "QueryParams::default_schema")]
-    schema: bool,
-}
-
-impl QueryParams {
-    fn default_limit() -> u64 {
-        100
-    }
-
-    fn default_schema() -> bool {
-        true
-    }
-}
-
-// TODO: This endpoint is temporary to enable some demo integrations
-// it should be properly re-designed in future to allow for different query
-// dialects, returning schema, error handling etc.
-pub async fn dataset_query_handler(
+pub async fn dataset_query_handler_post(
     Extension(catalog): Extension<dill::Catalog>,
-    Query(params): Query<QueryParams>,
-) -> Result<Json<serde_json::Value>, ApiError> {
+    extract::Json(body): extract::Json<QueryRequestBody>,
+) -> Result<Json<QueryResponseBody>, ApiError> {
     let query_svc = catalog.get_one::<dyn QueryService>().unwrap();
 
-    let df = query_svc
-        .sql_statement(&params.query, QueryOptions::default())
+    let res = query_svc
+        .sql_statement(&body.query, body.to_options())
         .await
         .int_err()
-        .api_err()?
+        .api_err()?;
+
+    // Apply pagination limits
+    let df = res
+        .df
         .limit(
-            usize::try_from(params.skip).unwrap(),
-            Some(usize::try_from(params.limit).unwrap()),
+            usize::try_from(body.skip).unwrap(),
+            Some(usize::try_from(body.limit).unwrap()),
         )
         .int_err()
         .api_err()?;
 
-    records_to_json(df, params.format, params.schema).await
+    let res = QueryResponse {
+        df,
+        state: res.state,
+    };
+
+    let arrow_schema = res.df.schema().inner().clone();
+
+    let schema = if body.include_schema {
+        Some(serialize_schema(res.df.schema(), body.schema_format).api_err()?)
+    } else {
+        None
+    };
+
+    let state = if body.include_state {
+        Some(res.state.into())
+    } else {
+        None
+    };
+
+    let record_batches = res.df.collect().await.int_err().api_err()?;
+    let json = serialize_data(&record_batches, body.data_format).api_err()?;
+    let data = serde_json::value::RawValue::from_string(json).unwrap();
+
+    let result_hash = if body.include_result_hash {
+        Some(kamu_data_utils::data::hash::get_batches_logical_hash(
+            &arrow_schema,
+            &record_batches,
+        ))
+    } else {
+        None
+    };
+
+    Ok(Json(QueryResponseBody {
+        data,
+        schema,
+        state,
+        result_hash,
+    }))
 }
 
 /////////////////////////////////////////////////////////////////////////////////
 
-// TODO: Replace with a serializable type
-pub(crate) async fn records_to_json(
-    df: DataFrame,
-    fmt: SubFormat,
-    with_schema: bool,
-) -> Result<Json<serde_json::Value>, ApiError> {
-    let schema: datafusion::arrow::datatypes::Schema = df.schema().into();
-    let record_batches = df.collect().await.int_err().api_err()?;
-
-    // TODO: Streaming?
-    let mut buf = Vec::new();
-    {
-        let mut writer = get_writer(fmt, &mut buf);
-        for batch in record_batches {
-            writer.write_batch(&batch).int_err().api_err()?;
-        }
-        writer.finish().int_err().api_err()?;
-    }
-
-    let raw_data =
-        serde_json::value::RawValue::from_string(String::from_utf8(buf).unwrap()).unwrap();
-
-    Ok(Json(if with_schema {
-        serde_json::json!({
-            "schema": schema,
-            "data": raw_data,
-        })
-    } else {
-        serde_json::json!({
-            "data": raw_data,
-        })
-    }))
+pub async fn dataset_query_handler(
+    catalog: Extension<dill::Catalog>,
+    Query(params): Query<QueryRequestParams>,
+) -> Result<Json<QueryResponseBody>, ApiError> {
+    dataset_query_handler_post(catalog, extract::Json(params.into())).await
 }
 
-pub fn get_writer<'a, W: std::io::Write + 'a>(fmt: SubFormat, w: W) -> Box<dyn RecordsWriter + 'a> {
-    match fmt {
-        SubFormat::JsonAos => Box::new(JsonArrayOfStructsWriter::new(w)),
-        SubFormat::JsonSoa => Box::new(JsonStructOfArraysWriter::new(w, MAX_SOA_BUFFER_SIZE)),
-        SubFormat::JsonAoa => Box::new(JsonArrayOfArraysWriter::new(w)),
+/////////////////////////////////////////////////////////////////////////////////
+
+// TODO: Sanity limits
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryRequestBody {
+    /// SQL query
+    query: String,
+
+    /// How data should be layed out in the response
+    #[serde(default)]
+    data_format: DataFormat,
+
+    /// What representation to use for the schema
+    #[serde(default)]
+    schema_format: SchemaFormat,
+
+    /// Mapping between dataset names used in the query and their stable IDs, to
+    /// make query resistant to datasets being renamed
+    aliases: Option<Vec<QueryDatasetAlias>>,
+
+    /// State information used to reproduce query at a specific point in time
+    as_of_state: Option<QueryState>,
+
+    /// Whether to include schema info about the response
+    #[serde(default = "QueryRequestBody::default_include_schema")]
+    include_schema: bool,
+
+    /// Whether to include dataset state info for query reproducibility
+    #[serde(default = "QueryRequestBody::default_include_state")]
+    include_state: bool,
+
+    /// Whether to include a logical hash of the resulting data batch.
+    /// See: https://docs.kamu.dev/odf/spec/#physical-and-logical-hashes
+    #[serde(default = "QueryRequestBody::default_include_result_hash")]
+    include_result_hash: bool,
+
+    /// Pagination: skips first N records
+    #[serde(default)]
+    skip: u64,
+    /// Pagination: limits number of records in response to N
+    #[serde(default = "QueryRequestBody::default_limit")]
+    limit: u64,
+}
+
+impl QueryRequestBody {
+    fn default_limit() -> u64 {
+        100
     }
+
+    fn default_include_schema() -> bool {
+        true
+    }
+
+    fn default_include_state() -> bool {
+        true
+    }
+
+    fn default_include_result_hash() -> bool {
+        true
+    }
+
+    fn to_options(&self) -> QueryOptions {
+        QueryOptions {
+            aliases: self
+                .aliases
+                .as_ref()
+                .map(|v| v.iter().map(|i| (i.alias.clone(), i.id.clone())).collect()),
+            as_of_state: self.as_of_state.as_ref().map(QueryState::to_state),
+            hints: None,
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryRequestParams {
+    query: String,
+    #[serde(default)]
+    skip: u64,
+    #[serde(default = "QueryRequestBody::default_limit")]
+    limit: u64,
+    #[serde(alias = "format")]
+    #[serde(default)]
+    data_format: DataFormat,
+    #[serde(default)]
+    schema_format: SchemaFormat,
+    #[serde(alias = "schema")]
+    #[serde(default = "QueryRequestBody::default_include_schema")]
+    include_schema: bool,
+    #[serde(default = "QueryRequestBody::default_include_state")]
+    include_state: bool,
+    #[serde(default = "QueryRequestBody::default_include_result_hash")]
+    include_result_hash: bool,
+}
+
+impl From<QueryRequestParams> for QueryRequestBody {
+    fn from(v: QueryRequestParams) -> Self {
+        Self {
+            query: v.query,
+            data_format: v.data_format,
+            schema_format: v.schema_format,
+            aliases: None,
+            as_of_state: None,
+            include_schema: v.include_schema,
+            include_state: v.include_state,
+            include_result_hash: v.include_result_hash,
+            skip: v.skip,
+            limit: v.limit,
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryResponseBody {
+    data: Box<serde_json::value::RawValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<QueryState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result_hash: Option<Multihash>,
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryDatasetAlias {
+    pub alias: String,
+    pub id: DatasetID,
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryState {
+    pub inputs: Vec<QueryDatasetState>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryDatasetState {
+    pub id: DatasetID,
+    pub block_hash: Multihash,
+}
+
+impl QueryState {
+    fn to_state(&self) -> kamu::domain::QueryState {
+        kamu::domain::QueryState {
+            inputs: self
+                .inputs
+                .iter()
+                .map(|i| (i.id.clone(), i.block_hash.clone()))
+                .collect(),
+        }
+    }
+}
+
+impl From<kamu::domain::QueryState> for QueryState {
+    fn from(value: kamu::domain::QueryState) -> Self {
+        Self {
+            inputs: value
+                .inputs
+                .into_iter()
+                .map(|(id, block_hash)| QueryDatasetState { id, block_hash })
+                .collect(),
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+pub enum DataFormat {
+    #[default]
+    #[serde(alias = "jsonaos")]
+    #[serde(alias = "json-aos")]
+    JsonAos,
+    #[serde(alias = "jsonsoa")]
+    #[serde(alias = "json-soa")]
+    JsonSoa,
+    #[serde(alias = "jsonaoa")]
+    #[serde(alias = "json-aoa")]
+    JsonAoa,
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+pub enum SchemaFormat {
+    #[default]
+    #[serde(alias = "arrowjson")]
+    #[serde(alias = "arrow-json")]
+    ArrowJson,
+    #[serde(alias = "parquet")]
+    Parquet,
+    #[serde(alias = "parquetjson")]
+    #[serde(alias = "parquet-json")]
+    ParquetJson,
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+pub(crate) fn serialize_schema(
+    schema: &DFSchema,
+    format: SchemaFormat,
+) -> Result<String, InternalError> {
+    use kamu_data_utils::schema::{convert, format};
+
+    let mut buf = Vec::new();
+    match format {
+        SchemaFormat::ArrowJson => {
+            let arrow_schema = datafusion::arrow::datatypes::Schema::from(schema);
+            format::write_schema_arrow_json(&mut buf, &arrow_schema)
+        }
+        SchemaFormat::Parquet => format::write_schema_parquet(
+            &mut buf,
+            convert::dataframe_schema_to_parquet_schema(schema).as_ref(),
+        ),
+        SchemaFormat::ParquetJson => format::write_schema_parquet_json(
+            &mut buf,
+            convert::dataframe_schema_to_parquet_schema(schema).as_ref(),
+        ),
+    }
+    .int_err()?;
+
+    Ok(String::from_utf8(buf).unwrap())
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+pub(crate) fn serialize_data(
+    record_batches: &[RecordBatch],
+    format: DataFormat,
+) -> Result<String, InternalError> {
+    let mut buf = Vec::new();
+
+    {
+        let mut writer: Box<dyn RecordsWriter> = match format {
+            DataFormat::JsonAos => Box::new(JsonArrayOfStructsWriter::new(&mut buf)),
+            DataFormat::JsonSoa => {
+                Box::new(JsonStructOfArraysWriter::new(&mut buf, MAX_SOA_BUFFER_SIZE))
+            }
+            DataFormat::JsonAoa => Box::new(JsonArrayOfArraysWriter::new(&mut buf)),
+        };
+
+        for batch in record_batches {
+            writer.write_batch(batch).int_err()?;
+        }
+        writer.finish().int_err()?;
+    }
+
+    Ok(String::from_utf8(buf).unwrap())
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/src/data/router.rs
+++ b/src/adapter/http/src/data/router.rs
@@ -17,13 +17,16 @@
 // by the Apache License, Version 2.0.
 
 use super::ingest_handler::dataset_ingest_handler;
-use super::query_handler::dataset_query_handler;
+use super::query_handler::{dataset_query_handler, dataset_query_handler_post};
 use super::tail_handler::dataset_tail_handler;
 
 /////////////////////////////////////////////////////////////////////////////////
 
 pub fn root_router() -> axum::Router {
-    axum::Router::new().route("/query", axum::routing::get(dataset_query_handler))
+    axum::Router::new().route(
+        "/query",
+        axum::routing::get(dataset_query_handler).post(dataset_query_handler_post),
+    )
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/src/data/tail_handler.rs
+++ b/src/adapter/http/src/data/tail_handler.rs
@@ -21,34 +21,10 @@ use axum::response::Json;
 use kamu::domain::*;
 use opendatafabric::DatasetRef;
 
-use super::query_handler::SubFormat;
+use super::query_handler::{DataFormat, SchemaFormat};
 use crate::api_error::*;
 
 /////////////////////////////////////////////////////////////////////////////////
-
-// TODO: Sanity limits
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TailParams {
-    #[serde(default)]
-    skip: u64,
-    #[serde(default = "TailParams::default_limit")]
-    limit: u64,
-    #[serde(default)]
-    format: SubFormat,
-    #[serde(default = "TailParams::default_schema")]
-    schema: bool,
-}
-
-impl TailParams {
-    fn default_limit() -> u64 {
-        100
-    }
-
-    fn default_schema() -> bool {
-        true
-    }
-}
 
 // TODO: This endpoint is temporary to enable some demo integrations
 // it should be properly re-designed in future to allow for different query
@@ -56,8 +32,8 @@ impl TailParams {
 pub async fn dataset_tail_handler(
     Extension(catalog): Extension<dill::Catalog>,
     Extension(dataset_ref): Extension<DatasetRef>,
-    Query(params): Query<TailParams>,
-) -> Result<Json<serde_json::Value>, ApiError> {
+    Query(params): Query<TailRequestParams>,
+) -> Result<Json<TailResponseBody>, ApiError> {
     let query_svc = catalog.get_one::<dyn QueryService>().unwrap();
 
     let df = query_svc
@@ -66,7 +42,58 @@ pub async fn dataset_tail_handler(
         .int_err()
         .api_err()?;
 
-    super::query_handler::records_to_json(df, params.format, params.schema).await
+    let schema = if params.include_schema {
+        Some(super::query_handler::serialize_schema(df.schema(), params.schema_format).api_err()?)
+    } else {
+        None
+    };
+
+    let record_batches = df.collect().await.int_err().api_err()?;
+    let json =
+        super::query_handler::serialize_data(&record_batches, params.data_format).api_err()?;
+    let data = serde_json::value::RawValue::from_string(json).unwrap();
+
+    Ok(Json(TailResponseBody { data, schema }))
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+// TODO: Sanity limits
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TailRequestParams {
+    #[serde(default)]
+    skip: u64,
+    #[serde(default = "TailRequestParams::default_limit")]
+    limit: u64,
+    #[serde(alias = "format")]
+    #[serde(default)]
+    data_format: DataFormat,
+    #[serde(default)]
+    schema_format: SchemaFormat,
+    #[serde(alias = "schema")]
+    #[serde(default = "TailRequestParams::default_include_schema")]
+    include_schema: bool,
+}
+
+impl TailRequestParams {
+    fn default_limit() -> u64 {
+        100
+    }
+
+    fn default_include_schema() -> bool {
+        true
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TailResponseBody {
+    data: Box<serde_json::value::RawValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema: Option<String>,
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/tests/tests/test_data_query.rs
+++ b/src/adapter/http/tests/tests/test_data_query.rs
@@ -7,12 +7,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use chrono::{TimeZone, Utc};
+use datafusion::arrow::array::{RecordBatch, StringArray, UInt64Array};
+use datafusion::arrow::datatypes::*;
+use datafusion::prelude::*;
 use dill::Component;
 use kamu::domain::*;
 use kamu::*;
-use opendatafabric::{MergeStrategy, *};
+use kamu_ingest_datafusion::DataWriterDataFusion;
+use opendatafabric::*;
 use serde_json::json;
+use testing::MetadataFactory;
 
 use crate::harness::*;
 
@@ -52,32 +59,54 @@ impl Harness {
         let system_time = Utc.with_ymd_and_hms(2050, 1, 1, 12, 0, 0).unwrap();
         server_harness.system_time_source().set(system_time);
 
+        let alias = DatasetAlias::new(
+            server_harness.operating_account_name(),
+            DatasetName::new_unchecked("population"),
+        );
         let create_result = server_harness
             .cli_dataset_repository()
-            .create_dataset_from_snapshot(DatasetSnapshot {
-                name: DatasetAlias::new(
-                    server_harness.operating_account_name(),
-                    DatasetName::new_unchecked("population"),
+            .create_dataset(
+                &alias,
+                MetadataFactory::metadata_block(MetadataFactory::seed(DatasetKind::Root).build())
+                    .system_time(system_time)
+                    .build_typed(),
+            )
+            .await
+            .unwrap();
+
+        let ctx = SessionContext::new();
+        let mut writer = DataWriterDataFusion::builder(create_result.dataset.clone(), ctx.clone())
+            .with_metadata_state_scanned(None)
+            .await
+            .unwrap()
+            .build();
+
+        writer
+            .write(
+                Some(
+                    ctx.read_batch(
+                        RecordBatch::try_new(
+                            Arc::new(Schema::new(vec![
+                                Field::new("city", DataType::Utf8, false),
+                                Field::new("population", DataType::UInt64, false),
+                            ])),
+                            vec![
+                                Arc::new(StringArray::from(vec!["A", "B"])),
+                                Arc::new(UInt64Array::from(vec![100, 200])),
+                            ],
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap(),
                 ),
-                kind: DatasetKind::Root,
-                metadata: vec![AddPushSource {
-                    source_name: "source1".to_string(),
-                    read: ReadStepNdJson {
-                        schema: Some(vec![
-                            "event_time TIMESTAMP".to_owned(),
-                            "city STRING".to_owned(),
-                            "population BIGINT".to_owned(),
-                        ]),
-                        ..Default::default()
-                    }
-                    .into(),
-                    preprocess: None,
-                    merge: MergeStrategy::Ledger(MergeStrategyLedger {
-                        primary_key: vec!["event_time".to_owned(), "city".to_owned()],
-                    }),
-                }
-                .into()],
-            })
+                WriteDataOpts {
+                    system_time,
+                    source_event_time: system_time,
+                    new_watermark: None,
+                    new_source_state: None,
+                    data_staging_path: run_info_dir.path().join(".temp-data"),
+                },
+            )
             .await
             .unwrap();
 
@@ -101,34 +130,6 @@ impl Harness {
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-// TODO: Replace with initialization using DF writer
-async fn add_example_data(cl: &reqwest::Client, dataset_url: &url::Url) {
-    let ingest_url = format!("{dataset_url}/ingest");
-
-    cl.post(&ingest_url)
-        .json(&json!(
-            [
-                {
-                    "event_time": "2020-01-01T00:00:00",
-                    "city": "A",
-                    "population": 100,
-                },
-                {
-                    "event_time": "2020-01-02T00:00:00",
-                    "city": "B",
-                    "population": 200,
-                }
-            ]
-        ))
-        .send()
-        .await
-        .unwrap()
-        .error_for_status()
-        .unwrap();
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-
 #[test_group::group(engine, datafusion)]
 #[test_log::test(tokio::test)]
 async fn test_data_tail_handler() {
@@ -136,13 +137,12 @@ async fn test_data_tail_handler() {
 
     let client = async move {
         let cl = reqwest::Client::new();
-        add_example_data(&cl, &harness.dataset_url).await;
 
         // All points
         let tail_url = format!("{}/tail", harness.dataset_url);
         let res = cl
             .get(&tail_url)
-            .query(&[("schema", "false")])
+            .query(&[("includeSchema", "false")])
             .send()
             .await
             .unwrap();
@@ -152,14 +152,14 @@ async fn test_data_tail_handler() {
             res.json::<serde_json::Value>().await.unwrap(),
             json!({"data": [{
                 "city": "A",
-                "event_time": "2020-01-01T00:00:00Z",
+                "event_time": "2050-01-01T12:00:00Z",
                 "offset": 0,
                 "op": 0,
                 "population": 100,
                 "system_time": "2050-01-01T12:00:00Z"
             }, {
                 "city": "B",
-                "event_time": "2020-01-02T00:00:00Z",
+                "event_time": "2050-01-01T12:00:00Z",
                 "offset": 1,
                 "op": 0,
                 "population": 200,
@@ -170,7 +170,7 @@ async fn test_data_tail_handler() {
         // Limit
         let res = cl
             .get(&tail_url)
-            .query(&[("limit", "1"), ("schema", "false")])
+            .query(&[("limit", "1"), ("includeSchema", "false")])
             .send()
             .await
             .unwrap()
@@ -181,7 +181,7 @@ async fn test_data_tail_handler() {
             res.json::<serde_json::Value>().await.unwrap(),
             json!({"data": [{
                 "city": "B",
-                "event_time": "2020-01-02T00:00:00Z",
+                "event_time": "2050-01-01T12:00:00Z",
                 "offset": 1,
                 "op": 0,
                 "population": 200,
@@ -192,7 +192,7 @@ async fn test_data_tail_handler() {
         // Skip
         let res = cl
             .get(&tail_url)
-            .query(&[("skip", "1"), ("schema", "false")])
+            .query(&[("skip", "1"), ("includeSchema", "false")])
             .send()
             .await
             .unwrap()
@@ -203,7 +203,7 @@ async fn test_data_tail_handler() {
             res.json::<serde_json::Value>().await.unwrap(),
             json!({"data": [{
                 "city": "A",
-                "event_time": "2020-01-01T00:00:00Z",
+                "event_time": "2050-01-01T12:00:00Z",
                 "offset": 0,
                 "op": 0,
                 "population": 100,
@@ -219,12 +219,11 @@ async fn test_data_tail_handler() {
 
 #[test_group::group(engine, datafusion)]
 #[test_log::test(tokio::test)]
-async fn test_data_query_handler() {
+async fn test_data_query_handler_full() {
     let harness = Harness::new().await;
 
     let client = async move {
         let cl = reqwest::Client::new();
-        add_example_data(&cl, &harness.dataset_url).await;
 
         let query = format!(
             "select offset, city, population from \"{}\" order by offset desc",
@@ -233,7 +232,7 @@ async fn test_data_query_handler() {
         let query_url = format!("{}query", harness.root_url);
         let res = cl
             .get(&query_url)
-            .query(&[("query", query.as_str()), ("schema", "true")])
+            .query(&[("query", query.as_str())])
             .send()
             .await
             .unwrap()
@@ -252,30 +251,13 @@ async fn test_data_query_handler() {
                     "offset": 0,
                     "population": 100,
                 }],
-                "schema": {
-                    "fields": [{
-                        "data_type": "Int64",
-                        "dict_id": 0,
-                        "dict_is_ordered": false,
-                        "metadata": {},
-                        "name": "offset",
-                        "nullable": true
-                    }, {
-                        "data_type": "Utf8",
-                        "dict_id": 0,
-                        "dict_is_ordered": false,
-                        "metadata": {},
-                        "name": "city",
-                        "nullable": true
-                    }, {
-                        "data_type": "Int64",
-                        "dict_id": 0,
-                        "dict_is_ordered": false,
-                        "metadata": {},
-                        "name": "population",
-                        "nullable": true
-                    }],
-                    "metadata": {}
+                "schema": "{\"fields\":[{\"name\":\"offset\",\"data_type\":\"Int64\",\"nullable\":true,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}},{\"name\":\"city\",\"data_type\":\"Utf8\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}},{\"name\":\"population\",\"data_type\":\"UInt64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}}],\"metadata\":{}}",
+                "resultHash": "f9680c001200b3483eecc3d5c6b50ee6b8cba11b51c08f89ea1f53d3a334c743199f5fe656e",
+                "state": {
+                    "inputs": [{
+                        "id": "did:odf:fed01df230b49615d175307d580c33d6fda61fc7b9aec91df0f5c1a5ebe3b8cbfee02",
+                        "blockHash": "f16204cec6245fadfbf0663b0e9e9a01c73268cc13e29087b33ce3454af08eb4d3e0b",
+                    }]
                 }
             })
         );
@@ -293,7 +275,6 @@ async fn test_data_query_handler_ranges() {
 
     let client = async move {
         let cl = reqwest::Client::new();
-        add_example_data(&cl, &harness.dataset_url).await;
 
         let query = format!(
             "select offset, city, population from \"{}\" order by offset desc",
@@ -307,7 +288,9 @@ async fn test_data_query_handler_ranges() {
             .query(&[
                 ("query", query.as_str()),
                 ("limit", "1"),
-                ("schema", "false"),
+                ("includeSchema", "false"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
             ])
             .send()
             .await
@@ -330,7 +313,9 @@ async fn test_data_query_handler_ranges() {
             .query(&[
                 ("query", query.as_str()),
                 ("skip", "1"),
-                ("schema", "false"),
+                ("includeSchema", "false"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
             ])
             .send()
             .await
@@ -355,12 +340,11 @@ async fn test_data_query_handler_ranges() {
 
 #[test_group::group(engine, datafusion)]
 #[test_log::test(tokio::test)]
-async fn test_data_query_handler_formats() {
+async fn test_data_query_handler_data_formats() {
     let harness = Harness::new().await;
 
     let client = async move {
         let cl = reqwest::Client::new();
-        add_example_data(&cl, &harness.dataset_url).await;
 
         let query = format!(
             "select offset, city, population from \"{}\" order by offset desc",
@@ -371,8 +355,10 @@ async fn test_data_query_handler_formats() {
             .get(&query_url)
             .query(&[
                 ("query", query.as_str()),
-                ("format", "json-aos"),
-                ("schema", "false"),
+                ("dataFormat", "json-aos"),
+                ("includeSchema", "false"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
             ])
             .send()
             .await
@@ -397,8 +383,10 @@ async fn test_data_query_handler_formats() {
             .get(&query_url)
             .query(&[
                 ("query", query.as_str()),
-                ("format", "json-soa"),
-                ("schema", "false"),
+                ("dataFormat", "json-soa"),
+                ("includeSchema", "false"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
             ])
             .send()
             .await
@@ -419,8 +407,10 @@ async fn test_data_query_handler_formats() {
             .get(&query_url)
             .query(&[
                 ("query", query.as_str()),
-                ("format", "json-aoa"),
-                ("schema", "false"),
+                ("dataFormat", "json-aoa"),
+                ("includeSchema", "false"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
             ])
             .send()
             .await
@@ -434,6 +424,120 @@ async fn test_data_query_handler_formats() {
                 [1, "B", 200],
                 [0, "A", 100],
             ]})
+        );
+    };
+
+    await_client_server_flow!(harness.server_harness.api_server_run(), client);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_data_query_handler_schema_formats() {
+    let harness = Harness::new().await;
+
+    let client = async move {
+        let cl = reqwest::Client::new();
+
+        let query = format!(
+            "select offset, city, population from \"{}\"",
+            harness.dataset_alias
+        );
+        let query_url = format!("{}query", harness.root_url);
+        let res = cl
+            .get(&query_url)
+            .query(&[
+                ("query", query.as_str()),
+                ("schemaFormat", "arrow-json"),
+                ("includeSchema", "true"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
+            ])
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+
+        assert_eq!(
+            res.json::<serde_json::Value>().await.unwrap()["schema"]
+                .as_str()
+                .unwrap(),
+            r#"{"fields":[{"name":"offset","data_type":"Int64","nullable":true,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"city","data_type":"Utf8","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"population","data_type":"UInt64","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}}],"metadata":{}}"#
+        );
+
+        let res = cl
+            .get(&query_url)
+            .query(&[
+                ("query", query.as_str()),
+                ("schemaFormat", "ArrowJson"),
+                ("includeSchema", "true"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
+            ])
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+
+        assert_eq!(
+            res.json::<serde_json::Value>().await.unwrap()["schema"]
+                .as_str()
+                .unwrap(),
+            r#"{"fields":[{"name":"offset","data_type":"Int64","nullable":true,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"city","data_type":"Utf8","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"population","data_type":"UInt64","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}}],"metadata":{}}"#
+        );
+
+        let res = cl
+            .get(&query_url)
+            .query(&[
+                ("query", query.as_str()),
+                ("schemaFormat", "parquet"),
+                ("includeSchema", "true"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
+            ])
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+
+        assert_eq!(
+            res.json::<serde_json::Value>().await.unwrap()["schema"]
+                .as_str()
+                .unwrap(),
+            indoc::indoc!(
+                r#"message arrow_schema {
+                  OPTIONAL INT64 offset;
+                  REQUIRED BYTE_ARRAY city (STRING);
+                  REQUIRED INT64 population (INTEGER(64,false));
+                }
+                "#
+            )
+        );
+
+        let res = cl
+            .get(&query_url)
+            .query(&[
+                ("query", query.as_str()),
+                ("schemaFormat", "parquet-json"),
+                ("includeSchema", "true"),
+                ("includeState", "false"),
+                ("includeResultHash", "false"),
+            ])
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+
+        assert_eq!(
+            res.json::<serde_json::Value>().await.unwrap()["schema"]
+                .as_str()
+                .unwrap(),
+            r#"{"name": "arrow_schema", "type": "struct", "fields": [{"name": "offset", "repetition": "OPTIONAL", "type": "INT64"}, {"name": "city", "repetition": "REQUIRED", "type": "BYTE_ARRAY", "logicalType": "STRING"}, {"name": "population", "repetition": "REQUIRED", "type": "INT64", "logicalType": "INTEGER(64,false)"}]}"#
         );
     };
 

--- a/src/app/cli/src/commands/sql_shell_command.rs
+++ b/src/app/cli/src/commands/sql_shell_command.rs
@@ -113,13 +113,13 @@ impl SqlShellCommand {
     }
 
     async fn run_datafusion_command(&self) -> Result<(), CLIError> {
-        let df = self
+        let res = self
             .query_svc
             .sql_statement(self.command.as_ref().unwrap(), QueryOptions::default())
             .await
             .map_err(CLIError::failure)?;
 
-        let records = df.collect().await.map_err(CLIError::failure)?;
+        let records = res.df.collect().await.map_err(CLIError::failure)?;
 
         let mut writer = self
             .output_config

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -71,6 +71,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "gzip",
     "brotli",
     "deflate",
+    "json",
 ] }
 ringbuf = "0.3"
 rumqttc = { version = "0.23" }


### PR DESCRIPTION
## Description

- The `/query` REST API endpoint now supports:
  - POST requests with all parameters being passed via body
  - Specifying schema format
  - Specifying `aliases` to associate table names with specific dataset IDs
  - Returning and providing state information to achieve full reproducibility of queries

Example oracle interaction will now look like this:
POST request:
```json
{
  "query": "select offset, city, population from foo order by offset desc",
  "dataFormat": "JsonAoA",
  "aliases": [{
    "alias": "foo",
    "id": "did:odf:fed01df230b49615d175307d580c33d6fda61fc7b9aec91df0f5c1a5ebe3b8cbfee02"
  }]
}
```
Response:
```json
{
    "data": [[1, "B", 200], [0, "A", 100]],
    "schema": "...",
    "resultHash": "f9680c001200b3483eecc3d5c6b50ee6b8cba11b51c08f89ea1f53d3a334c743199f5fe656e",
    "state": {
        "inputs": [{
            "id": "did:odf:fed01df230b49615d175307d580c33d6fda61fc7b9aec91df0f5c1a5ebe3b8cbfee02",
            "blockHash": "f16204cec6245fadfbf0663b0e9e9a01c73268cc13e29087b33ce3454af08eb4d3e0b",
        }]
    }
}
```

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ❌
    <!-- New version will work with the old workspaces, repositories, and metadata -->
    - All changes are backwards-compatible except making `schema` a string instead of JSON. Only oracle depends on `schema` currently and will be updated.
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅