### PR TITLE
Added the option of overriding the base URL in the API with `--external-address`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.188.5] - 2024-06-26
 ### Added
 - `kamu system api-server`: Added the option of overriding the base URL in the API with `--external-address`. 
   Can be handy when launching inside a container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `kamu system api-server`: Added the option of overriding the base URL in the API with `--external-address`. 
+  Can be handy when launching inside a container
+
 ## [0.188.4] - 2024-06-25
 ### Changed
 - Renamed all places compacting -> compacting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,7 +2274,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "container-runtime"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2673,7 +2673,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.188.4"
+version = "0.188.5"
 
 [[package]]
 name = "env_filter"
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "event-bus"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "dill",
@@ -3496,7 +3496,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-sourcing"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "quote",
  "syn 2.0.68",
@@ -4445,7 +4445,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "thiserror",
 ]
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -4685,7 +4685,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "base32",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4728,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "argon2",
  "chrono",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "argon2",
  "async-trait",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4829,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "dill",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "axum",
  "chrono",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "arrow-flight",
  "assert_cmd",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "indoc 2.0.5",
  "internal-error",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-inmem"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "chrono",
  "indoc 2.0.5",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5327,7 +5327,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "chrono",
  "dill",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5422,7 +5422,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "chrono",
  "clap",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5487,7 +5487,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "chrono",
  "dill",
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6031,7 +6031,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "bs58",
  "digest 0.10.7",
@@ -6350,7 +6350,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendatafabric"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "arrow",
  "base64 0.21.7",
@@ -7208,7 +7208,7 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "rand",
 ]
@@ -9208,7 +9208,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.188.4"
+version = "0.188.5"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,68 +66,68 @@ resolver = "2"
 [workspace.dependencies]
 
 # Apps
-kamu-cli = { version = "0.188.4", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.188.5", path = "src/app/cli", default-features = false }
 
 # Utils
-container-runtime = { version = "0.188.4", path = "src/utils/container-runtime", default-features = false }
-database-common = { version = "0.188.4", path = "src/utils/database-common", default-features = false }
-enum-variants = { version = "0.188.4", path = "src/utils/enum-variants", default-features = false }
-event-bus = { version = "0.188.4", path = "src/utils/event-bus", default-features = false }
-event-sourcing = { version = "0.188.4", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.188.4", path = "src/utils/event-sourcing-macros", default-features = false }
-internal-error = { version = "0.188.4", path = "src/utils/internal-error", default-features = false }
-kamu-data-utils = { version = "0.188.4", path = "src/utils/data-utils", default-features = false }
-kamu-datafusion-cli = { version = "0.188.4", path = "src/utils/datafusion-cli", default-features = false }
-multiformats = { version = "0.188.4", path = "src/utils/multiformats", default-features = false }
-random-names = { version = "0.188.4", path = "src/utils/random-names", default-features = false }
-tracing-perfetto = { version = "0.188.4", path = "src/utils/tracing-perfetto", default-features = false }
+container-runtime = { version = "0.188.5", path = "src/utils/container-runtime", default-features = false }
+database-common = { version = "0.188.5", path = "src/utils/database-common", default-features = false }
+enum-variants = { version = "0.188.5", path = "src/utils/enum-variants", default-features = false }
+event-bus = { version = "0.188.5", path = "src/utils/event-bus", default-features = false }
+event-sourcing = { version = "0.188.5", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.188.5", path = "src/utils/event-sourcing-macros", default-features = false }
+internal-error = { version = "0.188.5", path = "src/utils/internal-error", default-features = false }
+kamu-data-utils = { version = "0.188.5", path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { version = "0.188.5", path = "src/utils/datafusion-cli", default-features = false }
+multiformats = { version = "0.188.5", path = "src/utils/multiformats", default-features = false }
+random-names = { version = "0.188.5", path = "src/utils/random-names", default-features = false }
+tracing-perfetto = { version = "0.188.5", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-opendatafabric = { version = "0.188.4", path = "src/domain/opendatafabric", default-features = false }
-kamu-core = { version = "0.188.4", path = "src/domain/core", default-features = false }
-kamu-accounts = { version = "0.188.4", path = "src/domain/accounts/domain", default-features = false }
-kamu-task-system = { version = "0.188.4", path = "src/domain/task-system/domain", default-features = false }
-kamu-flow-system = { version = "0.188.4", path = "src/domain/flow-system/domain", default-features = false }
+opendatafabric = { version = "0.188.5", path = "src/domain/opendatafabric", default-features = false }
+kamu-core = { version = "0.188.5", path = "src/domain/core", default-features = false }
+kamu-accounts = { version = "0.188.5", path = "src/domain/accounts/domain", default-features = false }
+kamu-task-system = { version = "0.188.5", path = "src/domain/task-system/domain", default-features = false }
+kamu-flow-system = { version = "0.188.5", path = "src/domain/flow-system/domain", default-features = false }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.188.4", path = "src/domain/accounts/services", default-features = false }
-kamu-task-system-services = { version = "0.188.4", path = "src/domain/task-system/services", default-features = false }
-kamu-flow-system-services = { version = "0.188.4", path = "src/domain/flow-system/services", default-features = false }
+kamu-accounts-services = { version = "0.188.5", path = "src/domain/accounts/services", default-features = false }
+kamu-task-system-services = { version = "0.188.5", path = "src/domain/task-system/services", default-features = false }
+kamu-flow-system-services = { version = "0.188.5", path = "src/domain/flow-system/services", default-features = false }
 
 # Infra
-kamu = { version = "0.188.4", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.188.4", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.188.5", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.188.5", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.188.4", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.188.4", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.188.4", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.188.4", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.188.5", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.188.5", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.188.5", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.188.5", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.188.4", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.188.4", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.188.4", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.188.4", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.188.4", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.188.5", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.188.5", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.188.5", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.188.5", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.188.5", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.188.4", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.188.4", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.188.4", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.188.4", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.188.5", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.188.5", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.188.5", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.188.5", path = "src/infra/task-system/repo-tests", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso = { version = "0.188.4", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.188.4", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.188.4", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.188.4", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.188.4", path = "src/adapter/odata", defualt-features = false }
-kamu-adapter-oauth = { version = "0.188.4", path = "src/adapter/oauth", defualt-features = false }
+kamu-adapter-auth-oso = { version = "0.188.5", path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { version = "0.188.5", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.188.5", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.188.5", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.188.5", path = "src/adapter/odata", defualt-features = false }
+kamu-adapter-oauth = { version = "0.188.5", path = "src/adapter/oauth", defualt-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.188.4", path = "src/e2e/app/cli/common", defualt-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.188.4", path = "src/e2e/app/cli/repo-tests", defualt-features = false }
+kamu-cli-e2e-common = { version = "0.188.5", path = "src/e2e/app/cli/common", defualt-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.188.5", path = "src/e2e/app/cli/repo-tests", defualt-features = false }
 
 [workspace.package]
-version = "0.188.4"
+version = "0.188.5"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.188.4
+Licensed Work:             Kamu CLI Version 0.188.5
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -1097,6 +1097,7 @@ Run HTTP + GraphQL server
 * `--address <ADDRESS>` — Bind to a specific network interface
 * `--http-port <HTTP-PORT>` — Expose HTTP+GraphQL server on specific port
 * `--get-token` — Output a JWT token you can use to authorize API queries
+* `--external-address <EXTERNAL-ADDRESS>` — Allows changing the base URL used in the API. Can be handy when launching inside a container
 
 **Examples:**
 

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -463,6 +463,7 @@ pub fn get_command(
                         cli_catalog.get_one()?,
                         server_matches.get_one("address").copied(),
                         server_matches.get_one("http-port").copied(),
+                        server_matches.get_one("external-address").copied(),
                         server_matches.get_flag("get-token"),
                         cli_catalog.get_one()?,
                         cli_catalog.get_one()?,

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -1246,6 +1246,10 @@ pub fn cli() -> Command {
                                     .long("get-token")
                                     .action(ArgAction::SetTrue)
                                     .help("Output a JWT token you can use to authorize API queries"),
+                                Arg::new("external-address")
+                                    .long("external-address")
+                                    .value_parser(value_parser!(IpAddr))
+                                    .help("Allows changing the base URL used in the API. Can be handy when launching inside a container"),
                             ])
                             .after_help(indoc::indoc!(
                                 r#"

--- a/src/app/cli/src/commands/system_api_server_run_command.rs
+++ b/src/app/cli/src/commands/system_api_server_run_command.rs
@@ -30,6 +30,7 @@ pub struct APIServerRunCommand {
     output_config: Arc<OutputConfig>,
     address: Option<IpAddr>,
     port: Option<u16>,
+    external_address: Option<IpAddr>,
     get_token: bool,
     predefined_accounts_config: Arc<PredefinedAccountsConfig>,
     account_subject: Arc<CurrentAccountSubject>,
@@ -45,6 +46,7 @@ impl APIServerRunCommand {
         output_config: Arc<OutputConfig>,
         address: Option<IpAddr>,
         port: Option<u16>,
+        external_address: Option<IpAddr>,
         get_token: bool,
         predefined_accounts_config: Arc<PredefinedAccountsConfig>,
         account_subject: Arc<CurrentAccountSubject>,
@@ -58,6 +60,7 @@ impl APIServerRunCommand {
             output_config,
             address,
             port,
+            external_address,
             get_token,
             predefined_accounts_config,
             account_subject,
@@ -133,6 +136,7 @@ impl Command for APIServerRunCommand {
             self.multi_tenant_workspace,
             self.address,
             self.port,
+            self.external_address,
             self.is_e2e_testing,
         );
 

--- a/src/domain/core/src/services/server_url_config.rs
+++ b/src/domain/core/src/services/server_url_config.rs
@@ -48,9 +48,9 @@ impl Protocols {
 impl Default for Protocols {
     fn default() -> Self {
         Self {
-            base_url_platform: Url::parse("http://localhost:4200").expect("URL parse problem"),
-            base_url_rest: Url::parse("http://localhost:8080").expect("URL parse problem"),
-            base_url_flightsql: Url::parse("grpc://localhost:50050").expect("URL parse problem"),
+            base_url_platform: Url::parse("http://localhost:4200").expect("URL failed to parse"),
+            base_url_rest: Url::parse("http://localhost:8080").expect("URL failed to parse"),
+            base_url_flightsql: Url::parse("grpc://localhost:50050").expect("URL failed to parse"),
         }
     }
 }


### PR DESCRIPTION
## Description

Closes: 
- https://github.com/kamu-data/kamu-cli/issues/686

### Added
- `kamu system api-server`: Added the option of overriding the base URL in the API with `--external-address`. 
  Can be handy when launching inside a container

<!--- Describe your changes in detail and include your changelog entries -->

## Checklist before requesting a review

- [x] Unit and integration tests added, ❌ not needed
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌ not needed
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌ not needed