### PR TITLE
Normalize column names on read

### DIFF
--- a/src/infra/core/src/ingest/push_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/push_ingest_service_impl.rs
@@ -368,6 +368,7 @@ impl PushIngestServiceImpl {
             .await?;
 
         let df = reader.read(input_data_path).await?;
+        tracing::debug!(schema = ?df.schema(), "Reader created a dataframe");
 
         Ok(Some(df))
     }

--- a/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
@@ -693,7 +693,8 @@ async fn test_ingest_polling_bad_column_names_preserve() {
                 .build(),
         )
         .push_event(SetVocab {
-            event_time_column: Some("Date (UTC)".to_string()),
+            // Note: lowercase is explained in DataFrameExt::column_names_to_lowercase
+            event_time_column: Some("date (utc)".to_string()),
             ..Default::default()
         })
         .build();
@@ -724,16 +725,16 @@ async fn test_ingest_polling_bad_column_names_preserve() {
                   OPTIONAL INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  REQUIRED INT32 Date (UTC) (DATE);
-                  REQUIRED BYTE_ARRAY City Name (STRING);
-                  REQUIRED INT64 Population;
+                  REQUIRED INT32 date (utc) (DATE);
+                  REQUIRED BYTE_ARRAY city name (STRING);
+                  REQUIRED INT64 population;
                 }
                 "#
             ),
             indoc!(
                 r#"
                 +--------+----+----------------------+------------+-----------+------------+
-                | offset | op | system_time          | Date (UTC) | City Name | Population |
+                | offset | op | system_time          | date (utc) | city name | population |
                 +--------+----+----------------------+------------+-----------+------------+
                 | 0      | 0  | 2050-01-01T12:00:00Z | 2020-01-01 | A         | 1000       |
                 | 1      | 0  | 2050-01-01T12:00:00Z | 2020-01-01 | B         | 2000       |
@@ -773,12 +774,13 @@ async fn test_ingest_polling_bad_column_names_rename() {
                 .preprocess(TransformSql {
                     engine: "datafusion".to_string(),
                     version: None,
+                    // Note: lowercase is explained in DataFrameExt::column_names_to_lowercase
                     query: Some(
                         r#"
                     select
-                        to_timestamp_millis("Timestamp (UTC)") as event_time,
-                        "City Name" as city,
-                        "Population" as population
+                        to_timestamp_millis("timestamp (utc)") as event_time,
+                        "city name" as city,
+                        population
                     from input
                     "#
                         .to_string(),

--- a/src/infra/core/tests/tests/ingest/test_push_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_push_ingest.rs
@@ -471,6 +471,106 @@ async fn test_ingest_push_schema_stability() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// See: https://github.com/apache/datafusion/issues/7460
+#[test_group::group(engine, ingest, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_ingest_sql_case_sensitivity() {
+    let harness = IngestTestHarness::new();
+
+    let dataset_snapshot = MetadataFactory::dataset_snapshot()
+        .name("foo.bar")
+        .kind(DatasetKind::Root)
+        .push_event(
+            MetadataFactory::add_push_source()
+                .read(ReadStepNdJson::default())
+                .merge(MergeStrategyAppend {})
+                .preprocess(TransformSql {
+                    engine: "datafusion".into(),
+                    version: None,
+                    query: Some(
+                        indoc!(
+                            r#"
+                            select
+                                lower, -- matches lower exactly
+                                "MIXed", -- using quotes to disambiguate
+                                "mixED", -- using quotes to disambiguate
+                                "mixED" as mixed, -- using quotes to disambiguate and rename
+                                UPPER -- matches UPPER because:
+                                      -- enable_ident_normalization = true lowercases in query
+                                      -- we lowercase the fields in the reader
+                            from input
+                            "#
+                        )
+                        .into(),
+                    ),
+                    queries: None,
+                    temporal_tables: None,
+                })
+                .build(),
+        )
+        .build();
+
+    let dataset_alias = dataset_snapshot.name.clone();
+    let dataset_ref = dataset_alias.as_local_ref();
+
+    harness.create_dataset(dataset_snapshot).await;
+    let data_helper = harness.dataset_data_helper(&dataset_alias).await;
+
+    let src_path = harness.temp_dir.path().join("data.ndjson");
+    std::fs::write(
+        &src_path,
+        indoc!(
+            r#"
+            {"lower": "lower", "MIXed": "MIXed", "mixED": "mixED", "UPPER": "UPPER"}
+            "#
+        ),
+    )
+    .unwrap();
+
+    harness
+        .push_ingest_svc
+        .ingest_from_url(
+            &dataset_ref,
+            None,
+            url::Url::from_file_path(&src_path).unwrap(),
+            PushIngestOpts::default(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    data_helper
+        .assert_last_data_eq(
+            indoc!(
+                r#"
+                message arrow_schema {
+                  OPTIONAL INT64 offset;
+                  REQUIRED INT32 op;
+                  REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
+                  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                  OPTIONAL BYTE_ARRAY lower (STRING);
+                  OPTIONAL BYTE_ARRAY MIXed (STRING);
+                  OPTIONAL BYTE_ARRAY mixED (STRING);
+                  OPTIONAL BYTE_ARRAY mixed (STRING);
+                  OPTIONAL BYTE_ARRAY upper (STRING);
+                }
+                "#
+            ),
+            indoc!(
+                r#"
+                +--------+----+----------------------+----------------------+-------+-------+-------+-------+-------+
+                | offset | op | system_time          | event_time           | lower | MIXed | mixED | mixed | upper |
+                +--------+----+----------------------+----------------------+-------+-------+-------+-------+-------+
+                | 0      | 0  | 2050-01-01T12:00:00Z | 2050-01-01T12:00:00Z | lower | MIXed | mixED | mixED | UPPER |
+                +--------+----+----------------------+----------------------+-------+-------+-------+-------+-------+
+                "#
+            ),
+        )
+        .await;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 struct IngestTestHarness {
     temp_dir: TempDir,
     dataset_repo: Arc<DatasetRepositoryLocalFs>,

--- a/src/infra/ingest-datafusion/src/readers/csv.rs
+++ b/src/infra/ingest-datafusion/src/readers/csv.rs
@@ -14,6 +14,7 @@ use datafusion::datasource::file_format::file_compression_type::FileCompressionT
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::ReadError;
+use kamu_data_utils::data::dataframe_ext::DataFrameExt as _;
 use opendatafabric::*;
 
 use crate::*;
@@ -130,6 +131,19 @@ impl Reader for ReaderCsv {
             .read_csv(path.to_str().unwrap(), options)
             .await
             .int_err()?;
+
+        let df = if self
+            .ctx
+            .state()
+            .config()
+            .options()
+            .sql_parser
+            .enable_ident_normalization
+        {
+            df.column_names_to_lowercase().int_err()?
+        } else {
+            df
+        };
 
         Ok(df)
     }

--- a/src/infra/ingest-datafusion/src/readers/ndjson.rs
+++ b/src/infra/ingest-datafusion/src/readers/ndjson.rs
@@ -14,6 +14,7 @@ use datafusion::datasource::file_format::file_compression_type::FileCompressionT
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::ReadError;
+use kamu_data_utils::data::dataframe_ext::DataFrameExt;
 use opendatafabric::*;
 
 use crate::*;
@@ -79,6 +80,19 @@ impl Reader for ReaderNdJson {
             .read_json(path.to_str().unwrap(), options)
             .await
             .int_err()?;
+
+        let df = if self
+            .ctx
+            .state()
+            .config()
+            .options()
+            .sql_parser
+            .enable_ident_normalization
+        {
+            df.column_names_to_lowercase().int_err()?
+        } else {
+            df
+        };
 
         Ok(df)
     }

--- a/src/utils/data-utils/src/data/dataframe_ext.rs
+++ b/src/utils/data-utils/src/data/dataframe_ext.rs
@@ -7,11 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::Path;
-
 use datafusion::error::Result;
-use datafusion::parquet::file::properties::WriterProperties;
 use datafusion::prelude::*;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[async_trait::async_trait]
 pub trait DataFrameExt
@@ -21,7 +20,11 @@ where
     fn columns_to_front(self, front_cols: &[&str]) -> Result<Self>;
 
     fn without_columns(self, cols: &[&str]) -> Result<Self>;
+
+    fn column_names_to_lowercase(self) -> Result<DataFrame, datafusion::error::DataFusionError>;
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[async_trait::async_trait]
 impl DataFrameExt for DataFrame {
@@ -52,17 +55,87 @@ impl DataFrameExt for DataFrame {
 
         self.select(columns)
     }
+
+    // Case-sensitivity in DataFusion is following Postgres which is not very
+    // intuitive to use with identifiers containing upper case letters.
+    //
+    // See: https://github.com/apache/datafusion/issues/7460
+    //
+    // In SQL, DF uses `enable_ident_normalization` by default to transform all
+    // identifiers to lowercase.
+    //
+    // See: https://datafusion.apache.org/user-guide/configs.html
+    //
+    // When reading data from CSV, JSON and other sources, however, they return
+    // column names as-is, so upper case letters become very common.
+    //
+    // If JSON has `someField` column you'll have to use quoted identifiers to refer
+    // to it:
+    //
+    //   select "someFiled" -- works
+    //   select somefield   -- doesn't
+    //
+    // This is very painful when reading files with multiple columns as you'll have
+    // to quote every field appearance in schema, sql, merge, strategy, and
+    // vocab.
+    //
+    // Ideal solution would make DataFusion respect case-insensitivity unless there
+    // is an obvious ambiguity, but alas this is too intrusive. Instead using
+    // this function we normalize all identifiers to lowercase, unless this
+    // causes a collision between two columns.
+    //
+    // This approach is more in line with `enable_ident_normalization` config
+    // option.
+    //
+    // TODO: Support nested structs
+    fn column_names_to_lowercase(self) -> Result<DataFrame, datafusion::error::DataFusionError> {
+        let mut names_lower = std::collections::HashSet::<String>::new();
+        let mut names_lower_collisions = std::collections::HashSet::<String>::new();
+        let mut to_rename = 0;
+
+        for field in self.schema().fields() {
+            let name_lower = field.name().to_lowercase();
+            if name_lower != *field.name() {
+                to_rename += 1;
+            }
+            let collided = !names_lower.insert(name_lower);
+            if collided {
+                names_lower_collisions.insert(field.name().to_lowercase());
+            }
+        }
+
+        if to_rename == 0 {
+            return Ok(self);
+        }
+
+        let (session_state, plan) = self.into_parts();
+        let schema_before = plan.schema().clone();
+
+        let projection = plan
+            .schema()
+            .iter()
+            .map(|(qualifier, field)| {
+                let name_lower = field.name().to_lowercase();
+
+                if names_lower_collisions.contains(&name_lower) {
+                    // Propagate as-is
+                    col(Column::from((qualifier, field)))
+                } else {
+                    // Rename
+                    tracing::debug!(field = field.name(), "Renaming!!!!!!!!!!!!!!!");
+                    col(Column::from((qualifier, field))).alias(name_lower)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let project_plan = datafusion::logical_expr::LogicalPlanBuilder::from(plan)
+            .project(projection)?
+            .build()?;
+
+        tracing::debug!(?schema_before, schema_after = ?project_plan.schema(), "Normalizing field names on read");
+
+        Ok(DataFrame::new(session_state, project_plan))
+    }
 }
 
-#[async_trait::async_trait]
-pub trait SessionContextExt
-where
-    Self: Sized,
-{
-    async fn write_parquet_single_file(
-        &self,
-        df: DataFrame,
-        path: &Path,
-        writer_properties: Option<WriterProperties>,
-    ) -> Result<()>;
-}
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

See for context: https://github.com/apache/datafusion/issues/7460

To me this looks like Postgres behavior is somewhere in between case-sensitive and case-insensitive. This causes very unpleasant issues in our ingest as all fields containing uppercase letters have to be quoted in SQL queries, merge strategies, and vocab columns.

The proposed solution lowercases the column names on read (when possible without creating collisions), which is consistent with DataFusion's [`enable_ident_normalization`](https://datafusion.apache.org/user-guide/configs.html) config option which is on by default.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ❌ - This may break some examples - I will do thorough testing before merging
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [ ] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅