### PR TITLE
sqlx 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - The `/ingest` endpoint will try to infer the media type of a file by extension if not specified explicitly during upload. This resolves the problem with `415 Unsupported Media Type` errors when uploading `.ndjson` files from the Web UI.
+### Changed
+- `sqlx` v0.8
 
 ## [0.195.1] - 2024-08-16
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,9 +3641,14 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "event-sourcing"
@@ -4152,9 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -4188,9 +4202,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -6256,9 +6267,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -7063,6 +7074,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -8754,6 +8771,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -8855,9 +8875,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -8868,11 +8888,10 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
 dependencies = [
- "ahash",
  "atoi",
  "byteorder",
  "bytes",
@@ -8886,6 +8905,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
+ "hashbrown 0.14.5",
  "hashlink",
  "hex",
  "indexmap 2.4.0",
@@ -8912,26 +8932,26 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -8943,7 +8963,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
+ "syn 2.0.74",
  "tempfile",
  "tokio",
  "url",
@@ -8951,12 +8971,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
  "bytes",
@@ -8995,12 +9015,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
  "chrono",
@@ -9035,9 +9055,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
 dependencies = [
  "atoi",
  "chrono",
@@ -9051,10 +9071,10 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
  "tracing",
  "url",
- "urlencoding",
  "uuid",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -61,6 +61,7 @@ deny = [
     { name = "prost", deny-multiple-versions = true },
     # { name = "reqwest", deny-multiple-versions = true },
     # { name = "rustls", deny-multiple-versions = true },
+    { name = "sqlx", deny-multiple-versions = true },
     { name = "tokio", deny-multiple-versions = true },
     { name = "tonic", deny-multiple-versions = true },
 ]
@@ -109,5 +110,7 @@ allow-org = { github = [
 [advisories]
 yanked = "deny"
 # TODO: Remove when patches are available
-#       See more: https://rustsec.org/advisories/RUSTSEC-2023-0071.html
-ignore = ["RUSTSEC-2023-0071"]
+ignore = [
+    "RUSTSEC-2023-0071", # https://rustsec.org/advisories/RUSTSEC-2023-0071.html
+    "RUSTSEC-2024-0363"  # https://rustsec.org/advisories/RUSTSEC-2024-0363
+]

--- a/images/Makefile
+++ b/images/Makefile
@@ -4,7 +4,7 @@ IMAGE_JUPYTER_TAG = 0.6.2
 
 KAMU_VERSION = $(shell cargo metadata --format-version 1 | jq -r '.packages[] | select( .name == "kamu") | .version')
 
-SQLX_VERSION = 0.7.4
+SQLX_VERSION = 0.8.0
 IMAGE_SQLX_TAG = $(SQLX_VERSION)-1
 
 ################################################################################

--- a/src/domain/accounts/domain/Cargo.toml
+++ b/src/domain/accounts/domain/Cargo.toml
@@ -49,7 +49,7 @@ tracing = { version = "0.1", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v4"] }
 
 # Optional
-sqlx = { optional = true, version = "0.7", default-features = false, features = [
+sqlx = { optional = true, version = "0.8", default-features = false, features = [
     "macros",
 ] }
 

--- a/src/domain/datasets/domain/Cargo.toml
+++ b/src/domain/datasets/domain/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = { version = "1", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v4"] }
 
 # Optional
-sqlx = { optional = true, version = "0.7", default-features = false, features = [
+sqlx = { optional = true, version = "0.8", default-features = false, features = [
     "macros",
 ] }
 

--- a/src/domain/flow-system/domain/Cargo.toml
+++ b/src/domain/flow-system/domain/Cargo.toml
@@ -35,7 +35,7 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 cron = { version = "0.12", default-features = false }
 lazy_static = { version = "1" }
-sqlx = { version = "0.7", default-features = false, features = ["macros"] }
+sqlx = { version = "0.8", default-features = false, features = ["macros"] }
 thiserror = { version = "1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/src/domain/opendatafabric/Cargo.toml
+++ b/src/domain/opendatafabric/Cargo.toml
@@ -70,7 +70,7 @@ tonic = "0.11"
 arrow = { optional = true, version = "52", default-features = false, features = [
     "ipc",
 ] }
-sqlx = { optional = true, version = "0.7", default-features = false }
+sqlx = { optional = true, version = "0.8", default-features = false }
 
 [dev-dependencies]
 indoc = "2"

--- a/src/domain/opendatafabric/src/identity/sqlx.rs
+++ b/src/domain/opendatafabric/src/identity/sqlx.rs
@@ -14,7 +14,7 @@ macro_rules! impl_sqlx {
             &'r str: sqlx::Decode<'r, DB>,
         {
             fn decode(
-                value: <DB as sqlx::database::HasValueRef<'r>>::ValueRef,
+                value: <DB as sqlx::database::Database>::ValueRef<'r>,
             ) -> Result<Self, sqlx::error::BoxDynError> {
                 let value = <&str as sqlx::Decode<DB>>::decode(value)?;
                 let value = $typ::from_did_str(value)?;

--- a/src/e2e/app/cli/common/Cargo.toml
+++ b/src/e2e/app/cli/common/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1"
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "postgres",
     "mysql",
     "sqlite",

--- a/src/e2e/app/cli/mysql/Cargo.toml
+++ b/src/e2e/app/cli/mysql/Cargo.toml
@@ -30,7 +30,7 @@ kamu-cli-e2e-repo-tests = { workspace = true }
 
 indoc = "2"
 paste = "1"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "macros",
     "mysql",
 ] }

--- a/src/e2e/app/cli/postgres/Cargo.toml
+++ b/src/e2e/app/cli/postgres/Cargo.toml
@@ -30,7 +30,7 @@ kamu-cli-e2e-repo-tests = { workspace = true }
 
 indoc = "2"
 paste = "1"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "macros",
     "postgres",
 ] }

--- a/src/e2e/app/cli/sqlite/Cargo.toml
+++ b/src/e2e/app/cli/sqlite/Cargo.toml
@@ -30,7 +30,7 @@ kamu-cli-e2e-repo-tests = { workspace = true }
 
 indoc = "2"
 paste = "1"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "macros",
     "sqlite",
 ] }

--- a/src/infra/accounts/mysql/.sqlx/query-1d50e78b845054a7808c4c38be9b3dc0b66c6cb1cfcc2271bb7dc28accbbd120.json
+++ b/src/infra/accounts/mysql/.sqlx/query-1d50e78b845054a7808c4c38be9b3dc0b66c6cb1cfcc2271bb7dc28accbbd120.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "String",
           "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 32
         }
       },
@@ -19,7 +18,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       },
@@ -29,7 +27,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | UNIQUE_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       },
@@ -39,7 +36,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "UNIQUE_KEY",
-          "char_set": 224,
           "max_size": 1280
         }
       },
@@ -49,7 +45,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 800
         }
       },
@@ -59,7 +54,6 @@
         "type_info": {
           "type": "String",
           "flags": "NOT_NULL | ENUM | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 48
         }
       },
@@ -69,7 +63,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "",
-          "char_set": 224,
           "max_size": 4000
         }
       },
@@ -79,7 +72,6 @@
         "type_info": {
           "type": "Timestamp",
           "flags": "NOT_NULL | UNSIGNED | BINARY | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 26
         }
       },
@@ -89,7 +81,6 @@
         "type_info": {
           "type": "Tiny",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 4
         }
       },
@@ -99,7 +90,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 100
         }
       },
@@ -109,7 +99,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | UNIQUE_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-36a65d2c3c26a5f18b2bb9436f9941b50fa45c5cf731803384eedc801f5d77ad.json
+++ b/src/infra/accounts/mysql/.sqlx/query-36a65d2c3c26a5f18b2bb9436f9941b50fa45c5cf731803384eedc801f5d77ad.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-38c3d56c228c0fbbdd450b98b900d9580da47336d961ac60d7aa3f016ad0cd78.json
+++ b/src/infra/accounts/mysql/.sqlx/query-38c3d56c228c0fbbdd450b98b900d9580da47336d961ac60d7aa3f016ad0cd78.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-7c44992c25456bc4847a6217ce9f787b6724ffa18bd401c86237b2f822ef690b.json
+++ b/src/infra/accounts/mysql/.sqlx/query-7c44992c25456bc4847a6217ce9f787b6724ffa18bd401c86237b2f822ef690b.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       },
@@ -19,7 +18,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | UNIQUE_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       },
@@ -29,7 +27,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "UNIQUE_KEY",
-          "char_set": 224,
           "max_size": 1280
         }
       },
@@ -39,7 +36,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 800
         }
       },
@@ -49,7 +45,6 @@
         "type_info": {
           "type": "String",
           "flags": "NOT_NULL | ENUM | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 48
         }
       },
@@ -59,7 +54,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "",
-          "char_set": 224,
           "max_size": 4000
         }
       },
@@ -69,7 +63,6 @@
         "type_info": {
           "type": "Timestamp",
           "flags": "NOT_NULL | UNSIGNED | BINARY | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 26
         }
       },
@@ -79,7 +72,6 @@
         "type_info": {
           "type": "Tiny",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 4
         }
       },
@@ -89,7 +81,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 100
         }
       },
@@ -99,7 +90,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | UNIQUE_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-902f827497da6b3f0575cdb3c09dd04faa64e76c5e70fb51c15a478377fb7d7e.json
+++ b/src/infra/accounts/mysql/.sqlx/query-902f827497da6b3f0575cdb3c09dd04faa64e76c5e70fb51c15a478377fb7d7e.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "String",
           "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 144
         }
       },
@@ -19,7 +18,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       },
@@ -29,7 +27,6 @@
         "type_info": {
           "type": "String",
           "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 32
         }
       },
@@ -39,7 +36,6 @@
         "type_info": {
           "type": "Timestamp",
           "flags": "NOT_NULL | UNSIGNED | BINARY | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 26
         }
       },
@@ -49,7 +45,6 @@
         "type_info": {
           "type": "Timestamp",
           "flags": "UNSIGNED | BINARY",
-          "char_set": 63,
           "max_size": 26
         }
       },
@@ -59,7 +54,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | MULTIPLE_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-b6475d612aaafa7f66b351d7d05f03d000b22aa60021468e314a2849ba65c253.json
+++ b/src/infra/accounts/mysql/.sqlx/query-b6475d612aaafa7f66b351d7d05f03d000b22aa60021468e314a2849ba65c253.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-c09e46abcbc7462a088f8cf0e8953153bc668406e4d17df3b783d3a44c439a13.json
+++ b/src/infra/accounts/mysql/.sqlx/query-c09e46abcbc7462a088f8cf0e8953153bc668406e4d17df3b783d3a44c439a13.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "LongLong",
           "flags": "NOT_NULL | BINARY",
-          "char_set": 63,
           "max_size": 21
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-c8c8a7e5d88101c349a87a987718cdf52642840aad404c0f03cb2549b2e73217.json
+++ b/src/infra/accounts/mysql/.sqlx/query-c8c8a7e5d88101c349a87a987718cdf52642840aad404c0f03cb2549b2e73217.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       },
@@ -19,7 +18,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | UNIQUE_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       },
@@ -29,7 +27,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "UNIQUE_KEY",
-          "char_set": 224,
           "max_size": 1280
         }
       },
@@ -39,7 +36,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 800
         }
       },
@@ -49,7 +45,6 @@
         "type_info": {
           "type": "String",
           "flags": "NOT_NULL | ENUM | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 48
         }
       },
@@ -59,7 +54,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "",
-          "char_set": 224,
           "max_size": 4000
         }
       },
@@ -69,7 +63,6 @@
         "type_info": {
           "type": "Timestamp",
           "flags": "NOT_NULL | UNSIGNED | BINARY | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 26
         }
       },
@@ -79,7 +72,6 @@
         "type_info": {
           "type": "Tiny",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 4
         }
       },
@@ -89,7 +81,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 100
         }
       },
@@ -99,7 +90,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | UNIQUE_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-ddc683df2491b32acecf2366d524357991ba692930bdd284d901ad6e502bce7e.json
+++ b/src/infra/accounts/mysql/.sqlx/query-ddc683df2491b32acecf2366d524357991ba692930bdd284d901ad6e502bce7e.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/.sqlx/query-f8c0ca1c1e21257e35f539b7bf0614724f229ff813fcfc1a0905d90777d153ec.json
+++ b/src/infra/accounts/mysql/.sqlx/query-f8c0ca1c1e21257e35f539b7bf0614724f229ff813fcfc1a0905d90777d153ec.json
@@ -9,7 +9,6 @@
         "type_info": {
           "type": "String",
           "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 144
         }
       },
@@ -19,7 +18,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       },
@@ -29,7 +27,6 @@
         "type_info": {
           "type": "String",
           "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 32
         }
       },
@@ -39,7 +36,6 @@
         "type_info": {
           "type": "Timestamp",
           "flags": "NOT_NULL | UNSIGNED | BINARY | NO_DEFAULT_VALUE",
-          "char_set": 63,
           "max_size": 26
         }
       },
@@ -49,7 +45,6 @@
         "type_info": {
           "type": "Timestamp",
           "flags": "UNSIGNED | BINARY",
-          "char_set": 63,
           "max_size": 26
         }
       },
@@ -59,7 +54,6 @@
         "type_info": {
           "type": "VarString",
           "flags": "NOT_NULL | MULTIPLE_KEY | NO_DEFAULT_VALUE",
-          "char_set": 224,
           "max_size": 400
         }
       }

--- a/src/infra/accounts/mysql/Cargo.toml
+++ b/src/infra/accounts/mysql/Cargo.toml
@@ -30,7 +30,7 @@ opendatafabric = { workspace = true, features = ["sqlx-mysql"] }
 async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "macros",
     "mysql",

--- a/src/infra/accounts/postgres/Cargo.toml
+++ b/src/infra/accounts/postgres/Cargo.toml
@@ -30,7 +30,7 @@ opendatafabric = { workspace = true, features = ["sqlx-postgres"] }
 async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "macros",
     "postgres",

--- a/src/infra/accounts/sqlite/.sqlx/query-0369b12ee46e3144221bc74c96c29271a27b87242f49715b3265339ef08d13df.json
+++ b/src/infra/accounts/sqlite/.sqlx/query-0369b12ee46e3144221bc74c96c29271a27b87242f49715b3265339ef08d13df.json
@@ -6,7 +6,7 @@
       {
         "name": "count(*)",
         "ordinal": 0,
-        "type_info": "Int"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/accounts/sqlite/.sqlx/query-908411ed3618da0eef322d0e1133b7ee78cee2972f3ed09df952a7c137c20a4b.json
+++ b/src/infra/accounts/sqlite/.sqlx/query-908411ed3618da0eef322d0e1133b7ee78cee2972f3ed09df952a7c137c20a4b.json
@@ -46,7 +46,7 @@
       {
         "name": "is_admin: _",
         "ordinal": 8,
-        "type_info": "Int64"
+        "type_info": "Integer"
       },
       {
         "name": "provider",

--- a/src/infra/accounts/sqlite/.sqlx/query-9352be4594ce3d6292a0c57b04c54312662b5fce280508a51970d89c3b60b8a5.json
+++ b/src/infra/accounts/sqlite/.sqlx/query-9352be4594ce3d6292a0c57b04c54312662b5fce280508a51970d89c3b60b8a5.json
@@ -41,7 +41,7 @@
       {
         "name": "is_admin: _",
         "ordinal": 7,
-        "type_info": "Int64"
+        "type_info": "Integer"
       },
       {
         "name": "provider",

--- a/src/infra/accounts/sqlite/.sqlx/query-cbfebf088110fdf9a947cbd44117fa8592225d3492109fbb9ef26e9f235af7af.json
+++ b/src/infra/accounts/sqlite/.sqlx/query-cbfebf088110fdf9a947cbd44117fa8592225d3492109fbb9ef26e9f235af7af.json
@@ -41,7 +41,7 @@
       {
         "name": "is_admin: _",
         "ordinal": 7,
-        "type_info": "Int64"
+        "type_info": "Integer"
       },
       {
         "name": "provider",

--- a/src/infra/accounts/sqlite/Cargo.toml
+++ b/src/infra/accounts/sqlite/Cargo.toml
@@ -30,7 +30,7 @@ opendatafabric = { workspace = true, features = ["sqlx-sqlite"] }
 async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "macros",
     "sqlite",

--- a/src/infra/datasets/postgres/Cargo.toml
+++ b/src/infra/datasets/postgres/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 secrecy = "0.8"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "macros",
     "postgres",

--- a/src/infra/datasets/sqlite/.sqlx/query-75559118bbccfb88b1ecfd3ff44e49438d13be39bdcc2be800871f53177b2c4e.json
+++ b/src/infra/datasets/sqlite/.sqlx/query-75559118bbccfb88b1ecfd3ff44e49438d13be39bdcc2be800871f53177b2c4e.json
@@ -6,7 +6,7 @@
       {
         "name": "count(*)",
         "ordinal": 0,
-        "type_info": "Int"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/datasets/sqlite/Cargo.toml
+++ b/src/infra/datasets/sqlite/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 secrecy = "0.8"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "macros",
     "sqlite",

--- a/src/infra/flow-system/postgres/Cargo.toml
+++ b/src/infra/flow-system/postgres/Cargo.toml
@@ -32,7 +32,7 @@ chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
 serde_json = "1"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "json",
     "macros",

--- a/src/infra/flow-system/sqlite/.sqlx/query-0fced2f53b4b35c6b07202c89bed9f0153bf0f000c4006a1d5103a6fee499d3a.json
+++ b/src/infra/flow-system/sqlite/.sqlx/query-0fced2f53b4b35c6b07202c89bed9f0153bf0f000c4006a1d5103a6fee499d3a.json
@@ -6,7 +6,7 @@
       {
         "name": "event_id",
         "ordinal": 0,
-        "type_info": "Int64"
+        "type_info": "Integer"
       },
       {
         "name": "event_payload: _",

--- a/src/infra/flow-system/sqlite/.sqlx/query-427f644c7f09dc8ba8bea1c8d9702f97af2ca0903ac6a02e5126d07f6d8c9d55.json
+++ b/src/infra/flow-system/sqlite/.sqlx/query-427f644c7f09dc8ba8bea1c8d9702f97af2ca0903ac6a02e5126d07f6d8c9d55.json
@@ -6,7 +6,7 @@
       {
         "name": "count",
         "ordinal": 0,
-        "type_info": "Int"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/flow-system/sqlite/.sqlx/query-f1b80b1c4ed8bf92f225e4f91b14b3fa4ee0088cf3af415e0bdcfe5f408b5cbc.json
+++ b/src/infra/flow-system/sqlite/.sqlx/query-f1b80b1c4ed8bf92f225e4f91b14b3fa4ee0088cf3af415e0bdcfe5f408b5cbc.json
@@ -6,7 +6,7 @@
       {
         "name": "event_id",
         "ordinal": 0,
-        "type_info": "Int64"
+        "type_info": "Integer"
       },
       {
         "name": "event_payload: _",

--- a/src/infra/flow-system/sqlite/Cargo.toml
+++ b/src/infra/flow-system/sqlite/Cargo.toml
@@ -32,7 +32,7 @@ chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
 serde_json = "1"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "json",
     "macros",

--- a/src/infra/messaging-outbox/postgres/Cargo.toml
+++ b/src/infra/messaging-outbox/postgres/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "macros",
     "postgres",

--- a/src/infra/messaging-outbox/sqlite/.sqlx/query-738d1c4230062bd4a670e924ef842930c873cfedd1b8d864745ed7c26fede9ac.json
+++ b/src/infra/messaging-outbox/sqlite/.sqlx/query-738d1c4230062bd4a670e924ef842930c873cfedd1b8d864745ed7c26fede9ac.json
@@ -6,7 +6,7 @@
       {
         "name": "message_id",
         "ordinal": 0,
-        "type_info": "Int64"
+        "type_info": "Integer"
       },
       {
         "name": "producer_name",

--- a/src/infra/messaging-outbox/sqlite/.sqlx/query-8a52d43e1c3a16c91850be1c73d0cc65d1e880159e85aa9008e6f78ef28a006a.json
+++ b/src/infra/messaging-outbox/sqlite/.sqlx/query-8a52d43e1c3a16c91850be1c73d0cc65d1e880159e85aa9008e6f78ef28a006a.json
@@ -16,7 +16,7 @@
       {
         "name": "last_consumed_message_id",
         "ordinal": 2,
-        "type_info": "Int64"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/messaging-outbox/sqlite/.sqlx/query-a00e0b9831fc78664e606f8f6b2316cbd7ef346b7bbcd9c0e8aaa26fe0a2d95a.json
+++ b/src/infra/messaging-outbox/sqlite/.sqlx/query-a00e0b9831fc78664e606f8f6b2316cbd7ef346b7bbcd9c0e8aaa26fe0a2d95a.json
@@ -16,7 +16,7 @@
       {
         "name": "last_consumed_message_id",
         "ordinal": 2,
-        "type_info": "Int64"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/messaging-outbox/sqlite/.sqlx/query-d1d9fdcec93cbf10079386a1f8aaee30cde75a4a9afcb4c2485825e0fec0eb7b.json
+++ b/src/infra/messaging-outbox/sqlite/.sqlx/query-d1d9fdcec93cbf10079386a1f8aaee30cde75a4a9afcb4c2485825e0fec0eb7b.json
@@ -11,7 +11,7 @@
       {
         "name": "max_message_id",
         "ordinal": 1,
-        "type_info": "Int"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/messaging-outbox/sqlite/Cargo.toml
+++ b/src/infra/messaging-outbox/sqlite/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "macros",
     "sqlite",

--- a/src/infra/messaging-outbox/sqlite/src/repos/sqlite_outbox_message_repository.rs
+++ b/src/infra/messaging-outbox/sqlite/src/repos/sqlite_outbox_message_repository.rs
@@ -123,7 +123,7 @@ impl OutboxMessageRepository for SqliteOutboxMessageRepository {
             .map(|r| {
                 (
                     r.producer_name.unwrap(),
-                    OutboxMessageID::new(i64::from(r.max_message_id)),
+                    OutboxMessageID::new(r.max_message_id),
                 )
             })
             .collect())

--- a/src/infra/task-system/postgres/Cargo.toml
+++ b/src/infra/task-system/postgres/Cargo.toml
@@ -32,7 +32,7 @@ chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
 serde_json = "1"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "json",
     "macros",

--- a/src/infra/task-system/sqlite/.sqlx/query-3de78083e9e1b68c576ce420795cb8834ad3f370aa6cd103d5e1399137b9370b.json
+++ b/src/infra/task-system/sqlite/.sqlx/query-3de78083e9e1b68c576ce420795cb8834ad3f370aa6cd103d5e1399137b9370b.json
@@ -6,7 +6,7 @@
       {
         "name": "event_id: _",
         "ordinal": 0,
-        "type_info": "Int64"
+        "type_info": "Integer"
       },
       {
         "name": "event_payload: _",

--- a/src/infra/task-system/sqlite/.sqlx/query-515e14214498e1405deee168d1c297e4fe3946992049f4aa29fa513134c91de7.json
+++ b/src/infra/task-system/sqlite/.sqlx/query-515e14214498e1405deee168d1c297e4fe3946992049f4aa29fa513134c91de7.json
@@ -6,7 +6,7 @@
       {
         "name": "count",
         "ordinal": 0,
-        "type_info": "Int"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/task-system/sqlite/.sqlx/query-5aad9a609647d2df2ffc804adea19c35d595ace74c7cd5fb3f4f6b9ca8c61caa.json
+++ b/src/infra/task-system/sqlite/.sqlx/query-5aad9a609647d2df2ffc804adea19c35d595ace74c7cd5fb3f4f6b9ca8c61caa.json
@@ -6,7 +6,7 @@
       {
         "name": "count",
         "ordinal": 0,
-        "type_info": "Int"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/task-system/sqlite/.sqlx/query-ca5768b1007209e1141cd43a4a6bc6cfd8f92620a747be2459aabf30dc9e3037.json
+++ b/src/infra/task-system/sqlite/.sqlx/query-ca5768b1007209e1141cd43a4a6bc6cfd8f92620a747be2459aabf30dc9e3037.json
@@ -6,7 +6,7 @@
       {
         "name": "task_id",
         "ordinal": 0,
-        "type_info": "Int64"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/task-system/sqlite/.sqlx/query-febb2c5ca05ea2a4f9d20621a6d786269d9b83db21b2efcef8273c01f902859c.json
+++ b/src/infra/task-system/sqlite/.sqlx/query-febb2c5ca05ea2a4f9d20621a6d786269d9b83db21b2efcef8273c01f902859c.json
@@ -6,7 +6,7 @@
       {
         "name": "task_id: _",
         "ordinal": 0,
-        "type_info": "Int64"
+        "type_info": "Integer"
       }
     ],
     "parameters": {

--- a/src/infra/task-system/sqlite/Cargo.toml
+++ b/src/infra/task-system/sqlite/Cargo.toml
@@ -32,7 +32,7 @@ chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
 serde_json = "1"
-sqlx = { version = "0.7", default-features = false, features = [
+sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio-rustls",
     "json",
     "macros",

--- a/src/utils/database-common/Cargo.toml
+++ b/src/utils/database-common/Cargo.toml
@@ -41,7 +41,7 @@ sha2 = "0.10"
 uuid = "1"
 
 [dependencies.sqlx]
-version = "0.7"
+version = "0.8"
 default-features = false
 features = [
     "runtime-tokio-rustls",


### PR DESCRIPTION
## Description

Upgrade `sqlx` from 0.7.4 to 0.8.0 due to advised vulterability report.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [ ] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [ ] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [ ] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [ ] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [ ] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅