### PR TITLE
CI: build `sqlx-cli` image if not exist

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -43,6 +43,11 @@ jobs:
           make kamu-base-with-data-mt
           make kamu-base-with-env-var-storage
 
+      - name: Build sqlx-cli image
+        run: |
+          cd images/
+          make sqlx-cli
+
       - name: Build sqlx-cli image with migrations
         run: |
           cd images/
@@ -55,4 +60,5 @@ jobs:
           make kamu-base-with-data-push
           make kamu-base-with-data-mt-push
           make kamu-base-with-env-var-storage-push
+          make sqlx-cli-push
           make sqlx-cli-with-migrations-push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- CI: build `sqlx-cli` image if it is missing
+
 ## [0.196.0] - 2024-08-19
 ### Added
 - The `/ingest` endpoint will try to infer the media type of file by extension if not specified explicitly during upload. 
@@ -18,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `context_int_err()` - ability to add a context message to an error
 - Added macro `database_transactional_test!()` to minimize boilerplate code
 ### Changed
-- `sqlx` v0.8
+- Upgraded `sqlx` crate to v0.8
 - Renamed `setConfigSchedule` GQL api to `setConfigIngest`. Also extended
   `setConfigIngest` with new field `fetchUncacheable` which indicates to ingone cache
   during ingest step

--- a/images/Makefile
+++ b/images/Makefile
@@ -105,24 +105,37 @@ kamu-base-with-env-var-storage-push:
 
 ################################################################################
 
+sqlx-cli sqlx-cli-push: SQLX_CLI_IMAGE_EXISTS = $(shell \
+		docker manifest inspect $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG) > /dev/null 2>&1 \
+			&& echo yes \
+			|| echo no \
+	)
+
 
 .PHONY: sqlx-cli
 sqlx-cli:
-	docker build \
-		--build-arg VERSION=$(SQLX_VERSION) \
-		-t $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG) \
-		sqlx-cli/
+	@if [ "$(SQLX_CLI_IMAGE_EXISTS)" = "yes" ]; then \
+		echo "sqlx-cli:$(IMAGE_SQLX_TAG) image exists, skip this step" ; \
+	else \
+		docker build \
+			--build-arg VERSION=$(SQLX_VERSION) \
+			-t $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG) \
+			sqlx-cli/ \
+			; \
+	fi
 
 
 .PHONY: sqlx-push
 sqlx-cli-push:
-	docker push $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG)
-
-	docker tag $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG) $(IMAGE_REPO)/sqlx-cli:$(SQLX_VERSION)
-	docker push $(IMAGE_REPO)/sqlx-cli:$(SQLX_VERSION)
-
-	docker tag $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG) $(IMAGE_REPO)/sqlx-cli:latest
-	docker push $(IMAGE_REPO)/sqlx-cli:latest
+	@if [ "$(SQLX_CLI_IMAGE_EXISTS)" = "yes" ]; then \
+		echo "sqlx-cli:$(IMAGE_SQLX_TAG) image exists, skip this step" ; \
+	else \
+		docker push $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG) ; \
+		docker tag $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG) $(IMAGE_REPO)/sqlx-cli:$(SQLX_VERSION) ; \
+		docker push $(IMAGE_REPO)/sqlx-cli:$(SQLX_VERSION) ; \
+		docker tag $(IMAGE_REPO)/sqlx-cli:$(IMAGE_SQLX_TAG) $(IMAGE_REPO)/sqlx-cli:latest ; \
+		docker push $(IMAGE_REPO)/sqlx-cli:latest ; \
+	fi
 
 
 ################################################################################
@@ -137,7 +150,7 @@ sqlx-cli-with-migrations:
 		image
 
 
-.PHONY: sqlx-push
+.PHONY: sqlx-cli-with-migrations-push
 sqlx-cli-with-migrations-push:
 	make -C sqlx-cli-with-migrations/ \
 		IMAGE_REPO=$(IMAGE_REPO) \

--- a/images/sqlx-cli/Dockerfile
+++ b/images/sqlx-cli/Dockerfile
@@ -1,7 +1,7 @@
 ################################################################################
 # Builder
 ################################################################################
-FROM rust:1.78-alpine as builder
+FROM rust:1.78-alpine AS builder
 
 ARG VERSION
 
@@ -24,7 +24,7 @@ RUN cargo binstall sqlx-cli@$VERSION -y
 
 FROM alpine:latest
 
-LABEL org.opencontainers.image.source https://github.com/kamu-data/kamu-cli
+LABEL org.opencontainers.image.source=https://github.com/kamu-data/kamu-cli
 
 ################################################################################
 


### PR DESCRIPTION
## Description

Closes: #issue

<!--- Describe your changes in detail and include your changelog entries -->

### Added
- CI: build `sqlx-cli` image if it is missing

## Checklist before requesting a review

- [x] Unit and integration tests added ❌ code 
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: :warning: CI part updated
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌ not needed
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌ not needed