### PR TITLE
Release (patch): 0.198.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--- - Changed -->
 <!--- - Fixed -->
 
-## Unreleased
+## [0.198.1] - 2024-08-28
 ### Added
 - Private Datasets, ReBAC integration: 
   - ReBAC properties update based on `DatasetLifecycleMessage`'s:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,7 +2368,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2807,7 +2807,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "quote",
  "syn 2.0.76",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.198.0"
+version = "0.198.1"
 
 [[package]]
 name = "env_filter"
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "quote",
  "syn 2.0.76",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "axum",
  "http 0.2.12",
@@ -4660,7 +4660,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "thiserror",
 ]
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "base32",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4993,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "argon2",
  "chrono",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5056,7 +5056,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "dill",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "axum",
  "chrono",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-repo-tests"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "dill",
  "kamu-auth-rebac",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "dill",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "chrono",
  "indoc 2.0.5",
@@ -5470,7 +5470,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "quote",
  "syn 2.0.76",
@@ -5478,7 +5478,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-inmem"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5505,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "chrono",
  "indoc 2.0.5",
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -5565,7 +5565,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5642,7 +5642,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5684,7 +5684,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-repo-tests"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "chrono",
  "database-common",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5819,7 +5819,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5843,7 +5843,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "chrono",
  "dill",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-repo-tests"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "chrono",
  "database-common",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "chrono",
  "clap",
@@ -6050,7 +6050,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6085,7 +6085,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "chrono",
  "dill",
@@ -6119,7 +6119,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6143,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6533,7 +6533,7 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6680,7 +6680,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "bs58",
  "digest 0.10.7",
@@ -7005,7 +7005,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7869,7 +7869,7 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "rand",
 ]
@@ -9504,7 +9504,7 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9891,7 +9891,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.198.0"
+version = "0.198.1"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,91 +88,91 @@ resolver = "2"
 [workspace.dependencies]
 
 # Apps
-kamu-cli = { version = "0.198.0", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.198.1", path = "src/app/cli", default-features = false }
 
 # Utils
-container-runtime = { version = "0.198.0", path = "src/utils/container-runtime", default-features = false }
-database-common = { version = "0.198.0", path = "src/utils/database-common", default-features = false }
-database-common-macros = { version = "0.198.0", path = "src/utils/database-common-macros", default-features = false }
-enum-variants = { version = "0.198.0", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.198.0", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.198.0", path = "src/utils/event-sourcing-macros", default-features = false }
-http-common = { version = "0.198.0", path = "src/utils/http-common", default-features = false }
-internal-error = { version = "0.198.0", path = "src/utils/internal-error", default-features = false }
-kamu-cli-puppet = { version = "0.198.0", path = "src/utils/kamu-cli-puppet", default-features = false }
-kamu-data-utils = { version = "0.198.0", path = "src/utils/data-utils", default-features = false }
-kamu-datafusion-cli = { version = "0.198.0", path = "src/utils/datafusion-cli", default-features = false }
-messaging-outbox = { version = "0.198.0", path = "src/utils/messaging-outbox", default-features = false }
-multiformats = { version = "0.198.0", path = "src/utils/multiformats", default-features = false }
-random-names = { version = "0.198.0", path = "src/utils/random-names", default-features = false }
-time-source = { version = "0.198.0", path = "src/utils/time-source", default-features = false }
-tracing-perfetto = { version = "0.198.0", path = "src/utils/tracing-perfetto", default-features = false }
+container-runtime = { version = "0.198.1", path = "src/utils/container-runtime", default-features = false }
+database-common = { version = "0.198.1", path = "src/utils/database-common", default-features = false }
+database-common-macros = { version = "0.198.1", path = "src/utils/database-common-macros", default-features = false }
+enum-variants = { version = "0.198.1", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.198.1", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.198.1", path = "src/utils/event-sourcing-macros", default-features = false }
+http-common = { version = "0.198.1", path = "src/utils/http-common", default-features = false }
+internal-error = { version = "0.198.1", path = "src/utils/internal-error", default-features = false }
+kamu-cli-puppet = { version = "0.198.1", path = "src/utils/kamu-cli-puppet", default-features = false }
+kamu-data-utils = { version = "0.198.1", path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { version = "0.198.1", path = "src/utils/datafusion-cli", default-features = false }
+messaging-outbox = { version = "0.198.1", path = "src/utils/messaging-outbox", default-features = false }
+multiformats = { version = "0.198.1", path = "src/utils/multiformats", default-features = false }
+random-names = { version = "0.198.1", path = "src/utils/random-names", default-features = false }
+time-source = { version = "0.198.1", path = "src/utils/time-source", default-features = false }
+tracing-perfetto = { version = "0.198.1", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-kamu-accounts = { version = "0.198.0", path = "src/domain/accounts/domain", default-features = false }
-kamu-auth-rebac = { version = "0.198.0", path = "src/domain/auth-rebac/domain", default-features = false }
-kamu-core = { version = "0.198.0", path = "src/domain/core", default-features = false }
-kamu-datasets = { version = "0.198.0", path = "src/domain/datasets/domain", default-features = false }
-kamu-flow-system = { version = "0.198.0", path = "src/domain/flow-system/domain", default-features = false }
-kamu-task-system = { version = "0.198.0", path = "src/domain/task-system/domain", default-features = false }
-opendatafabric = { version = "0.198.0", path = "src/domain/opendatafabric", default-features = false }
+kamu-accounts = { version = "0.198.1", path = "src/domain/accounts/domain", default-features = false }
+kamu-auth-rebac = { version = "0.198.1", path = "src/domain/auth-rebac/domain", default-features = false }
+kamu-core = { version = "0.198.1", path = "src/domain/core", default-features = false }
+kamu-datasets = { version = "0.198.1", path = "src/domain/datasets/domain", default-features = false }
+kamu-flow-system = { version = "0.198.1", path = "src/domain/flow-system/domain", default-features = false }
+kamu-task-system = { version = "0.198.1", path = "src/domain/task-system/domain", default-features = false }
+opendatafabric = { version = "0.198.1", path = "src/domain/opendatafabric", default-features = false }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.198.0", path = "src/domain/accounts/services", default-features = false }
-kamu-auth-rebac-services = { version = "0.198.0", path = "src/domain/auth-rebac/services", default-features = false }
-kamu-datasets-services = { version = "0.198.0", path = "src/domain/datasets/services", default-features = false }
-kamu-flow-system-services = { version = "0.198.0", path = "src/domain/flow-system/services", default-features = false }
-kamu-task-system-services = { version = "0.198.0", path = "src/domain/task-system/services", default-features = false }
+kamu-accounts-services = { version = "0.198.1", path = "src/domain/accounts/services", default-features = false }
+kamu-auth-rebac-services = { version = "0.198.1", path = "src/domain/auth-rebac/services", default-features = false }
+kamu-datasets-services = { version = "0.198.1", path = "src/domain/datasets/services", default-features = false }
+kamu-flow-system-services = { version = "0.198.1", path = "src/domain/flow-system/services", default-features = false }
+kamu-task-system-services = { version = "0.198.1", path = "src/domain/task-system/services", default-features = false }
 
 # Infra
-kamu = { version = "0.198.0", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.198.0", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.198.1", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.198.1", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.198.0", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.198.0", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.198.0", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.198.0", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.198.1", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.198.1", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.198.1", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.198.1", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.198.0", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.198.0", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.198.0", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.198.0", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.198.0", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.198.1", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.198.1", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.198.1", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.198.1", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.198.1", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Datasets
-kamu-datasets-inmem = { version = "0.198.0", path = "src/infra/datasets/inmem", default-features = false }
-kamu-datasets-postgres = { version = "0.198.0", path = "src/infra/datasets/postgres", default-features = false }
-kamu-datasets-sqlite = { version = "0.198.0", path = "src/infra/datasets/sqlite", default-features = false }
-kamu-datasets-repo-tests = { version = "0.198.0", path = "src/infra/datasets/repo-tests", default-features = false }
+kamu-datasets-inmem = { version = "0.198.1", path = "src/infra/datasets/inmem", default-features = false }
+kamu-datasets-postgres = { version = "0.198.1", path = "src/infra/datasets/postgres", default-features = false }
+kamu-datasets-sqlite = { version = "0.198.1", path = "src/infra/datasets/sqlite", default-features = false }
+kamu-datasets-repo-tests = { version = "0.198.1", path = "src/infra/datasets/repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.198.0", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.198.0", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.198.0", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.198.0", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.198.1", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.198.1", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.198.1", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.198.1", path = "src/infra/task-system/repo-tests", default-features = false }
 ## ReBAC
-kamu-auth-rebac-inmem = { version = "0.198.0", path = "src/infra/auth-rebac/inmem", default-features = false }
-kamu-auth-rebac-repo-tests = { version = "0.198.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
-kamu-auth-rebac-sqlite = { version = "0.198.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
+kamu-auth-rebac-inmem = { version = "0.198.1", path = "src/infra/auth-rebac/inmem", default-features = false }
+kamu-auth-rebac-repo-tests = { version = "0.198.1", path = "src/infra/auth-rebac/repo-tests", default-features = false }
+kamu-auth-rebac-sqlite = { version = "0.198.1", path = "src/infra/auth-rebac/sqlite", default-features = false }
 ## Outbox
-kamu-messaging-outbox-inmem = { version = "0.198.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
-kamu-messaging-outbox-postgres = { version = "0.198.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
-kamu-messaging-outbox-sqlite = { version = "0.198.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
-kamu-messaging-outbox-repo-tests = { version = "0.198.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
+kamu-messaging-outbox-inmem = { version = "0.198.1", path = "src/infra/messaging-outbox/inmem", default-features = false }
+kamu-messaging-outbox-postgres = { version = "0.198.1", path = "src/infra/messaging-outbox/postgres", default-features = false }
+kamu-messaging-outbox-sqlite = { version = "0.198.1", path = "src/infra/messaging-outbox/sqlite", default-features = false }
+kamu-messaging-outbox-repo-tests = { version = "0.198.1", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso = { version = "0.198.0", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.198.0", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.198.0", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.198.0", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.198.0", path = "src/adapter/odata", default-features = false }
-kamu-adapter-oauth = { version = "0.198.0", path = "src/adapter/oauth", default-features = false }
+kamu-adapter-auth-oso = { version = "0.198.1", path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { version = "0.198.1", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.198.1", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.198.1", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.198.1", path = "src/adapter/odata", default-features = false }
+kamu-adapter-oauth = { version = "0.198.1", path = "src/adapter/oauth", default-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.198.0", path = "src/e2e/app/cli/common", default-features = false }
-kamu-cli-e2e-common-macros = { version = "0.198.0", path = "src/e2e/app/cli/common-macros", default-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.198.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
+kamu-cli-e2e-common = { version = "0.198.1", path = "src/e2e/app/cli/common", default-features = false }
+kamu-cli-e2e-common-macros = { version = "0.198.1", path = "src/e2e/app/cli/common-macros", default-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.198.1", path = "src/e2e/app/cli/repo-tests", default-features = false }
 
 [workspace.package]
-version = "0.198.0"
+version = "0.198.1"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.198.0
+Licensed Work:             Kamu CLI Version 0.198.1
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,


### PR DESCRIPTION
## [0.198.1] - 2024-08-28
### Added
- Private Datasets, ReBAC integration: 
  - ReBAC properties update based on `DatasetLifecycleMessage`'s:
  - `kamu add`: added hidden `--visibility private|public` argument, assumed to be used in multi-tenant case
  - GQL: `DatasetsMut`:
    - `createEmpty()`: added optional `datasetVisibility` argument
    - `createFromSnapshot()`: added optional `datasetVisibility` argument