### PR TITLE
Upgrade to datafusion v41

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,8 +60,8 @@ jobs:
         include:
           - name: Linux / amd64
             runs-on: ubuntu-latest
-            cargo-flags: --profile ci --features ftp
-            nextest-flags: --cargo-profile ci --features ftp
+            cargo-flags: --profile ci --features ingest-ftp
+            nextest-flags: --cargo-profile ci --features ingest-ftp
             nextest-exclusions-main-set-tests: -E '!(test(::database::) | test(::spark::)| test(::flink::))'
             nextest-exclusions-database-set-part: ''
             container-runtime: podman
@@ -71,8 +71,8 @@ jobs:
           # See: https://github.com/actions/runner/issues/1456
           - name: MacOS / amd64
             runs-on: macos-13
-            cargo-flags: --profile ci --features ftp
-            nextest-flags: --cargo-profile ci --features ftp
+            cargo-flags: --profile ci --features ingest-ftp
+            nextest-flags: --cargo-profile ci --features ingest-ftp
             nextest-exclusions-main-set-tests: -E '!(test(::containerized::) | test(::database::))'
             nextest-exclusions-database-set-part: ''
             container-runtime: ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,37 +20,37 @@ jobs:
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: true
-            features: ftp,web-ui
+            features: ingest-ftp,web-ui
           - name: Linux / amd64 / musl
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
-            features: ftp,web-ui
+            features: ingest-ftp,web-ui
           - name: Linux / arm64 / glibc
             runs-on: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
-            features: ftp,web-ui
+            features: ingest-ftp,web-ui
           - name: Linux / arm64 / musl
             runs-on: ubuntu-latest
             target: aarch64-unknown-linux-musl
             use-cross: true
-            features: ftp,web-ui
+            features: ingest-ftp,web-ui
           - name: MacOS / amd64
             runs-on: macos-13
             target: x86_64-apple-darwin
             use-cross: false
-            features: ftp,web-ui
+            features: ingest-ftp,web-ui
           - name: MacOS / arm64
             runs-on: macos-14
             target: aarch64-apple-darwin
             use-cross: false
-            features: ftp,web-ui
+            features: ingest-ftp,web-ui
           - name: Windows / amd64
             runs-on: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false
-            features: ftp
+            features: ingest-ftp
             binary-ext: '.exe'
     name: Build (${{ matrix.name }})
     runs-on: ${{ matrix.runs-on }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,9 +2089,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189"
+checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
 dependencies = [
  "jobserver",
  "libc",
@@ -2823,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f92d2d7a9cba4580900b32b009848d9eb35f1028ac84cdd6ddcf97612cd0068"
+checksum = "e4fd4a99fc70d40ef7e52b243b4a399c3f8d353a40d5ecb200deee05e49c61bb"
 dependencies = [
  "ahash",
  "arrow",
@@ -2837,17 +2837,19 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "dashmap 5.5.3",
+ "dashmap 6.0.1",
+ "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
  "datafusion-functions-aggregate",
- "datafusion-functions-array",
+ "datafusion-functions-nested",
  "datafusion-optimizer",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-sql",
  "flate2",
@@ -2876,10 +2878,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-common"
-version = "39.0.0"
+name = "datafusion-catalog"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effed030d2c1667eb1e11df5372d4981eaf5d11a521be32220b3985ae5ba6971"
+checksum = "e13b3cfbd84c6003594ae1972314e3df303a27ce8ce755fcea3240c90f4c0529"
+dependencies = [
+ "arrow-schema",
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fdbc877e3e40dcf88cc8f283d9f5c8851f0a3aa07fee657b1b75ac1ad49b9c"
 dependencies = [
  "ahash",
  "arrow",
@@ -2899,18 +2915,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0091318129dad1359f08e4c6c71f855163c35bba05d1dbf983196f727857894"
+checksum = "8a7496d1f664179f6ce3a5cbef6566056ccaf3ea4aa72cc455f80e62c1dd86b1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-ethers"
-version = "39.1.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4928a07ddc9090d5c2af910e80ea7f296d3df59d82addfe0a1b3ab0a081c39"
+checksum = "4bcd7ac5865439f41af63c42a8265c8e283adc522cc25fefbb007bbbd6c9d8bf"
 dependencies = [
  "alloy",
  "async-stream",
@@ -2925,13 +2941,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8385aba84fc4a06d3ebccfbcbf9b4f985e80c762fac634b49079f7cc14933fb1"
+checksum = "799e70968c815b611116951e3dd876aef04bf217da31b72eec01ee6a959336a1"
 dependencies = [
  "arrow",
  "chrono",
- "dashmap 5.5.3",
+ "dashmap 6.0.1",
  "datafusion-common",
  "datafusion-expr",
  "futures",
@@ -2946,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb192f0055d2ce64e38ac100abc18e4e6ae9734d3c28eee522bbbd6a32108a3"
+checksum = "1c1841c409d9518c17971d15c9bae62e629eb937e6fb6c68cd32e9186f8b30d2"
 dependencies = [
  "ahash",
  "arrow",
@@ -2965,11 +2981,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c081ae5b7edd712b92767fb8ed5c0e32755682f8075707666cd70835807c0b"
+checksum = "a8e481cf34d2a444bd8fa09b65945f0ce83dc92df8665b761505b3d9f351bebb"
 dependencies = [
  "arrow",
+ "arrow-buffer",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -2977,7 +2994,6 @@ dependencies = [
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.12.1",
@@ -2992,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb28a4ea52c28a26990646986a27c4052829a2a2572386258679e19263f8b78"
+checksum = "2b4ece19f73c02727e5e8654d79cd5652de371352c1df3c4ac3e419ecd6943fb"
 dependencies = [
  "ahash",
  "arrow",
@@ -3009,30 +3025,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-functions-array"
-version = "39.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b17c02a74cdc87380a56758ec27e7d417356bf806f33062700908929aedb8a"
-dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "itertools 0.12.1",
- "log",
- "paste",
-]
-
-[[package]]
 name = "datafusion-functions-json"
-version = "0.2.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae06296532afb91f5f77af4a9c65c175c5125da0308b1bdae1b75c9ac06ef3d"
+checksum = "00900606bdd73248f0a0bea254379ef06832f4958510581e752fedd17b33b8b4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3045,16 +3041,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-functions-nested"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1474552cc824e8c9c88177d454db5781d4b66757d4aca75719306b8343a5e8d"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "itertools 0.12.1",
+ "log",
+ "paste",
+ "rand",
+]
+
+[[package]]
 name = "datafusion-odata"
-version = "39.0.0"
-source = "git+https://github.com/kamu-data/datafusion-odata.git?branch=axum-0.6#21f7b230515cb33de1a1929db59b924d0cb26ad1"
+version = "41.0.0"
+source = "git+https://github.com/kamu-data/datafusion-odata.git?branch=41.0.0-axum-0.6#e9e09c87ba23d1fc88a6aecdca63c1ec179cd7a7"
 dependencies = [
  "async-trait",
  "axum",
  "chrono",
  "datafusion",
  "http 0.2.12",
- "quick-xml 0.32.0",
+ "quick-xml",
  "regex",
  "serde",
  "thiserror",
@@ -3063,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12172f2a6c9eb4992a51e62d709eeba5dedaa3b5369cce37ff6c2260e100ba76"
+checksum = "791ff56f55608bc542d1ea7a68a64bdc86a9413f5a381d06a39fd49c2a3ab906"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3077,14 +3095,15 @@ dependencies = [
  "indexmap 2.4.0",
  "itertools 0.12.1",
  "log",
+ "paste",
  "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3fce531b623e94180f6cd33d620ef01530405751b6ddd2fd96250cdbd78e2e"
+checksum = "9a223962b3041304a3e20ed07a21d5de3d88d7e4e71ca192135db6d24e3365a4"
 dependencies = [
  "ahash",
  "arrow",
@@ -3098,7 +3117,6 @@ dependencies = [
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate",
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
@@ -3113,21 +3131,35 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046400b6a2cc3ed57a7c576f5ae6aecc77804ac8e0186926b278b189305b2a77"
+checksum = "db5e7d8532a1601cd916881db87a70b0a599900d23f3db2897d389032da53bc6"
 dependencies = [
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
+ "hashbrown 0.14.5",
  "rand",
 ]
 
 [[package]]
-name = "datafusion-physical-plan"
-version = "39.0.0"
+name = "datafusion-physical-optimizer"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aed47f5a2ad8766260befb375b201592e86a08b260256e168ae4311426a2bff"
+checksum = "fdb9c78f308e050f5004671039786a925c3fee83b90004e9fcfd328d7febdcc0"
+dependencies = [
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1116949432eb2d30f6362707e2846d942e491052a206f2ddcb42d08aea1ffe"
 dependencies = [
  "ahash",
  "arrow",
@@ -3159,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "39.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa92bb1fd15e46ce5fb6f1c85f3ac054592560f294429a28e392b5f9cd4255e"
+checksum = "b45d0180711165fe94015d7c4123eb3e1cf5fb60b1506453200b8d1ce666bef0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4187,6 +4219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4642,11 +4680,11 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -4692,9 +4730,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jiter"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0d55889c66274e5a4386529f78f211871c66d6a0f7d7783ba3c65ee4aa7bc1"
+checksum = "02e23549143ef50eddffd46ba8cd0229b0a4500aef7518cf2eb0f41c9a09d22b"
 dependencies = [
  "ahash",
  "bitvec",
@@ -5194,6 +5232,7 @@ dependencies = [
  "kamu-accounts",
  "kamu-core",
  "opendatafabric",
+ "quick-xml",
  "reqwest 0.11.27",
  "serde",
  "tempfile",
@@ -6394,7 +6433,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -6661,7 +6700,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -6735,7 +6774,7 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.36.1",
+ "quick-xml",
  "rand",
  "reqwest 0.12.5",
  "ring",
@@ -7505,16 +7544,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-xml"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "quick-xml"
@@ -8374,9 +8403,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -8697,9 +8726,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.47.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
+checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
 dependencies = [
  "log",
  "sqlparser_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,10 +242,10 @@ debug = "line-tables-only"
 # Use this section to test or apply emergency overides to dependencies
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 [patch.crates-io]
-# datafusion = { git = 'https://github.com/apache/datafusion.git', tag = '39.0.0-rc1' }
-# datafusion-common = { git = 'https://github.com/apache/datafusion.git', tag = '39.0.0-rc1' }
-# datafusion-execution = { git = 'https://github.com/apache/datafusion.git', tag = '39.0.0-rc1' }
-# datafusion-expr = { git = 'https://github.com/apache/datafusion.git', tag = '39.0.0-rc1' }
-datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = 'axum-0.6' }
-# datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", tag = "v39.0.0" }
+# datafusion = { git = 'https://github.com/apache/datafusion.git', tag = '41.0.0-rc1' }
+# datafusion-common = { git = 'https://github.com/apache/datafusion.git', tag = '41.0.0-rc1' }
+# datafusion-execution = { git = 'https://github.com/apache/datafusion.git', tag = '41.0.0-rc1' }
+# datafusion-expr = { git = 'https://github.com/apache/datafusion.git', tag = '41.0.0-rc1' }
+datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = '41.0.0-axum-0.6' }
+# datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", tag = "41.0.0" }
 # object_store = { git = 'https://github.com/s373r/arrow-rs', branch = 'add-debug-logs', package = "object_store" }

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,10 @@ features = [
     ] },
     { name = "kamu", allow = [
         "default",
+        "ingest-evm",
+        "ingest-ftp",
+        "ingest-mqtt",
+        "query-extensions-json",
     ] },
     { name = "kamu-accounts", allow = [
         "default",

--- a/src/adapter/flight-sql/Cargo.toml
+++ b/src/adapter/flight-sql/Cargo.toml
@@ -26,7 +26,7 @@ arrow-flight = { version = "52", features = ["flight-sql-experimental"] }
 async-trait = { version = "0.1", default-features = false }
 base64 = { version = "0.22", default-features = false }
 dashmap = { version = "6", default-features = false }
-datafusion = { version = "39", default-features = false }
+datafusion = { version = "41", default-features = false }
 futures = "0.3"
 like = { version = "0.3", default-features = false }
 prost = { version = "0.12", default-features = false }

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -45,7 +45,7 @@ async-graphql = { version = "6", features = [
 async-trait = { version = "0.1", default-features = false }
 cron = { version = "0.12", default-features = false }
 chrono = "0.4"
-datafusion = { version = "39", default-features = false, features = [
+datafusion = { version = "41", default-features = false, features = [
     "serde",
 ] } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.8"

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -40,7 +40,7 @@ async-trait = "0.1"
 base64 = { version = "0.22", default-features = false }
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
-datafusion = { version = "39", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
+datafusion = { version = "41", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.8"
 flate2 = "1" # GZip decoder
 futures = "0.3"

--- a/src/adapter/odata/Cargo.toml
+++ b/src/adapter/odata/Cargo.toml
@@ -31,12 +31,12 @@ opendatafabric = { workspace = true }
 
 axum = { version = "0.6", features = ["headers"] }
 chrono = { version = "0.4", default-features = false }
-datafusion = { version = "39", default-features = false }
-# ToDo remove version pin after we will migrate axum to new major version
-datafusion-odata = { version = "39", default-features = false }
+datafusion = { version = "41", default-features = false }
+datafusion-odata = { version = "41", default-features = false }
 dill = { version = "0.8" }
 futures = { version = "0.3", default-features = false }
 http = "0.2"
+quick-xml = { version = "0.36", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -29,10 +29,13 @@ doctest = false
 
 
 [features]
-default = []
+default = ["kamu/ingest-evm", "kamu/ingest-mqtt", "kamu/query-extensions-json"]
 
 web-ui = ["rust-embed"]
-ftp = ["kamu/ftp"]
+ingest-evm = ["kamu/ingest-evm"]
+ingest-ftp = ["kamu/ingest-ftp"]
+ingest-mqtt = ["kamu/ingest-mqtt"]
+query-extensions-json = ["kamu/query-extensions-json"]
 
 
 [dependencies]
@@ -145,7 +148,7 @@ tracing-bunyan-formatter = "0.3"
 async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1" # Conditional compilation
-datafusion = { version = "39", default-features = false, features = [
+datafusion = { version = "41", default-features = false, features = [
     "crypto_expressions",
     "encoding_expressions",
     "parquet",
@@ -181,7 +184,9 @@ libc = "0.2" # For getting uid:gid
 
 
 [dev-dependencies]
-kamu-cli-puppet = { workspace = true, default-features = false, features = ["extensions"] }
+kamu-cli-puppet = { workspace = true, default-features = false, features = [
+    "extensions",
+] }
 
 pretty_assertions = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }

--- a/src/app/cli/src/commands/sql_shell_command.rs
+++ b/src/app/cli/src/commands/sql_shell_command.rs
@@ -138,14 +138,14 @@ impl SqlShellCommand {
             maxrows: MaxRows::Limited(DEFAULT_MAX_ROWS_FOR_OUTPUT),
         };
 
-        let mut ctx = self.query_svc.create_session().await.unwrap();
+        let ctx = self.query_svc.create_session().await.unwrap();
 
         eprintln!(
             "{}",
             console::style("Kamu + DataFusion SQL shell. Type \\? for help.").dim()
         );
 
-        exec::exec_from_repl(&mut ctx, &mut print_options)
+        Box::pin(exec::exec_from_repl(&ctx, &mut print_options))
             .await
             .map_err(CLIError::failure)?;
 

--- a/src/domain/core/Cargo.toml
+++ b/src/domain/core/Cargo.toml
@@ -44,7 +44,7 @@ tracing = { version = "0.1", default-features = false }
 url = { version = "2", default-features = false, features = ["serde"] }
 
 # TODO: Avoid this dependency or depend on sub-crates
-datafusion = { version = "39", default-features = false, features = [
+datafusion = { version = "41", default-features = false, features = [
     "parquet",
 ] }
 object_store = { version = "0.10", default-features = false }

--- a/src/domain/flow-system/domain/Cargo.toml
+++ b/src/domain/flow-system/domain/Cargo.toml
@@ -47,4 +47,4 @@ serde_with = { version = "3", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-datafusion = { version = "39", default-features = false }
+datafusion = { version = "41", default-features = false }

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -24,7 +24,10 @@ doctest = false
 [features]
 default = []
 
-ftp = ["dep:curl", "dep:curl-sys"]
+ingest-evm = ["dep:alloy", "dep:datafusion-ethers"]
+ingest-ftp = ["dep:curl", "dep:curl-sys"]
+ingest-mqtt = ["dep:rumqttc"]
+query-extensions-json = ["dep:datafusion-functions-json"]
 
 
 [dependencies]
@@ -49,21 +52,6 @@ serde_with = "3"
 serde_yaml = "0.9"
 
 # Ingest
-alloy = { version = "0.2", default-features = false, features = [
-    "std",
-    "provider-http",
-    "provider-ws",
-] }
-# TODO: Using curl brings a lot of overhead including compiling and linking openssl
-# We should replace it with reqwest + a separate FTP client or drop FTP support in favor of container-based ingest.
-curl = { optional = true, version = "0.4", features = [
-    "protocol-ftp",
-    "static-curl",
-    "static-ssl",
-] }
-curl-sys = { optional = true, version = "0.4" }
-datafusion-ethers = { version = "39", default-features = false }
-datafusion-functions-json = { version = "0.2", default-features = false }
 flate2 = "1" # GZip decoder
 reqwest = { version = "0.11", default-features = false, features = [
     "json",
@@ -75,12 +63,11 @@ reqwest = { version = "0.11", default-features = false, features = [
     "json",
 ] }
 ringbuf = "0.3"
-rumqttc = { version = "0.23" }
 secrecy = "0.8"
 zip = "0.6"
 
 # Data
-datafusion = { version = "39", default-features = false }
+datafusion = { version = "41", default-features = false }
 digest = "0.10"
 object_store = { version = "0.10", features = ["aws"] }
 parking_lot = { version = "0.12" }
@@ -136,6 +123,25 @@ tower = "0.4"
 tower-http = { version = "0.4", features = ["fs", "trace"] }
 axum = "0.6"
 
+# Optional dependencies
+alloy = { optional = true, version = "0.2", default-features = false, features = [
+    "std",
+    "provider-http",
+    "provider-ws",
+] }
+# TODO: Using curl brings a lot of overhead including compiling and linking openssl
+# We should replace it with reqwest + a separate FTP client or drop FTP support in favor of container-based ingest.
+curl = { optional = true, version = "0.4", features = [
+    "protocol-ftp",
+    "static-curl",
+    "static-ssl",
+] }
+curl-sys = { optional = true, version = "0.4" }
+datafusion-ethers = { optional = true, version = "41" }
+datafusion-functions-json = { optional = true, version = "0.41" }
+rumqttc = { optional = true, version = "0.23" }
+
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2" # For getting uid:gid
 
@@ -147,6 +153,9 @@ kamu-accounts-services = { workspace = true }
 kamu-datasets-services = { workspace = true }
 
 criterion = { version = "0.5", features = ["async_tokio"] }
+datafusion = { version = "41", default-features = false, features = [
+    "parquet",
+] }
 filetime = "0.2"
 indoc = "2"
 nanoid = "0.4.0"

--- a/src/infra/core/src/ingest/fetch_service.rs
+++ b/src/infra/core/src/ingest/fetch_service.rs
@@ -183,7 +183,13 @@ impl FetchService {
                         .await
                     }
                     "ftp" | "ftps" => {
-                        Self::fetch_ftp(url, target_path, system_time, &listener).await
+                        cfg_if::cfg_if! {
+                            if #[cfg(feature = "ingest-ftp")] {
+                                Self::fetch_ftp(url, target_path, system_time, &listener).await
+                            } else {
+                                unimplemented!("Kamu was compiled without FTP support")
+                            }
+                        }
                     }
                     // TODO: Replace with proper error type
                     scheme => unimplemented!("Unsupported scheme: {}", scheme),
@@ -207,24 +213,36 @@ impl FetchService {
                 &listener,
             ),
             FetchStep::Mqtt(fetch) => {
-                self.fetch_mqtt(
-                    dataset_handle,
-                    fetch,
-                    target_path,
-                    dataset_env_vars,
-                    &listener,
-                )
-                .await
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "ingest-mqtt")] {
+                    self.fetch_mqtt(
+                        dataset_handle,
+                        fetch,
+                        target_path,
+                        dataset_env_vars,
+                        &listener,
+                    )
+                    .await
+                } else {
+                    unimplemented!("Kamu was compiled without MQTT support")
+                }}
             }
             FetchStep::EthereumLogs(fetch) => {
-                self.fetch_ethereum_logs(
-                    fetch,
-                    prev_source_state,
-                    target_path,
-                    dataset_env_vars,
-                    &listener,
-                )
-                .await
+                cfg_if::cfg_if! {
+                        if #[cfg(feature = "ingest-evm")] {
+                        self.fetch_ethereum_logs(
+                            fetch,
+                            prev_source_state,
+                            target_path,
+                            dataset_env_vars,
+                            &listener,
+                        )
+                        .await
+                    }
+                    else {
+                        unimplemented!("Kamu was compiled without Ethereum support")
+                    }
+                }
             }
         }
     }
@@ -752,39 +770,27 @@ impl FetchService {
         }))
     }
 
-    #[allow(unused_variables)]
-    #[allow(clippy::unused_async)]
+    #[cfg(feature = "ingest-ftp")]
     async fn fetch_ftp(
         url: Url,
         target_path: &Path,
         system_time: &DateTime<Utc>,
         listener: &Arc<dyn FetchProgressListener>,
     ) -> Result<FetchResult, PollingIngestError> {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "ftp")] {
-                let target_path = target_path.to_owned();
-                let system_time = system_time.clone();
-                let listener = listener.clone();
-                tokio::task::spawn_blocking(move || {
-                        Self::fetch_ftp_impl(
-                            url,
-                            &target_path,
-                            system_time,
-                            listener.as_ref(),
-                        )
-                    })
-                    .await
-                    .int_err()?
-            } else {
-                unimplemented!("Kamu was compiled without FTP support")
-            }
-        }
+        let target_path = target_path.to_owned();
+        let system_time = system_time.clone();
+        let listener = listener.clone();
+        tokio::task::spawn_blocking(move || {
+            Self::fetch_ftp_impl(url, &target_path, system_time, listener.as_ref())
+        })
+        .await
+        .int_err()?
     }
 
     // TODO: convert to non-blocking
     // TODO: not implementing caching as some FTP servers throw errors at us
     // when we request filetime :(
-    #[cfg(feature = "ftp")]
+    #[cfg(feature = "ingest-ftp")]
     fn fetch_ftp_impl(
         url: Url,
         target_path: &Path,
@@ -854,6 +860,7 @@ impl FetchService {
         }))
     }
 
+    #[cfg(feature = "ingest-mqtt")]
     async fn fetch_mqtt(
         &self,
         dataset_handle: &DatasetHandle,
@@ -970,6 +977,7 @@ impl FetchService {
     // to scan through block ranges.
     //
     // TODO: Account for re-orgs
+    #[cfg(feature = "ingest-evm")]
     async fn fetch_ethereum_logs(
         &self,
         fetch: &FetchStepEthereumLogs,

--- a/src/infra/core/src/ingest/ingest_common.rs
+++ b/src/infra/core/src/ingest/ingest_common.rs
@@ -66,8 +66,17 @@ pub fn new_session_context(object_store_registry: Arc<dyn ObjectStoreRegistry>) 
 
     // TODO: As part of the ODF spec we should let people opt-in into various
     // SQL extensions on per-transform basis
-    datafusion_ethers::udf::register_all(&mut ctx).unwrap();
-    datafusion_functions_json::register_all(&mut ctx).unwrap();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "ingest-evm")] {
+            datafusion_ethers::udf::register_all(&mut ctx).unwrap();
+        }
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "query-extensions-json")] {
+            datafusion_functions_json::register_all(&mut ctx).unwrap();
+        }
+    }
 
     ctx
 }

--- a/src/infra/core/src/query/mod.rs
+++ b/src/infra/core/src/query/mod.rs
@@ -11,15 +11,14 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
-use datafusion::catalog::schema::SchemaProvider;
-use datafusion::catalog::CatalogProvider;
+use datafusion::catalog::{CatalogProvider, SchemaProvider, Session};
 use datafusion::common::{Constraints, Statistics};
 use datafusion::config::TableOptions;
 use datafusion::datasource::empty::EmptyTable;
 use datafusion::datasource::listing::{ListingTable, ListingTableConfig};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::DataFusionError;
-use datafusion::execution::context::{DataFilePaths, SessionState};
+use datafusion::execution::context::DataFilePaths;
 use datafusion::execution::options::ReadOptions;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
@@ -559,7 +558,7 @@ impl TableProvider for KamuTable {
 
     async fn scan(
         &self,
-        state: &SessionState,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,

--- a/src/infra/core/src/utils/docker_images.rs
+++ b/src/infra/core/src/utils/docker_images.rs
@@ -18,8 +18,10 @@ pub const JUPYTER: &str = "ghcr.io/kamu-data/jupyter:0.6.2";
 // Test Images
 pub const HTTPD: &str = "docker.io/httpd:2.4";
 pub const MINIO: &str = "docker.io/minio/minio:RELEASE.2021-08-31T05-46-54Z";
-pub const RUMQTTD: &str = "docker.io/bytebeamio/rumqttd:0.19.0";
 pub const BUSYBOX: &str = "docker.io/busybox:latest";
 
-#[cfg(feature = "ftp")]
+#[cfg(feature = "ingest-mqtt")]
+pub const RUMQTTD: &str = "docker.io/bytebeamio/rumqttd:0.19.0";
+
+#[cfg(feature = "ingest-ftp")]
 pub const FTP: &'static str = "docker.io/bogem/ftp";

--- a/src/infra/core/tests/tests/ingest/test_fetch.rs
+++ b/src/infra/core/tests/tests/ingest/test_fetch.rs
@@ -22,8 +22,6 @@ use kamu_datasets_services::DatasetKeyValueServiceSysEnv;
 use opendatafabric::*;
 use url::Url;
 
-use crate::MqttBroker;
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // URL: file
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -386,7 +384,7 @@ async fn test_fetch_url_http_env_interpolation() {
 // URL: ftp
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "ftp")]
+#[cfg(feature = "ingest-ftp")]
 #[test_group::group(containerized, flaky)]
 #[tokio::test]
 async fn test_fetch_url_ftp_ok() {
@@ -662,6 +660,7 @@ async fn test_fetch_files_glob() {
 // MQTT
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#[cfg(feature = "ingest-mqtt")]
 #[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
 async fn test_fetch_mqtt_empty() {
@@ -669,7 +668,7 @@ async fn test_fetch_mqtt_empty() {
 
     let target_path = harness.temp_dir.path().join("fetched.bin");
 
-    let broker = MqttBroker::new().await;
+    let broker = crate::MqttBroker::new().await;
 
     let fetch_step = FetchStep::Mqtt(FetchStepMqtt {
         host: "localhost".to_string(),
@@ -704,6 +703,7 @@ async fn test_fetch_mqtt_empty() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#[cfg(feature = "ingest-mqtt")]
 #[test_group::group(containerized)]
 #[test_log::test(tokio::test)]
 async fn test_fetch_mqtt_one_record() {
@@ -711,7 +711,7 @@ async fn test_fetch_mqtt_one_record() {
 
     let target_path = harness.temp_dir.path().join("fetched.bin");
 
-    let broker = MqttBroker::new().await;
+    let broker = crate::MqttBroker::new().await;
     let topic = "test-topic";
 
     // Publish one (retained) event

--- a/src/infra/core/tests/tests/test_setup.rs
+++ b/src/infra/core/tests/tests/test_setup.rs
@@ -44,13 +44,18 @@ async fn test_setup_pull_images() {
         .ensure_image(docker_images::MINIO, None)
         .await
         .unwrap();
-    container_runtime
-        .ensure_image(docker_images::RUMQTTD, None)
-        .await
-        .unwrap();
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "ftp")] {
+        if #[cfg(feature = "ingest-mqtt")] {
+            container_runtime
+                .ensure_image(docker_images::RUMQTTD, None)
+                .await
+                .unwrap();
+        }
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "ingest-ftp")] {
             container_runtime.ensure_image(docker_images::FTP, None).await.unwrap();
         }
     }

--- a/src/infra/core/tests/utils/mod.rs
+++ b/src/infra/core/tests/utils/mod.rs
@@ -7,16 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#[cfg(feature = "ftp")]
+#[cfg(feature = "ingest-ftp")]
 mod ftp_server;
 mod http_server;
 mod ipfs_daemon;
+#[cfg(feature = "ingest-mqtt")]
 mod mqtt_broker;
 
 pub mod mock_engine_provisioner;
 
-#[cfg(feature = "ftp")]
+#[cfg(feature = "ingest-ftp")]
 pub use ftp_server::*;
 pub use http_server::*;
 pub use ipfs_daemon::*;
+#[cfg(feature = "ingest-mqtt")]
 pub use mqtt_broker::*;

--- a/src/infra/ingest-datafusion/Cargo.toml
+++ b/src/infra/ingest-datafusion/Cargo.toml
@@ -27,7 +27,7 @@ opendatafabric = { workspace = true, features = ["arrow"] }
 kamu-core = { workspace = true }
 kamu-data-utils = { workspace = true }
 
-datafusion = { version = "39", default-features = false }
+datafusion = { version = "41", default-features = false }
 digest = "0.10"
 geo-types = { version = "0.7", default-features = false, features = [] }
 geojson = { version = "0.24", default-features = false, features = [

--- a/src/infra/ingest-datafusion/src/readers/csv.rs
+++ b/src/infra/ingest-datafusion/src/readers/csv.rs
@@ -105,6 +105,7 @@ impl Reader for ReaderCsv {
         let options = CsvReadOptions {
             schema: self.schema.as_ref(),
             delimiter,
+            comment: None,
             has_header: self.conf.header.unwrap_or(false),
             schema_infer_max_records: if self.conf.infer_schema.unwrap_or(false) {
                 Self::DEFAULT_INFER_SCHEMA_ROWS
@@ -120,6 +121,8 @@ impl Reader for ReaderCsv {
             // re-compress it.
             file_compression_type: FileCompressionType::UNCOMPRESSED,
             file_sort_order: Vec::new(),
+            // TODO: Expose in ODF
+            newlines_in_values: false,
         };
 
         let df = self

--- a/src/infra/ingest-datafusion/src/writer.rs
+++ b/src/infra/ingest-datafusion/src/writer.rs
@@ -16,8 +16,9 @@ use chrono::{DateTime, TimeZone, Utc};
 use datafusion::arrow::array::Array;
 use datafusion::arrow::datatypes::{DataType, Field, SchemaRef, TimeUnit};
 use datafusion::common::DFSchema;
-use datafusion::config::{ColumnOptions, ParquetOptions, TableParquetOptions};
+use datafusion::config::{ParquetColumnOptions, ParquetOptions, TableParquetOptions};
 use datafusion::dataframe::DataFrameWriteOptions;
+use datafusion::functions_aggregate::min_max::{max, min};
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::*;
@@ -417,14 +418,14 @@ impl DataWriterDataFusion {
                 (
                     // op column is low cardinality and best encoded as RLE_DICTIONARY
                     self.meta.vocab.operation_type_column.clone(),
-                    ColumnOptions {
+                    ParquetColumnOptions {
                         dictionary_enabled: Some(true),
                         ..Default::default()
                     },
                 ),
                 (
                     self.meta.vocab.system_time_column.clone(),
-                    ColumnOptions {
+                    ParquetColumnOptions {
                         // system_time value will be the same for all rows in a batch
                         dictionary_enabled: Some(true),
                         ..Default::default()

--- a/src/utils/data-utils/Cargo.toml
+++ b/src/utils/data-utils/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1"
 arrow = { version = "52", default-features = false }
 arrow-json = { version = "52", default-features = false }
 arrow-digest = { version = "52", default-features = false }
-datafusion = { version = "39", default-features = false, features = [
+datafusion = { version = "41", default-features = false, features = [
     "parquet",
     "serde",
 ] }

--- a/src/utils/datafusion-cli/Cargo.toml
+++ b/src/utils/datafusion-cli/Cargo.toml
@@ -35,7 +35,7 @@ async-trait = "0.1"
 aws-config = "0.57"
 aws-credential-types = "0.57"
 clap = { version = "4", features = ["derive"] }
-datafusion = { version = "39", features = [
+datafusion = { version = "41", features = [
     "crypto_expressions",
     "datetime_expressions",
     "encoding_expressions",
@@ -44,7 +44,7 @@ datafusion = { version = "39", features = [
     "unicode_expressions",
     "compression",
 ] }
-datafusion-common = { version = "39", default-features = false }
+datafusion-common = { version = "41", default-features = false }
 dirs = "5"
 futures = "0.3"
 object_store = { version = "0.10.1", features = ["aws", "gcp", "http"] }

--- a/src/utils/datafusion-cli/src/cli_context.rs
+++ b/src/utils/datafusion-cli/src/cli_context.rs
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use datafusion::dataframe::DataFrame;
+use datafusion::error::DataFusionError;
+use datafusion::execution::context::SessionState;
+use datafusion::execution::TaskContext;
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::prelude::SessionContext;
+use object_store::ObjectStore;
+
+use crate::object_storage::{AwsOptions, GcpOptions};
+
+#[async_trait::async_trait]
+/// The CLI session context trait provides a way to have a session context that
+/// can be used with datafusion's CLI code.
+pub trait CliSessionContext {
+    /// Get an atomic reference counted task context.
+    fn task_ctx(&self) -> Arc<TaskContext>;
+
+    /// Get the session state.
+    fn session_state(&self) -> SessionState;
+
+    /// Register an object store with the session context.
+    fn register_object_store(
+        &self,
+        url: &url::Url,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Option<Arc<dyn ObjectStore + 'static>>;
+
+    /// Register table options extension from scheme.
+    fn register_table_options_extension_from_scheme(&self, scheme: &str);
+
+    /// Execute a logical plan and return a DataFrame.
+    async fn execute_logical_plan(&self, plan: LogicalPlan) -> Result<DataFrame, DataFusionError>;
+}
+
+#[async_trait::async_trait]
+impl CliSessionContext for SessionContext {
+    fn task_ctx(&self) -> Arc<TaskContext> {
+        self.task_ctx()
+    }
+
+    fn session_state(&self) -> SessionState {
+        self.state()
+    }
+
+    fn register_object_store(
+        &self,
+        url: &url::Url,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Option<Arc<dyn ObjectStore + 'static>> {
+        self.register_object_store(url, object_store)
+    }
+
+    fn register_table_options_extension_from_scheme(&self, scheme: &str) {
+        match scheme {
+            // For Amazon S3 or Alibaba Cloud OSS
+            "s3" | "oss" | "cos" => {
+                // Register AWS specific table options in the session context:
+                self.register_table_options_extension(AwsOptions::default())
+            }
+            // For Google Cloud Storage
+            "gs" | "gcs" => {
+                // Register GCP specific table options in the session context:
+                self.register_table_options_extension(GcpOptions::default())
+            }
+            // For unsupported schemes, do nothing:
+            _ => {}
+        }
+    }
+
+    async fn execute_logical_plan(&self, plan: LogicalPlan) -> Result<DataFrame, DataFusionError> {
+        self.execute_logical_plan(plan).await
+    }
+}

--- a/src/utils/datafusion-cli/src/command.rs
+++ b/src/utils/datafusion-cli/src/command.rs
@@ -29,8 +29,8 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::exec_err;
 use datafusion::common::instant::Instant;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::prelude::SessionContext;
 
+use crate::cli_context::CliSessionContext;
 use crate::exec::{exec_and_print, exec_from_lines};
 use crate::functions::{display_all_functions, Function};
 use crate::print_format::PrintFormat;
@@ -57,7 +57,7 @@ pub enum OutputFormat {
 impl Command {
     pub async fn execute(
         &self,
-        ctx: &mut SessionContext,
+        ctx: &dyn CliSessionContext,
         print_options: &mut PrintOptions,
     ) -> Result<()> {
         match self {

--- a/src/utils/datafusion-cli/src/exec.rs
+++ b/src/utils/datafusion-cli/src/exec.rs
@@ -21,15 +21,14 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
-use std::str::FromStr;
 
 use datafusion::common::instant::Instant;
-use datafusion::common::{plan_datafusion_err, FileType};
+use datafusion::common::plan_datafusion_err;
+use datafusion::config::ConfigFileType;
 use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{DdlStatement, LogicalPlan};
 use datafusion::physical_plan::{collect, execute_stream, ExecutionPlanProperties};
-use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::{DFParser, Statement};
 use datafusion::sql::sqlparser;
 use datafusion::sql::sqlparser::dialect::dialect_from_str;
@@ -37,16 +36,17 @@ use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use tokio::signal;
 
+use crate::cli_context::CliSessionContext;
 use crate::command::{Command, OutputFormat};
 use crate::helper::{split_from_semicolon, unescape_input, CliHelper};
-use crate::object_storage::{get_object_store, register_options};
+use crate::object_storage::get_object_store;
 use crate::print_format::PrintFormat;
 use crate::print_options::{MaxRows, PrintOptions};
 
 /// run and execute SQL statements and commands, against a context with the
 /// given print options
 pub async fn exec_from_commands(
-    ctx: &mut SessionContext,
+    ctx: &dyn CliSessionContext,
     commands: Vec<String>,
     print_options: &PrintOptions,
 ) -> Result<()> {
@@ -60,7 +60,7 @@ pub async fn exec_from_commands(
 /// run and execute SQL statements and commands from a file, against a context
 /// with the given print options
 pub async fn exec_from_lines(
-    ctx: &mut SessionContext,
+    ctx: &dyn CliSessionContext,
     reader: &mut BufReader<File>,
     print_options: &PrintOptions,
 ) -> Result<()> {
@@ -100,7 +100,7 @@ pub async fn exec_from_lines(
 }
 
 pub async fn exec_from_files(
-    ctx: &mut SessionContext,
+    ctx: &dyn CliSessionContext,
     files: Vec<String>,
     print_options: &PrintOptions,
 ) -> Result<()> {
@@ -120,7 +120,7 @@ pub async fn exec_from_files(
 /// run and execute SQL statements and commands against a context with the given
 /// print options
 pub async fn exec_from_repl(
-    ctx: &mut SessionContext,
+    ctx: &dyn CliSessionContext,
     print_options: &mut PrintOptions,
 ) -> rustyline::Result<()> {
     let mut rl = Editor::new()?;
@@ -200,7 +200,7 @@ pub async fn exec_from_repl(
 }
 
 pub(super) async fn exec_and_print(
-    ctx: &mut SessionContext,
+    ctx: &dyn CliSessionContext,
     print_options: &PrintOptions,
     sql: String,
 ) -> Result<()> {
@@ -283,30 +283,39 @@ impl AdjustedPrintOptions {
     }
 }
 
+fn config_file_type_from_str(ext: &str) -> Option<ConfigFileType> {
+    match ext.to_lowercase().as_str() {
+        "csv" => Some(ConfigFileType::CSV),
+        "json" => Some(ConfigFileType::JSON),
+        "parquet" => Some(ConfigFileType::PARQUET),
+        _ => None,
+    }
+}
+
 async fn create_plan(
-    ctx: &mut SessionContext,
+    ctx: &dyn CliSessionContext,
     statement: Statement,
 ) -> Result<LogicalPlan, DataFusionError> {
-    let mut plan = ctx.state().statement_to_plan(statement).await?;
+    let mut plan = ctx.session_state().statement_to_plan(statement).await?;
 
     // Note that cmd is a mutable reference so that create_external_table function
     // can remove all datafusion-cli specific options before passing through to
     // datafusion. Otherwise, datafusion will raise Configuration errors.
     if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &plan {
         // To support custom formats, treat error as None
-        let format = FileType::from_str(&cmd.file_type).ok();
+        let format = config_file_type_from_str(&cmd.file_type);
         register_object_store_and_config_extensions(ctx, &cmd.location, &cmd.options, format)
             .await?;
     }
 
     if let LogicalPlan::Copy(copy_to) = &mut plan {
-        let format: FileType = (&copy_to.format_options).into();
+        let format = config_file_type_from_str(&copy_to.file_type.get_ext());
 
         register_object_store_and_config_extensions(
             ctx,
             &copy_to.output_url,
             &copy_to.options,
-            Some(format),
+            format,
         )
         .await?;
     }
@@ -343,10 +352,10 @@ async fn create_plan(
 /// alteration fails, or if the object store cannot be retrieved and registered
 /// successfully.
 pub(crate) async fn register_object_store_and_config_extensions(
-    ctx: &SessionContext,
+    ctx: &dyn CliSessionContext,
     location: &String,
     options: &HashMap<String, String>,
-    format: Option<FileType>,
+    format: Option<ConfigFileType>,
 ) -> Result<()> {
     // Parse the location URL to extract the scheme and other components
     let table_path = ListingTableUrl::parse(location)?;
@@ -358,18 +367,18 @@ pub(crate) async fn register_object_store_and_config_extensions(
     let url = table_path.as_ref();
 
     // Register the options based on the scheme extracted from the location
-    register_options(ctx, scheme);
+    ctx.register_table_options_extension_from_scheme(scheme);
 
     // Clone and modify the default table options based on the provided options
-    let mut table_options = ctx.state().default_table_options().clone();
+    let mut table_options = ctx.session_state().default_table_options().clone();
     if let Some(format) = format {
-        table_options.set_file_format(format);
+        table_options.set_config_format(format);
     }
     table_options.alter_with_string_hash_map(options)?;
 
     // Retrieve the appropriate object store based on the scheme, URL, and modified
     // table options
-    let store = get_object_store(&ctx.state(), scheme, url, &table_options).await?;
+    let store = get_object_store(&ctx.session_state(), scheme, url, &table_options).await?;
 
     // Register the retrieved object store in the session context's runtime
     // environment
@@ -380,8 +389,8 @@ pub(crate) async fn register_object_store_and_config_extensions(
 
 #[cfg(test)]
 mod tests {
-    use datafusion::common::config::FormatOptions;
     use datafusion::common::plan_err;
+    use datafusion::prelude::SessionContext;
     use url::Url;
 
     use super::*;
@@ -391,7 +400,7 @@ mod tests {
         let plan = ctx.state().create_logical_plan(sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &plan {
-            let format = FileType::from_str(&cmd.file_type).ok();
+            let format = config_file_type_from_str(&cmd.file_type);
             register_object_store_and_config_extensions(&ctx, &cmd.location, &cmd.options, format)
                 .await?;
         } else {
@@ -412,12 +421,12 @@ mod tests {
         let plan = ctx.state().create_logical_plan(sql).await?;
 
         if let LogicalPlan::Copy(cmd) = &plan {
-            let format: FileType = (&cmd.format_options).into();
+            let format = config_file_type_from_str(&cmd.file_type.get_ext());
             register_object_store_and_config_extensions(
                 &ctx,
                 &cmd.output_url,
                 &cmd.options,
-                Some(format),
+                format,
             )
             .await?;
         } else {
@@ -448,7 +457,7 @@ mod tests {
             "cos://bucket/path/file.parquet",
             "gcs://bucket/path/file.parquet",
         ];
-        let mut ctx = SessionContext::new();
+        let ctx = SessionContext::new();
         let task_ctx = ctx.task_ctx();
         let dialect = &task_ctx.session_config().options().sql_parser.dialect;
         let dialect = dialect_from_str(dialect).ok_or_else(|| {
@@ -462,10 +471,10 @@ mod tests {
             let statements = DFParser::parse_sql_with_dialect(&sql, dialect.as_ref())?;
             for statement in statements {
                 //Should not fail
-                let mut plan = create_plan(&mut ctx, statement).await?;
+                let mut plan = create_plan(&ctx, statement).await?;
                 if let LogicalPlan::Copy(copy_to) = &mut plan {
                     assert_eq!(copy_to.output_url, location);
-                    assert!(matches!(copy_to.format_options, FormatOptions::PARQUET(_)));
+                    assert_eq!(copy_to.file_type.get_ext(), "parquet".to_string());
                     ctx.runtime_env()
                         .object_store_registry
                         .get_store(&Url::parse(&copy_to.output_url).unwrap())?;

--- a/src/utils/datafusion-cli/src/functions.rs
+++ b/src/utils/datafusion-cli/src/functions.rs
@@ -26,11 +26,11 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::pretty_format_batches;
 use async_trait::async_trait;
+use datafusion::catalog::Session;
 use datafusion::common::{plan_err, Column};
 use datafusion::datasource::function::TableFunctionImpl;
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
-use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::memory::MemoryExec;
 use datafusion::physical_plan::ExecutionPlan;
@@ -234,7 +234,7 @@ impl TableProvider for ParquetMetadataTable {
 
     async fn scan(
         &self,
-        _state: &SessionState,
+        _state: &dyn Session,
         projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         _limit: Option<usize>,

--- a/src/utils/datafusion-cli/src/object_storage.rs
+++ b/src/utils/datafusion-cli/src/object_storage.rs
@@ -32,7 +32,6 @@ use datafusion::common::config::{
 use datafusion::common::{config_err, exec_datafusion_err, exec_err};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::SessionState;
-use datafusion::prelude::SessionContext;
 use object_store::aws::{AmazonS3Builder, AwsCredential};
 use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::http::HttpBuilder;
@@ -382,49 +381,6 @@ impl ConfigExtension for GcpOptions {
     const PREFIX: &'static str = "gcp";
 }
 
-/// Registers storage options for different cloud storage schemes in a given
-/// session context.
-///
-/// This function is responsible for extending the session context with specific
-/// options based on the storage scheme being used. These options are essential
-/// for handling interactions with different cloud storage services such as
-/// Amazon S3, Alibaba Cloud OSS, Google Cloud Storage, etc.
-///
-/// # Parameters
-///
-/// * `ctx` - A mutable reference to the session context where table options are
-///   to be registered. The session context holds configuration and environment
-///   for the current session.
-/// * `scheme` - A string slice that represents the cloud storage scheme. This
-///   determines which set of options will be registered in the session context.
-///
-/// # Supported Schemes
-///
-/// * `s3` or `oss` - Registers `AwsOptions` which are configurations specific
-///   to Amazon S3 and Alibaba Cloud OSS.
-/// * `gs` or `gcs` - Registers `GcpOptions` which are configurations specific
-///   to Google Cloud Storage.
-///
-/// NOTE: This function will not perform any action when given an unsupported
-/// scheme.
-pub(crate) fn register_options(ctx: &SessionContext, scheme: &str) {
-    // Match the provided scheme against supported cloud storage schemes:
-    match scheme {
-        // For Amazon S3 or Alibaba Cloud OSS
-        "s3" | "oss" | "cos" => {
-            // Register AWS specific table options in the session context:
-            ctx.register_table_options_extension(AwsOptions::default())
-        }
-        // For Google Cloud Storage
-        "gs" | "gcs" => {
-            // Register GCP specific table options in the session context:
-            ctx.register_table_options_extension(GcpOptions::default())
-        }
-        // For unsupported schemes, do nothing:
-        _ => {}
-    }
-}
-
 pub(crate) async fn get_object_store(
     state: &SessionState,
     scheme: &str,
@@ -487,6 +443,7 @@ mod tests {
     use object_store::gcp::GoogleConfigKey;
 
     use super::*;
+    use crate::cli_context::CliSessionContext;
 
     #[tokio::test]
     async fn s3_object_store_builder() -> Result<()> {
@@ -510,7 +467,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            register_options(&ctx, scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
@@ -552,7 +509,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            register_options(&ctx, scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
@@ -579,7 +536,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            register_options(&ctx, scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
@@ -611,7 +568,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            register_options(&ctx, scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
@@ -653,7 +610,7 @@ mod tests {
         let mut plan = ctx.state().create_logical_plan(&sql).await?;
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
-            register_options(&ctx, scheme);
+            ctx.register_table_options_extension_from_scheme(scheme);
             let mut table_options = ctx.state().default_table_options().clone();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let gcp_options = table_options.extensions.get::<GcpOptions>().unwrap();

--- a/src/utils/datafusion-cli/src/pool_type.rs
+++ b/src/utils/datafusion-cli/src/pool_type.rs
@@ -15,17 +15,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![doc = include_str!("../README.md")]
-pub const DATAFUSION_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
 
-pub mod catalog;
-pub mod cli_context;
-pub mod command;
-pub mod exec;
-pub mod functions;
-pub mod helper;
-pub mod highlighter;
-pub mod object_storage;
-pub mod pool_type;
-pub mod print_format;
-pub mod print_options;
+#[derive(PartialEq, Debug)]
+pub enum PoolType {
+    Greedy,
+    Fair,
+}
+
+impl FromStr for PoolType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Greedy" | "greedy" => Ok(PoolType::Greedy),
+            "Fair" | "fair" => Ok(PoolType::Fair),
+            _ => Err(format!("Invalid memory pool type '{}'", s)),
+        }
+    }
+}
+
+impl Display for PoolType {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            PoolType::Greedy => write!(f, "greedy"),
+            PoolType::Fair => write!(f, "fair"),
+        }
+    }
+}

--- a/src/utils/kamu-cli-puppet/Cargo.toml
+++ b/src/utils/kamu-cli-puppet/Cargo.toml
@@ -46,8 +46,10 @@ kamu-data-utils = { optional = true, workspace = true }
 opendatafabric = { optional = true, workspace = true }
 
 async-trait = { optional = true, version = "0.1" }
-datafusion = { optional = true, version = "39", default-features = false }
-serde = { optional = true, version = "1", default-features = false, features = ["derive"] }
+datafusion = { optional = true, version = "41", default-features = false }
+serde = { optional = true, version = "1", default-features = false, features = [
+    "derive",
+] }
 serde_json = { optional = true, version = "1" }
 
 


### PR DESCRIPTION
Besides the dependency upgrade this change introduces new crate features:
- `ingest-evm`
- `ingest-mqtt`
- `query-extensions-json`
- with `ftp` feature renamed to `ingest-ftp` for consistency

These features (except for `ingest-ftp`, as previously) are enabled by default in `kamu-cli` crate.

They allow compiling the kamu core without extra dependencies.