### PR TITLE
GQL: DatasetEndpoints::cli(): add the "odf" prefix to url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--- - Changed -->
 <!--- - Fixed -->
 
+### Unreleased
+### Changed
+- Get Data Panel: use SmTP for pull & push links 
+
 ## [0.198.2] - 2024-08-30
 ### Added
 - Container sources allow string interpolation in env vars and command

--- a/src/adapter/graphql/src/queries/datasets/dataset_endpoints.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_endpoints.rs
@@ -63,7 +63,7 @@ impl<'a> DatasetEndpoints<'a> {
     #[allow(clippy::unused_async)]
     async fn cli(&self) -> Result<CliProtocolDesc> {
         let url = format!(
-            "{}{}",
+            "odf+{}{}",
             self.config.protocols.base_url_rest,
             // to respect both kinds of workspaces: single-tenant & multi-tenant
             self.dataset_handle.alias

--- a/src/adapter/graphql/src/queries/datasets/datasets.rs
+++ b/src/adapter/graphql/src/queries/datasets/datasets.rs
@@ -144,12 +144,14 @@ impl Datasets {
         page: Option<usize>,
         per_page: Option<usize>,
     ) -> Result<DatasetConnection> {
-        let maybe_acccount = Account::from_account_name(ctx, account_name.into()).await?;
-        if let Some(account) = maybe_acccount {
+        let maybe_account = Account::from_account_name(ctx, account_name.into()).await?;
+
+        if let Some(account) = maybe_account {
             self.by_account_impl(ctx, account, page, per_page).await
         } else {
             let page = page.unwrap_or(0);
             let per_page = per_page.unwrap_or(Self::DEFAULT_PER_PAGE);
+
             Ok(DatasetConnection::new(vec![], page, per_page, 0))
         }
     }


### PR DESCRIPTION
## Description

Related issue: https://github.com/kamu-data/kamu-node/issues/122

<!--- Describe your changes in detail and include your changelog entries -->

## Checklist before requesting a review

- [x] Unit and integration tests added ❌ not needed
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌ not needed
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌ will be added later