### PR TITLE
Integrate prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--- - Fixed -->
 
 ## [Unreleased]
+### Added
+- Added first integration of Prometheus metrics starting with Outbox
+- Added `--metrics` CLI flag that will dump metrics into a file after command execution
 ### Changed
 - Telemetry improvements:
    - Improved data collected around transactional code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5426,9 +5426,11 @@ dependencies = [
  "mime_guess",
  "minus",
  "num-format",
+ "observability",
  "opendatafabric",
  "pretty_assertions",
  "prettytable-rs",
+ "prometheus",
  "random-names",
  "read_input",
  "regex",
@@ -6159,6 +6161,7 @@ dependencies = [
  "kamu-task-system-inmem",
  "messaging-outbox",
  "mockall",
+ "observability",
  "opendatafabric",
  "serde_json",
  "test-log",
@@ -6570,7 +6573,9 @@ dependencies = [
  "internal-error",
  "kamu-messaging-outbox-inmem",
  "mockall",
+ "observability",
  "paste",
+ "prometheus",
  "serde",
  "serde_json",
  "test-log",
@@ -7002,6 +7007,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "observability"
+version = "0.199.3"
+dependencies = [
+ "async-trait",
+ "axum",
+ "dill",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prometheus",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7081,6 +7110,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "lazy_static",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float 4.2.2",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7091,6 +7191,15 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
 dependencies = [
  "num-traits",
 ]
@@ -7704,6 +7813,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]
@@ -9489,7 +9612,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -9913,6 +10036,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-perfetto"
 version = "0.199.3"
 dependencies = [
@@ -9925,6 +10064,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9934,12 +10083,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -10365,6 +10517,16 @@ name = "web-sys"
 version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "src/utils/kamu-cli-puppet",
     "src/utils/messaging-outbox",
     "src/utils/multiformats",
+    "src/utils/observability",
     "src/utils/random-names",
     "src/utils/repo-tools",
     "src/utils/time-source",
@@ -104,6 +105,7 @@ kamu-data-utils = { version = "0.199.3", path = "src/utils/data-utils", default-
 kamu-datafusion-cli = { version = "0.199.3", path = "src/utils/datafusion-cli", default-features = false }
 messaging-outbox = { version = "0.199.3", path = "src/utils/messaging-outbox", default-features = false }
 multiformats = { version = "0.199.3", path = "src/utils/multiformats", default-features = false }
+observability = { version = "0.199.3", path = "src/utils/observability", default-features = false }
 random-names = { version = "0.199.3", path = "src/utils/random-names", default-features = false }
 time-source = { version = "0.199.3", path = "src/utils/time-source", default-features = false }
 tracing-perfetto = { version = "0.199.3", path = "src/utils/tracing-perfetto", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -11,34 +11,12 @@ skip-tree = []
 wildcards = "deny"
 
 # We specify features explicitly to avoid bloat
-workspace-default-features = "deny"
-features = [
-    { name = "opendatafabric", allow = [
-        "default",
-        "sqlx",
-        "sqlx-mysql",
-        "sqlx-postgres",
-        "sqlx-sqlite",
-    ] },
-    { name = "kamu", allow = [
-        "default",
-        "ingest-evm",
-        "ingest-ftp",
-        "ingest-mqtt",
-        "query-extensions-json",
-    ] },
-    { name = "kamu-accounts", allow = [
-        "default",
-        "sqlx",
-    ] },
-    { name = "kamu-datasets", allow = [
-        "default",
-        "sqlx",
-    ] },
-    { name = "kamu-cli", allow = [
-        "default",
-    ] },
-]
+# TODO: https://github.com/EmbarkStudios/cargo-deny/issues/699
+# external-default-features = "deny"
+
+# TODO: https://github.com/EmbarkStudios/cargo-deny/issues/700
+# workspace-default-features = "deny"
+
 
 deny = [
     ### Crates we shouldn't use ####

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -43,6 +43,7 @@ To regenerate this schema from existing code, use the following command:
 * `--no-color` — Disable color output in the terminal
 * `-q`, `--quiet` — Suppress all non-essential output
 * `--trace` — Record and visualize the command execution as perfetto.dev trace
+* `--metrics` — Dump all metrics at the end of command execution
 
 To get help for individual commands use:
     kamu <command> -h

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -45,6 +45,7 @@ database-common = { workspace = true }
 database-common-macros = { workspace = true }
 http-common = { workspace = true }
 internal-error = { workspace = true }
+observability = { workspace = true, features = ["prometheus"] }
 time-source = { workspace = true }
 
 kamu = { workspace = true }
@@ -139,7 +140,8 @@ serde = { version = "1", features = ["derive"] }
 serde_with = "3"
 serde_yaml = "0.9"
 
-# Tracing / logging / telemetry
+# Tracing / logging / telemetry / metrics
+prometheus = { version = "0.13", default-features = false }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-perfetto = { workspace = true }

--- a/src/app/cli/src/cli.rs
+++ b/src/app/cli/src/cli.rs
@@ -49,6 +49,10 @@ pub struct Cli {
     #[arg(long)]
     pub trace: bool,
 
+    /// Dump all metrics at the end of command execution
+    #[arg(long)]
+    pub metrics: bool,
+
     /// Overrides system time clock with provided value
     #[arg(long, value_name = "T", hide = true)]
     pub system_time: Option<parsers::DateTimeRfc3339>,

--- a/src/app/cli/src/output/output_config.rs
+++ b/src/app/cli/src/output/output_config.rs
@@ -24,6 +24,9 @@ pub struct OutputConfig {
     pub format: OutputFormat,
     /// Points to the output trace file if Perfetto tracing was enabled
     pub trace_file: Option<PathBuf>,
+    /// Points to the output metrics file if Prometheus metrics dump was
+    /// requested
+    pub metrics_file: Option<PathBuf>,
 }
 
 impl Default for OutputConfig {
@@ -34,6 +37,7 @@ impl Default for OutputConfig {
             is_tty: false,
             format: OutputFormat::Table,
             trace_file: None,
+            metrics_file: None,
         }
     }
 }

--- a/src/domain/task-system/services/Cargo.toml
+++ b/src/domain/task-system/services/Cargo.toml
@@ -26,6 +26,7 @@ database-common = { workspace = true }
 database-common-macros = { workspace = true }
 internal-error = { workspace = true }
 messaging-outbox = { workspace = true }
+observability = { workspace = true }
 opendatafabric = { workspace = true }
 kamu-core = { workspace = true }
 kamu-datasets = { workspace = true }

--- a/src/domain/task-system/services/src/task_executor_impl.rs
+++ b/src/domain/task-system/services/src/task_executor_impl.rs
@@ -126,8 +126,13 @@ impl TaskExecutorImpl {
         Ok(Some(task))
     }
 
-    #[tracing::instrument(level = "info", skip_all, fields(task_id = %task.task_id))]
     async fn run_task(&self, task: &Task) -> Result<TaskOutcome, InternalError> {
+        let span = observability::tracing::root_span!(
+            "run_task",
+            task_id = %task.task_id,
+        );
+        let _ = span.enter();
+
         // Run task via logical plan
         let task_run_result = self
             .task_logical_plan_runner

--- a/src/utils/messaging-outbox/Cargo.toml
+++ b/src/utils/messaging-outbox/Cargo.toml
@@ -25,6 +25,7 @@ doctest = false
 database-common = { workspace = true }
 database-common-macros = { workspace = true }
 internal-error = { workspace = true }
+observability = { workspace = true, features = ["prometheus"] }
 time-source = { workspace = true }
 
 async-trait = "0.1"
@@ -32,6 +33,7 @@ chrono = { version = "0.4" }
 dill = "0.9"
 futures = "0.3"
 mockall = "0.11"
+prometheus = { version = "0.13", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/src/utils/observability/Cargo.toml
+++ b/src/utils/observability/Cargo.toml
@@ -1,0 +1,70 @@
+[package]
+name = "observability"
+description = "Utilities for tracing, structured logging, and metrics"
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+
+
+[lints]
+workspace = true
+
+
+[lib]
+doctest = false
+
+
+[features]
+default = []
+
+opentelemetry = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry-semantic-conventions",
+    "dep:tracing-opentelemetry",
+]
+
+prometheus = ["dep:prometheus"]
+
+
+[dependencies]
+async-trait = { version = "0.1" }
+axum = { version = "0.6", default-features = false, features = [
+    "json",
+    "matched-path",
+    "query",
+] }
+dill = { version = "0.9", default-features = false }
+http = { version = "0.2", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive"] }
+serde_json = { version = "1", default-features = false }
+thiserror = { version = "1", default-features = false }
+tracing = { version = "0.1", default-features = false }
+tracing-appender = { version = "0.2", default-features = false }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tower = { version = "0.4", default-features = false }
+tower-http = { version = "0.4", default-features = false, features = ["trace"] }
+
+opentelemetry = { optional = true, version = "0.23", default-features = false }
+opentelemetry_sdk = { optional = true, version = "0.23", default-features = false, features = [
+    "rt-tokio",
+] }
+opentelemetry-otlp = { optional = true, version = "0.16", default-features = false, features = [
+    "trace",
+    "grpc-tonic",
+] }
+opentelemetry-semantic-conventions = { optional = true, version = "0.16", default-features = false }
+tracing-opentelemetry = { optional = true, version = "0.24", default-features = false }
+
+prometheus = { optional = true, version = "0.13", default-features = false }
+
+
+[dev-dependencies]

--- a/src/utils/observability/src/axum.rs
+++ b/src/utils/observability/src/axum.rs
@@ -1,0 +1,151 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use http::Uri;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub fn http_layer() -> tower_http::trace::TraceLayer<
+    tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>,
+    MakeSpan,
+    OnRequest,
+    OnResponse,
+> {
+    tower_http::trace::TraceLayer::new_for_http()
+        .on_request(OnRequest)
+        .on_response(OnResponse)
+        .make_span_with(MakeSpan)
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Clone, Debug)]
+pub struct OnRequest;
+
+impl<B> tower_http::trace::OnRequest<B> for OnRequest {
+    fn on_request(&mut self, request: &http::Request<B>, _: &tracing::Span) {
+        tracing::info!(
+            uri = %request.uri(),
+            version = ?request.version(),
+            headers = ?request.headers(),
+            "HTTP request",
+        );
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Clone, Debug)]
+pub struct OnResponse;
+
+impl<B> tower_http::trace::OnResponse<B> for OnResponse {
+    fn on_response(
+        self,
+        response: &http::Response<B>,
+        latency: std::time::Duration,
+        _span: &tracing::Span,
+    ) {
+        tracing::info!(
+            status = response.status().as_u16(),
+            headers = ?response.headers(),
+            latency = %Latency(latency),
+            "HTTP response"
+        );
+    }
+}
+
+struct Latency(std::time::Duration);
+
+impl std::fmt::Display for Latency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ms", self.0.as_millis())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct MakeSpan;
+
+impl<B> tower_http::trace::MakeSpan<B> for MakeSpan {
+    // TODO: Trace linking across requests
+    fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
+        let method = request.method();
+        let route = RouteOrUri::from(request);
+
+        let span = crate::tracing::root_span!(
+            "http_request",
+            %method,
+            %route,
+            "otel.name" = tracing::field::Empty,
+        );
+
+        #[cfg(feature = "opentelemetry")]
+        {
+            crate::tracing::include_otel_trace_id(&span);
+
+            span.record(
+                "otel.name",
+                tracing::field::display(SpanName::new(method, route)),
+            );
+        }
+
+        span
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(feature = "opentelemetry")]
+struct SpanName<'a> {
+    method: &'a http::Method,
+    route: RouteOrUri<'a>,
+}
+
+#[cfg(feature = "opentelemetry")]
+impl<'a> SpanName<'a> {
+    fn new(method: &'a http::Method, route: RouteOrUri<'a>) -> Self {
+        Self { method, route }
+    }
+}
+
+#[cfg(feature = "opentelemetry")]
+impl<'a> std::fmt::Display for SpanName<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.method, self.route)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+enum RouteOrUri<'a> {
+    Route(&'a str),
+    Uri(&'a Uri),
+}
+
+impl<'a, B> From<&'a http::Request<B>> for RouteOrUri<'a> {
+    fn from(request: &'a http::Request<B>) -> Self {
+        request
+            .extensions()
+            .get::<axum::extract::MatchedPath>()
+            .map_or_else(
+                || RouteOrUri::Uri(request.uri()),
+                |m| RouteOrUri::Route(m.as_str()),
+            )
+    }
+}
+
+impl<'a> std::fmt::Display for RouteOrUri<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RouteOrUri::Route(s) => write!(f, "{s}"),
+            RouteOrUri::Uri(uri) => write!(f, "{uri}"),
+        }
+    }
+}

--- a/src/utils/observability/src/config.rs
+++ b/src/utils/observability/src/config.rs
@@ -1,0 +1,84 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug)]
+pub struct Config {
+    /// Name of the service that will appear e.g. in OTEL traces
+    pub service_name: String,
+    /// Version of the service that will appear e.g. in OTEL traces
+    pub service_version: String,
+    /// Log levels that will be used if `RUST_LOG` was not specified explicitly
+    pub default_log_levels: String,
+    /// OpenTelemetry protocol endpoint to export traces to
+    pub otlp_endpoint: Option<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            service_name: "unnamed-service".to_string(),
+            service_version: "0.0.0".to_string(),
+            default_log_levels: "info".to_string(),
+            otlp_endpoint: None,
+        }
+    }
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        Self::from_env_with_prefix("")
+    }
+
+    pub fn from_env_with_prefix(prefix: &str) -> Self {
+        let mut cfg = Self::default();
+        if let Some(service_name) = std::env::var(format!("{prefix}SERVICE_NAME"))
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            cfg.service_name = service_name;
+        }
+        if let Some(service_version) = std::env::var(format!("{prefix}SERVICE_VERSION"))
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            cfg.service_version = service_version;
+        }
+        if let Some(otlp_endpoint) = std::env::var(format!("{prefix}OTLP_ENDPOINT"))
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            cfg.otlp_endpoint = Some(otlp_endpoint);
+        }
+        cfg
+    }
+
+    pub fn with_service_name(mut self, service_name: impl Into<String>) -> Self {
+        self.service_name = service_name.into();
+        self
+    }
+
+    pub fn with_service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = service_version.into();
+        self
+    }
+
+    pub fn with_default_log_levels(mut self, default_log_levels: impl Into<String>) -> Self {
+        self.default_log_levels = default_log_levels.into();
+        self
+    }
+
+    pub fn with_otlp_endpoint(mut self, otlp_endpoint: impl Into<String>) -> Self {
+        self.otlp_endpoint = Some(otlp_endpoint.into());
+        self
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/observability/src/health.rs
+++ b/src/utils/observability/src/health.rs
@@ -1,0 +1,87 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Type implementing this trait will be called during the health check
+/// procedure. Multiple checks can be added, in which case they will be called
+/// one by one with check considered failed upon the first error.
+#[async_trait::async_trait]
+pub trait HealthCheck: Send + Sync {
+    async fn check(&self, check_type: CheckType) -> Result<(), CheckError>;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Axum handler for serving the health checks. Depends on [`dill::Catalog`] to
+/// instantiate the implementations of the [`HealthCheck`] trait.
+pub async fn health_handler(
+    axum::Extension(catalog): axum::Extension<dill::Catalog>,
+    axum::extract::Query(args): axum::extract::Query<CheckArgs>,
+) -> Result<axum::Json<CheckSuccess>, CheckError> {
+    for checker in catalog.get::<dill::AllOf<dyn HealthCheck>>().unwrap() {
+        checker.check(args.r#type).await?;
+    }
+
+    Ok(axum::Json(CheckSuccess { ok: true }))
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckSuccess {
+    pub ok: bool,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, thiserror::Error)]
+#[error("{reason}")]
+pub struct CheckError {
+    pub reason: String,
+}
+
+impl axum::response::IntoResponse for CheckError {
+    fn into_response(self) -> axum::response::Response {
+        (
+            http::status::StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(serde_json::json!({
+                "ok": false,
+                "reason": self.reason,
+            })),
+        )
+            .into_response()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckType {
+    /// Determines when to restart the container
+    #[default]
+    Liveness,
+    /// Determines when to remove the instance from the loadbalancer
+    Readiness,
+    /// Is sent before liveness and readiness checks to determine when the
+    /// startup procedure is finished procedure is finished
+    Startup,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CheckArgs {
+    #[serde(default)]
+    pub r#type: CheckType,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/observability/src/init.rs
+++ b/src/utils/observability/src/init.rs
@@ -1,0 +1,182 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::io::IsTerminal;
+
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::EnvFilter;
+
+use super::config::Config;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// If application is started under a terminal will use the [`dev`] mode,
+/// otherwise will use [`service`] mode.
+pub fn auto(cfg: Config) -> Guard {
+    if std::io::stderr().is_terminal() {
+        dev(cfg)
+    } else {
+        service(cfg)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn dev(cfg: Config) -> Guard {
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new(cfg.default_log_levels.clone()));
+
+    let text_layer = tracing_subscriber::fmt::layer()
+        .pretty()
+        .with_writer(std::io::stderr)
+        .with_line_number(true)
+        .with_thread_names(true)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
+
+    #[cfg(feature = "opentelemetry")]
+    let (otel_layer, otlp_guard) = if cfg.otlp_endpoint.is_none() {
+        (None, None)
+    } else {
+        (
+            Some(
+                tracing_opentelemetry::layer()
+                    .with_error_records_to_exceptions(true)
+                    .with_tracer(init_otel_tracer(&cfg)),
+            ),
+            Some(OtlpGuard),
+        )
+    };
+
+    #[cfg(feature = "opentelemetry")]
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(otel_layer)
+        .with(text_layer)
+        .init();
+
+    #[cfg(not(feature = "opentelemetry"))]
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(text_layer)
+        .init();
+
+    Guard {
+        non_blocking_appender: None,
+
+        #[cfg(feature = "opentelemetry")]
+        otlp_guard,
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn service(cfg: Config) -> Guard {
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new(cfg.default_log_levels.clone()));
+
+    let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stderr());
+
+    let text_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(non_blocking)
+        .with_line_number(true)
+        .with_thread_names(true)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
+
+    #[cfg(feature = "opentelemetry")]
+    let (otel_layer, otlp_guard) = if cfg.otlp_endpoint.is_none() {
+        (None, None)
+    } else {
+        (
+            Some(
+                tracing_opentelemetry::layer()
+                    .with_error_records_to_exceptions(true)
+                    .with_tracer(init_otel_tracer(&cfg)),
+            ),
+            Some(OtlpGuard),
+        )
+    };
+
+    #[cfg(feature = "opentelemetry")]
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(otel_layer)
+        .with(text_layer)
+        .init();
+
+    #[cfg(not(feature = "opentelemetry"))]
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(text_layer)
+        .init();
+
+    Guard {
+        non_blocking_appender: Some(guard),
+
+        #[cfg(feature = "opentelemetry")]
+        otlp_guard,
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(feature = "opentelemetry")]
+fn init_otel_tracer(cfg: &Config) -> opentelemetry_sdk::trace::Tracer {
+    use std::time::Duration;
+
+    use opentelemetry::KeyValue;
+    use opentelemetry_otlp::WithExportConfig as _;
+    use opentelemetry_semantic_conventions::resource as otel_resource;
+
+    let otel_exporter = opentelemetry_otlp::new_exporter()
+        .tonic()
+        .with_endpoint(cfg.otlp_endpoint.as_ref().unwrap())
+        .with_timeout(Duration::from_secs(5));
+
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(otel_exporter)
+        .with_trace_config(
+            opentelemetry_sdk::trace::config()
+                .with_max_events_per_span(64)
+                .with_max_attributes_per_span(16)
+                .with_resource(opentelemetry_sdk::Resource::new([
+                    KeyValue::new(otel_resource::SERVICE_NAME, cfg.service_name.clone()),
+                    KeyValue::new(otel_resource::SERVICE_VERSION, cfg.service_version.clone()),
+                ]))
+                .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn),
+        )
+        .install_batch(opentelemetry_sdk::runtime::Tokio)
+        .expect("Creating tracer")
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[must_use]
+#[allow(dead_code)]
+#[derive(Default)]
+pub struct Guard {
+    pub non_blocking_appender: Option<tracing_appender::non_blocking::WorkerGuard>,
+
+    #[cfg(feature = "opentelemetry")]
+    pub otlp_guard: Option<OtlpGuard>,
+}
+
+pub struct OtlpGuard;
+
+#[cfg(feature = "opentelemetry")]
+impl Drop for OtlpGuard {
+    fn drop(&mut self) {
+        opentelemetry::global::shutdown_tracer_provider();
+    }
+}

--- a/src/utils/observability/src/lib.rs
+++ b/src/utils/observability/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod axum;
+pub mod config;
+pub mod health;
+pub mod init;
+pub mod tracing;
+
+#[cfg(feature = "prometheus")]
+pub mod metrics;

--- a/src/utils/observability/src/metrics.rs
+++ b/src/utils/observability/src/metrics.rs
@@ -1,0 +1,56 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use prometheus::Encoder as _;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Implementors of this trait will be aked during the startup to register
+/// metrics that they provide.
+pub trait MetricsProvider: Send + Sync {
+    /// Called during startup to register the metrics
+    ///
+    /// IMPORTANT: Metrics that you register must be static or live in the
+    /// [`dill::Singleton`] scope.
+    fn register(&self, reg: &prometheus::Registry) -> prometheus::Result<()>;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Uses catalog to extract all [`MetricsProvider`]s and register all provided
+/// metrics in the [`prometheus::Registry`]
+pub fn register_all(catalog: &dill::Catalog) -> Arc<prometheus::Registry> {
+    let registry: Arc<prometheus::Registry> = catalog
+        .get_one()
+        .expect("Prometheus registry is not in the DI catalog");
+
+    for builder in catalog.builders_for::<dyn MetricsProvider>() {
+        let metrics_set = builder.get(catalog).unwrap();
+        metrics_set.register(&registry).unwrap();
+    }
+
+    registry
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::unused_async)]
+pub async fn metrics_handler(axum::Extension(catalog): axum::Extension<dill::Catalog>) -> String {
+    let reg = catalog.get_one::<prometheus::Registry>().unwrap();
+
+    let mut buf = Vec::new();
+
+    prometheus::TextEncoder::new()
+        .encode(&reg.gather(), &mut buf)
+        .unwrap();
+
+    String::from_utf8(buf).unwrap()
+}

--- a/src/utils/observability/src/tracing.rs
+++ b/src/utils/observability/src/tracing.rs
@@ -1,0 +1,63 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#[cfg(feature = "opentelemetry")]
+#[macro_export]
+macro_rules! root_span {
+    ($name:expr) => {
+        $crate::tracing::root_span!($name,)
+    };
+    ($name:expr, $($field:tt)*) => {
+        {
+            let span = ::tracing::info_span!(
+                $name,
+                trace_id = tracing::field::Empty,
+                $($field)*
+            );
+
+            $crate::tracing::include_otel_trace_id(&span);
+
+            span
+        }
+    };
+}
+
+#[cfg(not(feature = "opentelemetry"))]
+#[macro_export]
+macro_rules! root_span {
+    ($name:expr) => {
+        $crate::tracing::root_span!($name,)
+    };
+    ($name:expr, $($field:tt)*) => {
+        tracing::info_span!(
+            $name,
+            trace_id = tracing::field::Empty,
+            $($field)*
+        )
+    };
+}
+
+pub use root_span;
+
+/// Extracts trace ID from the OTEL layer and adds it to the tracing span to
+/// allow cross-linking between logs and traces
+#[cfg(feature = "opentelemetry")]
+pub fn include_otel_trace_id(span: &tracing::Span) {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let context = span.context();
+    let otel_span = context.span();
+    let span_context = otel_span.span_context();
+    let trace_id = span_context.trace_id();
+
+    if span_context.is_valid() {
+        span.record("trace_id", tracing::field::display(trace_id));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/kamu-data/kamu-node/issues/130

- Moving `observability` crate from `kamu-node` down into `kamu-cli`
- Improved DI <> Prometheus integration
- Switched `kamu system api-server` to use same tracing middlewares as `kamu-node` and expose health and metrics endpoints
- Added `outbox_failed_consumers` metric

Example:
```
$ kamu -vv --metrics system api-server --http-port 8899

$ xh GET "http://localhost:8899/system/metrics"

HTTP/1.1 200 OK
Content-Length: 855
Content-Type: text/plain; charset=utf-8
Date: Fri, 13 Sep 2024 01:59:15 GMT

# HELP outbox_failed_consumers Number of consumers that are in the failed state and have stopped consuming messages
# TYPE outbox_failed_consumers gauge
outbox_failed_consumers{consumer="dev.kamu.domain.flow-system.FlowConfigurationService",producer="dev.kamu.domain.core.services.DatasetService"} 0
outbox_failed_consumers{consumer="dev.kamu.domain.flow-system.FlowExecutor",producer="dev.kamu.domain.core.services.DatasetService"} 0
outbox_failed_consumers{consumer="dev.kamu.domain.flow-system.FlowExecutor",producer="dev.kamu.domain.flow-system.FlowConfigurationService"} 0
outbox_failed_consumers{consumer="dev.kamu.domain.flow-system.FlowExecutor",producer="dev.kamu.domain.task-system.TaskExecutor"} 0
outbox_failed_consumers{consumer="dev.kamu.domain.flow-system.FlowTimeWheelService",producer="dev.kamu.domain.flow-system.FlowProgressService"} 0
```

I also added `--metrics` flag that will dump prometheus metrics into a file after command execution. It's not useful currently, but just thought it might be cool feature in future that would show us e.g. how many metadata blocks was read, how long hashing took etc.