### PR TITLE
Improved stability of Outbox and TaskExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Improved data collected around transactional code
    - Revised associating span objects with large JSON structures such as messages
    - Suppressed several noisy, but not very useful events
+- Improved Outbox stability when message consumers fail   
 
 ## [0.199.3] - 2024-09-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Improved data collected around transactional code
    - Revised associating span objects with large JSON structures such as messages
    - Suppressed several noisy, but not very useful events
-- Improved Outbox stability when message consumers fail   
+- Improved Outbox stability when message consumers fail
+- Similarly, Task Executor keeps executing next tasks 
+    in case running a task results in an internal error
 
 ## [0.199.3] - 2024-09-11
 ### Fixed

--- a/src/adapter/http/src/upload/upload_service_local.rs
+++ b/src/adapter/http/src/upload/upload_service_local.rs
@@ -181,7 +181,12 @@ impl UploadService for UploadServiceLocal {
 
         let file_path = upload_folder_path.join(&upload_token.file_name);
         tokio::fs::write(&file_path, file_data).await.map_err(|e| {
-            tracing::error!("{:?}", e);
+            tracing::error!(
+                error=?e,
+                error_msg=%e,
+                file_path=file_path.into_os_string().to_str(),
+                "Writing file failed"
+            );
             SaveUploadError::Internal(e.int_err())
         })?;
 

--- a/src/adapter/odata/src/context.rs
+++ b/src/adapter/odata/src/context.rs
@@ -180,7 +180,7 @@ impl CollectionContext for ODataCollectionContext {
             .try_first()
             .await
             .map_err(|e| {
-                tracing::error!(error = ?e, "Resolving last data slice failed");
+                tracing::error!(error = ?e, error_msg = %e, "Resolving last data slice failed");
                 e
             })
             .int_err()

--- a/src/domain/auth-rebac/services/src/multi_tenant_rebac_dataset_lifecycle_message_consumer.rs
+++ b/src/domain/auth-rebac/services/src/multi_tenant_rebac_dataset_lifecycle_message_consumer.rs
@@ -83,7 +83,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for MultiTenantRebacDatasetLifecy
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        label = "MultiTenantRebacDatasetLifecycleMessageConsumer[DatasetLifecycleMessage]"
+        name = "MultiTenantRebacDatasetLifecycleMessageConsumer[DatasetLifecycleMessage]"
     )]
     async fn consume_message(
         &self,

--- a/src/domain/auth-rebac/services/src/multi_tenant_rebac_dataset_lifecycle_message_consumer.rs
+++ b/src/domain/auth-rebac/services/src/multi_tenant_rebac_dataset_lifecycle_message_consumer.rs
@@ -90,7 +90,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for MultiTenantRebacDatasetLifecy
         _: &Catalog,
         message: &DatasetLifecycleMessage,
     ) -> Result<(), InternalError> {
-        tracing::debug!(message=?message, "Received dataset lifecycle message");
+        tracing::debug!(received_message=?message, "Received dataset lifecycle message");
 
         match message {
             DatasetLifecycleMessage::Created(message) => {

--- a/src/domain/flow-system/services/src/flow/flow_executor_impl.rs
+++ b/src/domain/flow-system/services/src/flow/flow_executor_impl.rs
@@ -276,7 +276,11 @@ impl FlowExecutorImpl {
             .filter(Result::is_err)
             .map(|e| e.err().unwrap())
             .for_each(|e: InternalError| {
-                tracing::error!(error=?e, "Scheduling flow failed");
+                tracing::error!(
+                    error=?e,
+                    error_msg=%e,
+                    "Scheduling flow failed"
+                );
             });
 
         // Publish progress event
@@ -500,7 +504,7 @@ impl MessageConsumerT<TaskProgressMessage> for FlowExecutorImpl {
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        label = "FlowExecutorImpl[TaskProgressMessage]"
+        name = "FlowExecutorImpl[TaskProgressMessage]"
     )]
     async fn consume_message(
         &self,
@@ -608,7 +612,7 @@ impl MessageConsumerT<FlowConfigurationUpdatedMessage> for FlowExecutorImpl {
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        label = "FlowExecutorImpl[FlowConfigurationUpdatedMessage]"
+        name = "FlowExecutorImpl[FlowConfigurationUpdatedMessage]"
     )]
     async fn consume_message(
         &self,
@@ -663,7 +667,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for FlowExecutorImpl {
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        label = "FlowExecutorImpl[DatasetLifecycleMessage]"
+        name = "FlowExecutorImpl[DatasetLifecycleMessage]"
     )]
     async fn consume_message(
         &self,

--- a/src/domain/flow-system/services/src/flow/flow_executor_impl.rs
+++ b/src/domain/flow-system/services/src/flow/flow_executor_impl.rs
@@ -511,7 +511,7 @@ impl MessageConsumerT<TaskProgressMessage> for FlowExecutorImpl {
         target_catalog: &Catalog,
         message: &TaskProgressMessage,
     ) -> Result<(), InternalError> {
-        tracing::debug!(message=?message, "Received task progress message");
+        tracing::debug!(received_message=?message, "Received task progress message");
 
         let flow_event_store = target_catalog.get_one::<dyn FlowEventStore>().unwrap();
 
@@ -619,7 +619,7 @@ impl MessageConsumerT<FlowConfigurationUpdatedMessage> for FlowExecutorImpl {
         target_catalog: &Catalog,
         message: &FlowConfigurationUpdatedMessage,
     ) -> Result<(), InternalError> {
-        tracing::debug!(message=?message, "Received flow configuration message");
+        tracing::debug!(received_message=?message, "Received flow configuration message");
 
         if message.paused {
             let maybe_pending_flow_id = {
@@ -674,7 +674,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for FlowExecutorImpl {
         target_catalog: &Catalog,
         message: &DatasetLifecycleMessage,
     ) -> Result<(), InternalError> {
-        tracing::debug!(message=?message, "Received dataset lifecycle message");
+        tracing::debug!(received_message=?message, "Received dataset lifecycle message");
 
         match message {
             DatasetLifecycleMessage::Deleted(message) => {

--- a/src/domain/flow-system/services/src/flow/flow_time_wheel_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow/flow_time_wheel_service_impl.rs
@@ -206,7 +206,7 @@ impl MessageConsumerT<FlowProgressMessage> for FlowTimeWheelServiceImpl {
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        label = "FlowTimeWheelServiceImpl[FlowProgressMessage]"
+        name = "FlowTimeWheelServiceImpl[FlowProgressMessage]"
     )]
     async fn consume_message(
         &self,

--- a/src/domain/flow-system/services/src/flow/flow_time_wheel_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow/flow_time_wheel_service_impl.rs
@@ -213,7 +213,7 @@ impl MessageConsumerT<FlowProgressMessage> for FlowTimeWheelServiceImpl {
         _: &Catalog,
         message: &FlowProgressMessage,
     ) -> Result<(), InternalError> {
-        tracing::debug!(message=?message, "Received flow progress message");
+        tracing::debug!(received_message=?message, "Received flow progress message");
 
         match message {
             FlowProgressMessage::Enqueued(e) => {

--- a/src/domain/flow-system/services/src/flow_configuration/flow_configuration_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow_configuration/flow_configuration_service_impl.rs
@@ -352,7 +352,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for FlowConfigurationServiceImpl 
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        label = "FlowConfigurationServiceImpl[DatasetLifecycleMessage]"
+        name = "FlowConfigurationServiceImpl[DatasetLifecycleMessage]"
     )]
     async fn consume_message(
         &self,

--- a/src/domain/flow-system/services/src/flow_configuration/flow_configuration_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow_configuration/flow_configuration_service_impl.rs
@@ -359,7 +359,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for FlowConfigurationServiceImpl 
         _: &Catalog,
         message: &DatasetLifecycleMessage,
     ) -> Result<(), InternalError> {
-        tracing::debug!(message=?message, "Received dataset lifecycle message");
+        tracing::debug!(received_message=?message, "Received dataset lifecycle message");
 
         match message {
             DatasetLifecycleMessage::Deleted(message) => {

--- a/src/domain/task-system/services/src/task_executor_impl.rs
+++ b/src/domain/task-system/services/src/task_executor_impl.rs
@@ -139,7 +139,12 @@ impl TaskExecutorImpl {
             Ok(outcome) => outcome,
             Err(e) => {
                 // No useful task result, but at least the error logged
-                tracing::error!(task=?task, error=?e, "Task run FAILED");
+                tracing::error!(
+                    task=?task,
+                    error=?e,
+                    error_msg=%e,
+                    "Task run failed"
+                );
                 TaskOutcome::Failed(TaskError::Empty)
             }
         };

--- a/src/infra/accounts/mysql/src/repos/mysql_account_repository.rs
+++ b/src/infra/accounts/mysql/src/repos/mysql_account_repository.rs
@@ -75,8 +75,8 @@ impl AccountRepository for MySqlAccountRepository {
                         CreateAccountDuplicateField::ProviderIdentityKey
                     } else {
                         tracing::error!(
-                            error=?e, 
-                            error_msg = mysql_error_message, 
+                            error=?e,
+                            error_msg = mysql_error_message,
                             "Unexpected MySQL error"
                         );
                         CreateAccountDuplicateField::Id

--- a/src/infra/accounts/mysql/src/repos/mysql_account_repository.rs
+++ b/src/infra/accounts/mysql/src/repos/mysql_account_repository.rs
@@ -74,7 +74,11 @@ impl AccountRepository for MySqlAccountRepository {
                     } else if mysql_error_message.contains("for key 'idx_accounts_provider_identity_key'") {
                         CreateAccountDuplicateField::ProviderIdentityKey
                     } else {
-                        tracing::error!("Unexpected MySQL error message: {}", mysql_error_message);
+                        tracing::error!(
+                            error=?e, 
+                            error_msg = mysql_error_message, 
+                            "Unexpected MySQL error"
+                        );
                         CreateAccountDuplicateField::Id
                     };
 

--- a/src/infra/accounts/postgres/src/repos/postgres_account_repository.rs
+++ b/src/infra/accounts/postgres/src/repos/postgres_account_repository.rs
@@ -68,7 +68,11 @@ impl AccountRepository for PostgresAccountRepository {
                         Some("idx_accounts_name") => CreateAccountDuplicateField::Name,
                         Some("idx_accounts_provider_identity_key") => CreateAccountDuplicateField::ProviderIdentityKey,
                         _ => {
-                            tracing::error!("Unexpected Postgres error message: {}", e.message());
+                            tracing::error!(
+                                error = ?e,
+                                error_msg = e.message(),
+                                "Unexpected Postgres error"
+                            );
                             CreateAccountDuplicateField::Id
                         }
                     };

--- a/src/infra/accounts/sqlite/src/repos/sqlite_account_repository.rs
+++ b/src/infra/accounts/sqlite/src/repos/sqlite_account_repository.rs
@@ -83,7 +83,11 @@ impl AccountRepository for SqliteAccountRepository {
                     } else if sqlite_error_message.contains("accounts.provider_identity_key") {
                         CreateAccountDuplicateField::ProviderIdentityKey
                     } else {
-                        tracing::error!("Unexpected SQLite error message: {}", sqlite_error_message);
+                        tracing::error!(
+                            error = ?e,
+                            error_msg = sqlite_error_message,
+                            "Unexpected SQLite error"
+                        );
                         CreateAccountDuplicateField::Id
                     };
 

--- a/src/infra/core/src/dataset_ownership_service_inmem.rs
+++ b/src/infra/core/src/dataset_ownership_service_inmem.rs
@@ -154,7 +154,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for DatasetOwnershipServiceInMemo
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        label = "DatasetOwnershipServiceInMemory[DatasetLifecycleMessage]"
+        name = "DatasetOwnershipServiceInMemory[DatasetLifecycleMessage]"
     )]
     async fn consume_message(
         &self,

--- a/src/infra/core/src/dataset_ownership_service_inmem.rs
+++ b/src/infra/core/src/dataset_ownership_service_inmem.rs
@@ -161,7 +161,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for DatasetOwnershipServiceInMemo
         _: &Catalog,
         message: &DatasetLifecycleMessage,
     ) -> Result<(), InternalError> {
-        tracing::debug!(message=?message, "Received dataset lifecycle message");
+        tracing::debug!(received_message=?message, "Received dataset lifecycle message");
 
         match message {
             DatasetLifecycleMessage::Created(message) => {

--- a/src/infra/core/src/dependency_graph_service_inmem.rs
+++ b/src/infra/core/src/dependency_graph_service_inmem.rs
@@ -393,7 +393,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for DependencyGraphServiceInMemor
         _: &Catalog,
         message: &DatasetLifecycleMessage,
     ) -> Result<(), InternalError> {
-        tracing::debug!(message=?message, "Received dataset lifecycle message");
+        tracing::debug!(received_message=?message, "Received dataset lifecycle message");
 
         let mut state = self.state.write().await;
 

--- a/src/infra/core/src/dependency_graph_service_inmem.rs
+++ b/src/infra/core/src/dependency_graph_service_inmem.rs
@@ -386,7 +386,7 @@ impl MessageConsumerT<DatasetLifecycleMessage> for DependencyGraphServiceInMemor
     #[tracing::instrument(
         level = "debug",
         skip_all,
-        label = "DependencyGraphServiceInMemory[DatasetLifecycleMessage]"
+        name = "DependencyGraphServiceInMemory[DatasetLifecycleMessage]"
     )]
     async fn consume_message(
         &self,

--- a/src/infra/core/src/ingest/polling_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/polling_ingest_service_impl.rs
@@ -199,7 +199,7 @@ impl PollingIngestServiceImpl {
                 Ok(res)
             }
             Err(err) => {
-                tracing::error!(error = ?err, "Ingest iteration failed");
+                tracing::error!(error = ?err, error_msg = %err, "Ingest iteration failed");
                 listener.error(&err);
                 Err(err)
             }

--- a/src/infra/core/src/ingest/push_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/push_ingest_service_impl.rs
@@ -132,7 +132,7 @@ impl PushIngestServiceImpl {
                 Ok(res)
             }
             Err(err) => {
-                tracing::error!(error = ?err, "Ingest iteration failed");
+                tracing::error!(error = ?err, error_msg = %err, "Ingest iteration failed");
                 listener.error(&err);
                 Err(err)
             }

--- a/src/infra/core/src/query_service_impl.rs
+++ b/src/infra/core/src/query_service_impl.rs
@@ -266,7 +266,7 @@ impl QueryServiceImpl {
             .await
             .int_err()
             .map_err(|e| {
-                tracing::error!(error = ?e, "Resolving last data slice failed");
+                tracing::error!(error = ?e, error_msg = %e, "Resolving last data slice failed");
                 e
             })?
             .into_event()
@@ -456,6 +456,7 @@ async fn read_data_slice_metadata(
         .map_err(|e| {
             tracing::error!(
                 error = ?e,
+                error_msg = %e,
                 "QueryService::read_data_slice_metadata: object store head failed",
             );
             e
@@ -471,6 +472,7 @@ async fn read_data_slice_metadata(
         .map_err(|e| {
             tracing::error!(
                 error = ?e,
+                error_msg = %e,
                 "QueryService::read_data_slice_metadata: Parquet reader get metadata failed"
             );
             e

--- a/src/infra/core/src/repos/object_store_builder_s3.rs
+++ b/src/infra/core/src/repos/object_store_builder_s3.rs
@@ -81,7 +81,7 @@ impl ObjectStoreBuilder for ObjectStoreBuilderS3 {
         let object_store = s3_builder
             .build()
             .map_err(|e| {
-                tracing::error!(error = ?e, "Failed to build S3 object store");
+                tracing::error!(error = ?e, error_msg = %e, "Failed to build S3 object store");
                 e
             })
             .int_err()?;

--- a/src/infra/core/src/transform_service_impl.rs
+++ b/src/infra/core/src/transform_service_impl.rs
@@ -74,7 +74,7 @@ impl TransformServiceImpl {
                 Ok(res)
             }
             Err(err) => {
-                tracing::error!(error = ?err, "Transform failed");
+                tracing::error!(error = ?err, error_msg = %err, "Transform failed");
                 listener.error(&err);
                 Err(err)
             }

--- a/src/utils/messaging-outbox/src/services/implementation/outbox_immediate_impl.rs
+++ b/src/utils/messaging-outbox/src/services/implementation/outbox_immediate_impl.rs
@@ -60,8 +60,11 @@ impl Outbox for OutboxImmediateImpl {
                 .await;
             if let Err(e) = dispatch_result {
                 tracing::error!(
-                    error=?e, producer_name, content_json=?content_json,
-                    "Immediate outbox message dispatching FAILED"
+                    error = ?e,
+                    error_msg = %e,
+                    producer_name,
+                    content_json=?content_json,
+                    "Immediate outbox message dispatching faioed"
                 );
             }
         }


### PR DESCRIPTION
## Description

Main loops of `Outbox` and `TaskExecutor` are not interrupted in case a particular message/task fails with an internal error.
The error is logged instead among with contextual information, and the execution loop continues.

## Checklist before requesting a review

- [ ] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅