### PR TITLE
Add name override parameter to add command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `kamu add` command accepts optional `--name` argument to add a snapshot under a different name
+
 ## [0.192.0] - 2024-08-07
 ### Added
 - `kamu --no-color` to disable color output in the terminal.

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -66,6 +66,7 @@ Add a new dataset or modify an existing one
 * `-r`, `--recursive` — Recursively search for all manifest in the specified directory
 * `--replace` — Delete and re-add datasets that already exist
 * `--stdin` — Read manifests from standard input
+* `--name <N>` — Overrides the name in a loaded manifest
 
 This command creates a new dataset from the provided DatasetSnapshot manifest.
 

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -29,6 +29,7 @@ pub fn get_command(
                 .get_many("manifest")
                 .unwrap_or_default()
                 .map(String::as_str),
+            submatches.get_one("name").cloned(),
             submatches.get_flag("recursive"),
             submatches.get_flag("replace"),
             submatches.get_flag("stdin"),

--- a/src/app/cli/src/cli_parser.rs
+++ b/src/app/cli/src/cli_parser.rs
@@ -97,6 +97,11 @@ pub fn cli() -> Command {
                             .long("stdin")
                             .action(ArgAction::SetTrue)
                             .help("Read manifests from standard input"),
+                        Arg::new("name")
+                            .long("name")
+                            .value_name("N")
+                            .value_parser(value_parser!(opendatafabric::DatasetAlias))
+                            .help("Overrides the name in a loaded manifest"),
                         Arg::new("manifest")
                             .action(ArgAction::Append)
                             .index(1)


### PR DESCRIPTION
## Description

Allows overriding a name on add:
```sh
kamu add my-dataset.yaml --name my-dataset-with-a-different-name
```

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅