### PR TITLE
Handle unparsable SQL error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- GQL API regression where unparsable SQL was ending up in internal error
+- REST API `/query` endpoint will return `400 Bad Request` in case of unparsable SQL
+
 ## [0.189.4] - 2024-07-02
 ### Fixed
 - GQL access token list pagination

--- a/src/adapter/http/src/data/query_handler.rs
+++ b/src/adapter/http/src/data/query_handler.rs
@@ -48,6 +48,9 @@ pub async fn dataset_query_handler_post(
     {
         Ok(res) => res,
         Err(QueryError::DatasetNotFound(err)) => Err(ApiError::not_found(err))?,
+        Err(QueryError::DataFusionError(DataFusionError::SQL(err, _))) => {
+            Err(ApiError::bad_request(err))?
+        }
         Err(QueryError::DataFusionError(err @ DataFusionError::Plan(_))) => {
             Err(ApiError::bad_request(err))?
         }


### PR DESCRIPTION
## Description

Closes: https://github.com/kamu-data/kamu-node/issues/92

My previous changes in #668 introduced a regression where unparsable SQL was causing internal errors.

This PR fixes it and covers with tests.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅