### PR TITLE
Fixed support of  ingestion via file upload in `kamu ui` mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,6 @@ KAMU_AUTH_GITHUB_CLIENT_SECRET=
 # Values: docker | podman
 KAMU_CONTAINER_RUNTIME_TYPE=
 
-# URLs generation
-KAMU_BASE_URL_PLATFORM=
-KAMU_BASE_URL_REST=
-KAMU_BASE_URL_FLIGHTSQL=
-
 # Override the path to the workspace
 KAMU_WORKSPACE=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.188.3] - 2024-06-24
+### Fixed
+- Fixed support of  ingestion via file upload in `kamu ui` mode 
+  and `kamu system api-server` mode with custom HTTP port
+- Fixed launching `kamu ui` mode (related to transactions management)
+
 ## [0.188.2] - 2024-06-20
 ### Added
 - Added an E2E test group for REST API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,12 +110,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2feb5f466b3a786d5a622d8926418bc6a0d38bf632909f6ee9298a4a1d8c6e0"
+checksum = "04e9a1892803b02f53e25bea3e414ddd0501f12d97456c9d5ade4edf88f9516f"
 dependencies = [
  "num_enum",
- "strum 0.26.2",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -336,7 +336,7 @@ checksum = "8037e03c7f462a063f28daec9fda285a9a89da003c552f8637a80b9c8fd96241"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -442,7 +442,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -460,7 +460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.66",
+ "syn 2.0.68",
  "syn-solidity",
 ]
 
@@ -1136,7 +1136,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.25.0",
- "syn 2.0.66",
+ "syn 2.0.68",
  "thiserror",
 ]
 
@@ -1172,7 +1172,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1242,7 +1242,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1656,7 +1656,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -2011,9 +2011,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 dependencies = [
  "jobserver",
  "libc",
@@ -2145,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.5"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2020fa13af48afc65a9a87335bda648309ab3d154cd03c7ff95b378c7ed39c4"
+checksum = "fbca90c87c2a04da41e95d1856e8bcd22f159bdbfa147314d2ce5218057b0e58"
 dependencies = [
  "clap",
 ]
@@ -2161,7 +2161,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2203,7 +2203,7 @@ version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width",
 ]
@@ -2274,7 +2274,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "container-runtime"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2608,7 +2608,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2638,7 +2638,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2649,7 +2649,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2673,7 +2673,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2824,7 +2824,7 @@ dependencies = [
  "paste",
  "serde_json",
  "sqlparser",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros 0.26.4",
 ]
 
@@ -3035,7 +3035,7 @@ dependencies = [
  "log",
  "regex",
  "sqlparser",
- "strum 0.26.2",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -3092,15 +3092,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3138,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "dill"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8465cf5d6f0f0389d5b2e26f5b9f88d826ced639db09093abbd9b5f957566a4"
+checksum = "c3a18eaae0c1d3dc669fa6388383dfce0420742a916950cbef6d090d13cb52a0"
 dependencies = [
  "dill-impl",
  "multimap",
@@ -3149,13 +3149,13 @@ dependencies = [
 
 [[package]]
 name = "dill-impl"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0f263fd9b684a66c34bea8aa1e814f82f451d9101078ed465193708da174c4"
+checksum = "5f2abd05d581140fcd1e4256e5c4006273515b00696ba11a883f11c7b3dc52fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3218,17 +3218,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -3408,12 +3397,12 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "enum-variants"
-version = "0.188.2"
+version = "0.188.3"
 
 [[package]]
 name = "env_filter"
@@ -3475,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "event-bus"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "dill",
@@ -3496,7 +3485,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-sourcing"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3511,10 +3500,10 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3647,7 +3636,7 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -3750,7 +3739,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4131,9 +4120,9 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -4218,18 +4207,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.3.1",
  "hyper-util",
- "rustls 0.22.4",
+ "rustls 0.23.10",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tower-service",
 ]
 
@@ -4289,124 +4279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4424,14 +4296,12 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -4564,7 +4434,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "thiserror",
 ]
@@ -4721,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -4804,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "base32",
@@ -4828,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4846,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4866,7 +4736,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4886,7 +4756,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "argon2",
  "chrono",
@@ -4901,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -4927,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4947,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "dill",
@@ -4967,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4990,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5035,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5088,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5108,7 +4978,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "axum",
  "chrono",
@@ -5138,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "arrow-flight",
  "assert_cmd",
@@ -5237,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "indoc 2.0.5",
  "internal-error",
@@ -5255,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-inmem"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5268,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5282,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "chrono",
  "indoc 2.0.5",
@@ -5295,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5309,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-wrapper"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "chrono",
  "datafusion",
@@ -5326,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5354,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -5379,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5401,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5426,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5453,7 +5323,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5476,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "chrono",
  "dill",
@@ -5487,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5525,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5548,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5585,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "chrono",
  "clap",
@@ -5598,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5613,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5628,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5650,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "chrono",
  "dill",
@@ -5661,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5680,7 +5550,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5748,11 +5618,11 @@ checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -5901,12 +5771,6 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -6060,9 +5924,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -6135,13 +5999,13 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin",
  "version_check",
 ]
 
 [[package]]
 name = "multiformats"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "bs58",
  "digest 0.10.7",
@@ -6376,7 +6240,7 @@ checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6431,7 +6295,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.31.0",
  "rand",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "ring",
  "rustls-pemfile 2.1.2",
  "serde",
@@ -6460,7 +6324,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendatafabric"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "arrow",
  "base64 0.21.7",
@@ -6775,7 +6639,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6873,7 +6737,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7120,18 +6984,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -7167,7 +7031,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7203,6 +7067,53 @@ checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7271,7 +7182,7 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "rand",
 ]
@@ -7411,7 +7322,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -7428,9 +7339,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7441,7 +7352,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
- "hyper-rustls 0.26.0",
+ "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -7450,16 +7361,17 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "quinn",
+ "rustls 0.23.10",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -7511,7 +7423,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -7631,7 +7543,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.66",
+ "syn 2.0.68",
  "walkdir",
 ]
 
@@ -7650,6 +7562,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hex"
@@ -7702,11 +7620,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
@@ -7982,7 +7900,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8054,7 +7972,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8270,12 +8188,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -8331,7 +8243,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8540,12 +8452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8598,9 +8504,9 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros 0.26.4",
 ]
@@ -8628,7 +8534,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8641,14 +8547,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -8663,9 +8569,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8681,7 +8587,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8691,15 +8597,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "synstructure"
-version = "0.13.1"
+name = "sync_wrapper"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -8778,7 +8679,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8800,7 +8701,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8829,7 +8730,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8905,16 +8806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8976,7 +8867,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -9002,11 +8893,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "tokio",
 ]
@@ -9225,7 +9116,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -9280,7 +9171,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.188.2"
+version = "0.188.3"
 dependencies = [
  "conv",
  "serde",
@@ -9500,12 +9391,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.0",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]
@@ -9523,18 +9414,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9542,9 +9421,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "3ea73390fe27785838dcbf75b91b1d84799e28f1ce71e6f372a5dc2200c80de5"
 dependencies = [
  "getrandom",
 ]
@@ -9649,7 +9528,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -9683,7 +9562,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10041,18 +9920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10113,30 +9980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10153,28 +9996,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -10194,29 +10016,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,66 +68,66 @@ resolver = "2"
 [workspace.dependencies]
 
 # Utils
-container-runtime = { version = "0.188.2", path = "src/utils/container-runtime", default-features = false }
-database-common = { version = "0.188.2", path = "src/utils/database-common", default-features = false }
-enum-variants = { version = "0.188.2", path = "src/utils/enum-variants", default-features = false }
-event-bus = { version = "0.188.2", path = "src/utils/event-bus", default-features = false }
-event-sourcing = { version = "0.188.2", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.188.2", path = "src/utils/event-sourcing-macros", default-features = false }
-internal-error = { version = "0.188.2", path = "src/utils/internal-error", default-features = false }
-kamu-cli-wrapper = { version = "0.188.2", path = "src/utils/kamu-cli-wrapper", default-features = false }
-kamu-data-utils = { version = "0.188.2", path = "src/utils/data-utils", default-features = false }
-kamu-datafusion-cli = { version = "0.188.2", path = "src/utils/datafusion-cli", default-features = false }
-multiformats = { version = "0.188.2", path = "src/utils/multiformats", default-features = false }
-random-names = { version = "0.188.2", path = "src/utils/random-names", default-features = false }
-tracing-perfetto = { version = "0.188.2", path = "src/utils/tracing-perfetto", default-features = false }
+container-runtime = { version = "0.188.3", path = "src/utils/container-runtime", default-features = false }
+database-common = { version = "0.188.3", path = "src/utils/database-common", default-features = false }
+enum-variants = { version = "0.188.3", path = "src/utils/enum-variants", default-features = false }
+event-bus = { version = "0.188.3", path = "src/utils/event-bus", default-features = false }
+event-sourcing = { version = "0.188.3", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.188.3", path = "src/utils/event-sourcing-macros", default-features = false }
+internal-error = { version = "0.188.3", path = "src/utils/internal-error", default-features = false }
+kamu-cli-wrapper = { version = "0.188.3", path = "src/utils/kamu-cli-wrapper", default-features = false }
+kamu-data-utils = { version = "0.188.3", path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { version = "0.188.3", path = "src/utils/datafusion-cli", default-features = false }
+multiformats = { version = "0.188.3", path = "src/utils/multiformats", default-features = false }
+random-names = { version = "0.188.3", path = "src/utils/random-names", default-features = false }
+tracing-perfetto = { version = "0.188.3", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-opendatafabric = { version = "0.188.2", path = "src/domain/opendatafabric", default-features = false }
-kamu-core = { version = "0.188.2", path = "src/domain/core", default-features = false }
-kamu-accounts = { version = "0.188.2", path = "src/domain/accounts/domain", default-features = false }
-kamu-task-system = { version = "0.188.2", path = "src/domain/task-system/domain", default-features = false }
-kamu-flow-system = { version = "0.188.2", path = "src/domain/flow-system/domain", default-features = false }
+opendatafabric = { version = "0.188.3", path = "src/domain/opendatafabric", default-features = false }
+kamu-core = { version = "0.188.3", path = "src/domain/core", default-features = false }
+kamu-accounts = { version = "0.188.3", path = "src/domain/accounts/domain", default-features = false }
+kamu-task-system = { version = "0.188.3", path = "src/domain/task-system/domain", default-features = false }
+kamu-flow-system = { version = "0.188.3", path = "src/domain/flow-system/domain", default-features = false }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.188.2", path = "src/domain/accounts/services", default-features = false }
-kamu-task-system-services = { version = "0.188.2", path = "src/domain/task-system/services", default-features = false }
-kamu-flow-system-services = { version = "0.188.2", path = "src/domain/flow-system/services", default-features = false }
+kamu-accounts-services = { version = "0.188.3", path = "src/domain/accounts/services", default-features = false }
+kamu-task-system-services = { version = "0.188.3", path = "src/domain/task-system/services", default-features = false }
+kamu-flow-system-services = { version = "0.188.3", path = "src/domain/flow-system/services", default-features = false }
 
 # Infra
-kamu = { version = "0.188.2", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.188.2", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.188.3", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.188.3", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.188.2", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.188.2", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.188.2", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.188.2", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.188.3", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.188.3", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.188.3", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.188.3", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.188.2", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.188.2", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.188.2", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.188.2", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.188.2", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.188.3", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.188.3", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.188.3", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.188.3", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.188.3", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.188.2", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.188.2", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.188.2", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.188.2", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.188.3", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.188.3", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.188.3", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.188.3", path = "src/infra/task-system/repo-tests", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso = { version = "0.188.2", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.188.2", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.188.2", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.188.2", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.188.2", path = "src/adapter/odata", defualt-features = false }
-kamu-adapter-oauth = { version = "0.188.2", path = "src/adapter/oauth", defualt-features = false }
+kamu-adapter-auth-oso = { version = "0.188.3", path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { version = "0.188.3", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.188.3", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.188.3", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.188.3", path = "src/adapter/odata", defualt-features = false }
+kamu-adapter-oauth = { version = "0.188.3", path = "src/adapter/oauth", defualt-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.188.2", path = "src/e2e/app/cli/common", defualt-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.188.2", path = "src/e2e/app/cli/repo-tests", defualt-features = false }
+kamu-cli-e2e-common = { version = "0.188.3", path = "src/e2e/app/cli/common", defualt-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.188.3", path = "src/e2e/app/cli/repo-tests", defualt-features = false }
 
 [workspace.package]
-version = "0.188.2"
+version = "0.188.3"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.188.2
+Licensed Work:             Kamu CLI Version 0.188.3
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,

--- a/src/adapter/http/src/upload/upload_service.rs
+++ b/src/adapter/http/src/upload/upload_service.rs
@@ -113,7 +113,33 @@ pub struct UploadNotSupportedError {}
 
 #[derive(Debug)]
 pub struct FileUploadLimitConfig {
-    pub max_file_size_in_bytes: usize,
+    max_file_size_in_bytes: usize,
+}
+
+impl FileUploadLimitConfig {
+    #[inline]
+    pub fn new_in_bytes(max_file_size_in_bytes: usize) -> Self {
+        Self {
+            max_file_size_in_bytes,
+        }
+    }
+
+    #[inline]
+    pub fn new_in_mb(max_file_size_in_mb: usize) -> Self {
+        Self {
+            max_file_size_in_bytes: max_file_size_in_mb * 1024 * 1024,
+        }
+    }
+
+    #[inline]
+    pub fn max_file_size_in_bytes(&self) -> usize {
+        self.max_file_size_in_bytes
+    }
+
+    #[inline]
+    pub fn max_file_size_in_mb(&self) -> usize {
+        self.max_file_size_in_bytes / 1024 / 1024
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/src/upload/upload_service_local.rs
+++ b/src/adapter/http/src/upload/upload_service_local.rs
@@ -86,7 +86,7 @@ impl UploadService for UploadServiceLocal {
         content_type: String,
         content_length: usize,
     ) -> Result<UploadContext, MakeUploadContextError> {
-        if content_length > self.uploads_config.max_file_size_in_bytes {
+        if content_length > self.uploads_config.max_file_size_in_bytes() {
             return Err(MakeUploadContextError::TooLarge(ContentTooLargeError {}));
         }
 
@@ -155,7 +155,7 @@ impl UploadService for UploadServiceLocal {
         content_length: usize,
         file_data: Bytes,
     ) -> Result<(), SaveUploadError> {
-        if content_length > self.uploads_config.max_file_size_in_bytes {
+        if content_length > self.uploads_config.max_file_size_in_bytes() {
             return Err(SaveUploadError::TooLarge(ContentTooLargeError {}));
         }
 

--- a/src/adapter/http/src/upload/upload_service_s3.rs
+++ b/src/adapter/http/src/upload/upload_service_s3.rs
@@ -61,7 +61,7 @@ impl UploadService for UploadServiceS3 {
         content_type: String,
         content_length: usize,
     ) -> Result<UploadContext, MakeUploadContextError> {
-        if content_length > self.upload_config.max_file_size_in_bytes {
+        if content_length > self.upload_config.max_file_size_in_bytes() {
             return Err(MakeUploadContextError::TooLarge(ContentTooLargeError {}));
         }
 

--- a/src/adapter/http/tests/tests/test_data_ingest.rs
+++ b/src/adapter/http/tests/tests/test_data_ingest.rs
@@ -514,9 +514,7 @@ impl DataIngestHarness {
             .add::<PushIngestServiceImpl>()
             .add::<EngineProvisionerNull>()
             .add::<UploadServiceLocal>()
-            .add_value(FileUploadLimitConfig {
-                max_file_size_in_bytes: 1000,
-            })
+            .add_value(FileUploadLimitConfig::new_in_bytes(1000))
             .build();
 
         let server_harness = ServerSideLocalFsHarness::new(ServerSideHarnessOptions {

--- a/src/adapter/http/tests/tests/test_upload_local.rs
+++ b/src/adapter/http/tests/tests/test_upload_local.rs
@@ -70,9 +70,7 @@ impl Harness {
                 .add::<LoginPasswordAuthProvider>()
                 .add_value(JwtAuthenticationConfig::default())
                 .add_value(ServerUrlConfig::new_test(Some(&api_server_address)))
-                .add_value(FileUploadLimitConfig {
-                    max_file_size_in_bytes: 100,
-                })
+                .add_value(FileUploadLimitConfig::new_in_bytes(100))
                 .add::<UploadServiceLocal>()
                 .add::<PredefinedAccountsRegistrator>();
 

--- a/src/adapter/http/tests/tests/test_upload_s3.rs
+++ b/src/adapter/http/tests/tests/test_upload_s3.rs
@@ -67,9 +67,7 @@ impl Harness {
                 .add::<LoginPasswordAuthProvider>()
                 .add_value(JwtAuthenticationConfig::default())
                 .add_value(ServerUrlConfig::new_test(Some(&api_server_address)))
-                .add_value(FileUploadLimitConfig {
-                    max_file_size_in_bytes: 100,
-                })
+                .add_value(FileUploadLimitConfig::new_in_bytes(100))
                 .add_builder(
                     UploadServiceS3::builder().with_s3_upload_context(s3_upload_context.clone()),
                 )

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -131,7 +131,6 @@ pub async fn run(
 
         let cli_catalog = configure_cli_catalog(&base_catalog, is_multi_tenant_workspace)
             .add_value(current_account.to_current_account_subject())
-            .add_value(ServerUrlConfig::load_from_env()?)
             .build();
 
         (guards, base_catalog, cli_catalog, output_config)

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -99,8 +99,6 @@ pub async fn run(
         base_catalog_builder.add_value(JwtAuthenticationConfig::load_from_env());
         base_catalog_builder.add_value(GithubAuthenticationConfig::load_from_env());
 
-        base_catalog_builder.add_value(ServerUrlConfig::load_from_env()?);
-
         if let Some(db_configuration) = maybe_db_configuration.as_ref() {
             configure_database_components(&mut base_catalog_builder, db_configuration)?;
         } else {
@@ -133,6 +131,7 @@ pub async fn run(
 
         let cli_catalog = configure_cli_catalog(&base_catalog, is_multi_tenant_workspace)
             .add_value(current_account.to_current_account_subject())
+            .add_value(ServerUrlConfig::load_from_env()?)
             .build();
 
         (guards, base_catalog, cli_catalog, output_config)
@@ -608,9 +607,9 @@ pub fn register_config_in_catalog(
     }
 
     let uploads_config = config.uploads.as_ref().unwrap();
-    catalog_builder.add_value(FileUploadLimitConfig {
-        max_file_size_in_bytes: uploads_config.max_file_size_in_mb.unwrap() * 1024 * 1024,
-    });
+    catalog_builder.add_value(FileUploadLimitConfig::new_in_mb(
+        uploads_config.max_file_size_in_mb.unwrap(),
+    ));
 }
 
 fn try_convert_into_db_configuration(config: DatabaseConfig) -> Option<DatabaseConfiguration> {

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -554,6 +554,7 @@ pub fn get_command(
                 current_account_name,
                 cli_catalog.get_one()?,
                 cli_catalog.get_one()?,
+                cli_catalog.get_one()?,
                 submatches.get_one("address").copied(),
                 submatches.get_one("http-port").copied(),
                 submatches.get_flag("get-token"),

--- a/src/app/cli/src/commands/system_api_server_run_command.rs
+++ b/src/app/cli/src/commands/system_api_server_run_command.rs
@@ -128,7 +128,7 @@ impl Command for APIServerRunCommand {
         let access_token = self.get_access_token().await?;
 
         let api_server = crate::explore::APIServer::new(
-            self.base_catalog.clone(),
+            &self.base_catalog,
             &self.cli_catalog,
             self.multi_tenant_workspace,
             self.address,

--- a/src/app/cli/src/commands/ui_command.rs
+++ b/src/app/cli/src/commands/ui_command.rs
@@ -18,6 +18,7 @@ use console::style as s;
 use dill::Catalog;
 use internal_error::ResultIntoInternal;
 use kamu_accounts::PredefinedAccountsConfig;
+use kamu_adapter_http::FileUploadLimitConfig;
 use opendatafabric::AccountName;
 
 use super::{CLIError, Command};
@@ -30,6 +31,7 @@ pub struct UICommand {
     multi_tenant_workspace: bool,
     current_account_name: AccountName,
     predefined_accounts_config: Arc<PredefinedAccountsConfig>,
+    file_upload_limit_config: Arc<FileUploadLimitConfig>,
     output_config: Arc<OutputConfig>,
     address: Option<IpAddr>,
     port: Option<u16>,
@@ -42,6 +44,7 @@ impl UICommand {
         multi_tenant_workspace: bool,
         current_account_name: AccountName,
         predefined_accounts_config: Arc<PredefinedAccountsConfig>,
+        file_upload_limit_config: Arc<FileUploadLimitConfig>,
         output_config: Arc<OutputConfig>,
         address: Option<IpAddr>,
         port: Option<u16>,
@@ -52,6 +55,7 @@ impl UICommand {
             multi_tenant_workspace,
             current_account_name,
             predefined_accounts_config,
+            file_upload_limit_config,
             output_config,
             address,
             port,
@@ -69,6 +73,7 @@ impl Command for UICommand {
             self.multi_tenant_workspace,
             self.current_account_name.clone(),
             self.predefined_accounts_config.clone(),
+            self.file_upload_limit_config.clone(),
             self.address,
             self.port,
         )

--- a/src/app/cli/src/explore/api_server.rs
+++ b/src/app/cli/src/explore/api_server.rs
@@ -67,13 +67,14 @@ impl APIServer {
         let api_server_url = Url::parse(&format!("http://{}", bound_addr.local_addr()))
             .expect("URL failed to parse");
 
+        let default_protocols = Protocols::default();
+
         let api_server_catalog = CatalogBuilder::new_chained(base_catalog)
             .add_value(ServerUrlConfig::new(Protocols {
-                base_url_platform: Url::parse("http://localhost:4200").unwrap(),
                 base_url_rest: api_server_url,
-                // Note: this is not a valid endpoint in "kamu system api-server" mode
-                base_url_flightsql: Url::parse("grpc://localhost:50050")
-                    .expect("URL failed to parse"),
+                base_url_platform: default_protocols.base_url_platform,
+                // Note: this is not a valid endpoint in Web UI mode
+                base_url_flightsql: default_protocols.base_url_flightsql,
             }))
             .build();
 

--- a/src/app/cli/src/explore/api_server.rs
+++ b/src/app/cli/src/explore/api_server.rs
@@ -37,7 +37,7 @@ pub struct APIServer {
 
 impl APIServer {
     pub fn new(
-        base_catalog: Catalog,
+        base_catalog: &Catalog,
         cli_catalog: &Catalog,
         multi_tenant_workspace: bool,
         address: Option<IpAddr>,
@@ -61,13 +61,13 @@ impl APIServer {
             port.unwrap_or(0),
         ));
         let bound_addr = hyper::server::conn::AddrIncoming::bind(&addr).unwrap_or_else(|e| {
-            panic!("error binding to {}: {}", addr, e);
+            panic!("error binding to {addr}: {e}");
         });
 
         let api_server_url = Url::parse(&format!("http://{}", bound_addr.local_addr()))
             .expect("URL failed to parse");
 
-        let api_server_catalog = CatalogBuilder::new_chained(&base_catalog)
+        let api_server_catalog = CatalogBuilder::new_chained(base_catalog)
             .add_value(ServerUrlConfig::new(Protocols {
                 base_url_platform: Url::parse("http://localhost:4200").unwrap(),
                 base_url_rest: api_server_url,

--- a/src/app/cli/src/explore/web_ui_server.rs
+++ b/src/app/cli/src/explore/web_ui_server.rs
@@ -12,7 +12,10 @@ use std::sync::Arc;
 
 use axum::http::Uri;
 use axum::response::{IntoResponse, Response};
-use dill::Catalog;
+use database_common::DatabaseTransactionRunner;
+use dill::{Catalog, CatalogBuilder};
+use internal_error::InternalError;
+use kamu::domain::{Protocols, ServerUrlConfig};
 use kamu_accounts::{
     AccountConfig,
     AuthenticationService,
@@ -20,9 +23,11 @@ use kamu_accounts::{
     PROVIDER_PASSWORD,
 };
 use kamu_accounts_services::PasswordLoginCredentials;
+use kamu_adapter_http::FileUploadLimitConfig;
 use opendatafabric::AccountName;
 use rust_embed::RustEmbed;
 use serde::Serialize;
+use url::Url;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
@@ -36,6 +41,8 @@ struct HttpRoot;
 #[serde(rename_all = "camelCase")]
 struct WebUIConfig {
     api_server_gql_url: String,
+    api_server_http_url: String,
+    ingest_upload_file_limit_mb: usize,
     login_instructions: Option<WebUILoginInstructions>,
     feature_flags: WebUIFeatureFlags,
 }
@@ -72,6 +79,7 @@ impl WebUIServer {
         multi_tenant_workspace: bool,
         current_account_name: AccountName,
         predefined_accounts_config: Arc<PredefinedAccountsConfig>,
+        file_upload_limit_config: Arc<FileUploadLimitConfig>,
         address: Option<IpAddr>,
         port: Option<u16>,
     ) -> Self {
@@ -101,19 +109,13 @@ impl WebUIServer {
             login_credentials_json: serde_json::to_string(&login_credentials).unwrap(),
         };
 
-        let auth_svc = base_catalog.get_one::<dyn AuthenticationService>().unwrap();
-        let access_token = auth_svc
-            .login(
-                &login_instructions.login_method,
-                login_instructions.login_credentials_json.clone(),
-            )
-            .await
-            .unwrap()
-            .access_token;
+        let web_ui_url = format!("http://{}", bound_addr.local_addr());
 
         let web_ui_config = WebUIConfig {
             api_server_gql_url: format!("http://{}/graphql", bound_addr.local_addr()),
-            login_instructions: Some(login_instructions),
+            api_server_http_url: web_ui_url.clone(),
+            login_instructions: Some(login_instructions.clone()),
+            ingest_upload_file_limit_mb: file_upload_limit_config.max_file_size_in_mb(),
             feature_flags: WebUIFeatureFlags {
                 // No way to log out, always logging in a predefined user
                 enable_logout: false,
@@ -121,6 +123,22 @@ impl WebUIServer {
                 enable_scheduling: false,
             },
         };
+
+        let access_token = Self::acquire_access_token(base_catalog.clone(), &login_instructions)
+            .await
+            .expect("Token not retreieved");
+
+        let web_ui_url = Url::parse(&web_ui_url).expect("URL failed to parse");
+
+        let web_ui_catalog = CatalogBuilder::new_chained(&base_catalog)
+            .add_value(ServerUrlConfig::new(Protocols {
+                base_url_platform: web_ui_url.clone(),
+                base_url_rest: web_ui_url,
+                // Note: this is not a valid endpoint in Web UI mode
+                base_url_flightsql: Url::parse("grpc://localhost:50050")
+                    .expect("URL failed to parse"),
+            }))
+            .build();
 
         let app = axum::Router::new()
             .route(
@@ -132,6 +150,14 @@ impl WebUIServer {
                 axum::routing::get(graphql_playground_handler).post(graphql_handler),
             )
             .nest("/", kamu_adapter_http::data::root_router())
+            .route(
+                "/platform/file/upload/prepare",
+                axum::routing::post(kamu_adapter_http::platform_file_upload_prepare_post_handler),
+            )
+            .route(
+                "/platform/file/upload/:upload_token",
+                axum::routing::post(kamu_adapter_http::platform_file_upload_post_handler),
+            )
             .nest(
                 "/odata",
                 if multi_tenant_workspace {
@@ -163,7 +189,7 @@ impl WebUIServer {
                             .allow_methods(vec![http::Method::GET, http::Method::POST])
                             .allow_headers(tower_http::cors::Any),
                     )
-                    .layer(axum::extract::Extension(base_catalog))
+                    .layer(axum::extract::Extension(web_ui_catalog))
                     .layer(axum::extract::Extension(gql_schema))
                     .layer(axum::extract::Extension(web_ui_config))
                     .layer(kamu_adapter_http::RunInDatabaseTransactionLayer::new())
@@ -176,6 +202,26 @@ impl WebUIServer {
             server,
             access_token,
         }
+    }
+
+    async fn acquire_access_token(
+        catalog: Catalog,
+        login_instructions: &WebUILoginInstructions,
+    ) -> Result<String, InternalError> {
+        let transaction_runner = DatabaseTransactionRunner::new(catalog);
+
+        transaction_runner
+            .transactional_with(|auth_svc: Arc<dyn AuthenticationService>| async move {
+                Ok(auth_svc
+                    .login(
+                        &login_instructions.login_method,
+                        login_instructions.login_credentials_json.clone(),
+                    )
+                    .await
+                    .unwrap()
+                    .access_token)
+            })
+            .await
     }
 
     pub fn local_addr(&self) -> SocketAddr {
@@ -222,7 +268,7 @@ async fn runtime_config_handler(
 
 async fn graphql_handler(
     schema: axum::extract::Extension<kamu_adapter_graphql::Schema>,
-    catalog: axum::extract::Extension<dill::Catalog>,
+    catalog: axum::extract::Extension<Catalog>,
     req: async_graphql_axum::GraphQLRequest,
 ) -> async_graphql_axum::GraphQLResponse {
     let graphql_request = req.into_inner().data(catalog.0);

--- a/src/app/cli/src/explore/web_ui_server.rs
+++ b/src/app/cli/src/explore/web_ui_server.rs
@@ -89,7 +89,7 @@ impl WebUIServer {
         ));
 
         let bound_addr = hyper::server::conn::AddrIncoming::bind(&addr).unwrap_or_else(|e| {
-            panic!("error binding to {}: {}", addr, e);
+            panic!("error binding to {addr}: {e}");
         });
 
         let account_config = predefined_accounts_config

--- a/src/app/cli/src/explore/web_ui_server.rs
+++ b/src/app/cli/src/explore/web_ui_server.rs
@@ -130,13 +130,14 @@ impl WebUIServer {
 
         let web_ui_url = Url::parse(&web_ui_url).expect("URL failed to parse");
 
+        let default_protocols = Protocols::default();
+
         let web_ui_catalog = CatalogBuilder::new_chained(&base_catalog)
             .add_value(ServerUrlConfig::new(Protocols {
                 base_url_platform: web_ui_url.clone(),
                 base_url_rest: web_ui_url,
                 // Note: this is not a valid endpoint in Web UI mode
-                base_url_flightsql: Url::parse("grpc://localhost:50050")
-                    .expect("URL failed to parse"),
+                base_url_flightsql: default_protocols.base_url_flightsql,
             }))
             .build();
 

--- a/src/domain/core/src/services/server_url_config.rs
+++ b/src/domain/core/src/services/server_url_config.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use internal_error::{InternalError, ResultIntoInternal};
 use url::Url;
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -17,31 +16,6 @@ pub struct ServerUrlConfig {
 }
 
 impl ServerUrlConfig {
-    fn get_url_from_env(env_var: &str, default: &str) -> Result<Url, InternalError> {
-        let raw = std::env::var(env_var).unwrap_or_else(|_| default.to_string());
-
-        Url::parse(&raw).int_err()
-    }
-
-    pub fn load_from_env() -> Result<Self, InternalError> {
-        Ok(Self {
-            protocols: Protocols {
-                base_url_platform: Self::get_url_from_env(
-                    "KAMU_BASE_URL_PLATFORM",
-                    "http://localhost:4200",
-                )?,
-                base_url_rest: Self::get_url_from_env(
-                    "KAMU_BASE_URL_REST",
-                    "http://localhost:8080",
-                )?,
-                base_url_flightsql: Self::get_url_from_env(
-                    "KAMU_BASE_URL_FLIGHTSQL",
-                    "grpc://localhost:50050",
-                )?,
-            },
-        })
-    }
-
     pub fn new(protocols: Protocols) -> Self {
         Self { protocols }
     }
@@ -68,6 +42,16 @@ pub struct Protocols {
 impl Protocols {
     pub fn odata_base_url(&self) -> String {
         format!("{}odata", self.base_url_rest)
+    }
+}
+
+impl Default for Protocols {
+    fn default() -> Self {
+        Self {
+            base_url_platform: Url::parse("http://localhost:4200").expect("URL parse problem"),
+            base_url_rest: Url::parse("http://localhost:8080").expect("URL parse problem"),
+            base_url_flightsql: Url::parse("grpc://localhost:50050").expect("URL parse problem"),
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Fixed support of  ingestion via file upload in `kamu ui` mode + `kamu system api-server` mode with custom HTTP port.
Fixed broken transaction in `kamu ui` mode

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [ ] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅