### PR TITLE
Ingest from file upload detects media type from extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- The `/ingest` endpoint will try to infer the media type of a file by extension if not specified explicitly during upload. This resolves the problem with `415 Unsupported Media Type` errors when uploading `.ndjson` files from the Web UI.
+
 ## [0.195.1] - 2024-08-16
 ### Fixed
 - Add `reset` ENUM variant to `dataset_flow_type` in postgres migration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,6 +5166,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "serde_with",
  "sha3",
  "tar",
  "tempfile",

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -59,6 +59,7 @@ reqwest = { version = "0.11", default-features = false, features = [
 ] }
 serde = "1"
 serde_json = "1"
+serde_with = { version = "3", default-features = false }
 tar = "0.4"
 thiserror = { version = "1", default-features = false }
 tokio = { version = "1", default-features = false, features = [] }

--- a/src/adapter/http/tests/tests/test_upload_s3.rs
+++ b/src/adapter/http/tests/tests/test_upload_s3.rs
@@ -24,13 +24,7 @@ use kamu_accounts_services::{
     LoginPasswordAuthProvider,
     PredefinedAccountsRegistrator,
 };
-use kamu_adapter_http::{
-    decode_upload_token_payload,
-    FileUploadLimitConfig,
-    UploadContext,
-    UploadService,
-    UploadServiceS3,
-};
+use kamu_adapter_http::{FileUploadLimitConfig, UploadContext, UploadService, UploadServiceS3};
 use time_source::SystemTimeSourceDefault;
 use tokio::io::AsyncReadExt;
 
@@ -216,13 +210,12 @@ async fn test_attempt_upload_file_authorized() {
 
         assert_eq!(200, s3_upload_response.status());
 
-        let upload_token_payload =
-            decode_upload_token_payload(&upload_context.upload_token).unwrap();
+        let upload_token = upload_context.upload_token.0;
 
         let expected_key = format!(
             "{}/{}/{}",
             DEFAULT_ACCOUNT_ID.as_multibase(),
-            upload_token_payload.upload_id,
+            upload_token.upload_id,
             "test.txt"
         );
         let file_exists = upload_bucket_context

--- a/src/domain/core/src/services/ingest/data_format_registry.rs
+++ b/src/domain/core/src/services/ingest/data_format_registry.rs
@@ -21,6 +21,8 @@ use super::{ReadError, Reader, UnsupportedMediaTypeError};
 pub trait DataFormatRegistry: Send + Sync {
     fn list_formats(&self) -> Vec<DataFormatDesc>;
 
+    fn format_by_file_extension(&self, ext: &str) -> Option<DataFormatDesc>;
+
     fn format_of(&self, conf: &odf::ReadStep) -> DataFormatDesc;
 
     // TODO: Avoid `async` poisoning by datafusion
@@ -54,12 +56,14 @@ pub trait DataFormatRegistry: Send + Sync {
 pub struct DataFormatDesc {
     pub short_name: &'static str,
     pub media_type: MediaTypeRef<'static>,
+    pub file_extensions: &'static [&'static str],
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // TODO: Consider a crate
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 pub struct MediaType(pub String);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,9 +81,10 @@ impl MediaType {
     pub const NDGEOJSON: MediaTypeRef<'static> = MediaTypeRef("application/x-ndgeojson");
     /// See: <https://issues.apache.org/jira/browse/PARQUET-1889>
     pub const PARQUET: MediaTypeRef<'static> = MediaTypeRef("application/vnd.apache.parquet");
-    /// No standard found
-    pub const ESRI_SHAPEFILE: MediaTypeRef<'static> =
-        MediaTypeRef("application/vnd.esri.shapefile");
+    /// Multiple in use
+    /// See: <https://www.iana.org/assignments/media-types/application/vnd.shp>
+    /// See: <https://en.wikipedia.org/wiki/Shapefile>
+    pub const ESRI_SHAPEFILE: MediaTypeRef<'static> = MediaTypeRef("application/vnd.shp");
 }
 
 impl<'a> MediaTypeRef<'a> {

--- a/src/infra/core/src/ingest/data_format_registry_impl.rs
+++ b/src/infra/core/src/ingest/data_format_registry_impl.rs
@@ -25,30 +25,37 @@ impl DataFormatRegistryImpl {
     pub const FMT_CSV: DataFormatDesc = DataFormatDesc {
         short_name: "CSV",
         media_type: MediaType::CSV,
+        file_extensions: &["csv"],
     };
     pub const FMT_JSON: DataFormatDesc = DataFormatDesc {
         short_name: "JSON",
         media_type: MediaType::JSON,
+        file_extensions: &["json"],
     };
     pub const FMT_NDJSON: DataFormatDesc = DataFormatDesc {
         short_name: "NDJSON",
         media_type: MediaType::NDJSON,
+        file_extensions: &["ndjson"],
     };
     pub const FMT_GEOJSON: DataFormatDesc = DataFormatDesc {
         short_name: "GeoJSON",
         media_type: MediaType::GEOJSON,
+        file_extensions: &["geojson"],
     };
     pub const FMT_NDGEOJSON: DataFormatDesc = DataFormatDesc {
         short_name: "NDGeoJSON",
         media_type: MediaType::NDGEOJSON,
+        file_extensions: &["ndgeojson"],
     };
     pub const FMT_PARQUET: DataFormatDesc = DataFormatDesc {
         short_name: "Parquet",
         media_type: MediaType::PARQUET,
+        file_extensions: &["parquet"],
     };
     pub const FMT_ESRI_SHAPEFILE: DataFormatDesc = DataFormatDesc {
         short_name: "Shapefile",
         media_type: MediaType::ESRI_SHAPEFILE,
+        file_extensions: &["shp", "shx"],
     };
 
     pub fn new() -> Self {
@@ -68,6 +75,18 @@ impl DataFormatRegistry for DataFormatRegistryImpl {
             Self::FMT_PARQUET,
             Self::FMT_ESRI_SHAPEFILE,
         ]
+    }
+
+    fn format_by_file_extension(&self, ext: &str) -> Option<DataFormatDesc> {
+        let ext = ext.to_lowercase();
+        for fmt in self.list_formats() {
+            for fext in fmt.file_extensions {
+                if *fext == ext {
+                    return Some(fmt);
+                }
+            }
+        }
+        None
     }
 
     fn format_of(&self, conf: &ReadStep) -> DataFormatDesc {
@@ -145,11 +164,13 @@ impl DataFormatRegistry for DataFormatRegistryImpl {
             MediaType::GEOJSON => Ok(ReadStepGeoJson { schema }.into()),
             MediaType::NDGEOJSON => Ok(ReadStepNdGeoJson { schema }.into()),
             MediaType::PARQUET => Ok(ReadStepParquet { schema }.into()),
-            MediaType::ESRI_SHAPEFILE => Ok(ReadStepEsriShapefile {
-                schema,
-                ..Default::default()
+            MediaType::ESRI_SHAPEFILE | MediaTypeRef("x-gis/x-shapefile") => {
+                Ok(ReadStepEsriShapefile {
+                    schema,
+                    ..Default::default()
+                }
+                .into())
             }
-            .into()),
             _ => Err(UnsupportedMediaTypeError::new(media_type.clone())),
         }
     }


### PR DESCRIPTION
## Description

Closes: kamu-data/kamu-node#98

When uploading a file via Web UI the media type is read in TypeScript through standard library and passed unchecked into query parameter. On `.ndjson` files the file type is empty and hits the backend as `&contentType=`.

* Refactoring of `UploadToken` serde to prevent empty strings like `content_type: Some(MediaType(""))` from getting into core services
* If content type is not specified - the handler will try to deduce it from file extension 

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅