### PR TITLE
Use dataset env vars in container sources

### DIFF
--- a/src/domain/core/src/services/ingest/polling_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/polling_ingest_service.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use container_runtime::ImagePullError;
 use internal_error::{BoxedError, InternalError};
-use kamu_datasets::DatasetEnvVar;
+use kamu_datasets::{DatasetEnvVar, FindDatasetEnvVarError};
 use opendatafabric::*;
 use thiserror::Error;
 
@@ -330,6 +330,17 @@ impl From<auth::DatasetActionUnauthorizedError> for PollingIngestError {
         match v {
             auth::DatasetActionUnauthorizedError::Access(e) => Self::Access(e),
             auth::DatasetActionUnauthorizedError::Internal(e) => Self::Internal(e),
+        }
+    }
+}
+
+impl From<FindDatasetEnvVarError> for PollingIngestError {
+    fn from(value: FindDatasetEnvVarError) -> Self {
+        match value {
+            FindDatasetEnvVarError::NotFound(e) => {
+                Self::ParameterNotFound(IngestParameterNotFound::new(e.dataset_env_var_key))
+            }
+            FindDatasetEnvVarError::Internal(e) => Self::Internal(e),
         }
     }
 }

--- a/src/domain/datasets/domain/src/entities/dataset_env_var.rs
+++ b/src/domain/datasets/domain/src/entities/dataset_env_var.rs
@@ -180,6 +180,14 @@ impl DatasetEnvVarValue {
             Self::Secret(secret_value) => secret_value.expose_secret(),
         }
     }
+
+    pub fn into_exposed_value(self) -> String {
+        match self {
+            Self::Regular(value) => value,
+            // TODO: Secrecy crate does not provide a way to extract inner value
+            Self::Secret(secret_value) => secret_value.expose_secret().to_owned(),
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/domain/src/services/dataset_key_value_service.rs
+++ b/src/domain/datasets/domain/src/services/dataset_key_value_service.rs
@@ -16,12 +16,11 @@ use crate::{DatasetEnvVar, DatasetEnvVarNotFoundError, DatasetEnvVarValue};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[async_trait::async_trait]
 pub trait DatasetKeyValueService: Sync + Send {
-    async fn find_dataset_env_var_value_by_key<'a>(
+    fn find_dataset_env_var_value_by_key(
         &self,
         dataset_env_var_key: &str,
-        dataset_env_vars: &'a HashMap<String, DatasetEnvVar>,
+        dataset_env_vars: &HashMap<String, DatasetEnvVar>,
     ) -> Result<DatasetEnvVarValue, FindDatasetEnvVarError>;
 }
 
@@ -30,10 +29,10 @@ pub trait DatasetKeyValueService: Sync + Send {
 #[derive(Error, Debug)]
 pub enum FindDatasetEnvVarError {
     #[error(transparent)]
-    NotFound(DatasetEnvVarNotFoundError),
+    NotFound(#[from] DatasetEnvVarNotFoundError),
 
     #[error(transparent)]
-    Internal(InternalError),
+    Internal(#[from] InternalError),
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/services/src/dataset_key_value_service_impl.rs
+++ b/src/domain/datasets/services/src/dataset_key_value_service_impl.rs
@@ -49,12 +49,11 @@ impl DatasetKeyValueServiceImpl {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[async_trait::async_trait]
 impl DatasetKeyValueService for DatasetKeyValueServiceImpl {
-    async fn find_dataset_env_var_value_by_key<'a>(
+    fn find_dataset_env_var_value_by_key(
         &self,
         dataset_env_var_key: &str,
-        dataset_env_vars: &'a HashMap<String, DatasetEnvVar>,
+        dataset_env_vars: &HashMap<String, DatasetEnvVar>,
     ) -> Result<DatasetEnvVarValue, FindDatasetEnvVarError> {
         if let Some(existing_dataset_env_var) = dataset_env_vars.get(dataset_env_var_key) {
             let exposed_value = existing_dataset_env_var

--- a/src/domain/datasets/services/src/dataset_key_value_service_sys_env.rs
+++ b/src/domain/datasets/services/src/dataset_key_value_service_sys_env.rs
@@ -10,9 +10,10 @@
 use std::collections::HashMap;
 
 use dill::*;
-use internal_error::ErrorIntoInternal;
+use internal_error::*;
 use kamu_datasets::{
     DatasetEnvVar,
+    DatasetEnvVarNotFoundError,
     DatasetEnvVarValue,
     DatasetKeyValueService,
     FindDatasetEnvVarError,
@@ -35,15 +36,28 @@ impl DatasetKeyValueServiceSysEnv {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[async_trait::async_trait]
 impl DatasetKeyValueService for DatasetKeyValueServiceSysEnv {
-    async fn find_dataset_env_var_value_by_key<'a>(
+    fn find_dataset_env_var_value_by_key(
         &self,
         dataset_env_var_key: &str,
-        _dataset_env_vars: &'a HashMap<String, DatasetEnvVar>,
+        dataset_env_vars: &HashMap<String, DatasetEnvVar>,
     ) -> Result<DatasetEnvVarValue, FindDatasetEnvVarError> {
+        // Search explicitly provided vars first
+        if let Some(var) = dataset_env_vars.get(dataset_env_var_key) {
+            return Ok(DatasetEnvVarValue::Regular(
+                var.get_non_secret_value()
+                    .expect("Unexpected encrypted value"),
+            ));
+        }
+
+        // Fall back to system environment
         match std::env::var(dataset_env_var_key) {
             Ok(value_string) => Ok(DatasetEnvVarValue::Secret(Secret::new(value_string))),
+            Err(std::env::VarError::NotPresent) => Err(FindDatasetEnvVarError::NotFound(
+                DatasetEnvVarNotFoundError {
+                    dataset_env_var_key: dataset_env_var_key.to_owned(),
+                },
+            )),
             Err(err) => Err(FindDatasetEnvVarError::Internal(err.int_err())),
         }
     }

--- a/src/infra/core/src/ingest/fetch_service/evm.rs
+++ b/src/infra/core/src/ingest/fetch_service/evm.rs
@@ -76,7 +76,7 @@ impl FetchService {
 
         // Setup node RPC client
         let node_url = if let Some(url) = &fetch.node_url {
-            self.template_url(url, dataset_env_vars).await?
+            self.template_url(url, dataset_env_vars)?
         } else if let Some(ep) = self
             .eth_source_config
             .get_endpoint_by_chain_id(fetch.chain_id.unwrap())

--- a/src/infra/core/src/ingest/fetch_service/mqtt.rs
+++ b/src/infra/core/src/ingest/fetch_service/mqtt.rs
@@ -42,7 +42,7 @@ impl FetchService {
 
         // TODO: Reconsider password propagation
         if let (Some(username), Some(password)) = (&fetch.username, &fetch.password) {
-            let password = self.template_string(password, dataset_env_vars).await?;
+            let password = self.template_string(password, dataset_env_vars)?;
             opts.set_credentials(username, password);
         }
 


### PR DESCRIPTION
Note: this is based off my refactoring branch

Initially I was just going to support templating in containerized source's env vars, but I realized that the container fetch was not converted to use the new vars service and was remaining a severe security threat as it continued to pull data from system env.

The fix took me longer than expected as I was fighting the API.

Will leave some inline comments to explain.