### PR TITLE
Add full compaction recursive flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Return `RootDatasetCompacted` error for manual triggered `EXECUTE_TRANSFROM` flows 
+### Changed
+- New recursive flag for `CompactionConditionFull` input to trigger
+  Hard compaction with keep metadata only mode for each derived dataset 
 
 ## [0.191.5] - 2024-07-30
 ### Fixed

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -249,6 +249,7 @@ type CommitResultSuccess implements CommitResult & UpdateReadmeResult {
 input CompactionConditionFull {
 	maxSliceSize: Int!
 	maxSliceRecords: Int!
+	recursive: Boolean!
 }
 
 input CompactionConditionInput @oneOf {
@@ -263,6 +264,7 @@ input CompactionConditionMetadataOnly {
 type CompactionFull {
 	maxSliceSize: Int!
 	maxSliceRecords: Int!
+	recursive: Boolean!
 }
 
 type CompactionMetadataOnly {

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -185,6 +185,7 @@ impl DatasetFlowConfigsMut {
                 match CompactionRuleFull::new_checked(
                     compaction_input.max_slice_size,
                     compaction_input.max_slice_records,
+                    compaction_input.recursive,
                 ) {
                     Ok(rule) => CompactionRule::Full(rule),
                     Err(e) => {

--- a/src/adapter/graphql/src/scalars/flow_configuration.rs
+++ b/src/adapter/graphql/src/scalars/flow_configuration.rs
@@ -101,6 +101,7 @@ pub enum FlowConfigurationCompaction {
 pub struct CompactionFull {
     pub max_slice_size: u64,
     pub max_slice_records: u64,
+    pub recursive: bool,
 }
 
 impl From<CompactionRuleFull> for CompactionFull {
@@ -108,6 +109,7 @@ impl From<CompactionRuleFull> for CompactionFull {
         Self {
             max_slice_records: value.max_slice_records(),
             max_slice_size: value.max_slice_size(),
+            recursive: value.recursive(),
         }
     }
 }

--- a/src/adapter/graphql/src/scalars/flow_configuration.rs
+++ b/src/adapter/graphql/src/scalars/flow_configuration.rs
@@ -264,6 +264,7 @@ pub enum CompactionConditionInput {
 pub struct CompactionConditionFull {
     pub max_slice_size: u64,
     pub max_slice_records: u64,
+    pub recursive: bool,
 }
 
 #[derive(InputObject)]
@@ -306,6 +307,7 @@ impl FlowRunConfiguration {
                         CompactionRuleFull::new_checked(
                             compaction_input.max_slice_size,
                             compaction_input.max_slice_records,
+                            compaction_input.recursive,
                         )
                         .map_err(|_| FlowInvalidRunConfigurations {
                             error: "Invalid compaction flow run configuration".to_string(),

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -2404,6 +2404,7 @@ async fn test_execute_transfrom_flow_error_after_compaction() {
         "HARD_COMPACTION",
         10000,
         1_000_000,
+        false,
     );
 
     let schema = kamu_adapter_graphql::schema_quiet();

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -2749,6 +2749,7 @@ async fn test_config_snapshot_returned_correctly() {
         "HARD_COMPACTION",
         10000,
         1_000_000,
+        false,
     );
 
     let schema = kamu_adapter_graphql::schema_quiet();
@@ -2834,6 +2835,7 @@ async fn test_config_snapshot_returned_correctly() {
                                             "compactionRule": {
                                                 "maxSliceRecords": 10000,
                                                 "maxSliceSize": 1_000_000,
+                                                "recursive": false
                                             }
                                         },
                                     }
@@ -3237,6 +3239,7 @@ impl FlowRunsHarness {
                                                     ... on CompactionFull {
                                                         maxSliceRecords
                                                         maxSliceSize
+                                                        recursive
                                                     }
                                                     ... on CompactionMetadataOnly {
                                                         recursive
@@ -3375,6 +3378,7 @@ impl FlowRunsHarness {
         dataset_flow_type: &str,
         max_slice_records: u64,
         max_slice_size: u64,
+        recursive: bool,
     ) -> String {
         indoc!(
             r#"
@@ -3389,7 +3393,8 @@ impl FlowRunsHarness {
                                         compaction: {
                                             full: {
                                                 maxSliceRecords: <max_slice_records>,
-                                                maxSliceSize: <max_slice_size>
+                                                maxSliceSize: <max_slice_size>,
+                                                recursive: <recursive>
                                             }
                                         }
                                     }
@@ -3436,6 +3441,7 @@ impl FlowRunsHarness {
         .replace("<dataset_flow_type>", dataset_flow_type)
         .replace("<max_slice_records>", &max_slice_records.to_string())
         .replace("<max_slice_size>", &max_slice_size.to_string())
+        .replace("<recursive>", if recursive { "true" } else { "false" })
     }
 
     fn cancel_scheduled_tasks_mutation(id: &DatasetID, flow_id: &str) -> String {

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -2531,6 +2531,7 @@ async fn test_execute_transfrom_flow_error_after_compaction() {
                                             "compactionRule": {
                                                 "maxSliceRecords": 10000,
                                                 "maxSliceSize": 1_000_000,
+                                                "recursive": false
                                             }
                                         },
                                     }

--- a/src/domain/flow-system/services/src/flow/flow_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow/flow_service_impl.rs
@@ -824,6 +824,11 @@ impl FlowServiceImpl {
                     .dataset_ownership_service
                     .get_dataset_owners(&fk_dataset.dataset_id)
                     .await?;
+                // Currently we trigger Hard compaction recursively only in keep metadata only
+                // mode
+                let config_snapshot = FlowConfigurationSnapshot::Compaction(
+                    CompactionRule::MetadataOnly(CompactionRuleMetadataOnly { recursive: true }),
+                );
 
                 for dependent_dataset_id in dependent_dataset_ids {
                     for owner_account_id in &dataset_owner_account_ids {
@@ -839,7 +844,7 @@ impl FlowServiceImpl {
                                 )
                                 .into(),
                                 flow_trigger_context: FlowTriggerContext::Unconditional,
-                                maybe_config_snapshot: maybe_config_snapshot.cloned(),
+                                maybe_config_snapshot: Some(config_snapshot.clone()),
                             });
                             break;
                         }

--- a/src/domain/flow-system/services/src/flow/flow_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow/flow_service_impl.rs
@@ -865,9 +865,8 @@ impl FlowServiceImpl {
             DatasetFlowType::HardCompaction => {
                 if let Some(config_snapshot) = &maybe_config_snapshot
                     && let FlowConfigurationSnapshot::Compaction(compaction_rule) = config_snapshot
-                    && let CompactionRule::MetadataOnly(metadata_only_rule) = compaction_rule
                 {
-                    if metadata_only_rule.recursive {
+                    if compaction_rule.recursive() {
                         DownstreamDependencyTriggerType::TriggerOwnUnconditionally
                     } else {
                         DownstreamDependencyTriggerType::Empty

--- a/src/domain/flow-system/services/tests/tests/test_flow_service_impl.rs
+++ b/src/domain/flow-system/services/tests/tests/test_flow_service_impl.rs
@@ -617,7 +617,7 @@ async fn test_manual_trigger_compaction_with_config() {
             foo_id.clone(),
             DatasetFlowType::HardCompaction,
             CompactionRule::Full(
-                CompactionRuleFull::new_checked(max_slice_size, max_slice_records).unwrap(),
+                CompactionRuleFull::new_checked(max_slice_size, max_slice_records, false).unwrap(),
             ),
         )
         .await;

--- a/src/domain/flow-system/services/tests/tests/test_flow_service_impl.rs
+++ b/src/domain/flow-system/services/tests/tests/test_flow_service_impl.rs
@@ -698,6 +698,236 @@ async fn test_manual_trigger_compaction_with_config() {
     );
 }
 
+#[test_log::test(tokio::test)]
+async fn test_full_hard_compaction_trigger_keep_metadata_compaction_for_derivatives() {
+    let max_slice_size = 1_000_000u64;
+    let max_slice_records = 1000u64;
+    let harness = FlowHarness::new().await;
+
+    let foo_id = harness
+        .create_root_dataset(DatasetAlias {
+            dataset_name: DatasetName::new_unchecked("foo"),
+            account_name: None,
+        })
+        .await;
+    let foo_bar_id = harness
+        .create_derived_dataset(
+            DatasetAlias {
+                dataset_name: DatasetName::new_unchecked("foo.bar"),
+                account_name: None,
+            },
+            vec![foo_id.clone()],
+        )
+        .await;
+    let foo_baz_id = harness
+        .create_derived_dataset(
+            DatasetAlias {
+                dataset_name: DatasetName::new_unchecked("foo.baz"),
+                account_name: None,
+            },
+            vec![foo_id.clone()],
+        )
+        .await;
+
+    harness
+        .set_dataset_flow_compaction_rule(
+            harness.now_datetime(),
+            foo_id.clone(),
+            DatasetFlowType::HardCompaction,
+            CompactionRule::Full(
+                CompactionRuleFull::new_checked(max_slice_size, max_slice_records, true).unwrap(),
+            ),
+        )
+        .await;
+
+    harness.eager_initialization().await;
+
+    let foo_flow_key: FlowKey =
+        FlowKeyDataset::new(foo_id.clone(), DatasetFlowType::HardCompaction).into();
+
+    let test_flow_listener = harness.catalog.get_one::<FlowSystemTestListener>().unwrap();
+    test_flow_listener.define_dataset_display_name(foo_id.clone(), "foo".to_string());
+    test_flow_listener.define_dataset_display_name(foo_bar_id.clone(), "foo_bar".to_string());
+    test_flow_listener.define_dataset_display_name(foo_baz_id.clone(), "foo_baz".to_string());
+
+    // Remember start time
+    let start_time = harness
+        .now_datetime()
+        .duration_round(Duration::try_milliseconds(SCHEDULING_ALIGNMENT_MS).unwrap())
+        .unwrap();
+
+    // Run scheduler concurrently with manual triggers script
+    tokio::select! {
+      // Run API service
+      res = harness.flow_service.run(start_time) => res.int_err(),
+
+      // Run simulation script and task drivers
+      _ = async {
+          let trigger0_driver = harness.manual_flow_trigger_driver(ManualFlowTriggerArgs {
+              flow_key: foo_flow_key,
+              run_since_start: Duration::try_milliseconds(10).unwrap(),
+              initiator_id: None,
+          });
+          let trigger0_handle = trigger0_driver.run();
+
+          // Task 0: "foo" start running at 20ms, finish at 90ms
+          let task0_driver = harness.task_driver(TaskDriverArgs {
+              task_id: TaskID::new(0),
+              dataset_id: Some(foo_id.clone()),
+              run_since_start: Duration::try_milliseconds(20).unwrap(),
+              finish_in_with: Some(
+                (
+                  Duration::try_milliseconds(70).unwrap(),
+                  TaskOutcome::Success(TaskResult::CompactionDatasetResult(TaskCompactionDatasetResult {
+                    compaction_result: CompactionResult::Success {
+                      old_head: Multihash::from_digest_sha3_256(b"old-slice"),
+                      new_head: Multihash::from_digest_sha3_256(b"new-slice"),
+                      old_num_blocks: 5,
+                      new_num_blocks: 4,
+                    }
+                  }))
+                )
+              ),
+              expected_logical_plan: LogicalPlan::HardCompactionDataset(HardCompactionDataset {
+                dataset_id: foo_id.clone(),
+                max_slice_size: Some(max_slice_size),
+                max_slice_records: Some(max_slice_records),
+                keep_metadata_only: false,
+              }),
+          });
+          let task0_handle = task0_driver.run();
+
+          // Task 1: "foo_bar" start running at 110ms, finish at 180sms
+          let task1_driver = harness.task_driver(TaskDriverArgs {
+              task_id: TaskID::new(1),
+              dataset_id: Some(foo_baz_id.clone()),
+              run_since_start: Duration::try_milliseconds(110).unwrap(),
+              finish_in_with: Some(
+                (
+                  Duration::try_milliseconds(70).unwrap(),
+                  TaskOutcome::Success(TaskResult::CompactionDatasetResult(TaskCompactionDatasetResult {
+                    compaction_result: CompactionResult::Success {
+                      old_head: Multihash::from_digest_sha3_256(b"old-slice-2"),
+                      new_head: Multihash::from_digest_sha3_256(b"new-slice-2"),
+                      old_num_blocks: 5,
+                      new_num_blocks: 4,
+                    }
+                  }
+                ))
+              )),
+              expected_logical_plan: LogicalPlan::HardCompactionDataset(HardCompactionDataset {
+                dataset_id: foo_baz_id.clone(),
+                max_slice_size: None,
+                max_slice_records: None,
+                keep_metadata_only: true,
+              }),
+          });
+          let task1_handle = task1_driver.run();
+
+          // Task 2: "foo_bar_baz" start running at 200ms, finish at 240ms
+          let task2_driver = harness.task_driver(TaskDriverArgs {
+              task_id: TaskID::new(2),
+              dataset_id: Some(foo_bar_id.clone()),
+              run_since_start: Duration::try_milliseconds(200).unwrap(),
+              finish_in_with: Some(
+                (
+                  Duration::try_milliseconds(40).unwrap(),
+                  TaskOutcome::Success(TaskResult::CompactionDatasetResult(TaskCompactionDatasetResult {
+                    compaction_result: CompactionResult::Success {
+                      old_head: Multihash::from_digest_sha3_256(b"old-slice-3"),
+                      new_head: Multihash::from_digest_sha3_256(b"new-slice-3"),
+                      old_num_blocks: 8,
+                      new_num_blocks: 3,
+                    }
+                  }
+                ))
+              )),
+              expected_logical_plan: LogicalPlan::HardCompactionDataset(HardCompactionDataset {
+                dataset_id: foo_bar_id.clone(),
+                max_slice_size: None,
+                max_slice_records: None,
+                keep_metadata_only: true,
+              }),
+          });
+          let task2_handle = task2_driver.run();
+
+          // Main simulation script
+          let main_handle = async {
+              harness.advance_time(Duration::try_milliseconds(300).unwrap()).await;
+          };
+
+          tokio::join!(trigger0_handle, task0_handle, task1_handle, task2_handle, main_handle)
+      } => Ok(())
+  }
+  .unwrap();
+
+    pretty_assertions::assert_eq!(
+        format!("{}", test_flow_listener.as_ref()),
+        indoc::indoc!(
+            r#"
+          #0: +0ms:
+
+          #1: +10ms:
+            "foo" HardCompaction:
+              Flow ID = 0 Waiting Manual Executor(task=0, since=10ms)
+
+          #2: +20ms:
+            "foo" HardCompaction:
+              Flow ID = 0 Running(task=0)
+
+          #3: +90ms:
+            "foo" HardCompaction:
+              Flow ID = 0 Finished Success
+            "foo_bar" HardCompaction:
+              Flow ID = 2 Waiting Input(foo)
+            "foo_baz" HardCompaction:
+              Flow ID = 1 Waiting Input(foo)
+
+          #4: +90ms:
+            "foo" HardCompaction:
+              Flow ID = 0 Finished Success
+            "foo_bar" HardCompaction:
+              Flow ID = 2 Waiting Input(foo) Executor(task=2, since=90ms)
+            "foo_baz" HardCompaction:
+              Flow ID = 1 Waiting Input(foo) Executor(task=1, since=90ms)
+
+          #5: +110ms:
+            "foo" HardCompaction:
+              Flow ID = 0 Finished Success
+            "foo_bar" HardCompaction:
+              Flow ID = 2 Waiting Input(foo) Executor(task=2, since=90ms)
+            "foo_baz" HardCompaction:
+              Flow ID = 1 Running(task=1)
+
+          #6: +180ms:
+            "foo" HardCompaction:
+              Flow ID = 0 Finished Success
+            "foo_bar" HardCompaction:
+              Flow ID = 2 Waiting Input(foo) Executor(task=2, since=90ms)
+            "foo_baz" HardCompaction:
+              Flow ID = 1 Finished Success
+
+          #7: +200ms:
+            "foo" HardCompaction:
+              Flow ID = 0 Finished Success
+            "foo_bar" HardCompaction:
+              Flow ID = 2 Running(task=2)
+            "foo_baz" HardCompaction:
+              Flow ID = 1 Finished Success
+
+          #8: +240ms:
+            "foo" HardCompaction:
+              Flow ID = 0 Finished Success
+            "foo_bar" HardCompaction:
+              Flow ID = 2 Finished Success
+            "foo_baz" HardCompaction:
+              Flow ID = 1 Finished Success
+
+          "#
+        )
+    );
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
## Description

Closes: https://github.com/kamu-data/kamu-cli/issues/740

<!--- Describe your changes in detail and include your changelog entries -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅