### PR TITLE
Release 0.198.0 (focus on the "address RUSTSEC-2024-0363")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.198.0] - 2024-08-27
 ### Changed
 - If a polling/push source does not declare a `read` schema or a `preprocess` step (which is the case when ingesting data from a file upload) we apply the following new inference rules:
   - If `event_time` column is present - we will try to coerce it into a timestamp:
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All tests related to databases use the `database_transactional_test` macro
 - Some skipped tests will now also be run
 - Access token with duplicate names can be created if such name exists but was revoked (now for MySQL as well)
+- Updated `sqlx` crate to address [RUSTSEC-2024-0363](https://rustsec.org/advisories/RUSTSEC-2024-0363)
 ### Fixed
 - Derivative transform crash when input datasets have `AddData` events but don't have any Parquet files yet
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b515e82c8468ddb6ff8db21c78a5997442f113fd8471fd5b2261b2602dd0c67"
+checksum = "bb07629a5d0645d29f68d2fb6f4d0cf15c89ec0965be915f303967180929743f"
 dependencies = [
  "num_enum",
  "strum 0.26.3",
@@ -389,7 +389,7 @@ checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -481,7 +481,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -498,7 +498,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -516,7 +516,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.75",
+ "syn 2.0.76",
  "syn-solidity",
 ]
 
@@ -1197,7 +1197,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.25.0",
- "syn 2.0.75",
+ "syn 2.0.76",
  "thiserror",
 ]
 
@@ -1233,7 +1233,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1255,7 +1255,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1266,7 +1266,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1303,7 +1303,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1921,7 +1921,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.0",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -2043,15 +2043,16 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf100c4cea8f207e883ff91ca886d621d8a166cb04971dfaa9bb8fd99ed95df"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
 dependencies = [
  "blst",
  "cc",
  "glob",
  "hex",
  "libc",
+ "once_cell",
  "serde",
 ]
 
@@ -2095,9 +2096,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
@@ -2229,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9340e41703683548f486fdfdce615b0520dd220d18b1d4ce5abbc87d461c221b"
+checksum = "531d7959c5bbb6e266cecdd0f20213639c3a5c3e4d615f97db87661745f781ff"
 dependencies = [
  "clap",
 ]
@@ -2245,7 +2246,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2361,13 +2362,13 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2721,7 +2722,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2751,7 +2752,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2762,7 +2763,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2806,7 +2807,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2830,10 +2831,10 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3294,7 +3295,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3349,7 +3350,7 @@ checksum = "9d0e68e1e07d64dbf3bb2991657979ec4e3fe13b7b3c18067b802052af1330a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3580,12 +3581,12 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "enum-variants"
-version = "0.197.0"
+version = "0.198.0"
 
 [[package]]
 name = "env_filter"
@@ -3658,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3674,10 +3675,10 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3691,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fastrlp"
@@ -3785,9 +3786,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
@@ -3913,7 +3914,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4338,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "axum",
  "http 0.2.12",
@@ -4580,7 +4581,7 @@ dependencies = [
  "libflate",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4659,7 +4660,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "thiserror",
 ]
@@ -4816,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -4903,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -4929,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4950,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4971,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4992,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "argon2",
  "chrono",
@@ -5008,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5034,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5055,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -5077,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5100,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5150,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5210,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5229,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "axum",
  "chrono",
@@ -5264,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5276,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -5290,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-repo-tests"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "dill",
  "kamu-auth-rebac",
@@ -5299,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -5310,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5327,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -5438,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "chrono",
  "indoc 2.0.5",
@@ -5458,15 +5459,15 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "kamu-cli-e2e-inmem"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5479,7 +5480,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5493,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5507,7 +5508,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "chrono",
  "indoc 2.0.5",
@@ -5523,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5537,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -5553,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5583,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -5608,7 +5609,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5630,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5649,7 +5650,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5672,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5694,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-repo-tests"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -5708,7 +5709,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5729,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5752,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5778,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5807,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5831,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "chrono",
  "dill",
@@ -5842,7 +5843,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5884,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5908,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5945,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5964,7 +5965,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5987,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-repo-tests"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -6001,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6023,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "chrono",
  "clap",
@@ -6038,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6054,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6073,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6096,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "chrono",
  "dill",
@@ -6107,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6131,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6321,9 +6322,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -6332,9 +6333,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -6521,7 +6522,7 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6668,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "bs58",
  "digest 0.10.7",
@@ -6903,7 +6904,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -6993,7 +6994,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7132,7 +7133,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -7314,7 +7315,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -7412,7 +7413,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -7635,11 +7636,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
@@ -7715,7 +7716,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -7793,9 +7794,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -7857,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "rand",
 ]
@@ -8229,7 +8230,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.75",
+ "syn 2.0.76",
  "walkdir",
 ]
 
@@ -8571,29 +8572,29 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -8659,7 +8660,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8933,14 +8934,14 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "sqlx"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
+checksum = "fcfa89bea9500db4a0d038513d7a060566bfc51d46d1c014847049a45cce85e8"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -8951,9 +8952,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
+checksum = "d06e2f2bd861719b1f3f0c7dbe1d80c30bf59e76cf019f07d9014ed7eefb8e08"
 dependencies = [
  "atoi",
  "byteorder",
@@ -8977,8 +8978,8 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls 0.23.12",
+ "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
  "sha2",
@@ -8990,27 +8991,27 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.25.4",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
+checksum = "2f998a9defdbd48ed005a89362bd40dd2117502f15294f61c8d47034107dbbdc"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
+checksum = "3d100558134176a2629d46cec0c8891ba0be8910f7896abfdb75ef4ab6f4e7ce"
 dependencies = [
  "dotenvy",
  "either",
@@ -9026,7 +9027,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.75",
+ "syn 2.0.76",
  "tempfile",
  "tokio",
  "url",
@@ -9034,9 +9035,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
+checksum = "936cac0ab331b14cb3921c62156d913e4c15b74fb6ec0f3146bd4ef6e4fb3c12"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -9078,9 +9079,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
+checksum = "9734dbce698c67ecf67c442f768a5e90a49b2a4d61a9f1d59f73874bd4cf0710"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -9118,9 +9119,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
+checksum = "a75b419c3c1b1697833dd927bdc4c6545a620bc1bbafabd44e1efbe9afcd337e"
 dependencies = [
  "atoi",
  "chrono",
@@ -9224,7 +9225,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9237,7 +9238,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9259,9 +9260,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9277,7 +9278,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9373,7 +9374,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9395,7 +9396,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9424,7 +9425,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9492,7 +9493,7 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9571,7 +9572,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9689,17 +9690,6 @@ name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.4.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.4.0",
  "toml_datetime",
@@ -9835,7 +9825,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9890,7 +9880,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.197.0"
+version = "0.198.0"
 dependencies = [
  "conv",
  "serde",
@@ -10278,7 +10268,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
@@ -10312,7 +10302,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10785,7 +10775,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -10805,7 +10795,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,91 +88,91 @@ resolver = "2"
 [workspace.dependencies]
 
 # Apps
-kamu-cli = { version = "0.197.0", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.198.0", path = "src/app/cli", default-features = false }
 
 # Utils
-container-runtime = { version = "0.197.0", path = "src/utils/container-runtime", default-features = false }
-database-common = { version = "0.197.0", path = "src/utils/database-common", default-features = false }
-database-common-macros = { version = "0.197.0", path = "src/utils/database-common-macros", default-features = false }
-enum-variants = { version = "0.197.0", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.197.0", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.197.0", path = "src/utils/event-sourcing-macros", default-features = false }
-http-common = { version = "0.197.0", path = "src/utils/http-common", default-features = false }
-internal-error = { version = "0.197.0", path = "src/utils/internal-error", default-features = false }
-kamu-cli-puppet = { version = "0.197.0", path = "src/utils/kamu-cli-puppet", default-features = false }
-kamu-data-utils = { version = "0.197.0", path = "src/utils/data-utils", default-features = false }
-kamu-datafusion-cli = { version = "0.197.0", path = "src/utils/datafusion-cli", default-features = false }
-messaging-outbox = { version = "0.197.0", path = "src/utils/messaging-outbox", default-features = false }
-multiformats = { version = "0.197.0", path = "src/utils/multiformats", default-features = false }
-random-names = { version = "0.197.0", path = "src/utils/random-names", default-features = false }
-time-source = { version = "0.197.0", path = "src/utils/time-source", default-features = false }
-tracing-perfetto = { version = "0.197.0", path = "src/utils/tracing-perfetto", default-features = false }
+container-runtime = { version = "0.198.0", path = "src/utils/container-runtime", default-features = false }
+database-common = { version = "0.198.0", path = "src/utils/database-common", default-features = false }
+database-common-macros = { version = "0.198.0", path = "src/utils/database-common-macros", default-features = false }
+enum-variants = { version = "0.198.0", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.198.0", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.198.0", path = "src/utils/event-sourcing-macros", default-features = false }
+http-common = { version = "0.198.0", path = "src/utils/http-common", default-features = false }
+internal-error = { version = "0.198.0", path = "src/utils/internal-error", default-features = false }
+kamu-cli-puppet = { version = "0.198.0", path = "src/utils/kamu-cli-puppet", default-features = false }
+kamu-data-utils = { version = "0.198.0", path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { version = "0.198.0", path = "src/utils/datafusion-cli", default-features = false }
+messaging-outbox = { version = "0.198.0", path = "src/utils/messaging-outbox", default-features = false }
+multiformats = { version = "0.198.0", path = "src/utils/multiformats", default-features = false }
+random-names = { version = "0.198.0", path = "src/utils/random-names", default-features = false }
+time-source = { version = "0.198.0", path = "src/utils/time-source", default-features = false }
+tracing-perfetto = { version = "0.198.0", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-kamu-accounts = { version = "0.197.0", path = "src/domain/accounts/domain", default-features = false }
-kamu-auth-rebac = { version = "0.197.0", path = "src/domain/auth-rebac/domain", default-features = false }
-kamu-core = { version = "0.197.0", path = "src/domain/core", default-features = false }
-kamu-datasets = { version = "0.197.0", path = "src/domain/datasets/domain", default-features = false }
-kamu-flow-system = { version = "0.197.0", path = "src/domain/flow-system/domain", default-features = false }
-kamu-task-system = { version = "0.197.0", path = "src/domain/task-system/domain", default-features = false }
-opendatafabric = { version = "0.197.0", path = "src/domain/opendatafabric", default-features = false }
+kamu-accounts = { version = "0.198.0", path = "src/domain/accounts/domain", default-features = false }
+kamu-auth-rebac = { version = "0.198.0", path = "src/domain/auth-rebac/domain", default-features = false }
+kamu-core = { version = "0.198.0", path = "src/domain/core", default-features = false }
+kamu-datasets = { version = "0.198.0", path = "src/domain/datasets/domain", default-features = false }
+kamu-flow-system = { version = "0.198.0", path = "src/domain/flow-system/domain", default-features = false }
+kamu-task-system = { version = "0.198.0", path = "src/domain/task-system/domain", default-features = false }
+opendatafabric = { version = "0.198.0", path = "src/domain/opendatafabric", default-features = false }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.197.0", path = "src/domain/accounts/services", default-features = false }
-kamu-auth-rebac-services = { version = "0.197.0", path = "src/domain/auth-rebac/services", default-features = false }
-kamu-datasets-services = { version = "0.197.0", path = "src/domain/datasets/services", default-features = false }
-kamu-flow-system-services = { version = "0.197.0", path = "src/domain/flow-system/services", default-features = false }
-kamu-task-system-services = { version = "0.197.0", path = "src/domain/task-system/services", default-features = false }
+kamu-accounts-services = { version = "0.198.0", path = "src/domain/accounts/services", default-features = false }
+kamu-auth-rebac-services = { version = "0.198.0", path = "src/domain/auth-rebac/services", default-features = false }
+kamu-datasets-services = { version = "0.198.0", path = "src/domain/datasets/services", default-features = false }
+kamu-flow-system-services = { version = "0.198.0", path = "src/domain/flow-system/services", default-features = false }
+kamu-task-system-services = { version = "0.198.0", path = "src/domain/task-system/services", default-features = false }
 
 # Infra
-kamu = { version = "0.197.0", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.197.0", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.198.0", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.198.0", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.197.0", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.197.0", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.197.0", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.197.0", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.198.0", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.198.0", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.198.0", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.198.0", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.197.0", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.197.0", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.197.0", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.197.0", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.197.0", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.198.0", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.198.0", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.198.0", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.198.0", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.198.0", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Datasets
-kamu-datasets-inmem = { version = "0.197.0", path = "src/infra/datasets/inmem", default-features = false }
-kamu-datasets-postgres = { version = "0.197.0", path = "src/infra/datasets/postgres", default-features = false }
-kamu-datasets-sqlite = { version = "0.197.0", path = "src/infra/datasets/sqlite", default-features = false }
-kamu-datasets-repo-tests = { version = "0.197.0", path = "src/infra/datasets/repo-tests", default-features = false }
+kamu-datasets-inmem = { version = "0.198.0", path = "src/infra/datasets/inmem", default-features = false }
+kamu-datasets-postgres = { version = "0.198.0", path = "src/infra/datasets/postgres", default-features = false }
+kamu-datasets-sqlite = { version = "0.198.0", path = "src/infra/datasets/sqlite", default-features = false }
+kamu-datasets-repo-tests = { version = "0.198.0", path = "src/infra/datasets/repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.197.0", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.197.0", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.197.0", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.197.0", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.198.0", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.198.0", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.198.0", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.198.0", path = "src/infra/task-system/repo-tests", default-features = false }
 ## ReBAC
-kamu-auth-rebac-inmem = { version = "0.197.0", path = "src/infra/auth-rebac/inmem", default-features = false }
-kamu-auth-rebac-repo-tests = { version = "0.197.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
-kamu-auth-rebac-sqlite = { version = "0.197.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
+kamu-auth-rebac-inmem = { version = "0.198.0", path = "src/infra/auth-rebac/inmem", default-features = false }
+kamu-auth-rebac-repo-tests = { version = "0.198.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
+kamu-auth-rebac-sqlite = { version = "0.198.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
 ## Outbox
-kamu-messaging-outbox-inmem = { version = "0.197.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
-kamu-messaging-outbox-postgres = { version = "0.197.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
-kamu-messaging-outbox-sqlite = { version = "0.197.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
-kamu-messaging-outbox-repo-tests = { version = "0.197.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
+kamu-messaging-outbox-inmem = { version = "0.198.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
+kamu-messaging-outbox-postgres = { version = "0.198.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
+kamu-messaging-outbox-sqlite = { version = "0.198.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
+kamu-messaging-outbox-repo-tests = { version = "0.198.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso = { version = "0.197.0", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.197.0", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.197.0", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.197.0", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.197.0", path = "src/adapter/odata", default-features = false }
-kamu-adapter-oauth = { version = "0.197.0", path = "src/adapter/oauth", default-features = false }
+kamu-adapter-auth-oso = { version = "0.198.0", path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { version = "0.198.0", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.198.0", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.198.0", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.198.0", path = "src/adapter/odata", default-features = false }
+kamu-adapter-oauth = { version = "0.198.0", path = "src/adapter/oauth", default-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.197.0", path = "src/e2e/app/cli/common", default-features = false }
-kamu-cli-e2e-common-macros = { version = "0.197.0", path = "src/e2e/app/cli/common-macros", default-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.197.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
+kamu-cli-e2e-common = { version = "0.198.0", path = "src/e2e/app/cli/common", default-features = false }
+kamu-cli-e2e-common-macros = { version = "0.198.0", path = "src/e2e/app/cli/common-macros", default-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.198.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
 
 [workspace.package]
-version = "0.197.0"
+version = "0.198.0"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.197.0
+Licensed Work:             Kamu CLI Version 0.198.0
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2028-08-22
+Change Date:               2028-08-27
 
 Change License:            Apache License, Version 2.0
 

--- a/deny.toml
+++ b/deny.toml
@@ -112,5 +112,4 @@ yanked = "deny"
 # TODO: Remove when patches are available
 ignore = [
     "RUSTSEC-2023-0071", # https://rustsec.org/advisories/RUSTSEC-2023-0071.html
-    "RUSTSEC-2024-0363"  # https://rustsec.org/advisories/RUSTSEC-2024-0363
 ]


### PR DESCRIPTION
### Changed
- If a polling/push source does not declare a `read` schema or a `preprocess` step (which is the case when ingesting data from a file upload) we apply the following new inference rules:
  - If `event_time` column is present - we will try to coerce it into a timestamp:
    - strings will be parsed as RFC3339 date-times
    - integers will be treated as UNIX timestamps in seconds
  - Columns with names that conflict with system columns will get renamed
- All tests related to databases use the `database_transactional_test` macro
- Some skipped tests will now also be run
- Access token with duplicate names can be created if such name exists but was revoked (now for MySQL as well)
- :warning: Updated `sqlx` crate to address [RUSTSEC-2024-0363](https://rustsec.org/advisories/RUSTSEC-2024-0363)
### Fixed
- Derivative transform crash when input datasets have `AddData` events but don't have any Parquet files yet
