### PR TITLE
Auto rename and coerce columns on ingest

### DIFF
--- a/src/adapter/http/src/data/ingest_handler.rs
+++ b/src/adapter/http/src/data/ingest_handler.rs
@@ -117,6 +117,7 @@ pub async fn dataset_ingest_handler(
                 media_type: arguments.media_type,
                 source_event_time,
                 auto_create_push_source: is_ingest_from_upload,
+                schema_inference: SchemaInferenceOpts::default(),
             },
             None,
         )

--- a/src/app/cli/src/commands/ingest_command.rs
+++ b/src/app/cli/src/commands/ingest_command.rs
@@ -201,6 +201,7 @@ impl Command for IngestCommand {
                         media_type: self.get_media_type()?,
                         source_event_time,
                         auto_create_push_source: false,
+                        schema_inference: SchemaInferenceOpts::default(),
                     },
                     listener.clone(),
                 )

--- a/src/app/cli/src/commands/pull_command.rs
+++ b/src/app/cli/src/commands/pull_command.rs
@@ -140,6 +140,7 @@ impl PullCommand {
                         fetch_uncacheable: self.fetch_uncacheable,
                         exhaust_sources: true,
                         dataset_env_vars: HashMap::new(),
+                        schema_inference: SchemaInferenceOpts::default(),
                     },
                     sync_options: SyncOptions {
                         force: self.force,

--- a/src/domain/core/src/services/ingest/polling_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/polling_ingest_service.rs
@@ -64,6 +64,28 @@ pub struct PollingIngestOptions {
     /// Dataset env vars to use if such presented in dataset metadata
     /// to use during fetch phase
     pub dataset_env_vars: HashMap<String, DatasetEnvVar>,
+    /// Schema inference configuration
+    pub schema_inference: SchemaInferenceOpts,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct SchemaInferenceOpts {
+    /// Whether to auto-rename a column if it conflicts with one of the system
+    /// columns
+    pub rename_on_conflict_with_system_column: bool,
+    /// Whether to attempt to coerce the event time column into a timestamp
+    pub coerce_event_time_column_type: bool,
+}
+
+impl Default for SchemaInferenceOpts {
+    fn default() -> Self {
+        Self {
+            rename_on_conflict_with_system_column: true,
+            coerce_event_time_column_type: true,
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/core/src/services/ingest/push_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_service.rs
@@ -60,9 +60,14 @@ pub trait PushIngestService: Send + Sync {
 
 #[derive(Debug, Default)]
 pub struct PushIngestOpts {
+    /// MIME type of the content
     pub media_type: Option<MediaType>,
+    /// Event time to use if data does not contain such column itself
     pub source_event_time: Option<DateTime<Utc>>,
+    /// Whether to automatically create a push source if it doesn't exist
     pub auto_create_push_source: bool,
+    /// Schema inference configuration
+    pub schema_inference: SchemaInferenceOpts,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/core/src/ingest/polling_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/polling_ingest_service_impl.rs
@@ -264,7 +264,15 @@ impl PollingIngestServiceImpl {
                 )
                 .await?
             } else {
-                Some(df)
+                Some(
+                    ingest_common::preprocess_default(
+                        df,
+                        &args.polling_source.read,
+                        args.data_writer.vocab(),
+                        &args.options.schema_inference,
+                    )
+                    .int_err()?,
+                )
             }
         } else {
             tracing::info!("Read produced an empty data frame");

--- a/src/infra/core/src/ingest/push_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/push_ingest_service_impl.rs
@@ -234,7 +234,15 @@ impl PushIngestServiceImpl {
                 )
                 .await?
             } else {
-                Some(df)
+                Some(
+                    ingest_common::preprocess_default(
+                        df,
+                        &args.push_source.read,
+                        args.data_writer.vocab(),
+                        &args.opts.schema_inference,
+                    )
+                    .int_err()?,
+                )
             }
         } else {
             tracing::info!("Read produced an empty data frame");


### PR DESCRIPTION
## Description

Closes: #790

If user does not declare `read` schema or `preprocess` step (which is always the case when ingesting data from a file upload) we apply the following new inference rules:
- if `event_time` column is present - we will try to coerce it into a timestamp
  - strings will be parsed as RFC3339 date-times
  - integers will be treated as UNIX timestamps in seconds
- if any of the columns conflicts with system column - it will get renamed with an underscore prefix

While I like being strict about names and types, I think this should improve the overall user experience.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [ ] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌
    will add a paragraph to public docs if this gets merged
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅