### PR TITLE
Add User-Agent header and externalize HTTP config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Push ingest from `csv` format will default to `header: true` in case schema was not explicitly provided
 - Access token with duplicate names can be created if such name exists but was revoked
 ### Fixed
-- Crash of kamu logic command with invalid access token
+- Crash in `kamu login` command on 5XX server responses
 ### Added
+- HTTP sources now include `User-Agent` header that defaults to `kamu-cli/{major}.{minor}.{patch}`
+- Externalized configuration of HTTP source parameters like timeouts and redirects
 - CI: build `sqlx-cli` image if it is missing
 
 ## [0.196.0] - 2024-08-19

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -553,6 +553,16 @@ pub fn register_config_in_catalog(
             .source
             .as_ref()
             .unwrap()
+            .http
+            .as_ref()
+            .unwrap()
+            .to_infra_cfg(),
+    );
+    catalog_builder.add_value(
+        config
+            .source
+            .as_ref()
+            .unwrap()
             .mqtt
             .as_ref()
             .unwrap()

--- a/src/infra/core/tests/tests/engine/test_engine_io.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_io.rs
@@ -54,6 +54,7 @@ async fn test_engine_io_common<
             None,
             None,
             None,
+            None,
             dataset_env_var_sys_env,
             run_info_dir.clone(),
         )),

--- a/src/infra/core/tests/tests/ingest/test_fetch.rs
+++ b/src/infra/core/tests/tests/ingest/test_fetch.rs
@@ -1265,6 +1265,7 @@ impl FetchTestHarness {
             None,
             None,
             None,
+            None,
             Arc::new(DatasetKeyValueServiceSysEnv::new()),
             Arc::new(RunInfoDir::new(temp_dir.path().join("run"))),
         );


### PR DESCRIPTION
## Description

Closes: #656

## Checklist before requesting a review

- [x] Unit and integration tests added: ❌ - tested manually
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅ - configuration should be exposed, but will not break the release if it isn't