### PR TITLE
Newtypes for common paths

### DIFF
--- a/src/adapter/graphql/tests/tests/test_gql_metadata.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_metadata.rs
@@ -30,17 +30,15 @@ async fn test_current_push_sources() {
     let base_catalog = {
         let mut b = CatalogBuilder::new();
 
-        b.add::<EventBus>()
+        b.add_value(RunInfoDir::new(tempdir.path().join("run")))
+            .add::<EventBus>()
             .add_builder(
                 DatasetRepositoryLocalFs::builder()
                     .with_root(datasets_dir)
                     .with_multi_tenant(false),
             )
             .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
-            .add_builder(
-                PushIngestServiceImpl::builder().with_run_info_dir(tempdir.path().join("run")),
-            )
-            .bind::<dyn PushIngestService, PushIngestServiceImpl>()
+            .add::<PushIngestServiceImpl>()
             .add::<SystemTimeSourceDefault>()
             .add::<EngineProvisionerNull>()
             .add::<ObjectStoreRegistryImpl>()

--- a/src/adapter/http/src/upload/upload_service_local.rs
+++ b/src/adapter/http/src/upload/upload_service_local.rs
@@ -12,7 +12,13 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use dill::*;
-use kamu::domain::{ErrorIntoInternal, InternalError, ResultIntoInternal, ServerUrlConfig};
+use kamu::domain::{
+    CacheDir,
+    ErrorIntoInternal,
+    InternalError,
+    ResultIntoInternal,
+    ServerUrlConfig,
+};
 use opendatafabric::AccountID;
 use thiserror::Error;
 use tokio::io::AsyncRead;
@@ -39,7 +45,7 @@ pub struct UploadServiceLocal {
     server_url_config: Arc<ServerUrlConfig>,
     uploads_config: Arc<FileUploadLimitConfig>,
     access_token: Arc<AccessToken>,
-    cache_dir: PathBuf,
+    cache_dir: Arc<CacheDir>,
 }
 
 impl UploadServiceLocal {
@@ -47,7 +53,7 @@ impl UploadServiceLocal {
         server_url_config: Arc<ServerUrlConfig>,
         uploads_config: Arc<FileUploadLimitConfig>,
         access_token: Arc<AccessToken>,
-        cache_dir: PathBuf,
+        cache_dir: Arc<CacheDir>,
     ) -> Self {
         Self {
             server_url_config,

--- a/src/adapter/http/tests/harness/client_side_harness.rs
+++ b/src/adapter/http/tests/harness/client_side_harness.rs
@@ -61,6 +61,10 @@ impl ClientSideHarness {
 
         let mut b = dill::CatalogBuilder::new();
 
+        b.add_value(RunInfoDir::new(run_info_dir));
+        b.add_value(CacheDir::new(cache_dir));
+        b.add_value(RemoteReposDir::new(repos_dir));
+
         b.add::<EventBus>();
 
         b.add::<DependencyGraphServiceInMemory>();
@@ -89,8 +93,7 @@ impl ClientSideHarness {
         )
         .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>();
 
-        b.add_builder(RemoteRepositoryRegistryImpl::builder().with_repos_dir(repos_dir))
-            .bind::<dyn RemoteRepositoryRegistry, RemoteRepositoryRegistryImpl>();
+        b.add::<RemoteRepositoryRegistryImpl>();
 
         b.add::<RemoteAliasesRegistryImpl>();
 
@@ -101,14 +104,9 @@ impl ClientSideHarness {
 
         b.add::<DataFormatRegistryImpl>();
 
-        b.add_builder(FetchService::builder().with_run_info_dir(run_info_dir.clone()));
+        b.add::<FetchService>();
 
-        b.add_builder(
-            PollingIngestServiceImpl::builder()
-                .with_run_info_dir(run_info_dir.clone())
-                .with_cache_dir(cache_dir),
-        )
-        .bind::<dyn PollingIngestService, PollingIngestServiceImpl>();
+        b.add::<PollingIngestServiceImpl>();
 
         b.add::<DatasetFactoryImpl>();
 
@@ -118,8 +116,7 @@ impl ClientSideHarness {
 
         b.add::<TransformServiceImpl>();
 
-        b.add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir))
-            .bind::<dyn CompactingService, CompactingServiceImpl>();
+        b.add::<CompactingServiceImpl>();
 
         b.add::<PullServiceImpl>();
 

--- a/src/adapter/http/tests/harness/server_side_s3_harness.rs
+++ b/src/adapter/http/tests/harness/server_side_s3_harness.rs
@@ -20,6 +20,7 @@ use kamu::domain::{
     InternalError,
     ObjectStoreBuilder,
     ResultIntoInternal,
+    RunInfoDir,
     ServerUrlConfig,
     SystemTimeSource,
     SystemTimeSourceStub,
@@ -79,6 +80,7 @@ impl ServerSideS3Harness {
         let mut base_catalog_builder = dill::CatalogBuilder::new();
         base_catalog_builder
             .add_value(time_source.clone())
+            .add_value(RunInfoDir::new(run_info_dir))
             .bind::<dyn SystemTimeSource, SystemTimeSourceStub>()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
@@ -91,8 +93,7 @@ impl ServerSideS3Harness {
             .add_value(server_authentication_mock())
             .bind::<dyn AuthenticationService, MockAuthenticationService>()
             .add_value(ServerUrlConfig::new_test(Some(&base_url_rest)))
-            .add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir.clone()))
-            .bind::<dyn CompactingService, CompactingServiceImpl>()
+            .add::<CompactingServiceImpl>()
             .add::<ObjectStoreRegistryImpl>()
             .add::<ObjectStoreBuilderLocalFs>()
             .add_value(ObjectStoreBuilderS3::new(s3_context, true))

--- a/src/adapter/http/tests/tests/test_data_ingest.rs
+++ b/src/adapter/http/tests/tests/test_data_ingest.rs
@@ -8,18 +8,12 @@
 // by the Apache License, Version 2.0.
 
 use chrono::{DateTime, TimeZone, Utc};
-use dill::Component;
 use indoc::indoc;
 use kamu::domain::*;
 use kamu::testing::DatasetDataHelper;
 use kamu::*;
 use kamu_accounts::DUMMY_ACCESS_TOKEN;
-use kamu_adapter_http::{
-    make_upload_token,
-    FileUploadLimitConfig,
-    UploadService,
-    UploadServiceLocal,
-};
+use kamu_adapter_http::{make_upload_token, FileUploadLimitConfig, UploadServiceLocal};
 use opendatafabric::{MergeStrategy, *};
 use serde_json::json;
 use url::Url;
@@ -509,24 +503,17 @@ async fn test_data_push_ingest_upload_token_actual_file_different_size() {
 /////////////////////////////////////////////////////////////////////////////////////////
 
 struct DataIngestHarness {
-    pub workspace_dir: tempfile::TempDir,
     pub server_harness: ServerSideLocalFsHarness,
     pub system_time: DateTime<Utc>,
 }
 
 impl DataIngestHarness {
     fn new() -> Self {
-        let workspace_dir = tempfile::tempdir().unwrap();
-        let run_info_dir = workspace_dir.path().join("run");
-        let cache_dir = workspace_dir.path().join("cache");
-
         let catalog = dill::CatalogBuilder::new()
             .add::<DataFormatRegistryImpl>()
-            .add_builder(PushIngestServiceImpl::builder().with_run_info_dir(run_info_dir))
-            .bind::<dyn PushIngestService, PushIngestServiceImpl>()
+            .add::<PushIngestServiceImpl>()
             .add::<EngineProvisionerNull>()
-            .add_builder(UploadServiceLocal::builder().with_cache_dir(cache_dir.clone()))
-            .bind::<dyn UploadService, UploadServiceLocal>()
+            .add::<UploadServiceLocal>()
             .add_value(FileUploadLimitConfig {
                 max_file_size_in_bytes: 1000,
             })
@@ -542,7 +529,6 @@ impl DataIngestHarness {
         server_harness.system_time_source().set(system_time);
 
         Self {
-            workspace_dir,
             server_harness,
             system_time,
         }
@@ -588,10 +574,13 @@ impl DataIngestHarness {
     }
 
     async fn upload_file(&self, upload_id: &str, file_name: &str, file_content: &str) {
-        let upload_dir = self
-            .workspace_dir
-            .path()
-            .join("cache")
+        let cache_dir = self
+            .server_harness
+            .base_catalog()
+            .get_one::<CacheDir>()
+            .unwrap();
+
+        let upload_dir = cache_dir
             .join("uploads")
             .join(
                 AccountID::new_seeded_ed25519(SERVER_ACCOUNT_NAME.as_bytes())

--- a/src/adapter/http/tests/tests/test_data_query.rs
+++ b/src/adapter/http/tests/tests/test_data_query.rs
@@ -13,7 +13,6 @@ use chrono::{TimeZone, Utc};
 use datafusion::arrow::array::{RecordBatch, StringArray, UInt64Array};
 use datafusion::arrow::datatypes::*;
 use datafusion::prelude::*;
-use dill::Component;
 use kamu::domain::*;
 use kamu::*;
 use kamu_ingest_datafusion::DataWriterDataFusion;
@@ -40,13 +39,10 @@ impl Harness {
         let run_info_dir = tempfile::tempdir().unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add_value(RunInfoDir::new(run_info_dir.path()))
             .add::<DataFormatRegistryImpl>()
             .add::<QueryServiceImpl>()
-            .add_builder(
-                PushIngestServiceImpl::builder()
-                    .with_run_info_dir(run_info_dir.path().to_path_buf()),
-            )
-            .bind::<dyn PushIngestService, PushIngestServiceImpl>()
+            .add::<PushIngestServiceImpl>()
             .add::<EngineProvisionerNull>()
             .build();
 

--- a/src/adapter/odata/tests/tests/test_handlers.rs
+++ b/src/adapter/odata/tests/tests/test_handlers.rs
@@ -329,12 +329,15 @@ impl TestHarness {
         let cache_dir = temp_dir.path().join("cache");
         let datasets_dir = temp_dir.path().join("datasets");
         std::fs::create_dir(&run_info_dir).unwrap();
-        std::fs::create_dir(cache_dir).unwrap();
+        std::fs::create_dir(&cache_dir).unwrap();
         std::fs::create_dir(&datasets_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add_value(RunInfoDir::new(run_info_dir))
+            .add_value(CacheDir::new(cache_dir))
             .add::<ObjectStoreRegistryImpl>()
             .add::<ObjectStoreBuilderLocalFs>()
+            .add::<DataFormatRegistryImpl>()
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_value(CurrentAccountSubject::new_test())
@@ -351,15 +354,7 @@ impl TestHarness {
             ))
             .bind::<dyn SystemTimeSource, SystemTimeSourceStub>()
             .add::<EngineProvisionerNull>()
-            .add_builder(
-                PushIngestServiceImpl::builder()
-                    .with_object_store_registry(Arc::new(ObjectStoreRegistryImpl::new(vec![
-                        Arc::new(ObjectStoreBuilderLocalFs::new()),
-                    ])))
-                    .with_data_format_registry(Arc::new(DataFormatRegistryImpl::new()))
-                    .with_run_info_dir(run_info_dir),
-            )
-            .bind::<dyn PushIngestService, PushIngestServiceImpl>()
+            .add::<PushIngestServiceImpl>()
             .add::<QueryServiceImpl>()
             .add_value(ServerUrlConfig::new_test(None))
             .build();

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -18,7 +18,7 @@ use kamu::domain::*;
 use kamu::*;
 use kamu_accounts::*;
 use kamu_accounts_services::PredefinedAccountsRegistrator;
-use kamu_adapter_http::{FileUploadLimitConfig, UploadService, UploadServiceLocal};
+use kamu_adapter_http::{FileUploadLimitConfig, UploadServiceLocal};
 use kamu_adapter_oauth::GithubAuthenticationConfig;
 
 use crate::accounts::AccountService;
@@ -245,6 +245,9 @@ pub fn configure_base_catalog(
     let mut b = CatalogBuilder::new();
 
     b.add_value(workspace_layout.clone());
+    b.add_value(RunInfoDir::new(&workspace_layout.run_info_dir));
+    b.add_value(CacheDir::new(&workspace_layout.cache_dir));
+    b.add_value(RemoteReposDir::new(&workspace_layout.repos_dir));
 
     b.add::<ContainerRuntime>();
 
@@ -268,10 +271,7 @@ pub fn configure_base_catalog(
 
     b.add::<DatasetChangesServiceImpl>();
 
-    b.add_builder(
-        RemoteRepositoryRegistryImpl::builder().with_repos_dir(workspace_layout.repos_dir.clone()),
-    );
-    b.bind::<dyn RemoteRepositoryRegistry, RemoteRepositoryRegistryImpl>();
+    b.add::<RemoteRepositoryRegistryImpl>();
 
     b.add::<RemoteAliasesRegistryImpl>();
 
@@ -279,28 +279,17 @@ pub fn configure_base_catalog(
 
     b.add::<DataFormatRegistryImpl>();
 
-    b.add_builder(FetchService::builder().with_run_info_dir(workspace_layout.run_info_dir.clone()));
+    b.add::<FetchService>();
 
-    b.add_builder(
-        PollingIngestServiceImpl::builder()
-            .with_run_info_dir(workspace_layout.run_info_dir.clone())
-            .with_cache_dir(workspace_layout.cache_dir.clone()),
-    );
-    b.bind::<dyn PollingIngestService, PollingIngestServiceImpl>();
+    b.add::<PollingIngestServiceImpl>();
 
-    b.add_builder(
-        PushIngestServiceImpl::builder().with_run_info_dir(workspace_layout.run_info_dir.clone()),
-    );
-    b.bind::<dyn PushIngestService, PushIngestServiceImpl>();
+    b.add::<PushIngestServiceImpl>();
 
     b.add::<TransformServiceImpl>();
 
     b.add::<VerificationServiceImpl>();
 
-    b.add_builder(
-        CompactingServiceImpl::builder().with_run_info_dir(workspace_layout.run_info_dir.clone()),
-    );
-    b.bind::<dyn CompactingService, CompactingServiceImpl>();
+    b.add::<CompactingServiceImpl>();
 
     b.add::<SearchServiceImpl>();
 
@@ -320,10 +309,7 @@ pub fn configure_base_catalog(
 
     b.add::<ObjectStoreBuilderLocalFs>();
 
-    b.add_builder(
-        EngineProvisionerLocal::builder().with_run_info_dir(workspace_layout.run_info_dir.clone()),
-    );
-    b.bind::<dyn EngineProvisioner, EngineProvisionerLocal>();
+    b.add::<EngineProvisionerLocal>();
 
     b.add::<kamu_adapter_http::SmartTransferProtocolClientWs>();
 
@@ -365,8 +351,7 @@ pub fn configure_base_catalog(
     b.add::<kamu_adapter_auth_oso::KamuAuthOso>();
     b.add::<kamu_adapter_auth_oso::OsoDatasetAuthorizer>();
 
-    b.add_builder(UploadServiceLocal::builder().with_cache_dir(workspace_layout.cache_dir.clone()));
-    b.bind::<dyn UploadService, UploadServiceLocal>();
+    b.add::<UploadServiceLocal>();
 
     b.add::<DatabaseTransactionRunner>();
 

--- a/src/domain/core/src/lib.rs
+++ b/src/domain/core/src/lib.rs
@@ -22,4 +22,5 @@ pub mod utils;
 pub use entities::{SetRefError, *};
 pub use repos::{DatasetNotFoundError, *};
 pub use services::*;
+pub use utils::paths::*;
 pub use utils::time_source::*;

--- a/src/domain/core/src/utils/mod.rs
+++ b/src/domain/core/src/utils/mod.rs
@@ -9,4 +9,5 @@
 
 pub mod metadata_chain_comparator;
 pub mod owned_file;
+pub mod paths;
 pub mod time_source;

--- a/src/domain/core/src/utils/paths.rs
+++ b/src/domain/core/src/utils/paths.rs
@@ -1,0 +1,81 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+/// Newtype path wrapper that designates a directory meant for transient data
+/// that can be frequently cleaned up. This directory is suitable for writing
+/// operation logs or creating temporary files to pass some state to
+/// subprocesses. In case of a local workspace it is guaranteed to be on the
+/// same file system as data, thus allowing atomic move operations into the
+/// workspace.
+///
+/// TODO: This type should be replaced by a service
+pub struct RunInfoDir(PathBuf);
+
+impl RunInfoDir {
+    pub fn new(inner: impl Into<PathBuf>) -> Self {
+        Self(inner.into())
+    }
+    pub fn inner(&self) -> &PathBuf {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> PathBuf {
+        self.0
+    }
+}
+
+impl AsRef<Path> for RunInfoDir {
+    fn as_ref(&self) -> &Path {
+        self.0.as_path()
+    }
+}
+
+impl Deref for RunInfoDir {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Newtype path wrapper that designates a directory meant for data that should
+/// be persisted for some unspecified time but can be safely clieaned up.
+///
+/// TODO: This type should be replaced by a service
+pub struct CacheDir(PathBuf);
+
+impl CacheDir {
+    pub fn new(inner: impl Into<PathBuf>) -> Self {
+        Self(inner.into())
+    }
+    pub fn inner(&self) -> &PathBuf {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> PathBuf {
+        self.0
+    }
+}
+
+impl AsRef<Path> for CacheDir {
+    fn as_ref(&self) -> &Path {
+        self.0.as_path()
+    }
+}
+
+impl Deref for CacheDir {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/infra/core/src/compacting_service_impl.rs
+++ b/src/infra/core/src/compacting_service_impl.rs
@@ -54,7 +54,7 @@ pub struct CompactingServiceImpl {
     dataset_authorizer: Arc<dyn domain::auth::DatasetActionAuthorizer>,
     object_store_registry: Arc<dyn ObjectStoreRegistry>,
     time_source: Arc<dyn SystemTimeSource>,
-    run_info_dir: PathBuf,
+    run_info_dir: Arc<RunInfoDir>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -105,7 +105,7 @@ impl CompactingServiceImpl {
         dataset_repo: Arc<dyn DatasetRepository>,
         object_store_registry: Arc<dyn ObjectStoreRegistry>,
         time_source: Arc<dyn SystemTimeSource>,
-        run_info_dir: PathBuf,
+        run_info_dir: Arc<RunInfoDir>,
     ) -> Self {
         Self {
             dataset_repo,

--- a/src/infra/core/src/engine/engine_odf.rs
+++ b/src/infra/core/src/engine/engine_odf.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 
@@ -28,7 +28,7 @@ pub struct ODFEngine {
     container_runtime: Arc<ContainerRuntime>,
     engine_config: ODFEngineConfig,
     image: String,
-    run_info_dir: Arc<Path>,
+    run_info_dir: Arc<RunInfoDir>,
     dataset_repo: Arc<dyn DatasetRepository>,
 }
 
@@ -37,7 +37,7 @@ impl ODFEngine {
         container_runtime: Arc<ContainerRuntime>,
         engine_config: ODFEngineConfig,
         image: &str,
-        run_info_dir: Arc<Path>,
+        run_info_dir: Arc<RunInfoDir>,
         dataset_repo: Arc<dyn DatasetRepository>,
     ) -> Self {
         Self {

--- a/src/infra/core/src/engine/engine_provisioner_local.rs
+++ b/src/infra/core/src/engine/engine_provisioner_local.rs
@@ -8,12 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use container_runtime::*;
-use dill::*;
 use kamu_core::engine::*;
 use kamu_core::*;
 
@@ -43,22 +41,20 @@ struct State {
     known_images: HashSet<String>,
 }
 
-#[component(pub)]
+#[dill::component(pub)]
+#[dill::interface(dyn EngineProvisioner)]
 impl EngineProvisionerLocal {
     #[allow(clippy::needless_pass_by_value)]
     pub fn new(
         config: EngineProvisionerLocalConfig,
         container_runtime: Arc<ContainerRuntime>,
         dataset_repo: Arc<dyn DatasetRepository>,
-        run_info_dir: PathBuf,
+        run_info_dir: Arc<RunInfoDir>,
     ) -> Self {
         let engine_config = ODFEngineConfig {
             start_timeout: config.start_timeout,
             shutdown_timeout: config.shutdown_timeout,
         };
-
-        // TODO: Eliminate
-        let run_info_dir: Arc<std::path::Path> = Arc::from(run_info_dir.as_path());
 
         Self {
             spark_engine: Arc::new(ODFEngine::new(
@@ -265,8 +261,8 @@ impl Default for EngineProvisionerLocalConfig {
 // Null Object
 /////////////////////////////////////////////////////////////////////////////////////////
 
-#[component(pub)]
-#[interface(dyn EngineProvisioner)]
+#[dill::component(pub)]
+#[dill::interface(dyn EngineProvisioner)]
 pub struct EngineProvisionerNull;
 
 #[async_trait::async_trait]

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -108,10 +108,10 @@ pub struct EthRpcEndpoint {
 
 pub struct FetchService {
     container_runtime: Arc<ContainerRuntime>,
-    run_info_dir: PathBuf,
     source_config: Arc<SourceConfig>,
     mqtt_source_config: Arc<MqttSourceConfig>,
     eth_source_config: Arc<EthereumSourceConfig>,
+    run_info_dir: Arc<RunInfoDir>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -121,17 +121,17 @@ pub struct FetchService {
 impl FetchService {
     pub fn new(
         container_runtime: Arc<ContainerRuntime>,
-        run_info_dir: PathBuf,
         source_config: Option<Arc<SourceConfig>>,
         mqtt_source_config: Option<Arc<MqttSourceConfig>>,
         eth_source_config: Option<Arc<EthereumSourceConfig>>,
+        run_info_dir: Arc<RunInfoDir>,
     ) -> Self {
         Self {
             container_runtime,
-            run_info_dir,
             source_config: source_config.unwrap_or_default(),
             mqtt_source_config: mqtt_source_config.unwrap_or_default(),
             eth_source_config: eth_source_config.unwrap_or_default(),
+            run_info_dir,
         }
     }
 

--- a/src/infra/core/src/ingest/push_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/push_ingest_service_impl.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use datafusion::prelude::{DataFrame, SessionContext};
-use dill::*;
 use kamu_core::ingest::*;
 use kamu_core::*;
 use kamu_ingest_datafusion::*;
@@ -29,32 +28,33 @@ pub struct PushIngestServiceImpl {
     dataset_action_authorizer: Arc<dyn auth::DatasetActionAuthorizer>,
     object_store_registry: Arc<dyn ObjectStoreRegistry>,
     data_format_registry: Arc<dyn DataFormatRegistry>,
-    run_info_dir: PathBuf,
     time_source: Arc<dyn SystemTimeSource>,
     engine_provisioner: Arc<dyn EngineProvisioner>,
+    run_info_dir: Arc<RunInfoDir>,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#[component(pub)]
+#[dill::component(pub)]
+#[dill::interface(dyn PushIngestService)]
 impl PushIngestServiceImpl {
     pub fn new(
         dataset_repo: Arc<dyn DatasetRepository>,
         dataset_action_authorizer: Arc<dyn auth::DatasetActionAuthorizer>,
         object_store_registry: Arc<dyn ObjectStoreRegistry>,
         data_format_registry: Arc<dyn DataFormatRegistry>,
-        run_info_dir: PathBuf,
         time_source: Arc<dyn SystemTimeSource>,
         engine_provisioner: Arc<dyn EngineProvisioner>,
+        run_info_dir: Arc<RunInfoDir>,
     ) -> Self {
         Self {
             dataset_repo,
             dataset_action_authorizer,
             object_store_registry,
             data_format_registry,
-            run_info_dir,
             time_source,
             engine_provisioner,
+            run_info_dir,
         }
     }
 

--- a/src/infra/core/tests/benches/parallel_simple_transfer_protocol.rs
+++ b/src/infra/core/tests/benches/parallel_simple_transfer_protocol.rs
@@ -28,6 +28,7 @@ use kamu::{
     DatasetRepositoryLocalFs,
     DependencyGraphServiceInMemory,
     IpfsGateway,
+    RemoteReposDir,
     RemoteRepositoryRegistryImpl,
     SyncServiceImpl,
 };
@@ -59,10 +60,8 @@ async fn setup_dataset(
                 .with_multi_tenant(false),
         )
         .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
-        .add_builder(
-            RemoteRepositoryRegistryImpl::builder().with_repos_dir(tmp_workspace_dir.join("repos")),
-        )
-        .bind::<dyn RemoteRepositoryRegistry, RemoteRepositoryRegistryImpl>()
+        .add_value(RemoteReposDir::new(tmp_workspace_dir.join("repos")))
+        .add::<RemoteRepositoryRegistryImpl>()
         .add::<auth::DummyOdfServerAccessTokenResolver>()
         .add::<DatasetFactoryImpl>()
         .add::<SyncServiceImpl>()

--- a/src/infra/core/tests/tests/engine/test_engine_io.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_io.rs
@@ -28,11 +28,14 @@ async fn test_engine_io_common(
     cache_dir: &Path,
     transform: Transform,
 ) {
+    let run_info_dir = Arc::new(RunInfoDir::new(run_info_dir.to_path_buf()));
+    let cache_dir = Arc::new(CacheDir::new(cache_dir.to_path_buf()));
+
     let engine_provisioner = Arc::new(EngineProvisionerLocal::new(
         EngineProvisionerLocalConfig::default(),
         Arc::new(ContainerRuntime::default()),
         dataset_repo.clone(),
-        run_info_dir.to_path_buf(),
+        run_info_dir.clone(),
     ));
 
     let dataset_action_authorizer = Arc::new(auth::AlwaysHappyDatasetActionAuthorizer::new());
@@ -44,16 +47,16 @@ async fn test_engine_io_common(
         dataset_action_authorizer.clone(),
         Arc::new(FetchService::new(
             Arc::new(ContainerRuntime::default()),
-            run_info_dir.to_path_buf(),
             None,
             None,
             None,
+            run_info_dir.clone(),
         )),
         engine_provisioner.clone(),
         object_store_registry.clone(),
         Arc::new(DataFormatRegistryImpl::new()),
-        run_info_dir.to_path_buf(),
-        cache_dir.to_path_buf(),
+        run_info_dir.clone(),
+        cache_dir,
         time_source.clone(),
     );
 
@@ -67,7 +70,7 @@ async fn test_engine_io_common(
             dataset_repo.clone(),
             object_store_registry.clone(),
             time_source.clone(),
-            run_info_dir.to_path_buf(),
+            run_info_dir.clone(),
         )),
     );
 

--- a/src/infra/core/tests/tests/engine/test_engine_transform.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_transform.rs
@@ -221,6 +221,8 @@ async fn test_transform_common(transform: Transform, test_retractions: bool) {
 
     let catalog = dill::CatalogBuilder::new()
         .add_value(ContainerRuntimeConfig::default())
+        .add_value(RunInfoDir::new(run_info_dir))
+        .add_value(CacheDir::new(cache_dir))
         .add::<ContainerRuntime>()
         .add::<EventBus>()
         .add::<kamu_core::auth::AlwaysHappyDatasetActionAuthorizer>()
@@ -232,27 +234,17 @@ async fn test_transform_common(transform: Transform, test_retractions: bool) {
                 .with_multi_tenant(false),
         )
         .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
-        .add_builder(
-            EngineProvisionerLocal::builder()
-                .with_config(EngineProvisionerLocalConfig::default())
-                .with_run_info_dir(run_info_dir.clone()),
-        )
-        .bind::<dyn EngineProvisioner, EngineProvisionerLocal>()
+        .add_value(EngineProvisionerLocalConfig::default())
+        .add::<EngineProvisionerLocal>()
         .add_value(ObjectStoreRegistryImpl::new(vec![Arc::new(
             ObjectStoreBuilderLocalFs::new(),
         )]))
         .bind::<dyn ObjectStoreRegistry, ObjectStoreRegistryImpl>()
         .add::<DataFormatRegistryImpl>()
-        .add_builder(FetchService::builder().with_run_info_dir(run_info_dir.clone()))
-        .add_builder(
-            PollingIngestServiceImpl::builder()
-                .with_cache_dir(cache_dir)
-                .with_run_info_dir(run_info_dir.clone()),
-        )
-        .bind::<dyn PollingIngestService, PollingIngestServiceImpl>()
+        .add::<FetchService>()
+        .add::<PollingIngestServiceImpl>()
         .add::<TransformServiceImpl>()
-        .add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir))
-        .bind::<dyn CompactingService, CompactingServiceImpl>()
+        .add::<CompactingServiceImpl>()
         .add_value(SystemTimeSourceStub::new_set(
             Utc.with_ymd_and_hms(2050, 1, 1, 12, 0, 0).unwrap(),
         ))

--- a/src/infra/core/tests/tests/ingest/test_fetch.rs
+++ b/src/infra/core/tests/tests/ingest/test_fetch.rs
@@ -1228,10 +1228,10 @@ impl FetchTestHarness {
 
         let fetch_svc = FetchService::new(
             Arc::new(ContainerRuntime::default()),
-            temp_dir.path().join("run"),
             None,
             None,
             None,
+            Arc::new(RunInfoDir::new(temp_dir.path().join("run"))),
         );
 
         Self {

--- a/src/infra/core/tests/tests/test_compact_service_impl.rs
+++ b/src/infra/core/tests/tests/test_compact_service_impl.rs
@@ -1080,6 +1080,7 @@ impl CompactTestHarness {
         let current_date_time = Utc.with_ymd_and_hms(2050, 1, 1, 12, 0, 0).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add_value(RunInfoDir::new(run_info_dir))
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_value(CurrentAccountSubject::new_test())
@@ -1094,17 +1095,9 @@ impl CompactTestHarness {
             .bind::<dyn SystemTimeSource, SystemTimeSourceStub>()
             .add::<ObjectStoreRegistryImpl>()
             .add::<ObjectStoreBuilderLocalFs>()
-            .add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir.clone()))
-            .bind::<dyn CompactingService, CompactingServiceImpl>()
-            .add_builder(
-                PushIngestServiceImpl::builder()
-                    .with_object_store_registry(Arc::new(ObjectStoreRegistryImpl::new(vec![
-                        Arc::new(ObjectStoreBuilderLocalFs::new()),
-                    ])))
-                    .with_data_format_registry(Arc::new(DataFormatRegistryImpl::new()))
-                    .with_run_info_dir(run_info_dir),
-            )
-            .bind::<dyn PushIngestService, PushIngestServiceImpl>()
+            .add::<DataFormatRegistryImpl>()
+            .add::<CompactingServiceImpl>()
+            .add::<PushIngestServiceImpl>()
             .add_value(
                 mock_engine_provisioner::MockEngineProvisioner::new().stub_provision_engine(),
             )
@@ -1133,12 +1126,13 @@ impl CompactTestHarness {
 
     async fn new_s3(s3: &LocalS3Server) -> Self {
         let temp_dir = tempfile::tempdir().unwrap();
-        let run_info_dir = temp_dir.path().join("run");
+        let run_info_dir = Arc::new(RunInfoDir::new(temp_dir.path().join("run")));
         let (endpoint, bucket, key_prefix) = S3Context::split_url(&s3.url);
         let s3_context = S3Context::from_items(endpoint.clone(), bucket, key_prefix).await;
         let current_date_time = Utc.with_ymd_and_hms(2050, 1, 1, 12, 0, 0).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add_builder(run_info_dir.clone())
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_builder(
@@ -1158,38 +1152,21 @@ impl CompactTestHarness {
             .add_value(TestTransformService::new(Arc::new(Mutex::new(Vec::new()))))
             .bind::<dyn TransformService, TestTransformService>()
             .add::<VerificationServiceImpl>()
+            .add::<PushIngestServiceImpl>()
+            .add::<DataFormatRegistryImpl>()
+            .add::<CompactingServiceImpl>()
             .add_value(CurrentAccountSubject::new_test())
             .build();
 
-        let dataset_repo = catalog.get_one::<dyn DatasetRepository>().unwrap();
-        let object_store_registry = catalog.get_one::<dyn ObjectStoreRegistry>().unwrap();
-        let compacting_svc = CompactingServiceImpl::new(
-            catalog.get_one().unwrap(),
-            dataset_repo.clone(),
-            object_store_registry.clone(),
-            catalog.get_one().unwrap(),
-            run_info_dir.clone(),
-        );
-        let push_ingest_svc = PushIngestServiceImpl::new(
-            dataset_repo.clone(),
-            catalog.get_one().unwrap(),
-            object_store_registry.clone(),
-            Arc::new(DataFormatRegistryImpl::new()),
-            run_info_dir,
-            catalog.get_one().unwrap(),
-            catalog.get_one().unwrap(),
-        );
-        let verification_svc = catalog.get_one::<dyn VerificationService>().unwrap();
-        let transform_svc = catalog.get_one::<dyn TransformService>().unwrap();
-        let ctx = new_session_context(object_store_registry);
+        let ctx = new_session_context(catalog.get_one().unwrap());
 
         Self {
             _temp_dir: temp_dir,
-            dataset_repo,
-            compacting_svc: Arc::new(compacting_svc),
-            push_ingest_svc: Arc::new(push_ingest_svc),
-            verification_svc,
-            transform_svc,
+            dataset_repo: catalog.get_one().unwrap(),
+            compacting_svc: catalog.get_one().unwrap(),
+            push_ingest_svc: catalog.get_one().unwrap(),
+            verification_svc: catalog.get_one().unwrap(),
+            transform_svc: catalog.get_one().unwrap(),
             current_date_time,
             ctx,
         }

--- a/src/infra/core/tests/tests/test_sync_service_impl.rs
+++ b/src/infra/core/tests/tests/test_sync_service_impl.rs
@@ -106,10 +106,8 @@ async fn do_test_sync(
                 .with_multi_tenant(false),
         )
         .bind::<dyn DatasetRepository, DatasetRepositoryLocalFs>()
-        .add_builder(
-            RemoteRepositoryRegistryImpl::builder().with_repos_dir(tmp_workspace_dir.join("repos")),
-        )
-        .bind::<dyn RemoteRepositoryRegistry, RemoteRepositoryRegistryImpl>()
+        .add_value(RemoteReposDir::new(tmp_workspace_dir.join("repos")))
+        .add::<RemoteRepositoryRegistryImpl>()
         .add::<auth::DummyOdfServerAccessTokenResolver>()
         .add::<DatasetFactoryImpl>()
         .add::<SyncServiceImpl>()

--- a/src/infra/core/tests/tests/test_transform_service_impl.rs
+++ b/src/infra/core/tests/tests/test_transform_service_impl.rs
@@ -50,6 +50,7 @@ impl TransformTestHarness {
         std::fs::create_dir(&run_info_dir).unwrap();
 
         let catalog = dill::CatalogBuilder::new()
+            .add_value(RunInfoDir::new(run_info_dir))
             .add::<EventBus>()
             .add::<DependencyGraphServiceInMemory>()
             .add_value(CurrentAccountSubject::new_test())
@@ -64,16 +65,9 @@ impl TransformTestHarness {
             .add::<SystemTimeSourceDefault>()
             .add::<ObjectStoreRegistryImpl>()
             .add::<ObjectStoreBuilderLocalFs>()
-            .add_builder(CompactingServiceImpl::builder().with_run_info_dir(run_info_dir.clone()))
-            .bind::<dyn CompactingService, CompactingServiceImpl>()
-            .add_builder(
-                PushIngestServiceImpl::builder()
-                    .with_object_store_registry(Arc::new(ObjectStoreRegistryImpl::new(vec![
-                        Arc::new(ObjectStoreBuilderLocalFs::new()),
-                    ])))
-                    .with_data_format_registry(Arc::new(DataFormatRegistryImpl::new()))
-                    .with_run_info_dir(run_info_dir),
-            )
+            .add::<CompactingServiceImpl>()
+            .add::<DataFormatRegistryImpl>()
+            .add::<PushIngestServiceImpl>()
             .bind::<dyn PushIngestService, PushIngestServiceImpl>()
             .add_value(engine_provisioner)
             .bind::<dyn EngineProvisioner, TEngineProvisioner>()
@@ -81,17 +75,12 @@ impl TransformTestHarness {
             .add::<VerificationServiceImpl>()
             .build();
 
-        let dataset_repo = catalog.get_one::<dyn DatasetRepository>().unwrap();
-        let compacting_service = catalog.get_one::<dyn CompactingService>().unwrap();
-        let push_ingest_svc = catalog.get_one::<PushIngestServiceImpl>().unwrap();
-        let transform_service = catalog.get_one::<TransformServiceImpl>().unwrap();
-
         Self {
             _tempdir: tempdir,
-            dataset_repo,
-            transform_service,
-            compacting_service,
-            push_ingest_svc,
+            dataset_repo: catalog.get_one().unwrap(),
+            transform_service: catalog.get_one().unwrap(),
+            compacting_service: catalog.get_one().unwrap(),
+            push_ingest_svc: catalog.get_one().unwrap(),
         }
     }
 


### PR DESCRIPTION
Simplifies dependency injection configuration by wrapping run/cache directories into new types.

This way they don't have to be passed into builders using e.g. `with_run_dir(..)` calls, and thus most types can be added without going through a builder interface, which in its turn avoids the need for binding them to interfaces explicitly.

This removes a ton of boilerplate.