### PR TITLE
Correct dataset id is sent when input dataset was compacted before transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--- - Changed -->
 <!--- - Fixed -->
 
+## [Unreleased]
+### Fixed
+- Associating correct input dataset that was hard compacted with the error during transformation of derived dataset
+
 ## [0.199.2] - 2024-09-09
 ### Added
 - REST API: The `/query` endpoint now supports response proofs via reproducibility and signing (#816)

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -995,11 +995,6 @@ type FlowConnection {
 	edges: [FlowEdge!]!
 }
 
-type FlowDatasetCompactedFailedError {
-	rootDataset: Dataset!
-	message: String!
-}
-
 union FlowDescription = FlowDescriptionDatasetPollingIngest | FlowDescriptionDatasetPushIngest | FlowDescriptionDatasetExecuteTransform | FlowDescriptionDatasetHardCompaction | FlowDescriptionDatasetReset | FlowDescriptionSystemGC
 
 type FlowDescriptionDatasetExecuteTransform {
@@ -1106,14 +1101,19 @@ type FlowEventTriggerAdded implements FlowEvent {
 }
 
 type FlowFailedError {
-	reason: FlowFailedReason!
+	reason: FlowFailureReason!
 }
 
-type FlowFailedMessage {
+union FlowFailureReason = FlowFailureReasonGeneral | FlowFailureReasonInputDatasetCompacted
+
+type FlowFailureReasonGeneral {
 	message: String!
 }
 
-union FlowFailedReason = FlowFailedMessage | FlowDatasetCompactedFailedError
+type FlowFailureReasonInputDatasetCompacted {
+	inputDataset: Dataset!
+	message: String!
+}
 
 scalar FlowID
 

--- a/src/adapter/graphql/tests/tests/test_gql_account_flow_configs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_account_flow_configs.rs
@@ -823,12 +823,12 @@ impl FlowConfigHarness {
                                           }
                                           ...on FlowFailedError {
                                               reason {
-                                                  ...on FlowFailedMessage {
+                                                  ...on FlowFailureReasonGeneral {
                                                       message
                                                   }
-                                                  ...on FlowDatasetCompactedFailedError {
+                                                  ...on FlowFailureReasonInputDatasetCompacted {
                                                       message
-                                                      rootDataset {
+                                                      inputDataset {
                                                           id
                                                       }
                                                   }
@@ -927,12 +927,12 @@ impl FlowConfigHarness {
                                               }
                                               ...on FlowFailedError {
                                                   reason {
-                                                      ...on FlowFailedMessage {
+                                                    ...on FlowFailureReasonGeneral {
+                                                        message
+                                                    }
+                                                    ...on FlowFailureReasonInputDatasetCompacted {
                                                           message
-                                                      }
-                                                      ...on FlowDatasetCompactedFailedError {
-                                                          message
-                                                          rootDataset {
+                                                          inputDataset {
                                                               id
                                                           }
                                                       }

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -2703,11 +2703,11 @@ async fn test_execute_transfrom_flow_error_after_compaction() {
     })
     .await;
 
-    let create_result = harness.create_root_dataset().await;
+    let create_root_result = harness.create_root_dataset().await;
     let create_derived_result = harness.create_derived_dataset().await;
 
     let mutation_code = FlowRunsHarness::trigger_flow_with_compaction_config_mutation(
-        &create_result.dataset_handle.id,
+        &create_root_result.dataset_handle.id,
         "HARD_COMPACTION",
         10000,
         1_000_000,
@@ -2781,7 +2781,7 @@ async fn test_execute_transfrom_flow_error_after_compaction() {
         )
         .await;
 
-    let request_code = FlowRunsHarness::list_flows_query(&create_result.dataset_handle.id);
+    let request_code = FlowRunsHarness::list_flows_query(&create_root_result.dataset_handle.id);
     let response = schema
         .execute(
             async_graphql::Request::new(request_code.clone())
@@ -2803,7 +2803,7 @@ async fn test_execute_transfrom_flow_error_after_compaction() {
                                         "flowId": "0",
                                         "description": {
                                             "__typename": "FlowDescriptionDatasetHardCompaction",
-                                            "datasetId": create_result.dataset_handle.id.to_string(),
+                                            "datasetId": create_root_result.dataset_handle.id.to_string(),
                                             "compactionResult": {
                                                 "originalBlocksCount": 5,
                                                 "resultingBlocksCount": 4,
@@ -2920,8 +2920,8 @@ async fn test_execute_transfrom_flow_error_after_compaction() {
             flow_task_metadata,
             complete_time,
             ts::TaskOutcome::Failed(ts::TaskError::UpdateDatasetError(
-                ts::UpdateDatasetTaskError::RootDatasetCompacted(ts::RootDatasetCompactedError {
-                    dataset_id: create_result.dataset_handle.id.clone(),
+                ts::UpdateDatasetTaskError::InputDatasetCompacted(ts::InputDatasetCompactedError {
+                    dataset_id: create_root_result.dataset_handle.id.clone(),
                 }),
             )),
         )
@@ -2955,9 +2955,9 @@ async fn test_execute_transfrom_flow_error_after_compaction() {
                                         "status": "FINISHED",
                                         "outcome": {
                                             "reason": {
-                                                "message": "Root dataset was compacted",
-                                                "rootDataset": {
-                                                    "id": create_result.dataset_handle.id.to_string()
+                                                "message": "Input dataset was compacted",
+                                                "inputDataset": {
+                                                    "id": create_root_result.dataset_handle.id.to_string()
                                                 }
                                             }
                                         },
@@ -3509,12 +3509,12 @@ impl FlowRunsHarness {
                                             }
                                             ...on FlowFailedError {
                                                 reason {
-                                                    ...on FlowFailedMessage {
+                                                    ...on FlowFailureReasonGeneral {
                                                         message
                                                     }
-                                                    ...on FlowDatasetCompactedFailedError {
+                                                    ...on FlowFailureReasonInputDatasetCompacted {
                                                         message
-                                                        rootDataset {
+                                                        inputDataset {
                                                             id
                                                         }
                                                     }
@@ -3720,12 +3720,12 @@ impl FlowRunsHarness {
                                                 }
                                                 ...on FlowFailedError {
                                                     reason {
-                                                        ...on FlowFailedMessage {
+                                                        ...on FlowFailureReasonGeneral {
                                                             message
                                                         }
-                                                        ...on FlowDatasetCompactedFailedError {
+                                                        ...on FlowFailureReasonInputDatasetCompacted {
                                                             message
-                                                            rootDataset {
+                                                            inputDataset {
                                                                 id
                                                             }
                                                         }
@@ -3790,12 +3790,12 @@ impl FlowRunsHarness {
                                                 }
                                                 ...on FlowFailedError {
                                                     reason {
-                                                        ...on FlowFailedMessage {
+                                                        ...on FlowFailureReasonGeneral {
                                                             message
                                                         }
-                                                        ...on FlowDatasetCompactedFailedError {
+                                                        ...on FlowFailureReasonInputDatasetCompacted {
                                                             message
-                                                            rootDataset {
+                                                            inputDataset {
                                                                 id
                                                             }
                                                         }
@@ -3861,12 +3861,12 @@ impl FlowRunsHarness {
                                                 }
                                                 ...on FlowFailedError {
                                                     reason {
-                                                        ...on FlowFailedMessage {
+                                                        ...on FlowFailureReasonGeneral {
                                                             message
                                                         }
-                                                        ...on FlowDatasetCompactedFailedError {
+                                                        ...on FlowFailureReasonInputDatasetCompacted {
                                                             message
-                                                            rootDataset {
+                                                            inputDataset {
                                                                 id
                                                             }
                                                         }
@@ -3917,12 +3917,12 @@ impl FlowRunsHarness {
                                                 }
                                                 ...on FlowFailedError {
                                                     reason {
-                                                        ...on FlowFailedMessage {
+                                                        ...on FlowFailureReasonGeneral {
                                                             message
                                                         }
-                                                        ...on FlowDatasetCompactedFailedError {
+                                                        ...on FlowFailureReasonInputDatasetCompacted {
                                                             message
-                                                            rootDataset {
+                                                            inputDataset {
                                                                 id
                                                             }
                                                         }

--- a/src/domain/core/src/services/transform_service.rs
+++ b/src/domain/core/src/services/transform_service.rs
@@ -149,10 +149,10 @@ pub enum TransformError {
         AccessError,
     ),
     #[error(transparent)]
-    InvalidInterval(
+    InvalidInputInterval(
         #[from]
         #[backtrace]
-        InvalidIntervalError,
+        InvalidInputIntervalError,
     ),
     #[error(transparent)]
     Internal(
@@ -174,6 +174,16 @@ pub struct TransformNotDefinedError {}
 #[error("Dataset {dataset_handle} has not defined a schema yet")]
 pub struct InputSchemaNotDefinedError {
     pub dataset_handle: DatasetHandle,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Error, Debug)]
+#[error("Invalid block interval [{head}, {tail}) in input dataset '{input_dataset_id}'")]
+pub struct InvalidInputIntervalError {
+    pub input_dataset_id: DatasetID,
+    pub head: Multihash,
+    pub tail: Multihash,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/domain/src/entities/flow/flow_outcome.rs
+++ b/src/domain/flow-system/domain/src/entities/flow/flow_outcome.rs
@@ -58,12 +58,12 @@ impl FlowResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FlowError {
     Failed,
-    RootDatasetCompacted(FlowRootDatasetCompactedError),
+    InputDatasetCompacted(FlowInputDatasetCompactedError),
     ResetHeadNotFound,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FlowRootDatasetCompactedError {
+pub struct FlowInputDatasetCompactedError {
     pub dataset_id: DatasetID,
 }
 
@@ -72,8 +72,8 @@ impl From<&TaskError> for FlowError {
         match value {
             TaskError::Empty => Self::Failed,
             TaskError::UpdateDatasetError(update_dataset_error) => match update_dataset_error {
-                UpdateDatasetTaskError::RootDatasetCompacted(err) => {
-                    Self::RootDatasetCompacted(FlowRootDatasetCompactedError {
+                UpdateDatasetTaskError::InputDatasetCompacted(err) => {
+                    Self::InputDatasetCompacted(FlowInputDatasetCompactedError {
                         dataset_id: err.dataset_id.clone(),
                     })
                 }

--- a/src/domain/task-system/domain/src/entities/task_status.rs
+++ b/src/domain/task-system/domain/src/entities/task_status.rs
@@ -88,11 +88,11 @@ pub enum TaskError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UpdateDatasetTaskError {
-    RootDatasetCompacted(RootDatasetCompactedError),
+    InputDatasetCompacted(InputDatasetCompactedError),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RootDatasetCompactedError {
+pub struct InputDatasetCompactedError {
     pub dataset_id: DatasetID,
 }
 

--- a/src/domain/task-system/services/src/task_logical_plan_runner_impl.rs
+++ b/src/domain/task-system/services/src/task_logical_plan_runner_impl.rs
@@ -88,10 +88,10 @@ impl TaskLogicalPlanRunnerImpl {
                 TaskUpdateDatasetResult { pull_result },
             ))),
             Err(err) => match err {
-                PullError::TransformError(TransformError::InvalidInterval(_)) => {
+                PullError::TransformError(TransformError::InvalidInputInterval(e)) => {
                     Ok(TaskOutcome::Failed(TaskError::UpdateDatasetError(
-                        UpdateDatasetTaskError::RootDatasetCompacted(RootDatasetCompactedError {
-                            dataset_id: args.dataset_id.clone(),
+                        UpdateDatasetTaskError::InputDatasetCompacted(InputDatasetCompactedError {
+                            dataset_id: e.input_dataset_id,
                         }),
                     )))
                 }

--- a/src/infra/core/src/transform_service_impl.rs
+++ b/src/infra/core/src/transform_service_impl.rs
@@ -394,7 +394,13 @@ impl TransformServiceImpl {
                 .try_collect()
                 .await
                 .map_err(|chain_err| match chain_err {
-                    IterBlocksError::InvalidInterval(err) => TransformError::InvalidInterval(err),
+                    IterBlocksError::InvalidInterval(err) => {
+                        TransformError::InvalidInputInterval(InvalidInputIntervalError {
+                            head: err.head,
+                            tail: err.tail,
+                            input_dataset_id: dataset_handle.id.clone(),
+                        })
+                    }
                     _ => TransformError::Internal(chain_err.int_err()),
                 })?
         } else {
@@ -704,7 +710,7 @@ impl TransformServiceImpl {
                 listener.success(&TransformResult::UpToDate);
                 Ok(TransformResult::UpToDate)
             }
-            Err(err @ TransformError::InvalidInterval(_))
+            Err(err @ TransformError::InvalidInputInterval(_))
                 if options.reset_derivatives_on_diverged_input =>
             {
                 tracing::warn!(

--- a/src/infra/core/tests/tests/test_transform_service_impl.rs
+++ b/src/infra/core/tests/tests/test_transform_service_impl.rs
@@ -728,7 +728,9 @@ async fn test_transform_with_compaction_retry() {
 
     assert_matches!(
         transform_result,
-        Err(TransformError::InvalidInterval(InvalidIntervalError { .. }))
+        Err(TransformError::InvalidInputInterval(
+            InvalidInputIntervalError { .. }
+        ))
     );
 
     let transform_result = harness


### PR DESCRIPTION
## Description

Closes: #820


## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [ ] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [ ] Network APIs: ✅
    UI update required, GraphQL schema has renamings.
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅