### PR TITLE
Avoid referencing SessionState in KamuTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `<owner/dataset>/tail` REST API endpoint will:
   - return `404 Not Found` on not found datasets
   - return `202 No Content` on empty datasets
-- Temporarily disabled tests for OData
 ### Fixed
 - Stabilized query handling in case of database usage; affected:
   - The `<owner/dataset>/tail` REST API

--- a/src/adapter/graphql/src/queries/data.rs
+++ b/src/adapter/graphql/src/queries/data.rs
@@ -38,26 +38,24 @@ impl DataQueries {
 
         let query_svc = from_catalog::<dyn domain::QueryService>(ctx).unwrap();
 
-        let df_with_ctx = match query_dialect {
+        let df = match query_dialect {
             QueryDialect::SqlDataFusion => {
                 let sql_result = query_svc
                     .sql_statement(&query, domain::QueryOptions::default())
                     .await;
                 match sql_result {
-                    Ok(r) => r.df_with_ctx,
+                    Ok(r) => r.df,
                     Err(e) => return Ok(e.into()),
                 }
             }
             _ => unimplemented!(),
-        };
-        let df = df_with_ctx
-            .df
-            // TODO: Sanity limits
-            .limit(
-                usize::try_from(skip.unwrap_or(0)).unwrap(),
-                Some(usize::try_from(limit).unwrap()),
-            )
-            .int_err()?;
+        }
+        // TODO: Sanity limits
+        .limit(
+            usize::try_from(skip.unwrap_or(0)).unwrap(),
+            Some(usize::try_from(limit).unwrap()),
+        )
+        .int_err()?;
 
         let schema = DataSchema::from_data_frame_schema(df.schema(), schema_format)?;
         let record_batches = match df.collect().await {

--- a/src/adapter/graphql/src/queries/datasets/dataset_data.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_data.rs
@@ -89,7 +89,7 @@ impl DatasetData {
                 limit,
             )
             .await;
-        let df_with_ctx = match tail_result {
+        let df = match tail_result {
             Ok(r) => r,
             Err(err) => {
                 return if let QueryError::DatasetSchemaNotAvailable(_) = err {
@@ -101,8 +101,8 @@ impl DatasetData {
             }
         };
 
-        let schema = DataSchema::from_data_frame_schema(df_with_ctx.df.schema(), schema_format)?;
-        let record_batches = match df_with_ctx.df.collect().await {
+        let schema = DataSchema::from_data_frame_schema(df.schema(), schema_format)?;
+        let record_batches = match df.collect().await {
             Ok(rb) => rb,
             Err(e) => return Ok(e.into()),
         };

--- a/src/adapter/http/src/data/query_handler.rs
+++ b/src/adapter/http/src/data/query_handler.rs
@@ -56,7 +56,6 @@ pub async fn dataset_query_handler_post(
 
     // Apply pagination limits
     let df = res
-        .df_with_ctx
         .df
         .limit(
             usize::try_from(body.skip).unwrap(),

--- a/src/adapter/odata/src/context.rs
+++ b/src/adapter/odata/src/context.rs
@@ -214,13 +214,13 @@ impl CollectionContext for ODataCollectionContext {
 
         let query_svc: Arc<dyn QueryService> = self.catalog.get_one().unwrap();
 
-        let df_with_ctx = query_svc
+        let df = query_svc
             .get_data(&self.dataset_handle.as_local_ref())
             .await
             .unwrap();
 
         query.apply(
-            df_with_ctx.df,
+            df,
             &self.addr,
             &vocab.offset_column,
             KEY_COLUMN_ALIAS,

--- a/src/adapter/odata/tests/tests/test_handlers.rs
+++ b/src/adapter/odata/tests/tests/test_handlers.rs
@@ -134,7 +134,6 @@ async fn test_metadata_handler() {
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[test_group::group(engine, datafusion)]
-#[ignore = "Enable after migration of ODataCollectionContext to DataFrameWithContext"]
 #[test_log::test(tokio::test)]
 async fn test_collection_handler() {
     let harness = TestHarness::new();
@@ -231,7 +230,6 @@ async fn test_collection_handler() {
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[test_group::group(engine, datafusion)]
-#[ignore = "Enable after migration of ODataCollectionContext to DataFrameWithContext"]
 #[test_log::test(tokio::test)]
 async fn test_collection_handler_by_id() {
     let harness = TestHarness::new();
@@ -289,7 +287,6 @@ async fn test_collection_handler_by_id() {
 /////////////////////////////////////////////////////////////////////////////////////////
 
 #[test_group::group(engine, datafusion)]
-#[ignore = "Enable after migration of ODataCollectionContext to DataFrameWithContext"]
 #[test_log::test(tokio::test)]
 async fn test_collection_handler_by_id_not_found() {
     let harness = TestHarness::new();

--- a/src/app/cli/src/commands/sql_shell_command.rs
+++ b/src/app/cli/src/commands/sql_shell_command.rs
@@ -119,12 +119,7 @@ impl SqlShellCommand {
             .await
             .map_err(CLIError::failure)?;
 
-        let records = res
-            .df_with_ctx
-            .df
-            .collect()
-            .await
-            .map_err(CLIError::failure)?;
+        let records = res.df.collect().await.map_err(CLIError::failure)?;
 
         let mut writer = self
             .output_config

--- a/src/app/cli/src/commands/tail_command.rs
+++ b/src/app/cli/src/commands/tail_command.rs
@@ -46,17 +46,13 @@ impl TailCommand {
 #[async_trait::async_trait(?Send)]
 impl Command for TailCommand {
     async fn run(&mut self) -> Result<(), CLIError> {
-        let tail_response = self
+        let df = self
             .query_svc
             .tail(&self.dataset_ref, self.skip, self.limit)
             .await
             .map_err(CLIError::failure)?;
 
-        let record_batches = tail_response
-            .df
-            .collect()
-            .await
-            .map_err(CLIError::failure)?;
+        let record_batches = df.collect().await.map_err(CLIError::failure)?;
 
         let mut writer =
             self.output_cfg

--- a/src/infra/core/tests/tests/test_query_service_impl.rs
+++ b/src/infra/core/tests/tests/test_query_service_impl.rs
@@ -347,10 +347,10 @@ async fn test_dataset_tail_common(catalog: dill::Catalog, tempdir: &TempDir) {
 
     // Within last block
     let query_svc = catalog.get_one::<dyn QueryService>().unwrap();
-    let df_with_ctx = query_svc.tail(&dataset_ref, 1, 1).await.unwrap();
+    let df = query_svc.tail(&dataset_ref, 1, 1).await.unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        df_with_ctx.df,
+        df,
         indoc::indoc!(
             r#"
             +--------+------+
@@ -364,10 +364,10 @@ async fn test_dataset_tail_common(catalog: dill::Catalog, tempdir: &TempDir) {
     .await;
 
     // Crosses block boundary
-    let df_with_ctx = query_svc.tail(&dataset_ref, 1, 2).await.unwrap();
+    let df = query_svc.tail(&dataset_ref, 1, 2).await.unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        df_with_ctx.df,
+        df,
         indoc::indoc!(
             r#"
             +--------+------+
@@ -476,7 +476,7 @@ async fn test_dataset_sql_authorized_common(catalog: dill::Catalog, tempdir: &Te
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        res.df_with_ctx.df,
+        res.df,
         indoc::indoc!(
             r#"
             +-------------+
@@ -610,7 +610,7 @@ async fn test_sql_statement_by_alias() {
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        result.df_with_ctx.df,
+        result.df,
         indoc::indoc!(
             r#"
             +-------------+
@@ -750,7 +750,7 @@ async fn test_sql_statement_with_state_simple() {
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        res.df_with_ctx.df,
+        res.df,
         indoc::indoc!(
             r#"
             +-----+-----+
@@ -828,7 +828,7 @@ async fn test_sql_statement_with_state_simple() {
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        res.df_with_ctx.df,
+        res.df,
         indoc::indoc!(
             r#"
             +-----+-----+
@@ -861,7 +861,7 @@ async fn test_sql_statement_with_state_simple() {
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        res.df_with_ctx.df,
+        res.df,
         indoc::indoc!(
             r#"
             +-----+-----+
@@ -1017,7 +1017,7 @@ async fn test_sql_statement_with_state_cte() {
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        res.df_with_ctx.df,
+        res.df,
         indoc::indoc!(
             r#"
             +-----+-----+
@@ -1138,7 +1138,7 @@ async fn test_sql_statement_with_state_cte() {
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        res2.df_with_ctx.df,
+        res2.df,
         indoc::indoc!(
             r#"
             +-----+-----+
@@ -1181,7 +1181,7 @@ async fn test_sql_statement_with_state_cte() {
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        res2.df_with_ctx.df,
+        res2.df,
         indoc::indoc!(
             r#"
             +-----+-----+
@@ -1226,7 +1226,7 @@ async fn test_sql_statement_with_state_cte() {
         .unwrap();
 
     kamu_data_utils::testing::assert_data_eq(
-        res2.df_with_ctx.df,
+        res2.df,
         indoc::indoc!(
             r#"
             +-----+-----+


### PR DESCRIPTION
In this PR:
- We avoid the need for having `SessionState` in `KamuTable`
  - This is possible because `KamuTable` only needs the state to call `resolve_schema()` that may need to infer the schema from files, bun in our case we already know exactly what the schema is
- This in turn avoids the need to have a strong reference for `SessionContext` somewhere and thus the need for `DataFrameWithContext` struct, so all `QueryService` API changes can be reverted