### PR TITLE
E2E: Parallel running of tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,15 +2,10 @@
 fail-fast = false
 
 [test-groups]
-e2e = { max-threads = 1 }  # We do not support parallel running (as there is a hardcoded port present).
 setup = { max-threads = 1 }  # Serialize the setup steps
 containerized = { max-threads = 8 }  # Don't use too much memory
 engine = { max-threads = 2 }  # Engine tests are very memory-hungry
 database = { max-threads = 8 }  # Don't use too much memory
-
-[[profile.default.overrides]]
-filter = "test(::e2e::)"
-test-group = "e2e"
 
 [[profile.default.overrides]]
 filter = "test(::setup::)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- E2E: unblocked parallel run for tests
 ### Fixed
 - Obscure error during push duplicate dataset with different aliases
+- Fixed base_url calculation for random port
+- Minor corrections to references in generated code documentation
 
 ## [0.190.1] - 2024-07-10
 ### Fixed
@@ -23,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `saveEnvVariable` to store new dataset env var
   - `deleteEnvVariable` to delete dataset env var
   - `modifyEnvVariable` to modify dataset env var
-
 
 ## [0.189.7] - 2024-07-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - E2E: unblocked parallel run for tests
 ### Fixed
 - Obscure error during push duplicate dataset with different aliases
-- Fixed base_url calculation for random port
+- Get Data Panel: fixed `base_url_rest` calculation  in case the API server is started on a random port
 - Minor corrections to references in generated code documentation
 
 ## [0.190.1] - 2024-07-10

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -85,7 +85,7 @@ pub async fn run(
         .transpose()
         .map_err(CLIError::usage_error_from)?
         .map(Into::into);
-    let is_e2e_testing = matches.get_flag("e2e-testing");
+    let is_e2e_testing = matches.get_one::<PathBuf>("e2e-output-data-path").is_some();
 
     prepare_run_dir(&workspace_layout.run_info_dir);
 

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -85,7 +85,7 @@ pub async fn run(
         .transpose()
         .map_err(CLIError::usage_error_from)?
         .map(Into::into);
-    let is_e2e_testing = matches.get_one::<PathBuf>("e2e-output-data-path").is_some();
+    let is_e2e_testing = matches.contains_id("e2e-output-data-path");
 
     prepare_run_dir(&workspace_layout.run_info_dir);
 

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -469,7 +469,7 @@ pub fn get_command(
                         cli_catalog.get_one()?,
                         cli_catalog.get_one()?,
                         cli_catalog.get_one()?,
-                        arg_matches.get_flag("e2e-testing"),
+                        arg_matches.get_one("e2e-output-data-path").cloned(),
                     ))
                 }
                 Some(("gql-query", query_matches)) => Box::new(APIServerGqlQueryCommand::new(

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -14,66 +14,22 @@ use clap::{value_parser, Arg, ArgAction, Command};
 
 use super::cli_value_parser::*;
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 fn tabular_output_params(app: Command) -> Command {
-    app.args([
-        Arg::new("output-format")
-            .long("output-format")
-            .short('o')
-            .value_name("FMT")
-            .value_parser([
-                "table", "csv", "json", "ndjson", "json-soa",
-                "json-aoa",
-                // "vertical",
-                // "tsv",
-                // "xmlattrs",
-                // "xmlelements",
-            ])
-            .help("Format to display the results in"),
-        /*Arg::new("no-color")
-            .long("no-color")
-            .action(ArgAction::SetTrue)
-            .help("Control whether color is used for display"),
-        Arg::new("incremental")
-            .long("incremental")
-            .action(ArgAction::SetTrue)
-            .help("Display result rows immediately as they are fetched"),
-        Arg::new("no-header")
-            .long("no-header")
-            .action(ArgAction::SetTrue)
-            .help("Whether to show column names in query results"),
-        Arg::new("header-interval")
-            .long("header-interval")
-            .value_name("INT")
-            .help("The number of rows between which headers are displayed"),
-        Arg::new("csv-delimiter")
-            .long("csv-delimiter")
-            .value_name("DELIM")
-            .help("Delimiter in the csv output format"),
-        Arg::new("csv-quote-character")
-            .long("csv-quote-character")
-            .value_name("CHAR")
-            .help("Quote character in the csv output format"),
-        Arg::new("null-value")
-            .long("null-value")
-            .value_name("VAL")
-            .help("Use specified string in place of NULL values"),
-        Arg::new("number-format")
-            .long("number-format")
-            .value_name("FMT")
-            .help("Format numbers using DecimalFormat pattern"),
-        Arg::new("date-format")
-            .long("date-format")
-            .value_name("FMT")
-            .help("Format dates using SimpleDateFormat pattern"),
-        Arg::new("time-format")
-            .long("time-format")
-            .value_name("FMT")
-            .help("Format times using SimpleDateFormat pattern"),
-        Arg::new("timestamp-format")
-            .long("timestamp-format")
-            .value_name("FMT")
-            .help("Format timestamps using SimpleDateFormat pattern"),*/
-    ])
+    app.args([Arg::new("output-format")
+        .long("output-format")
+        .short('o')
+        .value_name("FMT")
+        .value_parser([
+            "table", "csv", "json", "ndjson", "json-soa",
+            "json-aoa",
+            // "vertical",
+            // "tsv",
+            // "xmlattrs",
+            // "xmlelements",
+        ])
+        .help("Format to display the results in")])
 }
 
 pub fn cli() -> Command {
@@ -1495,3 +1451,5 @@ pub fn cli() -> Command {
             ],
         )
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::net::IpAddr;
+use std::path::PathBuf;
 
 use clap::{value_parser, Arg, ArgAction, Command};
 
@@ -105,10 +106,10 @@ pub fn cli() -> Command {
                 .action(ArgAction::Set)
                 .help("Specifies account for multi-tenant Workspace")
                 .hide(true),
-            Arg::new("e2e-testing")
-                .long("e2e-testing")
-                .action(ArgAction::SetTrue)
-                .help("Activates additional functions required for E2E testing")
+            Arg::new("e2e-output-data-path")
+                .long("e2e-output-data-path")
+                .help("E2E test interface: file path from which socket bound address will be read out")
+                .value_parser(value_parser!(PathBuf))
                 .hide(true),
         ])
         .after_help(indoc::indoc!(

--- a/src/app/cli/src/commands/system_api_server_run_command.rs
+++ b/src/app/cli/src/commands/system_api_server_run_command.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::net::IpAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use console::style as s;
@@ -35,7 +36,7 @@ pub struct APIServerRunCommand {
     predefined_accounts_config: Arc<PredefinedAccountsConfig>,
     account_subject: Arc<CurrentAccountSubject>,
     github_auth_config: Arc<GithubAuthenticationConfig>,
-    is_e2e_testing: bool,
+    e2e_output_data_path: Option<PathBuf>,
 }
 
 impl APIServerRunCommand {
@@ -51,7 +52,7 @@ impl APIServerRunCommand {
         predefined_accounts_config: Arc<PredefinedAccountsConfig>,
         account_subject: Arc<CurrentAccountSubject>,
         github_auth_config: Arc<GithubAuthenticationConfig>,
-        is_e2e_testing: bool,
+        e2e_output_data_path: Option<PathBuf>,
     ) -> Self {
         Self {
             base_catalog,
@@ -65,7 +66,7 @@ impl APIServerRunCommand {
             predefined_accounts_config,
             account_subject,
             github_auth_config,
-            is_e2e_testing,
+            e2e_output_data_path,
         }
     }
 
@@ -137,7 +138,7 @@ impl Command for APIServerRunCommand {
             self.address,
             self.port,
             self.external_address,
-            self.is_e2e_testing,
+            self.e2e_output_data_path.as_ref(),
         );
 
         tracing::info!(

--- a/src/app/cli/src/services/config/models.rs
+++ b/src/app/cli/src/services/config/models.rs
@@ -412,7 +412,7 @@ pub struct IpfsConfig {
     /// For safety, it defaults to `http://localhost:8080` - a local IPFS daemon.
     /// If you don't have IPFS installed, you can set this URL to
     /// one of the public gateways like `https://ipfs.io`.
-    /// List of public gateways can be found here: https://ipfs.github.io/public-gateway-checker/
+    /// List of public gateways can be found here: `https://ipfs.github.io/public-gateway-checker/`
     pub http_gateway: Option<Url>,
 
     /// Whether kamu should pre-resolve IPNS DNSLink names using DNS or leave it

--- a/src/e2e/app/cli/common/src/e2e_harness.rs
+++ b/src/e2e/app/cli/common/src/e2e_harness.rs
@@ -174,10 +174,10 @@ impl KamuCliApiServerHarness {
     {
         let kamu = self.into_kamu().await;
 
-        let server_addr = kamu.get_server_address();
-        let server_run_fut = kamu.start_api_server(server_addr);
+        let e2e_data_file_path = kamu.get_e2e_output_data_path();
+        let server_run_fut = kamu.start_api_server(e2e_data_file_path.clone());
 
-        api_server_e2e_test(server_addr, server_run_fut, fixture).await;
+        api_server_e2e_test(e2e_data_file_path, server_run_fut, fixture).await;
     }
 
     pub async fn execute_command<Fixture, FixtureResult>(self, fixture: Fixture)

--- a/src/e2e/app/cli/common/src/lib.rs
+++ b/src/e2e/app/cli/common/src/lib.rs
@@ -69,7 +69,9 @@ macro_rules! kamu_cli_run_api_server_e2e_test {
     };
     (mysql, $test_package: expr, $test_name: expr) => {
         paste::paste! {
-            #[test_group::group(e2e, database, mysql)]
+            // flaky: when running in parallel, errors occur with table not found (or sporadic deadlocks),
+            //        restarting again solves the problem.
+            #[test_group::group(e2e, database, mysql, flaky)]
             #[test_log::test(sqlx::test(migrations = "../../../../../migrations/mysql"))]
             async fn [<$test_name>] (mysql_pool: sqlx::MySqlPool) {
                 KamuCliApiServerHarness::mysql(&mysql_pool, None)
@@ -80,7 +82,9 @@ macro_rules! kamu_cli_run_api_server_e2e_test {
     };
     (mysql, $test_package: expr, $test_name: expr, $test_options: expr) => {
         paste::paste! {
-            #[test_group::group(e2e, database, mysql)]
+            // flaky: when running in parallel, errors occur with table not found (or sporadic deadlocks),
+            //        restarting again solves the problem.
+            #[test_group::group(e2e, database, mysql, flaky)]
             #[test_log::test(sqlx::test(migrations = "../../../../../migrations/mysql"))]
             async fn [<$test_name>] (mysql_pool: sqlx::MySqlPool) {
                 KamuCliApiServerHarness::mysql(&mysql_pool, Some($test_options))

--- a/src/infra/core/src/repos/dataset_factory_impl.rs
+++ b/src/infra/core/src/repos/dataset_factory_impl.rs
@@ -117,8 +117,8 @@ impl DatasetFactoryImpl {
     ///
     /// WARNING: This function will create a new [S3Context] that will do
     /// credential resolution from scratch which can be very expensive. If you
-    /// already have an established [S3Context] use [get_s3_with_context]
-    /// function instead.
+    /// already have an established [S3Context] use
+    /// [DatasetFactoryImpl::get_s3_from_context()] function instead.
     pub async fn get_s3_from_url(
         base_url: Url,
         event_bus: Arc<EventBus>,

--- a/src/utils/event-sourcing/src/aggregate.rs
+++ b/src/utils/event-sourcing/src/aggregate.rs
@@ -116,7 +116,7 @@ where
         }
     }
 
-    /// Same as [EventStore::load()] but with extra control knobs
+    /// Same as [Aggregate::load()] but with extra control knobs
     #[tracing::instrument(
         level = "debug",
         name = "load",
@@ -176,7 +176,7 @@ where
         self.update_ext(event_store, LoadOpts::default()).await
     }
 
-    /// Same as [EventStore::update()] but with extra control knobs
+    /// Same as [Aggregate::update()] but with extra control knobs
     #[tracing::instrument(
         level = "debug",
         name = "update",


### PR DESCRIPTION
## Description

Closes: #666

Depend on: 
- https://github.com/kamu-data/kamu-cli/pull/712

<!--- Describe your changes in detail and include your changelog entries -->

### Changed
- E2E: unblocked parallel run for tests
### Fixed
- Fixed base_url calculation for random port
- Minor corrections to references in generated code documentation

## Checklist before requesting a review

- [x] Unit and integration tests added ❌ no new tests
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌ not needed
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌ not needed