### PR TITLE
Make schedule param for ingest optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Make `schedule` configuration optional in `FlowConfigurationIngest` type for GQL flow mutations
+
 ## [0.197.0] - 2024-08-22
 ### Changed
 - **Breaking:** Using DataFusion's [`enable_ident_normalization = false`](https://datafusion.apache.org/user-guide/configs.html) setting to work with upper case identifiers without needing to put quotes everywhere. This may impact your root and derivative datasets.

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -947,7 +947,7 @@ type FlowConfigurationCompactionRule {
 }
 
 type FlowConfigurationIngest {
-	schedule: FlowConfigurationSchedule!
+	schedule: FlowConfigurationSchedule
 	fetchUncacheable: Boolean!
 }
 
@@ -1240,7 +1240,7 @@ input IngestConditionInput {
 	Flag indicates to ignore cache during ingest step for API calls
 	"""
 	fetchUncacheable: Boolean!
-	schedule: ScheduleInput!
+	schedule: ScheduleInput
 }
 
 input InitiatorFilterInput @oneOf {

--- a/src/domain/flow-system/domain/src/entities/shared/ingest_rule.rs
+++ b/src/domain/flow-system/domain/src/entities/shared/ingest_rule.rs
@@ -18,5 +18,5 @@ pub struct IngestRule {
     pub fetch_uncacheable: bool,
     // ToDo: Schedule should be on higher level and not mixed up
     // with general configuration rules
-    pub schedule_condition: Schedule,
+    pub schedule_condition: Option<Schedule>,
 }

--- a/src/domain/flow-system/services/src/flow/active_configs_state.rs
+++ b/src/domain/flow-system/services/src/flow/active_configs_state.rs
@@ -79,13 +79,15 @@ impl ActiveConfigsState {
 
     pub fn try_get_flow_schedule(&self, flow_key: &FlowKey) -> Option<Schedule> {
         match flow_key {
-            FlowKey::Dataset(flow_key) => self
-                .dataset_ingest_rules
-                .get(
+            FlowKey::Dataset(flow_key) => {
+                if let Some(ingest_rule) = self.dataset_ingest_rules.get(
                     BorrowedFlowKeyDataset::new(&flow_key.dataset_id, flow_key.flow_type)
                         .as_trait(),
-                )
-                .map(|ingest_rule| ingest_rule.schedule_condition.clone()),
+                ) {
+                    return ingest_rule.schedule_condition.clone();
+                }
+                None
+            }
             FlowKey::System(flow_key) => self.system_schedules.get(&flow_key.flow_type).cloned(),
         }
     }

--- a/src/domain/flow-system/services/src/flow/flow_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow/flow_service_impl.rs
@@ -218,12 +218,14 @@ impl FlowServiceImpl {
                     | FlowConfigurationRule::Schedule(_)
                     | FlowConfigurationRule::ResetRule(_) => (),
                     FlowConfigurationRule::IngestRule(ingest_rule) => {
-                        self.enqueue_scheduled_auto_polling_flow(
-                            start_time,
-                            &flow_key,
-                            &ingest_rule.schedule_condition,
-                        )
-                        .await?;
+                        if let Some(schedule_condition) = &ingest_rule.schedule_condition {
+                            self.enqueue_scheduled_auto_polling_flow(
+                                start_time,
+                                &flow_key,
+                                schedule_condition,
+                            )
+                            .await?;
+                        }
                     }
                 }
             }

--- a/src/domain/flow-system/services/tests/tests/test_flow_service_impl.rs
+++ b/src/domain/flow-system/services/tests/tests/test_flow_service_impl.rs
@@ -48,7 +48,7 @@ async fn test_read_initial_config_and_queue_without_waiting() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(60).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(60).unwrap().into()),
             },
         )
         .await;
@@ -178,10 +178,10 @@ async fn test_cron_config() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Schedule::Cron(ScheduleCron {
+                schedule_condition: Some(Schedule::Cron(ScheduleCron {
                     source_5component_cron_expression: String::from("<irrelevant>"),
                     cron_schedule: cron::Schedule::from_str("*/5 * * * * *").unwrap(),
-                }),
+                })),
             },
         )
         .await;
@@ -284,7 +284,7 @@ async fn test_manual_trigger() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(90).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(90).unwrap().into()),
             },
         )
         .await;
@@ -498,7 +498,7 @@ async fn test_ingest_trigger_with_ingest_config() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: true,
-                schedule_condition: Duration::try_milliseconds(90).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(90).unwrap().into()),
             },
         )
         .await;
@@ -2095,7 +2095,7 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(50).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(50).unwrap().into()),
             },
         )
         .await;
@@ -2106,7 +2106,7 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(80).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(80).unwrap().into()),
             },
         )
         .await;
@@ -2184,7 +2184,7 @@ async fn test_dataset_flow_configuration_paused_resumed_modified() {
                 harness.resume_dataset_flow(start_time + Duration::try_milliseconds(80).unwrap(), foo_id.clone(), DatasetFlowType::Ingest).await;
                 harness.set_dataset_flow_ingest(start_time + Duration::try_milliseconds(80).unwrap(), bar_id.clone(), DatasetFlowType::Ingest, IngestRule {
                   fetch_uncacheable: false,
-                  schedule_condition: Duration::try_milliseconds(70).unwrap().into(),
+                  schedule_condition: Some(Duration::try_milliseconds(70).unwrap().into()),
               }).await;
                 test_flow_listener
                     .make_a_snapshot(start_time + Duration::try_milliseconds(80).unwrap())
@@ -2316,7 +2316,7 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(100).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(100).unwrap().into()),
             },
         )
         .await;
@@ -2328,7 +2328,7 @@ async fn test_respect_last_success_time_when_schedule_resumes() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(60).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(60).unwrap().into()),
             },
         )
         .await;
@@ -2540,7 +2540,7 @@ async fn test_dataset_deleted() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(50).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(50).unwrap().into()),
             },
         )
         .await;
@@ -2551,7 +2551,7 @@ async fn test_dataset_deleted() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(70).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(70).unwrap().into()),
             },
         )
         .await;
@@ -2745,7 +2745,7 @@ async fn test_task_completions_trigger_next_loop_on_success() {
                 DatasetFlowType::Ingest,
                 IngestRule {
                     fetch_uncacheable: false,
-                    schedule_condition: Duration::try_milliseconds(40).unwrap().into(),
+                    schedule_condition: Some(Duration::try_milliseconds(40).unwrap().into()),
                 },
             )
             .await;
@@ -2966,7 +2966,7 @@ async fn test_derived_dataset_triggered_initially_and_after_input_change() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(80).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(80).unwrap().into()),
             },
         )
         .await;
@@ -3364,7 +3364,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(50).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(50).unwrap().into()),
             },
         )
         .await;
@@ -3376,7 +3376,7 @@ async fn test_throttling_derived_dataset_with_2_parents() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(150).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(150).unwrap().into()),
             },
         )
         .await;
@@ -3844,7 +3844,7 @@ async fn test_batching_condition_records_reached() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(50).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(50).unwrap().into()),
             },
         )
         .await;
@@ -4168,7 +4168,7 @@ async fn test_batching_condition_timeout() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(50).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(50).unwrap().into()),
             },
         )
         .await;
@@ -4444,7 +4444,7 @@ async fn test_batching_condition_watermark() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(40).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(40).unwrap().into()),
             },
         )
         .await;
@@ -4777,7 +4777,7 @@ async fn test_batching_condition_with_2_inputs() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(80).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(80).unwrap().into()),
             },
         )
         .await;
@@ -4789,7 +4789,7 @@ async fn test_batching_condition_with_2_inputs() {
             DatasetFlowType::Ingest,
             IngestRule {
                 fetch_uncacheable: false,
-                schedule_condition: Duration::try_milliseconds(120).unwrap().into(),
+                schedule_condition: Some(Duration::try_milliseconds(120).unwrap().into()),
             },
         )
         .await;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail and include your changelog entries -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [ ] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅