### PR TITLE
Jupyter images version bump

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -1,6 +1,6 @@
 IMAGE_PLATFORMS = linux/amd64,linux/arm64
 IMAGE_REPO = ghcr.io/kamu-data
-IMAGE_JUPYTER_TAG = 0.6.2
+IMAGE_JUPYTER_TAG = 0.6.3
 
 KAMU_VERSION = $(shell cargo metadata --format-version 1 | jq -r '.packages[] | select( .name == "kamu") | .version')
 

--- a/images/demo/Makefile
+++ b/images/demo/Makefile
@@ -1,7 +1,7 @@
 IMAGE_PLATFORMS = linux/amd64,linux/arm64
 IMAGE_REPO = ghcr.io/kamu-data
 KAMU_VERSION = $(shell cargo metadata --format-version 1 | jq -r '.packages[] | select( .name == "kamu") | .version')
-DEMO_VERSION = 0.16.1
+DEMO_VERSION = 0.16.2
 
 #########################################################################################
 

--- a/src/infra/core/src/utils/docker_images.rs
+++ b/src/infra/core/src/utils/docker_images.rs
@@ -13,7 +13,7 @@ pub const DATAFUSION: &str = "ghcr.io/kamu-data/engine-datafusion:0.8.1";
 pub const RISINGWAVE: &str = "ghcr.io/kamu-data/engine-risingwave:0.2.0-risingwave_1.7.0-alpha";
 
 pub const LIVY: &str = SPARK;
-pub const JUPYTER: &str = "ghcr.io/kamu-data/jupyter:0.6.2";
+pub const JUPYTER: &str = "ghcr.io/kamu-data/jupyter:0.6.3";
 
 // Test Images
 pub const HTTPD: &str = "docker.io/httpd:2.4";


### PR DESCRIPTION
This PR updates the image versions and also confirms that the following commands are executed:

- [x] `IMAGE_JUPYTER_TAG = 0.6.3` 
  - [x] `cd images/ && make jupyter-multi-arch`
    - https://github.com/kamu-data/kamu-cli/pkgs/container/jupyter/266143027?tag=0.6.3
- [x] `DEMO_VERSION = 0.16.2`
  - [x] `cd images/demo/ && make jupyter-multi-arch` 
    - https://github.com/kamu-data/kamu-cli/pkgs/container/kamu-cli-demo-jupyter/266147557?tag=0.16.2
  - [x] `cd images/demo/ && make minio-data && make minio-multi-arch`
    - https://github.com/kamu-data/kamu-cli/pkgs/container/kamu-cli-demo-minio/266162771?tag=0.16.2