### PR TITLE
Expose metadata only compaction for derived datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--- - Changed -->
 <!--- - Fixed -->
 
-### Unreleased
+## Unreleased
 ### Changed
 - Get Data Panel: use SmTP for pull & push links 
+- GQL api method `setConfigCompaction` allows to set `metadataOnly` configuration for both root and derived datasets
+- GQL api `triggerFlow` allows to trigger `HARD_COMPACTION` flow in `metadataOnly` only for both root and derived datasets
 
 ## [0.198.2] - 2024-08-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Get Data Panel: use SmTP for pull & push links 
 - GQL api method `setConfigCompaction` allows to set `metadataOnly` configuration for both root and derived datasets
-- GQL api `triggerFlow` allows to trigger `HARD_COMPACTION` flow in `metadataOnly` only for both root and derived datasets
+- GQL api `triggerFlow` allows to trigger `HARD_COMPACTION` flow in `metadataOnly` mode for both root and derived datasets
 
 ## [0.198.2] - 2024-08-30
 ### Added

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -54,7 +54,7 @@ impl DatasetFlowConfigsMut {
         ingest: IngestConditionInput,
     ) -> Result<SetFlowConfigResult> {
         let flow_run_config: FlowRunConfiguration = ingest.clone().into();
-        if let Err(err) = flow_run_config.check_type_compatible(&dataset_flow_type) {
+        if let Err(err) = flow_run_config.check_type_compatible(dataset_flow_type) {
             return Ok(SetFlowConfigResult::TypeIsNotSupported(err));
         };
 
@@ -108,7 +108,7 @@ impl DatasetFlowConfigsMut {
         transform: TransformConditionInput,
     ) -> Result<SetFlowTransformConfigResult> {
         let flow_run_config: FlowRunConfiguration = transform.clone().into();
-        if let Err(err) = flow_run_config.check_type_compatible(&dataset_flow_type) {
+        if let Err(err) = flow_run_config.check_type_compatible(dataset_flow_type) {
             return Ok(SetFlowTransformConfigResult::TypeIsNotSupported(err));
         };
 
@@ -172,7 +172,7 @@ impl DatasetFlowConfigsMut {
         compaction_args: CompactionConditionInput,
     ) -> Result<SetFlowCompactionConfigResult> {
         let flow_run_config: FlowRunConfiguration = compaction_args.clone().into();
-        if let Err(err) = flow_run_config.check_type_compatible(&dataset_flow_type) {
+        if let Err(err) = flow_run_config.check_type_compatible(dataset_flow_type) {
             return Ok(SetFlowCompactionConfigResult::TypeIsNotSupported(err));
         };
 

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -26,7 +26,6 @@ use super::{
     ensure_expected_dataset_kind,
     ensure_flow_preconditions,
     ensure_scheduling_permission,
-    ensure_set_config_flow_supported,
     FlowIncompatibleDatasetKind,
     FlowPreconditionsNotMet,
 };
@@ -55,11 +54,10 @@ impl DatasetFlowConfigsMut {
         ingest: IngestConditionInput,
     ) -> Result<SetFlowConfigResult> {
         let flow_run_config: FlowRunConfiguration = ingest.clone().into();
-        if !ensure_set_config_flow_supported(dataset_flow_type, &flow_run_config) {
-            return Ok(SetFlowConfigResult::TypeIsNotSupported(
-                FlowTypeIsNotSupported,
-            ));
-        }
+        if let Err(err) = flow_run_config.check_type_compatible(&dataset_flow_type) {
+            return Ok(SetFlowConfigResult::TypeIsNotSupported(err));
+        };
+
         if let Some(e) = ensure_expected_dataset_kind(
             ctx,
             &self.dataset_handle,
@@ -110,11 +108,10 @@ impl DatasetFlowConfigsMut {
         transform: TransformConditionInput,
     ) -> Result<SetFlowTransformConfigResult> {
         let flow_run_config: FlowRunConfiguration = transform.clone().into();
-        if !ensure_set_config_flow_supported(dataset_flow_type, &flow_run_config) {
-            return Ok(SetFlowTransformConfigResult::TypeIsNotSupported(
-                FlowTypeIsNotSupported,
-            ));
-        }
+        if let Err(err) = flow_run_config.check_type_compatible(&dataset_flow_type) {
+            return Ok(SetFlowTransformConfigResult::TypeIsNotSupported(err));
+        };
+
         let transform_rule = match TransformRule::new_checked(
             transform.min_records_to_await,
             transform.max_batching_interval.into(),
@@ -175,11 +172,9 @@ impl DatasetFlowConfigsMut {
         compaction_args: CompactionConditionInput,
     ) -> Result<SetFlowCompactionConfigResult> {
         let flow_run_config: FlowRunConfiguration = compaction_args.clone().into();
-        if !ensure_set_config_flow_supported(dataset_flow_type, &flow_run_config) {
-            return Ok(SetFlowCompactionConfigResult::TypeIsNotSupported(
-                FlowTypeIsNotSupported,
-            ));
-        }
+        if let Err(err) = flow_run_config.check_type_compatible(&dataset_flow_type) {
+            return Ok(SetFlowCompactionConfigResult::TypeIsNotSupported(err));
+        };
 
         let compaction_rule = match compaction_args {
             CompactionConditionInput::Full(compaction_input) => {

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -16,7 +16,6 @@ use kamu_flow_system::{
     FlowConfigurationService,
     FlowKeyDataset,
     IngestRule,
-    Schedule,
     ScheduleCronError,
     SetFlowConfigurationError,
     TransformRule,
@@ -55,13 +54,19 @@ impl DatasetFlowConfigsMut {
         paused: bool,
         ingest: IngestConditionInput,
     ) -> Result<SetFlowConfigResult> {
-        if !ensure_set_config_flow_supported(dataset_flow_type, std::any::type_name::<Schedule>()) {
+        let flow_run_config: FlowRunConfiguration = ingest.clone().into();
+        if !ensure_set_config_flow_supported(dataset_flow_type, &flow_run_config) {
             return Ok(SetFlowConfigResult::TypeIsNotSupported(
                 FlowTypeIsNotSupported,
             ));
         }
-        if let Some(e) =
-            ensure_expected_dataset_kind(ctx, &self.dataset_handle, dataset_flow_type).await?
+        if let Some(e) = ensure_expected_dataset_kind(
+            ctx,
+            &self.dataset_handle,
+            dataset_flow_type,
+            Some(&flow_run_config),
+        )
+        .await?
         {
             return Ok(SetFlowConfigResult::IncompatibleDatasetKind(e));
         }
@@ -104,10 +109,8 @@ impl DatasetFlowConfigsMut {
         paused: bool,
         transform: TransformConditionInput,
     ) -> Result<SetFlowTransformConfigResult> {
-        if !ensure_set_config_flow_supported(
-            dataset_flow_type,
-            std::any::type_name::<TransformRule>(),
-        ) {
+        let flow_run_config: FlowRunConfiguration = transform.clone().into();
+        if !ensure_set_config_flow_supported(dataset_flow_type, &flow_run_config) {
             return Ok(SetFlowTransformConfigResult::TypeIsNotSupported(
                 FlowTypeIsNotSupported,
             ));
@@ -126,8 +129,13 @@ impl DatasetFlowConfigsMut {
             }
         };
 
-        if let Some(e) =
-            ensure_expected_dataset_kind(ctx, &self.dataset_handle, dataset_flow_type).await?
+        if let Some(e) = ensure_expected_dataset_kind(
+            ctx,
+            &self.dataset_handle,
+            dataset_flow_type,
+            Some(&flow_run_config),
+        )
+        .await?
         {
             return Ok(SetFlowTransformConfigResult::IncompatibleDatasetKind(e));
         }
@@ -166,10 +174,8 @@ impl DatasetFlowConfigsMut {
         dataset_flow_type: DatasetFlowType,
         compaction_args: CompactionConditionInput,
     ) -> Result<SetFlowCompactionConfigResult> {
-        if !ensure_set_config_flow_supported(
-            dataset_flow_type,
-            std::any::type_name::<CompactionRule>(),
-        ) {
+        let flow_run_config: FlowRunConfiguration = compaction_args.clone().into();
+        if !ensure_set_config_flow_supported(dataset_flow_type, &flow_run_config) {
             return Ok(SetFlowCompactionConfigResult::TypeIsNotSupported(
                 FlowTypeIsNotSupported,
             ));
@@ -199,8 +205,13 @@ impl DatasetFlowConfigsMut {
             }
         };
 
-        if let Some(e) =
-            ensure_expected_dataset_kind(ctx, &self.dataset_handle, dataset_flow_type).await?
+        if let Some(e) = ensure_expected_dataset_kind(
+            ctx,
+            &self.dataset_handle,
+            dataset_flow_type,
+            Some(&flow_run_config),
+        )
+        .await?
         {
             return Ok(SetFlowCompactionConfigResult::IncompatibleDatasetKind(e));
         }

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_runs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_runs_mut.rs
@@ -44,8 +44,13 @@ impl DatasetFlowRunsMut {
         dataset_flow_type: DatasetFlowType,
         flow_run_configuration: Option<FlowRunConfiguration>,
     ) -> Result<TriggerFlowResult> {
-        if let Some(e) =
-            ensure_expected_dataset_kind(ctx, &self.dataset_handle, dataset_flow_type).await?
+        if let Some(e) = ensure_expected_dataset_kind(
+            ctx,
+            &self.dataset_handle,
+            dataset_flow_type,
+            flow_run_configuration.as_ref(),
+        )
+        .await?
         {
             return Ok(TriggerFlowResult::IncompatibleDatasetKind(e));
         }

--- a/src/adapter/graphql/src/mutations/flows_mut/flows_mut_utils.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/flows_mut_utils.rs
@@ -67,12 +67,15 @@ pub(crate) async fn ensure_expected_dataset_kind(
     ctx: &Context<'_>,
     dataset_handle: &odf::DatasetHandle,
     dataset_flow_type: DatasetFlowType,
-    flow_run_configuration: Option<&FlowRunConfiguration>,
+    flow_run_configuration_maybe: Option<&FlowRunConfiguration>,
 ) -> Result<Option<FlowIncompatibleDatasetKind>> {
+    if let Some(FlowRunConfiguration::Compaction(CompactionConditionInput::MetadataOnly(_))) =
+        flow_run_configuration_maybe
+    {
+        return Ok(None);
+    }
     let dataset_flow_type: kamu_flow_system::DatasetFlowType = dataset_flow_type.into();
-    match dataset_flow_type.dataset_kind_restriction(
-        flow_run_configuration.map(FlowRunConfiguration::configuration_rule_type),
-    ) {
+    match dataset_flow_type.dataset_kind_restriction() {
         Some(expected_kind) => {
             let dataset = utils::get_dataset(ctx, dataset_handle);
 

--- a/src/adapter/graphql/src/mutations/flows_mut/flows_mut_utils.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/flows_mut_utils.rs
@@ -67,9 +67,12 @@ pub(crate) async fn ensure_expected_dataset_kind(
     ctx: &Context<'_>,
     dataset_handle: &odf::DatasetHandle,
     dataset_flow_type: DatasetFlowType,
+    flow_run_configuration: Option<&FlowRunConfiguration>,
 ) -> Result<Option<FlowIncompatibleDatasetKind>> {
     let dataset_flow_type: kamu_flow_system::DatasetFlowType = dataset_flow_type.into();
-    match dataset_flow_type.dataset_kind_restriction() {
+    match dataset_flow_type.dataset_kind_restriction(
+        flow_run_configuration.map(FlowRunConfiguration::configuration_rule_type),
+    ) {
         Some(expected_kind) => {
             let dataset = utils::get_dataset(ctx, dataset_handle);
 
@@ -176,10 +179,10 @@ pub(crate) async fn ensure_flow_preconditions(
 
 pub(crate) fn ensure_set_config_flow_supported(
     dataset_flow_type: DatasetFlowType,
-    flow_configuration_type: &'static str,
+    flow_configuration: &FlowRunConfiguration,
 ) -> bool {
     let dataset_flow_type: kamu_flow_system::DatasetFlowType = dataset_flow_type.into();
-    dataset_flow_type.config_restriction(flow_configuration_type)
+    dataset_flow_type.config_restriction(flow_configuration.configuration_rule_type())
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/mutations/flows_mut/flows_mut_utils.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/flows_mut_utils.rs
@@ -177,16 +177,6 @@ pub(crate) async fn ensure_flow_preconditions(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-pub(crate) fn ensure_set_config_flow_supported(
-    dataset_flow_type: DatasetFlowType,
-    flow_configuration: &FlowRunConfiguration,
-) -> bool {
-    let dataset_flow_type: kamu_flow_system::DatasetFlowType = dataset_flow_type.into();
-    dataset_flow_type.config_restriction(flow_configuration.configuration_rule_type())
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 #[derive(SimpleObject, Debug, Clone)]
 #[graphql(complex)]
 pub struct FlowPreconditionsNotMet {

--- a/src/adapter/graphql/src/scalars/flow_configuration.rs
+++ b/src/adapter/graphql/src/scalars/flow_configuration.rs
@@ -564,74 +564,31 @@ impl FlowRunConfiguration {
 
     pub fn check_type_compatible(
         &self,
-        flow_type: &DatasetFlowType,
+        flow_type: DatasetFlowType,
     ) -> Result<(), FlowTypeIsNotSupported> {
         match self {
             Self::Ingest(_) => {
-                if flow_type != &DatasetFlowType::Ingest {
-                    return Err(FlowTypeIsNotSupported);
+                if flow_type == DatasetFlowType::Ingest {
+                    return Ok(());
                 }
             }
             Self::Transform(_) => {
-                if flow_type != &DatasetFlowType::ExecuteTransform {
-                    return Err(FlowTypeIsNotSupported);
+                if flow_type == DatasetFlowType::ExecuteTransform {
+                    return Ok(());
                 }
             }
             Self::Compaction(_) => {
-                if flow_type != &DatasetFlowType::HardCompaction {
-                    return Err(FlowTypeIsNotSupported);
+                if flow_type == DatasetFlowType::HardCompaction {
+                    return Ok(());
                 }
             }
             Self::Reset(_) => {
-                if flow_type != &DatasetFlowType::Reset {
-                    return Err(FlowTypeIsNotSupported);
+                if flow_type == DatasetFlowType::Reset {
+                    return Ok(());
                 }
             }
         }
-        Ok(())
-    }
-
-    pub fn check_dataset_kind_compatible(
-        &self,
-        flow_type: &DatasetFlowType,
-    ) -> Result<(), FlowTypeIsNotSupported> {
-        match self {
-            Self::Ingest(_) => {
-                if flow_type != &DatasetFlowType::Ingest {
-                    return Err(FlowTypeIsNotSupported);
-                }
-            }
-            Self::Transform(_) => {
-                if flow_type != &DatasetFlowType::ExecuteTransform {
-                    return Err(FlowTypeIsNotSupported);
-                }
-            }
-            Self::Compaction(_) => {
-                if flow_type != &DatasetFlowType::HardCompaction {
-                    return Err(FlowTypeIsNotSupported);
-                }
-            }
-            Self::Reset(_) => {
-                if flow_type != &DatasetFlowType::Reset {
-                    return Err(FlowTypeIsNotSupported);
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub fn configuration_rule_type(&self) -> &'static str {
-        match self {
-            Self::Compaction(compaction_input) => match compaction_input {
-                CompactionConditionInput::Full(_) => std::any::type_name::<CompactionRuleFull>(),
-                CompactionConditionInput::MetadataOnly(_) => {
-                    std::any::type_name::<CompactionRuleMetadataOnly>()
-                }
-            },
-            Self::Ingest(_) => std::any::type_name::<IngestRule>(),
-            Self::Transform(_) => std::any::type_name::<TransformRule>(),
-            Self::Reset(_) => std::any::type_name::<ResetRule>(),
-        }
+        Err(FlowTypeIsNotSupported)
     }
 }
 

--- a/src/adapter/graphql/src/scalars/flow_configuration.rs
+++ b/src/adapter/graphql/src/scalars/flow_configuration.rs
@@ -24,7 +24,7 @@ use kamu_flow_system::{
 };
 use opendatafabric::DatasetHandle;
 
-use crate::mutations::FlowInvalidRunConfigurations;
+use crate::mutations::{FlowInvalidRunConfigurations, FlowTypeIsNotSupported};
 use crate::prelude::*;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -560,6 +560,64 @@ impl FlowRunConfiguration {
             }
         }
         Ok(None)
+    }
+
+    pub fn check_type_compatible(
+        &self,
+        flow_type: &DatasetFlowType,
+    ) -> Result<(), FlowTypeIsNotSupported> {
+        match self {
+            Self::Ingest(_) => {
+                if flow_type != &DatasetFlowType::Ingest {
+                    return Err(FlowTypeIsNotSupported);
+                }
+            }
+            Self::Transform(_) => {
+                if flow_type != &DatasetFlowType::ExecuteTransform {
+                    return Err(FlowTypeIsNotSupported);
+                }
+            }
+            Self::Compaction(_) => {
+                if flow_type != &DatasetFlowType::HardCompaction {
+                    return Err(FlowTypeIsNotSupported);
+                }
+            }
+            Self::Reset(_) => {
+                if flow_type != &DatasetFlowType::Reset {
+                    return Err(FlowTypeIsNotSupported);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn check_dataset_kind_compatible(
+        &self,
+        flow_type: &DatasetFlowType,
+    ) -> Result<(), FlowTypeIsNotSupported> {
+        match self {
+            Self::Ingest(_) => {
+                if flow_type != &DatasetFlowType::Ingest {
+                    return Err(FlowTypeIsNotSupported);
+                }
+            }
+            Self::Transform(_) => {
+                if flow_type != &DatasetFlowType::ExecuteTransform {
+                    return Err(FlowTypeIsNotSupported);
+                }
+            }
+            Self::Compaction(_) => {
+                if flow_type != &DatasetFlowType::HardCompaction {
+                    return Err(FlowTypeIsNotSupported);
+                }
+            }
+            Self::Reset(_) => {
+                if flow_type != &DatasetFlowType::Reset {
+                    return Err(FlowTypeIsNotSupported);
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn configuration_rule_type(&self) -> &'static str {

--- a/src/domain/flow-system/domain/src/entities/shared/flow_type.rs
+++ b/src/domain/flow-system/domain/src/entities/shared/flow_type.rs
@@ -43,11 +43,12 @@ impl DatasetFlowType {
             DatasetFlowType::Reset => None,
             DatasetFlowType::HardCompaction => {
                 if let Some(flow_cofiguration_rule_type) = flow_cofiguration_rule_type_maybe
-                    && flow_cofiguration_rule_type == std::any::type_name::<CompactionRuleFull>()
+                    && flow_cofiguration_rule_type
+                        == std::any::type_name::<CompactionRuleMetadataOnly>()
                 {
-                    return Some(opendatafabric::DatasetKind::Root);
+                    return None;
                 }
-                None
+                Some(opendatafabric::DatasetKind::Root)
             }
         }
     }

--- a/src/domain/flow-system/domain/src/entities/shared/flow_type.rs
+++ b/src/domain/flow-system/domain/src/entities/shared/flow_type.rs
@@ -33,23 +33,13 @@ impl DatasetFlowType {
         ]
     }
 
-    pub fn dataset_kind_restriction(
-        &self,
-        flow_cofiguration_rule_type_maybe: Option<&str>,
-    ) -> Option<opendatafabric::DatasetKind> {
+    pub fn dataset_kind_restriction(&self) -> Option<opendatafabric::DatasetKind> {
         match self {
-            DatasetFlowType::Ingest => Some(opendatafabric::DatasetKind::Root),
-            DatasetFlowType::ExecuteTransform => Some(opendatafabric::DatasetKind::Derivative),
-            DatasetFlowType::Reset => None,
-            DatasetFlowType::HardCompaction => {
-                if let Some(flow_cofiguration_rule_type) = flow_cofiguration_rule_type_maybe
-                    && flow_cofiguration_rule_type
-                        == std::any::type_name::<CompactionRuleMetadataOnly>()
-                {
-                    return None;
-                }
+            DatasetFlowType::Ingest | DatasetFlowType::HardCompaction => {
                 Some(opendatafabric::DatasetKind::Root)
             }
+            DatasetFlowType::ExecuteTransform => Some(opendatafabric::DatasetKind::Derivative),
+            DatasetFlowType::Reset => None,
         }
     }
 

--- a/src/domain/flow-system/domain/src/entities/shared/flow_type.rs
+++ b/src/domain/flow-system/domain/src/entities/shared/flow_type.rs
@@ -11,9 +11,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::CompactionRuleFull;
-use crate::{CompactionRuleMetadataOnly, IngestRule, ResetRule, Schedule, TransformRule};
-
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "dataset_flow_type", rename_all = "snake_case")]
 pub enum DatasetFlowType {
@@ -40,23 +37,6 @@ impl DatasetFlowType {
             }
             DatasetFlowType::ExecuteTransform => Some(opendatafabric::DatasetKind::Derivative),
             DatasetFlowType::Reset => None,
-        }
-    }
-
-    pub fn config_restriction(&self, flow_configuration_type: &'static str) -> bool {
-        match self {
-            DatasetFlowType::Ingest => {
-                flow_configuration_type == std::any::type_name::<Schedule>()
-                    || flow_configuration_type == std::any::type_name::<IngestRule>()
-            }
-            DatasetFlowType::ExecuteTransform => {
-                flow_configuration_type == std::any::type_name::<TransformRule>()
-            }
-            DatasetFlowType::HardCompaction => {
-                flow_configuration_type == std::any::type_name::<CompactionRuleMetadataOnly>()
-                    || flow_configuration_type == std::any::type_name::<CompactionRuleFull>()
-            }
-            DatasetFlowType::Reset => flow_configuration_type == std::any::type_name::<ResetRule>(),
         }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅