### PR TITLE
E2E: modify a workaround for MySQL tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,10 +2,24 @@
 fail-fast = false
 
 [test-groups]
+mysql = { max-threads = 1 } # Explanation below
 setup = { max-threads = 1 }  # Serialize the setup steps
 containerized = { max-threads = 8 }  # Don't use too much memory
 engine = { max-threads = 2 }  # Engine tests are very memory-hungry
 database = { max-threads = 8 }  # Don't use too much memory
+
+# TODO: Delete this workaround when this PR is merged:
+#       - Fix: nextest cleanup race condition by bonega
+#         https://github.com/launchbadge/sqlx/pull/3334
+#
+# NOTE: There is an incompatibility between nextest and sqlx:
+#       - nextest implies multiprocessing,
+#       - while sqlx has a lock on cleanup within the current process
+#         (https://github.com/launchbadge/sqlx/pull/2640#issuecomment-1659455042).
+[[profile.default.overrides]]
+filter = "test(::mysql::)"
+test-group = "mysql"
+retries = { count = 3, backoff = "exponential", delay = "3s" }
 
 [[profile.default.overrides]]
 filter = "test(::setup::)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Upgraded to `datafusion v41` (#713)
+### Fixed
+- E2E: added additional force off colors to exclude sometimes occurring ANSI color sequences
+- E2E: modify a workaround for MySQL tests
 
 ## [0.194.1] - 2024-08-14
 ### Fixed
@@ -20,8 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Private Datasets, preparation work:
   - Added in-mem implementation of ReBAC repository
   - Added in-mem implementation of `DatasetEntryRepository`
-### Fixed
-- E2E: added additional force off colors to exclude sometimes occurring ANSI color sequences
 
 ## [0.193.1] - 2024-08-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Private Datasets, preparation work:
   - Added in-mem implementation of ReBAC repository
   - Added in-mem implementation of `DatasetEntryRepository`
+### Fixed
+- E2E: added additional force off colors to exclude sometimes occurring ANSI color sequences
 
 ## [0.193.1] - 2024-08-09
 ### Fixed

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -686,6 +686,7 @@ fn configure_logging(
             .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
             .with_writer(std::io::stderr)
             .pretty()
+            .with_ansi(!no_color_output)
             .init();
 
         return Guards::default();

--- a/src/e2e/app/cli/common-macros/src/lib.rs
+++ b/src/e2e/app/cli/common-macros/src/lib.rs
@@ -70,9 +70,7 @@ fn kamu_cli_e2e_test_impl(harness_method: &Ident, input: TokenStream) -> TokenSt
             }
         },
         "mysql" => quote! {
-            // flaky: when running in parallel, errors occur with table not found (or sporadic deadlocks),
-            //        restarting again solves the problem.
-            #[test_group::group(e2e, database, mysql, flaky, #extra_test_groups)]
+            #[test_group::group(e2e, database, mysql, #extra_test_groups)]
             #[test_log::test(sqlx::test(migrations = "../../../../../migrations/mysql"))]
             async fn #test_function_name (mysql_pool: sqlx::MySqlPool) {
                 KamuCliApiServerHarness::mysql(&mysql_pool, #options )

--- a/src/utils/kamu-cli-puppet/src/kamu_cli_puppet.rs
+++ b/src/utils/kamu-cli-puppet/src/kamu_cli_puppet.rs
@@ -110,7 +110,7 @@ impl KamuCliPuppet {
     {
         let mut command = assert_cmd::Command::cargo_bin("kamu-cli").unwrap();
 
-        command.env("RUST_LOG", "trace");
+        command.env("RUST_LOG", "info,sqlx=debug");
 
         command.arg("-v");
         command.arg("--no-color");


### PR DESCRIPTION
## Description

Related issue: https://github.com/kamu-data/kamu-cli/issues/718

### Fixed
- E2E: modify a workaround for MySQL tests

## Checklist before requesting a review

- [x] Unit and integration tests added ❌ this change for the tests themselves
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌ not needed
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌ only this repo