### PR TITLE
Disable DataFusion ident normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- **Breaking:** Using DataFusion's [`enable_ident_normalization = false`](https://datafusion.apache.org/user-guide/configs.html) setting to work with upper case identifiers without needing to put quotes everywhere. This may impact your root and derivative datasets.
 - Push ingest from `csv` format will default to `header: true` in case schema was not explicitly provided
 - Access token with duplicate names can be created if such name exists but was revoked
 ### Fixed

--- a/examples/covid/british-columbia.case-details.yaml
+++ b/examples/covid/british-columbia.case-details.yaml
@@ -25,12 +25,12 @@ content:
         # not providing us any viable primary key to deduplicate records on
         query: |
           select
-            to_timestamp("Reported_Date") as reported_date,
-            "Classification_Reported" as classification,
-            cast(row_number() over (order by "Reported_Date") as bigint) as id,
-            "HA" as ha,
-            "Sex" as sex,
-            "Age_Group" as age_group
+            to_timestamp(Reported_Date) as reported_date,
+            Classification_Reported as classification,
+            cast(row_number() over (order by Reported_Date) as bigint) as id,
+            HA as ha,
+            Sex as sex,
+            Age_Group as age_group
           from input
       # How to combine newly-ingested data with data that is already in the dataset
       merge:

--- a/examples/covid/canada.case-details.yaml
+++ b/examples/covid/canada.case-details.yaml
@@ -16,38 +16,41 @@ content:
       transform:
         kind: Sql
         engine: datafusion
+        # Note the `order by` to guarantee stability of the output for verification
         query: |
-          select
-            'AB' as province,
-            id,
-            reported_date,
-            gender,
-            location
+          select * from (
+            select
+              'AB' as province,
+              id,
+              reported_date,
+              gender,
+              location
             from "covid19.alberta.case-details.hm"
-          union all
-          select
-            'BC' as province,
-            id,
-            reported_date,
-            gender,
-            location
+            union all
+            select
+              'BC' as province,
+              id,
+              reported_date,
+              gender,
+              location
             from "covid19.british-columbia.case-details.hm"
-          union all
-          select
-            'ON' as province,
-            id,
-            reported_date,
-            gender,
-            location
+            union all
+            select
+              'ON' as province,
+              id,
+              reported_date,
+              gender,
+              location
             from "covid19.ontario.case-details.hm"
-          union all
-          select
-            'QC' as province,
-            id,
-            reported_date,
-            gender,
-            location
+            union all
+            select
+              'QC' as province,
+              id,
+              reported_date,
+              gender,
+              location
             from "covid19.quebec.case-details.hm"
+          ) order by reported_date, province, id
     - kind: SetVocab
       eventTimeColumn: reported_date
     - kind: SetInfo

--- a/examples/covid/ontario.case-details.yaml
+++ b/examples/covid/ontario.case-details.yaml
@@ -29,18 +29,18 @@ content:
         engine: datafusion
         query: |
           SELECT
-            cast("Row_ID" as bigint) as id,
-            to_timestamp(coalesce("Case_Reported_Date", "Test_Reported_Date")) as case_reported_date,
+            cast(Row_ID as bigint) as id,
+            to_timestamp(coalesce(Case_Reported_Date, Test_Reported_Date)) as case_reported_date,
             case
-              when "Test_Reported_Date" != '' then to_timestamp("Test_Reported_Date")
+              when Test_Reported_Date != '' then to_timestamp(Test_Reported_Date)
               else null
             end as test_reported_date,
-            "Outcome1" as outcome,
-            "Reporting_PHU_City" as city,
-            "Client_Gender" as gender,
-            "Age_Group" as age_group,
-            "Reporting_PHU_Latitude" as latitude,
-            "Reporting_PHU_Longitude" as longitude
+            Outcome1 as outcome,
+            Reporting_PHU_City as city,
+            Client_Gender as gender,
+            Age_Group as age_group,
+            Reporting_PHU_Latitude as latitude,
+            Reporting_PHU_Longitude as longitude
           FROM input
       merge:
         kind: Ledger

--- a/examples/reth-vs-snp500/account.tokens.transfers.yaml
+++ b/examples/reth-vs-snp500/account.tokens.transfers.yaml
@@ -25,24 +25,24 @@ content:
         engine: datafusion
         query: |
           SELECT
-            to_timestamp_seconds(cast("timeStamp" as bigint)) as block_time,
-            cast("blockNumber" as bigint) as block_number,
-            "blockHash" as block_hash,
-            "hash" as transaction_hash,
-            "transactionIndex" as transaction_index,
-            "nonce",
+            to_timestamp_seconds(cast(timeStamp as bigint)) as block_time,
+            cast(blockNumber as bigint) as block_number,
+            blockHash as block_hash,
+            hash as transaction_hash,
+            transactionIndex as transaction_index,
+            nonce,
             "from",
-            "to",
-            "value",
-            "contractAddress" as contract_address,
-            "tokenName" as token_name,
-            "tokenSymbol" as token_symbol,
-            "tokenDecimal" as token_decimal,
-            "gas",
-            "gasPrice" as gas_price,
-            "gasUsed" as gas_used,
-            "cumulativeGasUsed" as cumulative_gas_used,
-            "confirmations"
+            to,
+            value,
+            contractAddress as contract_address,
+            tokenName as token_name,
+            tokenSymbol as token_symbol,
+            tokenDecimal as token_decimal,
+            gas,
+            gasPrice as gas_price,
+            gasUsed as gas_used,
+            cumulativeGasUsed as cumulative_gas_used,
+            confirmations
           FROM input
       merge:
         kind: Ledger

--- a/examples/reth-vs-snp500/account.transactions.yaml
+++ b/examples/reth-vs-snp500/account.transactions.yaml
@@ -25,25 +25,25 @@ content:
         engine: datafusion
         query: |
           SELECT
-            to_timestamp_seconds(cast("timeStamp" as bigint)) as block_time,
-            "blockNumber" as block_number,
-            "blockHash" as block_hash,
+            to_timestamp_seconds(cast(timeStamp as bigint)) as block_time,
+            blockNumber as block_number,
+            blockHash as block_hash,
             'eth' as symbol,
-            "hash" as transaction_hash,
-            "transactionIndex" as transaction_index,
-            "nonce",
+            hash as transaction_hash,
+            transactionIndex as transaction_index,
+            nonce,
             "from",
-            "to",
-            "value",
-            "input",
-            "isError",
-            "txreceipt_status",
-            "contractAddress" as contract_address,
-            "gas",
-            "gasPrice" as gas_price,
-            "gasUsed" as gas_used,
-            "cumulativeGasUsed" as cumulative_gas_used,
-            "confirmations"
+            to,
+            value,
+            input,
+            isError,
+            txreceipt_status,
+            contractAddress as contract_address,
+            gas,
+            gasPrice as gas_price,
+            gasUsed as gas_used,
+            cumulativeGasUsed as cumulative_gas_used,
+            confirmations
           FROM input
       merge:
         kind: Ledger

--- a/examples/reth-vs-snp500/com.cryptocompare.ohlcv.eth-usd.yaml
+++ b/examples/reth-vs-snp500/com.cryptocompare.ohlcv.eth-usd.yaml
@@ -20,8 +20,8 @@ content:
           - volumefrom DOUBLE
           - volumeto DOUBLE
           - close DOUBLE
-          - '"conversionType" STRING'
-          - '"conversionSymbol" STRING'
+          - conversionType STRING
+          - conversionSymbol STRING
       preprocess:
         kind: Sql
         engine: datafusion
@@ -36,8 +36,8 @@ content:
             close,
             volumefrom,
             volumeto,
-            "conversionType" as conversion_type,
-            "conversionSymbol" as conversion_symbol
+            conversionType as conversion_type,
+            conversionSymbol as conversion_symbol
           from input
       merge:
         kind: Ledger

--- a/examples/reth-vs-snp500/net.rocketpool.reth.mint-burn.yaml
+++ b/examples/reth-vs-snp500/net.rocketpool.reth.mint-burn.yaml
@@ -38,7 +38,7 @@ content:
             log_index,
             token_symbol,
             event_name,
-            from as holder_address,
+            "from" as holder_address,
             amount,
             eth_amount
           from tokens_burned

--- a/examples/reth-vs-snp500/net.rocketpool.reth.tokens-burned.yaml
+++ b/examples/reth-vs-snp500/net.rocketpool.reth.tokens-burned.yaml
@@ -44,7 +44,7 @@ content:
             'TokensBurned' as event_name,
             event.from as from,
             cast(event.amount as double) / pow(10.0, 18) as amount,
-            cast(event."ethAmount" as double) / pow(10.0, 18) as eth_amount
+            cast(event.ethAmount as double) / pow(10.0, 18) as eth_amount
           from input
       merge:
         kind: Append

--- a/examples/reth-vs-snp500/net.rocketpool.reth.tokens-minted.yaml
+++ b/examples/reth-vs-snp500/net.rocketpool.reth.tokens-minted.yaml
@@ -44,7 +44,7 @@ content:
             'TokensMinted' as event_name,
             event.to as to,
             cast(event.amount as double) / pow(10.0, 18) as amount,
-            cast(event."ethAmount" as double) / pow(10.0, 18) as eth_amount
+            cast(event.ethAmount as double) / pow(10.0, 18) as eth_amount
           from input
       merge:
         kind: Append

--- a/images/demo/user-home/01 - Kamu Basics (COVID-19 example)/datasets/british-columbia.case-details.yaml
+++ b/images/demo/user-home/01 - Kamu Basics (COVID-19 example)/datasets/british-columbia.case-details.yaml
@@ -25,12 +25,12 @@ content:
         # not providing us any viable primary key to deduplicate records on
         query: |
           select
-            to_timestamp("Reported_Date") as reported_date,
-            "Classification_Reported" as classification,
-            cast(row_number() over (order by "Reported_Date") as bigint) as id,
-            "HA" as ha,
-            "Sex" as sex,
-            "Age_Group" as age_group
+            to_timestamp(Reported_Date) as reported_date,
+            Classification_Reported as classification,
+            cast(row_number() over (order by Reported_Date) as bigint) as id,
+            HA as ha,
+            Sex as sex,
+            Age_Group as age_group
           from input
       # How to combine newly-ingested data with data that is already in the dataset
       merge:

--- a/images/demo/user-home/01 - Kamu Basics (COVID-19 example)/datasets/canada.case-details.yaml
+++ b/images/demo/user-home/01 - Kamu Basics (COVID-19 example)/datasets/canada.case-details.yaml
@@ -14,35 +14,38 @@ content:
       transform:
         kind: Sql
         engine: datafusion
+        # Note the `order by` to guarantee stability of the output for verification
         query: |
-          select
-            'BC' as province,
-            id,
-            reported_date,
-            sex as gender,
-            case when age_group = '<10' then '<20'
-                 when age_group = '10-19' then '<20' 
-                 when age_group = '20-29' then '20s'
-                 when age_group = '30-39' then '30s'
-                 when age_group = '40-49' then '40s'
-                 when age_group = '50-59' then '50s'
-                 when age_group = '60-69' then '60s'
-                 when age_group = '70-79' then '70s'
-                 when age_group = '80-89' then '80s'
-                 when age_group = '90+' then '90+'
-                 else 'UNKNOWN' end as age_group,
-            ha as location
-          from "covid19.british-columbia.case-details"
-          union all
-          select
-            'ON' as province,
-            id,
-            case_reported_date as reported_date,
-            case when lower(gender) = 'male' then 'M' 
-                 when lower(gender) = 'female' then 'F' 
-                 else 'U' end as gender,
-            age_group,
-            city as location
-          from "covid19.ontario.case-details"
+          select * from (
+            select
+              'BC' as province,
+              id,
+              reported_date,
+              sex as gender,
+              case when age_group = '<10' then '<20'
+                  when age_group = '10-19' then '<20'
+                  when age_group = '20-29' then '20s'
+                  when age_group = '30-39' then '30s'
+                  when age_group = '40-49' then '40s'
+                  when age_group = '50-59' then '50s'
+                  when age_group = '60-69' then '60s'
+                  when age_group = '70-79' then '70s'
+                  when age_group = '80-89' then '80s'
+                  when age_group = '90+' then '90+'
+                  else 'UNKNOWN' end as age_group,
+              ha as location
+            from "covid19.british-columbia.case-details"
+            union all
+            select
+              'ON' as province,
+              id,
+              case_reported_date as reported_date,
+              case when lower(gender) = 'male' then 'M'
+                  when lower(gender) = 'female' then 'F'
+                  else 'U' end as gender,
+              age_group,
+              city as location
+            from "covid19.ontario.case-details"
+          ) order by reported_date, province, id
     - kind: SetVocab
       eventTimeColumn: reported_date

--- a/images/demo/user-home/01 - Kamu Basics (COVID-19 example)/datasets/ontario.case-details.yaml
+++ b/images/demo/user-home/01 - Kamu Basics (COVID-19 example)/datasets/ontario.case-details.yaml
@@ -29,18 +29,18 @@ content:
         engine: datafusion
         query: |
           SELECT
-            cast("Row_ID" as bigint) as id,
-            to_timestamp(coalesce("Case_Reported_Date", "Test_Reported_Date")) as case_reported_date,
+            cast(Row_ID as bigint) as id,
+            to_timestamp(coalesce(Case_Reported_Date, Test_Reported_Date)) as case_reported_date,
             case
-              when "Test_Reported_Date" != '' then to_timestamp("Test_Reported_Date")
+              when Test_Reported_Date != '' then to_timestamp(Test_Reported_Date)
               else null
             end as test_reported_date,
-            "Outcome1" as outcome,
-            "Reporting_PHU_City" as city,
-            "Client_Gender" as gender,
-            "Age_Group" as age_group,
-            "Reporting_PHU_Latitude" as latitude,
-            "Reporting_PHU_Longitude" as longitude
+            Outcome1 as outcome,
+            Reporting_PHU_City as city,
+            Client_Gender as gender,
+            Age_Group as age_group,
+            Reporting_PHU_Latitude as latitude,
+            Reporting_PHU_Longitude as longitude
           FROM input
       merge:
         kind: Ledger

--- a/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/account.tokens.transfers.yaml
+++ b/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/account.tokens.transfers.yaml
@@ -25,24 +25,24 @@ content:
         engine: datafusion
         query: |
           SELECT
-            to_timestamp_seconds(cast("timeStamp" as bigint)) as block_time,
-            cast("blockNumber" as bigint) as block_number,
-            "blockHash" as block_hash,
-            "hash" as transaction_hash,
-            "transactionIndex" as transaction_index,
-            "nonce",
+            to_timestamp_seconds(cast(timeStamp as bigint)) as block_time,
+            cast(blockNumber as bigint) as block_number,
+            blockHash as block_hash,
+            hash as transaction_hash,
+            transactionIndex as transaction_index,
+            nonce,
             "from",
-            "to",
-            "value",
-            "contractAddress" as contract_address,
-            "tokenName" as token_name,
-            "tokenSymbol" as token_symbol,
-            "tokenDecimal" as token_decimal,
-            "gas",
-            "gasPrice" as gas_price,
-            "gasUsed" as gas_used,
-            "cumulativeGasUsed" as cumulative_gas_used,
-            "confirmations"
+            to,
+            value,
+            contractAddress as contract_address,
+            tokenName as token_name,
+            tokenSymbol as token_symbol,
+            tokenDecimal as token_decimal,
+            gas,
+            gasPrice as gas_price,
+            gasUsed as gas_used,
+            cumulativeGasUsed as cumulative_gas_used,
+            confirmations
           FROM input
       merge:
         kind: Ledger

--- a/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/account.transactions.yaml
+++ b/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/account.transactions.yaml
@@ -25,25 +25,25 @@ content:
         engine: datafusion
         query: |
           SELECT
-            to_timestamp_seconds(cast("timeStamp" as bigint)) as block_time,
-            "blockNumber" as block_number,
-            "blockHash" as block_hash,
+            to_timestamp_seconds(cast(timeStamp as bigint)) as block_time,
+            blockNumber as block_number,
+            blockHash as block_hash,
             'eth' as symbol,
-            "hash" as transaction_hash,
-            "transactionIndex" as transaction_index,
-            "nonce",
+            hash as transaction_hash,
+            transactionIndex as transaction_index,
+            nonce,
             "from",
-            "to",
-            "value",
-            "input",
-            "isError",
-            "txreceipt_status",
-            "contractAddress" as contract_address,
-            "gas",
-            "gasPrice" as gas_price,
-            "gasUsed" as gas_used,
-            "cumulativeGasUsed" as cumulative_gas_used,
-            "confirmations"
+            to,
+            value,
+            input,
+            isError,
+            txreceipt_status,
+            contractAddress as contract_address,
+            gas,
+            gasPrice as gas_price,
+            gasUsed as gas_used,
+            cumulativeGasUsed as cumulative_gas_used,
+            confirmations
           FROM input
       merge:
         kind: Ledger

--- a/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/com.cryptocompare.ohlcv.eth-usd.yaml
+++ b/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/com.cryptocompare.ohlcv.eth-usd.yaml
@@ -20,8 +20,8 @@ content:
           - volumefrom DOUBLE
           - volumeto DOUBLE
           - close DOUBLE
-          - '"conversionType" STRING'
-          - '"conversionSymbol" STRING'
+          - conversionType STRING
+          - conversionSymbol STRING
       preprocess:
         kind: Sql
         engine: datafusion
@@ -36,8 +36,8 @@ content:
             close,
             volumefrom,
             volumeto,
-            "conversionType" as conversion_type,
-            "conversionSymbol" as conversion_symbol
+            conversionType as conversion_type,
+            conversionSymbol as conversion_symbol
           from input
       merge:
         kind: Ledger

--- a/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/net.rocketpool.reth.mint-burn.yaml
+++ b/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/net.rocketpool.reth.mint-burn.yaml
@@ -38,7 +38,7 @@ content:
             log_index,
             token_symbol,
             event_name,
-            from as holder_address,
+            "from" as holder_address,
             amount,
             eth_amount
           from tokens_burned

--- a/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/net.rocketpool.reth.tokens-burned.yaml
+++ b/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/net.rocketpool.reth.tokens-burned.yaml
@@ -44,7 +44,7 @@ content:
             'TokensBurned' as event_name,
             event.from as from,
             cast(event.amount as double) / pow(10.0, 18) as amount,
-            cast(event."ethAmount" as double) / pow(10.0, 18) as eth_amount
+            cast(event.ethAmount as double) / pow(10.0, 18) as eth_amount
           from input
       merge:
         kind: Append

--- a/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/net.rocketpool.reth.tokens-minted.yaml
+++ b/images/demo/user-home/02 - Web3 Data (Ethereum trading example)/datasets/net.rocketpool.reth.tokens-minted.yaml
@@ -44,7 +44,7 @@ content:
             'TokensMinted' as event_name,
             event.to as to,
             cast(event.amount as double) / pow(10.0, 18) as amount,
-            cast(event."ethAmount" as double) / pow(10.0, 18) as eth_amount
+            cast(event.ethAmount as double) / pow(10.0, 18) as eth_amount
           from input
       merge:
         kind: Append

--- a/src/infra/core/src/compaction_service_impl.rs
+++ b/src/infra/core/src/compaction_service_impl.rs
@@ -283,7 +283,7 @@ impl CompactionServiceImpl {
                     .int_err()?
                     // TODO: PERF: Consider passing sort order hint to `read_parquet` to let DF now
                     // that the data is already pre-sorted
-                    .sort(vec![col(offset_column).sort(true, false)])
+                    .sort(vec![col(Column::from_name(offset_column)).sort(true, false)])
                     .int_err()?;
 
                 let new_file_path =

--- a/src/infra/core/src/ingest/ingest_common.rs
+++ b/src/infra/core/src/ingest/ingest_common.rs
@@ -54,7 +54,16 @@ pub fn new_session_context(object_store_registry: Arc<dyn ObjectStoreRegistry>) 
     use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
     use datafusion::prelude::*;
 
-    let config = SessionConfig::new().with_default_catalog_and_schema("kamu", "kamu");
+    let mut config = SessionConfig::new().with_default_catalog_and_schema("kamu", "kamu");
+
+    // Forcing cese-sensitive identifiers in case-insensitive language seems to
+    // be a lesser evil than following DataFusion's default behavior of forcing
+    // identifiers to lowercase instead of case-insensitive matching.
+    //
+    // See: https://github.com/apache/datafusion/issues/7460
+    // TODO: Consider externalizing this config (e.g. by allowing custom engine
+    // options in transform DTOs)
+    config.options_mut().sql_parser.enable_ident_normalization = false;
 
     let runtime_config = RuntimeConfig {
         object_store_registry: object_store_registry.as_datafusion_registry(),

--- a/src/infra/core/src/ingest/push_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/push_ingest_service_impl.rs
@@ -368,6 +368,7 @@ impl PushIngestServiceImpl {
             .await?;
 
         let df = reader.read(input_data_path).await?;
+        tracing::debug!(schema = ?df.schema(), "Reader created a dataframe");
 
         Ok(Some(df))
     }

--- a/src/infra/core/src/repos/metadata_chain_validators.rs
+++ b/src/infra/core/src/repos/metadata_chain_validators.rs
@@ -790,10 +790,12 @@ impl<'a> MetadataChainVisitor for ValidateExecuteTransformVisitor<'a> {
         if e.new_data.is_none()
             && e.new_checkpoint.as_ref().map(|v| &v.physical_hash) == e.prev_checkpoint.as_ref()
             && e.new_watermark.as_ref() == prev_watermark
+            // All inputs had new blocks that only update source state?
+            && e.query_inputs.iter().all(|i| i.new_block_hash.is_none())
         {
             return Err(AppendValidationError::no_op_event(
                 (*e).clone(),
-                "Event neither has data nor it advances checkpoint or watermark",
+                "Event neither has data nor it advances inputs, checkpoint, or watermark",
             ));
         }
 

--- a/src/infra/core/src/transform_service_impl.rs
+++ b/src/infra/core/src/transform_service_impl.rs
@@ -274,6 +274,8 @@ impl TransformServiceImpl {
             .await?;
 
         // Nothing to do?
+        // TODO: Detect the situation where inputs only had source updates and skip
+        // running the engine
         if inputs
             .iter()
             .all(|i| i.data_slices.is_empty() && i.explicit_watermarks.is_empty())

--- a/src/infra/core/src/utils/docker_images.rs
+++ b/src/infra/core/src/utils/docker_images.rs
@@ -9,7 +9,7 @@
 
 pub const SPARK: &str = "ghcr.io/kamu-data/engine-spark:0.23.1-spark_3.5.0";
 pub const FLINK: &str = "ghcr.io/kamu-data/engine-flink:0.18.2-flink_1.16.0-scala_2.12-java8";
-pub const DATAFUSION: &str = "ghcr.io/kamu-data/engine-datafusion:0.7.2";
+pub const DATAFUSION: &str = "ghcr.io/kamu-data/engine-datafusion:0.8.0";
 pub const RISINGWAVE: &str = "ghcr.io/kamu-data/engine-risingwave:0.2.0-risingwave_1.7.0-alpha";
 
 pub const LIVY: &str = SPARK;

--- a/src/infra/ingest-datafusion/src/merge_strategies/append.rs
+++ b/src/infra/ingest-datafusion/src/merge_strategies/append.rs
@@ -44,6 +44,6 @@ impl MergeStrategy for MergeStrategyAppend {
     }
 
     fn sort_order(&self) -> Vec<Expr> {
-        vec![col(&self.vocab.event_time_column).sort(true, true)]
+        vec![col(Column::from_name(&self.vocab.event_time_column)).sort(true, true)]
     }
 }

--- a/src/infra/ingest-datafusion/src/merge_strategies/ledger.rs
+++ b/src/infra/ingest-datafusion/src/merge_strategies/ledger.rs
@@ -45,7 +45,12 @@ impl MergeStrategy for MergeStrategyLedger {
         let new_records = if prev.is_none() {
             // Validate PK columns exist
             new.clone()
-                .select(self.primary_key.iter().map(col).collect())
+                .select(
+                    self.primary_key
+                        .iter()
+                        .map(|name| col(Column::from_name(name)))
+                        .collect(),
+                )
                 .int_err()?;
 
             new
@@ -71,6 +76,6 @@ impl MergeStrategy for MergeStrategyLedger {
     }
 
     fn sort_order(&self) -> Vec<Expr> {
-        vec![col(&self.vocab.event_time_column).sort(true, true)]
+        vec![col(Column::from_name(&self.vocab.event_time_column)).sort(true, true)]
     }
 }

--- a/src/infra/ingest-datafusion/src/writer.rs
+++ b/src/infra/ingest-datafusion/src/writer.rs
@@ -306,7 +306,7 @@ impl DataWriterDataFusion {
                 // TODO: Using `case` expression instead of `coalesce()` due to DataFusion bug
                 // See: https://github.com/apache/arrow-datafusion/issues/8790
                 when(
-                    col(&self.meta.vocab.event_time_column).is_null(),
+                    col(Column::from_name(&self.meta.vocab.event_time_column)).is_null(),
                     cast(
                         Expr::Literal(ScalarValue::TimestampMillisecond(
                             Some(fallback_event_time.timestamp_millis()),
@@ -315,7 +315,7 @@ impl DataWriterDataFusion {
                         event_time_data_type,
                     ),
                 )
-                .otherwise(col(&self.meta.vocab.event_time_column))
+                .otherwise(col(Column::from_name(&self.meta.vocab.event_time_column)))
                 .int_err()?,
             )
             .int_err()?;
@@ -349,7 +349,7 @@ impl DataWriterDataFusion {
             .with_column(
                 &self.meta.vocab.offset_column,
                 cast(
-                    col(&self.meta.vocab.offset_column as &str)
+                    col(Column::from_name(&self.meta.vocab.offset_column))
                         + lit(i64::try_from(start_offset).unwrap() - 1),
                     // TODO: Replace with UInt64 after Spark is updated
                     // See: https://github.com/kamu-data/kamu-cli/issues/445
@@ -510,10 +510,10 @@ impl DataWriterDataFusion {
             .aggregate(
                 vec![],
                 vec![
-                    min(col(&self.meta.vocab.offset_column)),
-                    max(col(&self.meta.vocab.offset_column)),
+                    min(col(Column::from_name(&self.meta.vocab.offset_column))),
+                    max(col(Column::from_name(&self.meta.vocab.offset_column))),
                     // TODO: Add support for more watermark strategies
-                    max(col(&self.meta.vocab.event_time_column)),
+                    max(col(Column::from_name(&self.meta.vocab.event_time_column))),
                 ],
             )
             .int_err()?;

--- a/src/infra/ingest-datafusion/tests/utils/mod.rs
+++ b/src/infra/ingest-datafusion/tests/utils/mod.rs
@@ -61,14 +61,14 @@ pub async fn assert_dfs_equivalent(
             .schema()
             .fields()
             .iter()
-            .map(|f| col(f.name()).sort(false, true))
+            .map(|f| col(Column::from_name(f.name())).sort(false, true))
             .collect();
 
         let rhs_cols = rhs
             .schema()
             .fields()
             .iter()
-            .map(|f| col(f.name()).sort(false, true))
+            .map(|f| col(Column::from_name(f.name())).sort(false, true))
             .collect();
 
         (lhs.sort(lhs_cols).unwrap(), rhs.sort(rhs_cols).unwrap())

--- a/src/utils/data-utils/src/data/dataframe_ext.rs
+++ b/src/utils/data-utils/src/data/dataframe_ext.rs
@@ -7,11 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::Path;
-
 use datafusion::error::Result;
-use datafusion::parquet::file::properties::WriterProperties;
 use datafusion::prelude::*;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[async_trait::async_trait]
 pub trait DataFrameExt
@@ -22,6 +21,8 @@ where
 
     fn without_columns(self, cols: &[&str]) -> Result<Self>;
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[async_trait::async_trait]
 impl DataFrameExt for DataFrame {
@@ -52,17 +53,4 @@ impl DataFrameExt for DataFrame {
 
         self.select(columns)
     }
-}
-
-#[async_trait::async_trait]
-pub trait SessionContextExt
-where
-    Self: Sized,
-{
-    async fn write_parquet_single_file(
-        &self,
-        df: DataFrame,
-        path: &Path,
-        writer_properties: Option<WriterProperties>,
-    ) -> Result<()>;
 }


### PR DESCRIPTION
## Description

See for context: https://github.com/apache/datafusion/issues/7460

To me it appears that Postgre's behavior is stuck somewhere in between case-sensitive and case-insensitive, which causes very unpleasant issues in our ingest, as all fields containing uppercase letters have to be quoted in SQL queries, merge strategies, and vocab columns.

The proposed solution is to disable DataFusion's [`enable_ident_normalization`](https://datafusion.apache.org/user-guide/configs.html) config option which is on by default to stop it from casting all identifiers to lower case.

Corresponding change in the DF engine:
https://github.com/kamu-data/kamu-engine-datafusion/pull/10

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ❌
    Note that these changes didn't break any examples. All modifications were made to simplify them, but new version could successfully execute all examples unchanged.
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅