### PR TITLE
Set schema early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--- - Changed -->
 <!--- - Fixed -->
 
+## Unreleased
+### Added
+- Container sources env vars now allow string interpolation
+### Changed
+- Schema propagation improvements:
+  - Dataset schema will be defined upon first ingest, even if no records were returned by the source
+  - Schema will also be defined for derivative datasets even if no records produced by the transformation
+  - Above ensures that datasets that for a long time don't produce any data will not block data pipelines
+
 ## [0.198.1] - 2024-08-28
 ### Added
 - Private Datasets, ReBAC integration: 

--- a/examples/leaderboard/init.sh
+++ b/examples/leaderboard/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 kamu init --exists-ok

--- a/images/demo/jupyter/kamu-start-hook.sh
+++ b/images/demo/jupyter/kamu-start-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/images/sqlx-cli-with-migrations/scripts/fetch-db-secret.sh
+++ b/images/sqlx-cli-with-migrations/scripts/fetch-db-secret.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/images/sqlx-cli-with-migrations/scripts/run-db-migrations.sh
+++ b/images/sqlx-cli-with-migrations/scripts/run-db-migrations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/src/adapter/graphql/src/scalars/data_query.rs
+++ b/src/adapter/graphql/src/scalars/data_query.rs
@@ -85,7 +85,7 @@ impl From<QueryError> for DataQueryResult {
     fn from(e: QueryError) -> Self {
         match e {
             QueryError::DatasetNotFound(e) => DataQueryResult::invalid_sql(e.to_string()),
-            QueryError::DataFusionError(e) => e.into(),
+            QueryError::DataFusionError(e) => e.source.into(),
             QueryError::DatasetSchemaNotAvailable(_) => unreachable!(),
             QueryError::Access(e) => DataQueryResult::unauthorized(e.to_string()),
             QueryError::Internal(e) => DataQueryResult::internal(e.to_string()),

--- a/src/app/cli/src/commands/list_command.rs
+++ b/src/app/cli/src/commands/list_command.rs
@@ -218,9 +218,11 @@ impl Command for ListCommand {
             .with_default_column_format(ColumnFormat::default().with_null_value("-"))
             .with_column_formats(self.column_formats(show_owners));
 
-        let mut writer = self.output_config.get_records_writer(records_format);
-
         let schema = Arc::new(Schema::new(self.schema_fields(show_owners)));
+
+        let mut writer = self
+            .output_config
+            .get_records_writer(&schema, records_format);
 
         let mut id: Vec<String> = Vec::new();
         let mut name: Vec<String> = Vec::new();

--- a/src/app/cli/src/commands/search_command.rs
+++ b/src/app/cli/src/commands/search_command.rs
@@ -119,7 +119,7 @@ impl Command for SearchCommand {
         }
 
         let records = RecordBatch::try_new(
-            schema,
+            schema.clone(),
             vec![
                 Arc::new(StringArray::from(alias)),
                 Arc::new(StringArray::from(kind)),
@@ -131,7 +131,9 @@ impl Command for SearchCommand {
         )
         .unwrap();
 
-        let mut writer = self.output_config.get_records_writer(records_format);
+        let mut writer = self
+            .output_config
+            .get_records_writer(&schema, records_format);
         writer.write_batch(&records)?;
         writer.finish()?;
 

--- a/src/app/cli/src/commands/sql_shell_command.rs
+++ b/src/app/cli/src/commands/sql_shell_command.rs
@@ -119,11 +119,12 @@ impl SqlShellCommand {
             .await
             .map_err(CLIError::failure)?;
 
-        let records = res.df.collect().await.map_err(CLIError::failure)?;
-
         let mut writer = self
             .output_config
-            .get_records_writer(RecordsFormat::default());
+            .get_records_writer(res.df.schema().as_arrow(), RecordsFormat::default());
+
+        let records = res.df.collect().await.map_err(CLIError::failure)?;
+
         writer.write_batches(&records)?;
         writer.finish()?;
 

--- a/src/app/cli/src/commands/tail_command.rs
+++ b/src/app/cli/src/commands/tail_command.rs
@@ -52,41 +52,42 @@ impl Command for TailCommand {
             .await
             .map_err(CLIError::failure)?;
 
-        let record_batches = df.collect().await.map_err(CLIError::failure)?;
+        let mut writer = self.output_cfg.get_records_writer(
+            df.schema().as_arrow(),
+            RecordsFormat::default().with_column_formats(vec![
+                // TODO: `RecordsFormat` should allow specifying column formats by name, not
+                // only positionally
+                ColumnFormat::default(),
+                ColumnFormat::default().with_value_fmt(|array, row, _| {
+                    let err = Err(InvalidOperationType(0));
+                    let op = match array.data_type() {
+                        DataType::UInt8 => array
+                            .as_any()
+                            .downcast_ref::<UInt8Array>()
+                            .map(|a| a.value(row))
+                            .map_or(err, OperationType::try_from),
+                        // Compatibility fallback
+                        DataType::Int32 => array
+                            .as_any()
+                            .downcast_ref::<Int32Array>()
+                            .and_then(|a| u8::try_from(a.value(row)).ok())
+                            .map(OperationType::try_from)
+                            .unwrap_or(err),
+                        _ => err,
+                    };
+                    match op {
+                        Ok(OperationType::Append) => "+A",
+                        Ok(OperationType::Retract) => "-R",
+                        Ok(OperationType::CorrectFrom) => "-C",
+                        Ok(OperationType::CorrectTo) => "+C",
+                        _ => "??",
+                    }
+                    .to_string()
+                }),
+            ]),
+        );
 
-        let mut writer =
-            self.output_cfg
-                .get_records_writer(RecordsFormat::default().with_column_formats(vec![
-                    // TODO: `RecordsFormat` should allow specifying column formats by name, not
-                    // only positionally
-                    ColumnFormat::default(),
-                    ColumnFormat::default().with_value_fmt(|array, row, _| {
-                        let err = Err(InvalidOperationType(0));
-                        let op = match array.data_type() {
-                            DataType::UInt8 => array
-                                .as_any()
-                                .downcast_ref::<UInt8Array>()
-                                .map(|a| a.value(row))
-                                .map_or(err, OperationType::try_from),
-                            // Compatibility fallback
-                            DataType::Int32 => array
-                                .as_any()
-                                .downcast_ref::<Int32Array>()
-                                .and_then(|a| u8::try_from(a.value(row)).ok())
-                                .map(OperationType::try_from)
-                                .unwrap_or(err),
-                            _ => err,
-                        };
-                        match op {
-                            Ok(OperationType::Append) => "+A",
-                            Ok(OperationType::Retract) => "-R",
-                            Ok(OperationType::CorrectFrom) => "-C",
-                            Ok(OperationType::CorrectTo) => "+C",
-                            _ => "??",
-                        }
-                        .to_string()
-                    }),
-                ]));
+        let record_batches = df.collect().await.map_err(CLIError::failure)?;
         writer.write_batches(&record_batches)?;
         writer.finish()?;
         Ok(())

--- a/src/app/cli/src/output/output_config.rs
+++ b/src/app/cli/src/output/output_config.rs
@@ -9,6 +9,8 @@
 
 use std::path::PathBuf;
 
+use datafusion::arrow::datatypes::Schema;
+
 use super::records_writers::*;
 pub use super::records_writers::{ColumnFormat, RecordsFormat};
 
@@ -25,7 +27,11 @@ pub struct OutputConfig {
 }
 
 impl OutputConfig {
-    pub fn get_records_writer(&self, fmt: RecordsFormat) -> Box<dyn RecordsWriter> {
+    pub fn get_records_writer(
+        &self,
+        schema: &Schema,
+        fmt: RecordsFormat,
+    ) -> Box<dyn RecordsWriter> {
         match self.format {
             OutputFormat::Csv => Box::new(CsvWriter::new(
                 std::io::stdout(),
@@ -40,7 +46,7 @@ impl OutputConfig {
             }
             OutputFormat::JsonAoA => Box::new(JsonArrayOfArraysWriter::new(std::io::stdout())),
             OutputFormat::NdJson => Box::new(JsonLineDelimitedWriter::new(std::io::stdout())),
-            OutputFormat::Table => Box::new(TableWriter::new(fmt, std::io::stdout())),
+            OutputFormat::Table => Box::new(TableWriter::new(schema, fmt, std::io::stdout())),
         }
     }
 }

--- a/src/domain/core/src/entities/engine.rs
+++ b/src/domain/core/src/entities/engine.rs
@@ -123,10 +123,10 @@ pub struct TransformRequestInputExt {
     /// `(prevOffset, newOffset]` interval of data records that will be
     /// considered in this transaction.
     pub new_offset: Option<u64>,
+    /// Arrow schema of the slices
+    pub schema: SchemaRef,
     /// List of data files that will be read
     pub data_slices: Vec<Multihash>,
-    /// TODO: replace with actual schema
-    pub schema_slice: Multihash,
     /// TODO: remove?
     pub explicit_watermarks: Vec<Watermark>,
 }
@@ -137,9 +137,13 @@ pub struct TransformResponseExt {
     pub new_offset_interval: Option<OffsetInterval>,
     /// Watermark advanced by the transaction, if any
     pub new_watermark: Option<DateTime<Utc>>,
+    /// Schema of the output
+    /// TODO: This field should be made required once all engines are updated
+    pub output_schema: Option<SchemaRef>,
     /// New checkpoint written by the engine, if any
     pub new_checkpoint: Option<OwnedFile>,
-    /// Data produced by the operation, if any
+    /// Data produced by the operation, if any. Must be `None` if offset
+    /// interval is empty.
     pub new_data: Option<OwnedFile>,
 }
 

--- a/src/domain/core/src/services/ingest/data_writer.rs
+++ b/src/domain/core/src/services/ingest/data_writer.rs
@@ -86,7 +86,7 @@ pub struct WriteDataOpts {
 pub struct WriteDataResult {
     pub old_head: odf::Multihash,
     pub new_head: odf::Multihash,
-    pub new_block: odf::MetadataBlockTyped<odf::AddData>,
+    pub add_data_block: Option<odf::MetadataBlockTyped<odf::AddData>>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -95,8 +95,11 @@ pub struct WriteDataResult {
 #[derive(Debug)]
 pub struct StageDataResult {
     pub system_time: DateTime<Utc>,
-    pub add_data: AddDataParams,
+    /// Set when `SetDataSchema` event needs to be committed
     pub new_schema: Option<SchemaRef>,
+    /// Set when `AddData` event needs to be committed
+    pub add_data: Option<AddDataParams>,
+    /// Set when commmit will contains some data
     pub data_file: Option<OwnedFile>,
 }
 

--- a/src/domain/core/src/services/ingest/reader.rs
+++ b/src/domain/core/src/services/ingest/reader.rs
@@ -10,7 +10,7 @@
 use std::backtrace::Backtrace;
 use std::path::Path;
 
-use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::prelude::*;
 use internal_error::*;
 
@@ -22,7 +22,7 @@ use internal_error::*;
 pub trait Reader: Send + Sync {
     /// Returns schema that the input will be coerced into, if such schema
     /// is defined explicitly.
-    async fn input_schema(&self) -> Option<Schema>;
+    async fn input_schema(&self) -> Option<SchemaRef>;
 
     /// Returns a [DataFrame] with a logical plan set up to read the data.
     ///

--- a/src/domain/core/src/services/query_service.rs
+++ b/src/domain/core/src/services/query_service.rs
@@ -10,7 +10,6 @@
 use std::collections::BTreeMap;
 
 use datafusion::arrow;
-use datafusion::error::DataFusionError;
 use datafusion::parquet::schema::types::Type;
 use datafusion::prelude::{DataFrame, SessionContext};
 use internal_error::InternalError;
@@ -206,6 +205,27 @@ pub enum QueryError {
         #[backtrace]
         InternalError,
     ),
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Wraps [`datafusion::error::DataFusionError`] error to attach a backtrace at
+/// the earliest point
+#[derive(Error, Debug)]
+#[error("DataFusion error")]
+pub struct DataFusionError {
+    #[from]
+    pub source: datafusion::error::DataFusionError,
+    pub backtrace: std::backtrace::Backtrace,
+}
+
+impl From<datafusion::error::DataFusionError> for QueryError {
+    fn from(value: datafusion::error::DataFusionError) -> Self {
+        Self::DataFusionError(DataFusionError {
+            source: value,
+            backtrace: std::backtrace::Backtrace::capture(),
+        })
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/core/src/services/transform_service.rs
+++ b/src/domain/core/src/services/transform_service.rs
@@ -119,6 +119,12 @@ pub enum TransformError {
         TransformNotDefinedError,
     ),
     #[error(transparent)]
+    InputSchemaNotDefined(
+        #[from]
+        #[backtrace]
+        InputSchemaNotDefinedError,
+    ),
+    #[error(transparent)]
     EngineProvisioningError(
         #[from]
         #[backtrace]
@@ -156,9 +162,21 @@ pub enum TransformError {
     ),
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 #[derive(Debug, thiserror::Error)]
 #[error("Dataset does not define a transform")]
 pub struct TransformNotDefinedError {}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, thiserror::Error)]
+#[error("Dataset {dataset_handle} has not defined a schema yet")]
+pub struct InputSchemaNotDefinedError {
+    pub dataset_handle: DatasetHandle,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 impl From<GetDatasetError> for TransformError {
     fn from(v: GetDatasetError) -> Self {
@@ -177,3 +195,5 @@ impl From<auth::DatasetActionUnauthorizedError> for TransformError {
         }
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/core/src/ingest/polling_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/polling_ingest_service_impl.rs
@@ -536,7 +536,10 @@ impl PollingIngestServiceImpl {
             )
             .await?;
 
-        if !input_data_path.exists() || input_data_path.metadata().int_err()?.len() == 0 {
+        let input_is_missing_or_empty =
+            !input_data_path.exists() || input_data_path.metadata().int_err()?.len() == 0;
+
+        if input_is_missing_or_empty {
             if let Some(read_schema) = reader.input_schema().await {
                 tracing::info!(
                     path = ?input_data_path,

--- a/src/infra/core/src/testing/dataset_data_helper.rs
+++ b/src/infra/core/src/testing/dataset_data_helper.rs
@@ -33,17 +33,14 @@ impl DatasetDataHelper {
     }
 
     pub async fn data_slice_count(&self) -> usize {
-        let v: Vec<_> = self
-            .dataset
+        self.dataset
             .as_metadata_chain()
             .iter_blocks()
             .filter_data_stream_blocks()
             .filter_map_ok(|(_, b)| b.event.new_data.map(|_| 1))
-            .try_collect()
+            .try_fold(0, |a, b| async move { Ok(a + b) })
             .await
-            .unwrap();
-
-        v.iter().sum()
+            .unwrap()
     }
 
     pub async fn get_last_block_typed<T: VariantOf<MetadataEvent>>(&self) -> MetadataBlockTyped<T> {

--- a/src/infra/core/src/utils/docker_images.rs
+++ b/src/infra/core/src/utils/docker_images.rs
@@ -9,7 +9,7 @@
 
 pub const SPARK: &str = "ghcr.io/kamu-data/engine-spark:0.23.1-spark_3.5.0";
 pub const FLINK: &str = "ghcr.io/kamu-data/engine-flink:0.18.2-flink_1.16.0-scala_2.12-java8";
-pub const DATAFUSION: &str = "ghcr.io/kamu-data/engine-datafusion:0.8.0";
+pub const DATAFUSION: &str = "ghcr.io/kamu-data/engine-datafusion:0.8.1";
 pub const RISINGWAVE: &str = "ghcr.io/kamu-data/engine-risingwave:0.2.0-risingwave_1.7.0-alpha";
 
 pub const LIVY: &str = SPARK;

--- a/src/infra/core/tests/tests/ingest/test_fetch.rs
+++ b/src/infra/core/tests/tests/ingest/test_fetch.rs
@@ -906,10 +906,7 @@ async fn test_fetch_container_batch_size_default() {
         command: Some(vec!["sh".to_owned()]),
         args: Some(vec![
             "-c".to_owned(),
-            format!(
-                "env | grep -q {ODF_BATCH_SIZE}={}",
-                SourceConfig::default().target_records_per_slice
-            ),
+            "env | grep ODF_BATCH_SIZE".to_owned(),
         ]),
         env: None,
     });
@@ -929,7 +926,15 @@ async fn test_fetch_container_batch_size_default() {
         .await
         .unwrap();
 
-    assert_matches!(res, FetchResult::UpToDate);
+    assert_matches!(res, FetchResult::Updated(_));
+
+    assert_eq!(
+        std::str::from_utf8(&std::fs::read(target_path).unwrap()).unwrap(),
+        format!(
+            "ODF_BATCH_SIZE={}\n",
+            SourceConfig::default().target_records_per_slice
+        ),
+    );
 }
 
 #[test_group::group(containerized)]
@@ -945,7 +950,7 @@ async fn test_fetch_container_batch_size_set() {
         command: Some(vec!["sh".to_owned()]),
         args: Some(vec![
             "-c".to_owned(),
-            format!("env | grep -q {ODF_BATCH_SIZE}={custom_batch_size}"),
+            "env | grep ODF_BATCH_SIZE".to_owned(),
         ]),
         env: Some(vec![EnvVar {
             name: ODF_BATCH_SIZE.to_owned(),
@@ -968,7 +973,12 @@ async fn test_fetch_container_batch_size_set() {
         .await
         .unwrap();
 
-    assert_matches!(res, FetchResult::UpToDate);
+    assert_matches!(res, FetchResult::Updated(_));
+
+    assert_eq!(
+        std::str::from_utf8(&std::fs::read(target_path).unwrap()).unwrap(),
+        format!("ODF_BATCH_SIZE={custom_batch_size}\n"),
+    );
 }
 
 #[test_group::group(containerized)]
@@ -1043,7 +1053,7 @@ async fn test_fetch_container_has_more_no_data() {
         .await
         .unwrap();
 
-    assert_matches!(res, FetchResult::UpToDate);
+    assert_matches!(res, FetchResult::Updated(_));
     assert!(target_path.exists());
     assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "");
 }

--- a/src/infra/core/tests/tests/ingest/test_writer.rs
+++ b/src/infra/core/tests/tests/ingest/test_writer.rs
@@ -96,7 +96,7 @@ async fn test_data_writer_happy_path() {
     .await;
 
     assert_eq!(
-        res.new_block.event.new_watermark.as_ref(),
+        res.add_data_block.unwrap().event.new_watermark.as_ref(),
         Some(&harness.source_event_time)
     );
 
@@ -159,7 +159,12 @@ async fn test_data_writer_happy_path() {
     .await;
 
     assert_eq!(
-        res.new_block.event.new_watermark.as_ref(),
+        res.add_data_block
+            .as_ref()
+            .unwrap()
+            .event
+            .new_watermark
+            .as_ref(),
         Some(&harness.source_event_time)
     );
 
@@ -167,7 +172,7 @@ async fn test_data_writer_happy_path() {
     assert_eq!(schema_block_hash, harness.get_last_schema_block().await.0);
 
     // Round 3 (nothing to commit)
-    let prev_watermark = res.new_block.event.new_watermark.unwrap();
+    let prev_watermark = res.add_data_block.unwrap().event.new_watermark.unwrap();
     harness.set_system_time(Utc.with_ymd_and_hms(2010, 1, 3, 12, 0, 0).unwrap());
     harness.set_source_event_time(Utc.with_ymd_and_hms(2000, 1, 3, 12, 0, 0).unwrap());
 
@@ -215,11 +220,13 @@ async fn test_data_writer_happy_path() {
         .await
         .unwrap();
 
-    assert_eq!(res.new_block.event.new_data, None);
+    let new_block = res.add_data_block.unwrap();
+
+    assert_eq!(new_block.event.new_data, None);
     // Watermark is carried
-    assert_eq!(res.new_block.event.new_watermark, Some(prev_watermark));
+    assert_eq!(new_block.event.new_watermark, Some(prev_watermark));
     // Source state updated
-    assert_eq!(res.new_block.event.new_source_state, Some(source_state));
+    assert_eq!(new_block.event.new_source_state, Some(source_state));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -471,7 +478,8 @@ async fn test_data_writer_ledger_orders_by_event_time() {
     .await;
 
     assert_eq!(
-        res.new_block
+        res.add_data_block
+            .unwrap()
             .event
             .new_watermark
             .as_ref()
@@ -546,7 +554,8 @@ async fn test_data_writer_snapshot_orders_by_pk_and_operation_type() {
     .await;
 
     assert_eq!(
-        res.new_block
+        res.add_data_block
+            .unwrap()
             .event
             .new_watermark
             .as_ref()
@@ -610,7 +619,8 @@ async fn test_data_writer_snapshot_orders_by_pk_and_operation_type() {
     .await;
 
     assert_eq!(
-        res.new_block
+        res.add_data_block
+            .unwrap()
             .event
             .new_watermark
             .as_ref()

--- a/src/infra/core/tests/tests/test_query_service_impl.rs
+++ b/src/infra/core/tests/tests/test_query_service_impl.rs
@@ -410,7 +410,7 @@ async fn test_dataset_tail_empty_dataset() {
     let tempdir = tempfile::tempdir().unwrap();
     let catalog = create_catalog_with_local_workspace(
         tempdir.path(),
-        MockDatasetActionAuthorizer::new().expect_check_read_a_dataset(1, true),
+        MockDatasetActionAuthorizer::new().expect_check_read_a_dataset(2, true),
     );
 
     let dataset_repo_writer = catalog.get_one::<dyn DatasetRepositoryWriter>().unwrap();
@@ -532,9 +532,10 @@ async fn test_dataset_sql_unauthorized_common(catalog: dill::Catalog, tempdir: &
 
     assert_matches!(
         result,
-        Err(QueryError::DataFusionError(
-            datafusion::common::DataFusionError::Plan(s)
-        ))  if s.contains("table 'kamu.kamu.foo' not found")
+        Err(QueryError::DataFusionError(DataFusionError {
+            source: datafusion::common::DataFusionError::Plan(s),
+            ..
+        }))  if s.contains("table 'kamu.kamu.foo' not found")
     );
 }
 
@@ -577,9 +578,10 @@ async fn test_sql_statement_not_found() {
 
     assert_matches!(
         result,
-        Err(QueryError::DataFusionError(
-            ::datafusion::common::DataFusionError::Plan(s)
-        ))  if s.contains("table 'kamu.kamu.does_not_exist' not found")
+        Err(QueryError::DataFusionError(DataFusionError {
+            source: ::datafusion::common::DataFusionError::Plan(s),
+            ..
+        }))  if s.contains("table 'kamu.kamu.does_not_exist' not found")
     );
 }
 

--- a/src/infra/core/tests/tests/test_transform_service_impl.rs
+++ b/src/infra/core/tests/tests/test_transform_service_impl.rs
@@ -148,6 +148,7 @@ impl TransformTestHarness {
             .unwrap()
     }
 
+    // TODO: Simplify using writer
     pub async fn append_data_block(
         &self,
         alias: &DatasetAlias,
@@ -238,7 +239,7 @@ async fn test_get_next_operation() {
             prev_offset: None,
             new_offset: Some(9),
             data_slices: vec![foo_slice.physical_hash.clone()],
-            schema_slice: foo_slice.physical_hash.clone(),
+            schema: MetadataFactory::set_data_schema().build().schema_as_arrow().unwrap(),
             explicit_watermarks: vec![Watermark {
                 system_time: foo_block.system_time,
                 event_time: Utc.with_ymd_and_hms(2020, 1, 1, 10, 0, 0).unwrap(),

--- a/src/infra/core/tests/utils/mock_engine_provisioner.rs
+++ b/src/infra/core/tests/utils/mock_engine_provisioner.rs
@@ -62,6 +62,7 @@ impl Engine for EngineStub {
         Ok(TransformResponseExt {
             new_offset_interval: None,
             new_watermark: Some(Utc::now()),
+            output_schema: None,
             new_checkpoint: None,
             new_data: None,
         })

--- a/src/infra/ingest-datafusion/src/readers/geojson.rs
+++ b/src/infra/ingest-datafusion/src/readers/geojson.rs
@@ -9,7 +9,7 @@
 
 use std::path::{Path, PathBuf};
 
-use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::ReadError;
@@ -100,7 +100,7 @@ impl ReaderGeoJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderGeoJson {
-    async fn input_schema(&self) -> Option<Schema> {
+    async fn input_schema(&self) -> Option<SchemaRef> {
         self.inner.input_schema().await
     }
 

--- a/src/infra/ingest-datafusion/src/readers/json.rs
+++ b/src/infra/ingest-datafusion/src/readers/json.rs
@@ -9,7 +9,7 @@
 
 use std::path::{Path, PathBuf};
 
-use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::ReadError;
@@ -98,7 +98,7 @@ impl ReaderJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderJson {
-    async fn input_schema(&self) -> Option<Schema> {
+    async fn input_schema(&self) -> Option<SchemaRef> {
         self.inner.input_schema().await
     }
 

--- a/src/infra/ingest-datafusion/src/readers/ndgeojson.rs
+++ b/src/infra/ingest-datafusion/src/readers/ndgeojson.rs
@@ -9,7 +9,7 @@
 
 use std::path::{Path, PathBuf};
 
-use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::ReadError;
@@ -104,7 +104,7 @@ impl ReaderNdGeoJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderNdGeoJson {
-    async fn input_schema(&self) -> Option<Schema> {
+    async fn input_schema(&self) -> Option<SchemaRef> {
         self.inner.input_schema().await
     }
 

--- a/src/infra/ingest-datafusion/src/readers/ndjson.rs
+++ b/src/infra/ingest-datafusion/src/readers/ndjson.rs
@@ -8,8 +8,9 @@
 // by the Apache License, Version 2.0.
 
 use std::path::Path;
+use std::sync::Arc;
 
-use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
 use datafusion::prelude::*;
 use internal_error::*;
@@ -22,7 +23,7 @@ use crate::*;
 
 pub struct ReaderNdJson {
     ctx: SessionContext,
-    schema: Option<Schema>,
+    schema: Option<SchemaRef>,
     conf: ReadStepNdJson,
 }
 
@@ -31,7 +32,9 @@ impl ReaderNdJson {
 
     pub async fn new(ctx: SessionContext, conf: ReadStepNdJson) -> Result<Self, ReadError> {
         Ok(Self {
-            schema: super::from_ddl_schema(&ctx, &conf.schema).await?,
+            schema: super::from_ddl_schema(&ctx, &conf.schema)
+                .await?
+                .map(Arc::new),
             ctx,
             conf,
         })
@@ -42,7 +45,7 @@ impl ReaderNdJson {
 
 #[async_trait::async_trait]
 impl Reader for ReaderNdJson {
-    async fn input_schema(&self) -> Option<Schema> {
+    async fn input_schema(&self) -> Option<SchemaRef> {
         self.schema.clone()
     }
 
@@ -64,7 +67,7 @@ impl Reader for ReaderNdJson {
         let options = NdJsonReadOptions {
             file_extension: path.extension().and_then(|s| s.to_str()).unwrap_or(""),
             table_partition_cols: Vec::new(),
-            schema: self.schema.as_ref(),
+            schema: self.schema.as_deref(),
             schema_infer_max_records: Self::DEFAULT_INFER_SCHEMA_ROWS,
             // TODO: PERF: Reader support compression, thus we could detect decompress step and
             // optimize the ingest plan to avoid writing uncompressed data to disc or having to

--- a/src/infra/ingest-datafusion/src/readers/parquet.rs
+++ b/src/infra/ingest-datafusion/src/readers/parquet.rs
@@ -8,8 +8,9 @@
 // by the Apache License, Version 2.0.
 
 use std::path::Path;
+use std::sync::Arc;
 
-use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::ReadError;
@@ -21,13 +22,15 @@ use crate::*;
 
 pub struct ReaderParquet {
     ctx: SessionContext,
-    schema: Option<Schema>,
+    schema: Option<SchemaRef>,
 }
 
 impl ReaderParquet {
     pub async fn new(ctx: SessionContext, conf: ReadStepParquet) -> Result<Self, ReadError> {
         Ok(Self {
-            schema: super::from_ddl_schema(&ctx, &conf.schema).await?,
+            schema: super::from_ddl_schema(&ctx, &conf.schema)
+                .await?
+                .map(Arc::new),
             ctx,
         })
     }
@@ -37,13 +40,13 @@ impl ReaderParquet {
 
 #[async_trait::async_trait]
 impl Reader for ReaderParquet {
-    async fn input_schema(&self) -> Option<Schema> {
+    async fn input_schema(&self) -> Option<SchemaRef> {
         self.schema.clone()
     }
 
     async fn read(&self, path: &Path) -> Result<DataFrame, ReadError> {
         let options = ParquetReadOptions {
-            schema: self.schema.as_ref(),
+            schema: self.schema.as_deref(),
             file_extension: path.extension().and_then(|s| s.to_str()).unwrap_or(""),
             table_partition_cols: Vec::new(),
             parquet_pruning: None,

--- a/src/infra/ingest-datafusion/src/readers/shapefile.rs
+++ b/src/infra/ingest-datafusion/src/readers/shapefile.rs
@@ -9,7 +9,7 @@
 
 use std::path::{Path, PathBuf};
 
-use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_core::ingest::ReadError;
@@ -222,7 +222,7 @@ impl ReaderEsriShapefile {
 
 #[async_trait::async_trait]
 impl Reader for ReaderEsriShapefile {
-    async fn input_schema(&self) -> Option<Schema> {
+    async fn input_schema(&self) -> Option<SchemaRef> {
         self.inner.input_schema().await
     }
 


### PR DESCRIPTION
## Description

Problem scenario:
- I created datasets for each of our GH repo that track who gave it a "star"
- I then combined them all into one "community" derivative dataset
- Because some of our repos are mostly internal - they may not have any stars
- This causes a problem - currently if the source of a root dataset does not produce any data - the `SetDataSchema` event is not written - and datasets without schema will block derivative transformations from executing

In this PR:
- I change push/pull ingest to define schema as soon as possible, even if input data is empty using the `read` stage schema
- I changed DF engine to produce Parquet files even if output DataFrame is empty - this way I can propagate output schema to kamu
- kamu now handles engines propagating empty Parquet files to define derivative dataset schema, even if the dataset stays empty
- I eliminate the hack where one of the old Parquet files was passed as a "Schema carrier" to the engine - instead kamu will always write an empty Parquet file using schema from `SetDataSchema`

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ❌
    Requires new DF engine. I will consider updating Flink, Spark, RW too
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅