### PR TITLE
Upgrade to datafusion 42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,15 +114,16 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4a4aaae80afd4be443a6aecd92a6b255dcdd000f97996928efb33d8a71e100"
+checksum = "8367891bf380210abb0d6aa30c5f85a9080cb4a066c4d5c5acadad630823751b"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
@@ -145,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c309895995eaa4bfcc345f5515a39c7df9447798645cc8bf462b6c5bf1dc96"
+checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -159,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4e0ef72b0876ae3068b2ed7dfae9ae1779ce13cfaec2ee1f08f5bd0348dc57"
+checksum = "0eefe64fd344cffa9cf9e3435ec4e93e6e9c3481bc37269af988bf497faf4a6a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -180,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529fc6310dc1126c8de51c376cbc59c79c7f662bd742be7dc67055d5421a81b4"
+checksum = "88b095eb0533144b4497e84a9cc3e44a5c2e3754a3983c0376a55a2f9183a53e"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -192,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413902aa18a97569e60f679c23f46a18db1656d87ab4d4e49d0e1e52042f66df"
+checksum = "4004925bff5ba0a11739ae84dbb6601a981ea692f3bd45b626935ee90a6b8471"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -208,15 +209,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "0.2.1"
+name = "alloy-eip2930"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9431c99a3b3fe606ede4b3d4043bdfbcb780c45b8d8d226c3804e2b75cfbe68"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d319bb544ca6caeab58c39cea8921c55d924d4f68f2c60f24f914673f9a74a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
+ "derive_more",
  "once_cell",
  "serde",
  "sha2",
@@ -224,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79614dfe86144328da11098edcc7bc1a3f25ad8d3134a9eb9e857e06f0d9840d"
+checksum = "3a7a18afb0b318616b6b2b0e2e7ac5529d32a966c673b48091c9919e284e6aca"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -235,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc05b04ac331a9f07e3a4036ef7926e49a8bf84a99a1ccfc7e2ab55a5fcbb372"
+checksum = "9996daf962fd0a90d3c93b388033228865953b92de7bb1959b891d78750a4091"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -247,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e2865c4c3bb4cdad3f0d9ec1ab5c0c657ba69a375651bd35e32fb6c180ccc2"
+checksum = "d3c717b5298fad078cd3a418335b266eba91b511383ca9bd497f742d5975d5ab"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -261,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e701fc87ef9a3139154b0b4ccb935b565d27ffd9de020fe541bf2dec5ae4ede"
+checksum = "fb3705ce7d8602132bcf5ac7a1dd293a42adc2f183abf5907c30ac535ceca049"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -282,10 +308,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d5a0f9170b10988b6774498a022845e13eda94318440d17709d50687f67f9"
+checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "serde",
@@ -293,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
+checksum = "411aff151f2a73124ee473708e82ed51b2535f68928b6a1caa8bc1246ae6f7cd"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -315,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9c0ab10b93de601a6396fc7ff2ea10d3b28c46f079338fa562107ebf9857c8"
+checksum = "927f708dd457ed63420400ee5f06945df9632d5d101851952056840426a10dc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -334,22 +361,23 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-utils-wasm",
  "lru",
  "pin-project",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5da2c55cbaf229bad3c5f8b00b5ab66c74ef093e5f3a753d874cfecf7d2281"
+checksum = "2d05f63677e210d758cd5d6d1ce10f20c980c3560ccfbe79ba1997791862a04f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -360,7 +388,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.1",
  "tracing",
 ]
 
@@ -388,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38e3ffdb285df5d9f60cb988d336d9b8e3505acb78750c3bc60336a7af41d3"
+checksum = "7d82952dca71173813d4e5733e2c986d8b04aea9e0f3b0a576664c232ad050a5"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -404,16 +432,16 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c31a3750b8f5a350d17354e46a52b0f2f19ec5f2006d816935af599dedc521"
+checksum = "64333d639f2a0cf73491813c629a405744e16343a4bc5640931be707c345ecc5"
 dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -422,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e18424d962d7700a882fe423714bd5b9dde74c7a7589d4255ea64068773aef"
+checksum = "83aa984386deda02482660aa31cb8ca1e63d533f1c31a52d7d181ac5ec68e9b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -433,17 +461,19 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
+ "cfg-if",
+ "derive_more",
+ "hashbrown 0.14.5",
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33feda6a53e6079895aed1d08dcb98a1377b000d80d16370fbbdb8155d547ef"
+checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -452,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740a25b92e849ed7b0fa013951fe2f64be9af1ad5abe805037b44fb7770c5c47"
+checksum = "307324cca94354cd654d6713629f0383ec037e1ff9e3e3d547212471209860c0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -466,13 +496,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
+checksum = "0458ccb02a564228fcd76efb8eb5a520521a8347becde37b402afec9a1b83859"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -480,16 +510,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
+checksum = "2bc65475025fc1e84bf86fc840f04f63fcccdcf3cf12053c99918e4054dfbc69"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.5.0",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -499,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
+checksum = "6ed10f0715a0b69fde3236ff3b9ae5f6f7c97db5a387747100070d3016b9266b"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -516,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcba3ca07cf7975f15d871b721fb18031eec8bce51103907f6dcce00b255d98"
+checksum = "3edae8ea1de519ccba896b6834dec874230f72fe695ff3c9c118e90ec7cff783"
 dependencies = [
  "serde",
  "winnow 0.6.18",
@@ -526,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
+checksum = "1eb88e4da0a1b697ed6a9f811fdba223cf4d5c21410804fd1707836af73a462b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -539,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0590afbdacf2f8cca49d025a2466f3b6584a016a8b28f532f29f8da1007bae"
+checksum = "33616b2edf7454302a1d48084db185e52c309f73f6c10be99b0fe39354b3f1e9"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -551,16 +581,16 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2437d145d80ea1aecde8574d2058cceb8b3c9cba05f6aea8e67907c660d46698"
+checksum = "a944f5310c690b62bbb3e7e5ce34527cbd36b2d18532a797af123271ce595a49"
 dependencies = [
  "alloy-transport",
  "url",
@@ -568,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.2.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af855163e7df008799941aa6dd324a43ef2bf264b08ba4b22d44aad6ced65300"
+checksum = "a9704761f6297fe482276bee7f77a93cb42bd541c2bd6c1c560b6f3a9ece672e"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -819,9 +849,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05048a8932648b63f21c37d88b552ccc8a65afb6dfe9fc9f30ce79174c2e7a85"
+checksum = "45aef0d9cf9a039bf6cd1acc451b137aca819977b0928dece52bd92811b640ba"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -840,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a57966e43bfe9a3277984a14c24ec617ad874e4c0e1d2a1b083a39cfbf22c"
+checksum = "03675e42d1560790f3524800e41403b40d0da1c793fe9528929fde06d8c7649a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -855,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
+checksum = "cd2bf348cf9f02a5975c5962c7fa6dee107a2009a7b41ac5fb1a027e12dc033f"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -872,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c975484888fc95ec4a632cdc98be39c085b1bb518531b0c80c5d462063e5daa1"
+checksum = "3092e37715f168976012ce52273c3989b5793b0db5f06cbaa246be25e5f0924d"
 dependencies = [
  "bytes",
  "half",
@@ -883,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da26719e76b81d8bc3faad1d4dbdc1bcc10d14704e63dc17fc9f3e7e1e567c8e"
+checksum = "7ce1018bb710d502f9db06af026ed3561552e493e989a79d0d0f5d9cf267a785"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -904,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13c36dc5ddf8c128df19bab27898eea64bf9da2b555ec1cd17a8ff57fba9ec2"
+checksum = "fd178575f45624d045e4ebee714e246a05d9652e41363ee3f57ec18cca97f740"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -923,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
+checksum = "4e4ac0c4ee79150afe067dc4857154b3ee9c1cd52b5f40d59a77306d0ed18d65"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -935,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-digest"
-version = "52.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565ca1b27d65d78eccb0189820aa64fbe3fb1492de4b74a8741ab2285966b934"
+checksum = "1837691c84fd6db88d121604c7179857e7cb271af798d85afba079ecd95c0b47"
 dependencies = [
  "arrow",
  "digest 0.10.7",
@@ -945,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7ffbc96072e466ae5188974725bb46757587eafe427f77a25b828c375ae882"
+checksum = "b915fb36d935b969894d7909ad417c67ddeadebbbd57c3c168edf64721a37d31"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -965,17 +995,17 @@ dependencies = [
  "futures",
  "once_cell",
  "paste",
- "prost",
+ "prost 0.13.2",
  "prost-types",
  "tokio",
- "tonic",
+ "tonic 0.12.2",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e786e1cdd952205d9a8afc69397b317cfbb6e0095e445c69cda7e8da5c1eeb0f"
+checksum = "bb307482348a1267f91b0912e962cd53440e5de0f7fb24c5f7b10da70b38c94a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -988,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb22284c5a2a01d73cebfd88a33511a3234ab45d66086b2ca2d1228c3498e445"
+checksum = "d24805ba326758effdd6f2cbdd482fcfab749544f21b134701add25b33f474e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1008,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42745f86b1ab99ef96d1c0bcf49180848a64fe2c7a7a0d945bc64fa2b21ba9bc"
+checksum = "644046c479d80ae8ed02a7f1e1399072ea344ca6a7b0e293ab2d5d9ed924aa3b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1023,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd09a518c602a55bd406bcc291a967b284cfa7a63edfbf8b897ea4748aad23c"
+checksum = "a29791f8eb13b340ce35525b723f5f0df17ecb955599e11f65c2a94ab34e2efb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1037,18 +1067,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
+checksum = "c85320a3a2facf2b2822b57aa9d6d9d55edb8aee0b6b5d3b8df158e503d10858"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600bae05d43483d216fb3494f8c32fdbefd8aa4e1de237e790dbb3d9f44690a3"
+checksum = "9cc7e6b582e23855fd1625ce46e51647aa440c20ea2e71b1d748e0839dd73cba"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1060,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc1985b67cb45f6606a248ac2b4a288849f196bab8c657ea5589f47cdd55e6"
+checksum = "0775b6567c66e56ded19b87a954b6b1beffbdd784ef95a3a2b03f59570c1d230"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1168,7 +1198,7 @@ checksum = "01a1c20a2059bffbc95130715b23435a05168c518fba9709c81fa2a38eed990c"
 dependencies = [
  "async-graphql",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "bytes",
  "futures-util",
  "serde_json",
@@ -1312,19 +1342,19 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bf00cb9416daab4ce4927c54ebe63c08b9caf4d7b9314b6d7a4a2c5a1afb09"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-http",
- "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-runtime 0.57.2",
+ "aws-sdk-sso 0.36.0",
+ "aws-sdk-ssooidc 0.36.0",
+ "aws-sdk-sts 0.36.0",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
+ "aws-smithy-runtime 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "fastrand",
  "hex",
@@ -1338,14 +1368,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848d7b9b605720989929279fa644ce8f244d0ce3146fcca5b70e4eb7b3c020fc"
+dependencies = [
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.3",
+ "aws-sdk-sso 1.43.0",
+ "aws-sdk-ssooidc 1.44.0",
+ "aws-sdk-sts 1.43.0",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
+ "aws-types 1.3.3",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb9073c88dbf12f68ce7d0e149f989627a1d1ae3d2b680459f04ccc29d1cbd0f"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+dependencies = [
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
  "zeroize",
 ]
 
@@ -1355,10 +1427,10 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24067106d09620cf02d088166cdaedeaca7146d4d499c41b37accecbea11b246"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -1372,18 +1444,43 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6ee0152c06d073602236a4e94a8c52a327d310c1ecd596570ce795af8777ff"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-http",
- "aws-sigv4",
- "aws-smithy-async",
+ "aws-sigv4 0.57.2",
+ "aws-smithy-async 0.57.2",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "fastrand",
  "http 0.2.12",
  "percent-encoding",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+dependencies = [
+ "aws-credential-types 1.2.1",
+ "aws-sigv4 1.2.4",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
+ "aws-types 1.3.3",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
  "tracing",
  "uuid",
 ]
@@ -1394,20 +1491,20 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84022763485483ea17d417f9832d5da198bc36829b59f086c0d35ecd2ce59991"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-http",
- "aws-runtime",
- "aws-sigv4",
- "aws-smithy-async",
+ "aws-runtime 0.57.2",
+ "aws-sigv4 0.57.2",
+ "aws-smithy-async 0.57.2",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
+ "aws-smithy-runtime 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "aws-smithy-xml 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -1424,16 +1521,16 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7146800d907748fe1a0dd1a12a1387f5be249bac8bd5902af30f8559972a7272"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-http",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-runtime 0.57.2",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
+ "aws-smithy-runtime 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "fastrand",
  "http 0.2.12",
@@ -1447,19 +1544,41 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb8158015232b4596ccef74a205600398e152d704b40b7ec9f486092474d7fa"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-http",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-runtime 0.57.2",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
+ "aws-smithy-runtime 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "http 0.2.12",
  "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a9d27ed1c12b1140c47daf1bc541606c43fdafd918c4797d520db0043ceef2"
+dependencies = [
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.3",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
+ "aws-types 1.3.3",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
@@ -1469,19 +1588,41 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36a1493e1c57f173e53621935bfb5b6217376168dbdb4cd459aebcf645924a48"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-http",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-runtime 0.57.2",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
+ "aws-smithy-runtime 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "aws-types 0.57.2",
  "bytes",
  "http 0.2.12",
  "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44514a6ca967686cde1e2a1b81df6ef1883d0e3e570da8d8bc5c491dcb6fc29b"
+dependencies = [
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.3",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
+ "aws-types 1.3.3",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
@@ -1491,20 +1632,43 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e032b77f5cd1dd3669d777a38ac08cbf8ec68e29460d4ef5d3e50cffa74ec75a"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-http",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-runtime 0.57.2",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-json 0.57.2",
+ "aws-smithy-query 0.57.2",
+ "aws-smithy-runtime 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "aws-smithy-xml 0.57.2",
+ "aws-types 0.57.2",
  "http 0.2.12",
  "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7a4d279762a35b9df97209f6808b95d4fe78547fe2316b4d200a0283960c5a"
+dependencies = [
+ "aws-credential-types 1.2.1",
+ "aws-runtime 1.4.3",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-query 0.60.7",
+ "aws-smithy-runtime 1.7.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
+ "aws-smithy-xml 0.60.9",
+ "aws-types 1.3.3",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
  "tracing",
 ]
 
@@ -1514,10 +1678,10 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64f81a6abc4daab06b53cabf27c54189928893283093e37164ca53aa47488a5b"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.57.2",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
  "bytes",
  "form_urlencoded",
  "hex",
@@ -1536,10 +1700,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sigv4"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
+dependencies = [
+ "aws-credential-types 1.2.1",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-async"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe53fccd3b10414b9cae63767a15a2789b34e6c6727b6e32b33e8c7998a3e80"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1552,8 +1750,8 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb5701fbfb40600cc0fa547f318552dfd4e632b2099bd75d95fb0faae70675d"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-types 0.57.2",
  "bytes",
  "crc32c",
  "crc32fast",
@@ -1573,7 +1771,7 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b33fa99f928a5815b94ee07e1377901bcf51aa749034a2c802dc38f9dcfacf5"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
  "bytes",
  "crc32fast",
 ]
@@ -1585,8 +1783,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7972373213d1d6e619c0edc9dda2d6634154e4ed75c5e0b2bf065cd5ec9f0d1"
 dependencies = [
  "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+dependencies = [
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -1605,7 +1823,16 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d64d5af16dd585de9ff6c606423c1aaad47c6baa38de41c2beb32ef21c6645"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types 1.2.6",
 ]
 
 [[package]]
@@ -1614,7 +1841,17 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7527bf5335154ba1b285479c50b630e44e93d1b4a759eaceb8d0bf9fbc82caa5"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.57.2",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types 1.2.6",
  "urlencoding",
 ]
 
@@ -1624,14 +1861,41 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "839b363adf3b2bdab2742a1f540fec23039ea8bc9ec0f9f61df48470cfe5527b"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
  "bytes",
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+dependencies = [
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-http 0.60.11",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
+ "bytes",
+ "fastrand",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
  "hyper 0.14.30",
  "hyper-rustls 0.24.2",
  "once_cell",
@@ -1648,10 +1912,27 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24ecc446e62c3924539e7c18dec8038dba4fdf8718d5c2de62f9d2fecca8ba9"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-types 0.57.2",
  "bytes",
  "http 0.2.12",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+dependencies = [
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-types 1.2.6",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1682,10 +1963,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-types"
+version = "1.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03701449087215b5369c7ea17fef0dd5d24cb93439ec5af0c7615f58c3f22605"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "aws-smithy-xml"
 version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb1e3ac22c652662096c8e37a6f9af80c6f3520cab5610b2fe76c725bce18eac"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
 dependencies = [
  "xmlparser",
 ]
@@ -1696,11 +2012,25 @@ version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048bbf1c24cdf4eb1efcdc243388a93a90ebf63979e25fc1c7b8cbd9cb6beb38"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-credential-types 0.57.2",
+ "aws-smithy-async 0.57.2",
+ "aws-smithy-runtime-api 0.57.2",
+ "aws-smithy-types 0.57.2",
  "http 0.2.12",
+ "rustc_version 0.4.1",
+ "tracing",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types 1.2.1",
+ "aws-smithy-async 1.2.1",
+ "aws-smithy-runtime-api 1.7.2",
+ "aws-smithy-types 1.2.6",
  "rustc_version 0.4.1",
  "tracing",
 ]
@@ -1712,7 +2042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "base64 0.21.7",
  "bitflags 1.3.2",
  "bytes",
@@ -1737,7 +2067,34 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "tokio",
  "tokio-tungstenite 0.20.1",
- "tower",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.1",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -1760,13 +2117,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-extra"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ab90e7b70bea63a153137162affb6a0bce26b584c24a4c7885509783e2cf30b"
 dependencies = [
- "axum",
- "axum-core",
+ "axum 0.6.20",
+ "axum-core 0.3.4",
  "bytes",
  "futures-util",
  "http 0.2.12",
@@ -1776,7 +2153,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -2126,6 +2503,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -2264,13 +2647,11 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -2403,12 +2784,6 @@ checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 dependencies = [
  "custom_derive",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -2781,19 +3156,6 @@ checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -2817,8 +3179,8 @@ name = "database-common"
 version = "0.201.0"
 dependencies = [
  "async-trait",
- "aws-config",
- "aws-credential-types",
+ "aws-config 0.57.2",
+ "aws-credential-types 0.57.2",
  "aws-sdk-secretsmanager",
  "chrono",
  "dill",
@@ -2846,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4fd4a99fc70d40ef7e52b243b4a399c3f8d353a40d5ecb200deee05e49c61bb"
+checksum = "ee907b081e45e1d14e1f327e89ef134f91fcebad0bfc2dc229fa9f6044379682"
 dependencies = [
  "ahash",
  "arrow",
@@ -2860,7 +3222,7 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -2869,6 +3231,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-nested",
+ "datafusion-functions-window",
  "datafusion-optimizer",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
@@ -2881,7 +3244,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "num_cpus",
  "object_store",
@@ -2902,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b3cfbd84c6003594ae1972314e3df303a27ce8ce755fcea3240c90f4c0529"
+checksum = "6c2b914f6e33c429af7d8696c72a47ed9225d7e2b82c747ebdfa2408ed53579f"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2912,13 +3275,14 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-physical-plan",
+ "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fdbc877e3e40dcf88cc8f283d9f5c8851f0a3aa07fee657b1b75ac1ad49b9c"
+checksum = "3a84f8e76330c582a6b8ada0b2c599ca46cfe46b7585e458fc3f4092bc722a18"
 dependencies = [
  "ahash",
  "arrow",
@@ -2933,23 +3297,26 @@ dependencies = [
  "num_cpus",
  "object_store",
  "parquet",
+ "paste",
  "sqlparser",
+ "tokio",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7496d1f664179f6ce3a5cbef6566056ccaf3ea4aa72cc455f80e62c1dd86b1"
+checksum = "cf08cc30d92720d557df13bd5a5696213bd5ea0f38a866d8d85055d866fba774"
 dependencies = [
+ "log",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-ethers"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd7ac5865439f41af63c42a8265c8e283adc522cc25fefbb007bbbd6c9d8bf"
+checksum = "928d2f79aedef55b7c85ee9daf884d440ae2f6a3e1cbd91f78077bdc79e6a7db"
 dependencies = [
  "alloy",
  "async-stream",
@@ -2964,13 +3331,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e70968c815b611116951e3dd876aef04bf217da31b72eec01ee6a959336a1"
+checksum = "86bc4183d5c45b9f068a6f351678a0d1eb1225181424542bb75db18ec280b822"
 dependencies = [
  "arrow",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap",
  "datafusion-common",
  "datafusion-expr",
  "futures",
@@ -2985,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1841c409d9518c17971d15c9bae62e629eb937e6fb6c68cd32e9186f8b30d2"
+checksum = "202119ce58e4d103e37ae64aab40d4e574c97bdd2bea994bf307b175fcbfa74d"
 dependencies = [
  "ahash",
  "arrow",
@@ -2995,6 +3362,9 @@ dependencies = [
  "arrow-buffer",
  "chrono",
  "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
  "paste",
  "serde_json",
  "sqlparser",
@@ -3003,10 +3373,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-functions"
-version = "41.0.0"
+name = "datafusion-expr-common"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e481cf34d2a444bd8fa09b65945f0ce83dc92df8665b761505b3d9f351bebb"
+checksum = "f8b181ce8569216abb01ef3294aa16c0a40d7d39350c2ff01ede00f167a535f2"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4124b8066444e05a24472f852e94cf56546c0f4d92d00f018f207216902712"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3019,7 +3400,7 @@ dependencies = [
  "datafusion-expr",
  "hashbrown 0.14.5",
  "hex",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "md-5",
  "rand",
@@ -3031,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4ece19f73c02727e5e8654d79cd5652de371352c1df3c4ac3e419ecd6943fb"
+checksum = "b94acdac235ea21810150a89751617ef2db7e32eba27f54be48a81bde2bfe119"
 dependencies = [
  "ahash",
  "arrow",
@@ -3041,23 +3422,36 @@ dependencies = [
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "half",
  "log",
  "paste",
  "sqlparser",
 ]
 
 [[package]]
-name = "datafusion-functions-json"
-version = "0.41.0"
+name = "datafusion-functions-aggregate-common"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00900606bdd73248f0a0bea254379ef06832f4958510581e752fedd17b33b8b4"
+checksum = "5c9ea085bbf900bf16e2ca0f56fc56236b2e4f2e1a2cccb67bcd83c5ab4ad0ef"
 dependencies = [
+ "ahash",
  "arrow",
- "arrow-schema",
  "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
+ "rand",
+]
+
+[[package]]
+name = "datafusion-functions-json"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532feb5c208fd1708f4d93b1984fb7a7ed678a9f0e6f799af97118d7c4e863a1"
+dependencies = [
+ "datafusion",
  "jiter",
  "log",
  "paste",
@@ -3065,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1474552cc824e8c9c88177d454db5781d4b66757d4aca75719306b8343a5e8d"
+checksum = "6c882e61665ed60c5ce9b061c1e587aeb8ae5ae4bcb5e5f2465139ab25328e0f"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3079,19 +3473,32 @@ dependencies = [
  "datafusion-expr",
  "datafusion-functions",
  "datafusion-functions-aggregate",
- "itertools 0.12.1",
+ "datafusion-physical-expr-common",
+ "itertools 0.13.0",
  "log",
  "paste",
  "rand",
 ]
 
 [[package]]
+name = "datafusion-functions-window"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a354ce96df3ca6d025093adac9fd55ca09931c9b6f2630140721a95873fde4"
+dependencies = [
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "log",
+]
+
+[[package]]
 name = "datafusion-odata"
-version = "41.0.0"
-source = "git+https://github.com/kamu-data/datafusion-odata.git?branch=41.0.0-axum-0.6#e9e09c87ba23d1fc88a6aecdca63c1ec179cd7a7"
+version = "42.0.0"
+source = "git+https://github.com/kamu-data/datafusion-odata.git?branch=42.0.0-axum-0.6#f7dc02a5e2e27219ee530aafcb85f2e52b68da27"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "chrono",
  "datafusion",
  "http 0.2.12",
@@ -3104,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791ff56f55608bc542d1ea7a68a64bdc86a9413f5a381d06a39fd49c2a3ab906"
+checksum = "baf677c74fb7b5a1899ef52709e4a70fff3ed80bdfb4bbe495909810e83d5f39"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3116,7 +3523,7 @@ dependencies = [
  "datafusion-physical-expr",
  "hashbrown 0.14.5",
  "indexmap 2.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "paste",
  "regex-syntax 0.8.4",
@@ -3124,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a223962b3041304a3e20ed07a21d5de3d88d7e4e71ca192135db6d24e3365a4"
+checksum = "30b077999f6eb6c43d6b25bc66332a3be2f693c382840f008dd763b8540f9530"
 dependencies = [
  "ahash",
  "arrow",
@@ -3140,12 +3547,14 @@ dependencies = [
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
  "hex",
  "indexmap 2.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "paste",
  "petgraph",
@@ -3154,35 +3563,37 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5e7d8532a1601cd916881db87a70b0a599900d23f3db2897d389032da53bc6"
+checksum = "dce847f885c2b13bbe29f5c8b7948797131aa470af6e16d2a94f4428b4f4f1bd"
 dependencies = [
  "ahash",
  "arrow",
  "datafusion-common",
- "datafusion-expr",
+ "datafusion-expr-common",
  "hashbrown 0.14.5",
  "rand",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb9c78f308e050f5004671039786a925c3fee83b90004e9fcfd328d7febdcc0"
+checksum = "d13238e3b9fdd62a4c18760bfef714bb990d1e1d3430e9f416aae4b3cfaa71af"
 dependencies = [
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
+ "itertools 0.13.0",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1116949432eb2d30f6362707e2846d942e491052a206f2ddcb42d08aea1ffe"
+checksum = "faba6f55a7eaf0241d07d12c2640de52742646b10f754485d5192bdfe2c9ceae"
 dependencies = [
  "ahash",
  "arrow",
@@ -3197,13 +3608,14 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "once_cell",
  "parking_lot",
@@ -3214,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45d0180711165fe94015d7c4123eb3e1cf5fb60b1506453200b8d1ce666bef0"
+checksum = "dad8d96a9b52e1aa24f9373696a815be828193efce7cb0bbd2140b6bb67d1819"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3294,15 +3706,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "convert_case",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
  "syn 2.0.77",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3602,6 +4022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -3613,6 +4034,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
+ "humantime",
  "log",
 ]
 
@@ -3634,13 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "etcetera"
@@ -3716,13 +4134,13 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.13"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4176,6 +4594,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -4348,7 +4767,7 @@ dependencies = [
 name = "http-common"
 version = "0.201.0"
 dependencies = [
- "axum",
+ "axum 0.6.20",
  "http 0.2.12",
  "internal-error",
  "kamu-core",
@@ -4429,6 +4848,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -4483,6 +4903,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,7 +4930,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -4833,12 +5266,12 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
- "aws-config",
- "aws-credential-types",
+ "aws-config 0.57.2",
+ "aws-credential-types 0.57.2",
  "aws-sdk-s3",
- "aws-smithy-http",
- "aws-smithy-types",
- "axum",
+ "aws-smithy-http 0.57.2",
+ "aws-smithy-types 0.57.2",
+ "axum 0.6.20",
  "bytes",
  "cfg-if",
  "chrono",
@@ -4846,7 +5279,7 @@ dependencies = [
  "criterion",
  "curl",
  "curl-sys",
- "dashmap 6.1.0",
+ "dashmap",
  "database-common",
  "datafusion",
  "datafusion-ethers",
@@ -4902,7 +5335,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -5093,17 +5526,17 @@ dependencies = [
  "arrow-flight",
  "async-trait",
  "base64 0.22.1",
- "dashmap 6.1.0",
+ "dashmap",
  "datafusion",
  "futures",
  "indoc 2.0.5",
  "kamu-data-utils",
  "like",
- "prost",
+ "prost 0.13.2",
  "test-log",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.2",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -5165,7 +5598,7 @@ version = "0.201.0"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
- "axum",
+ "axum 0.6.20",
  "axum-extra",
  "base64 0.22.1",
  "bytes",
@@ -5215,7 +5648,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.20.1",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -5246,7 +5679,7 @@ dependencies = [
 name = "kamu-adapter-odata"
 version = "0.201.0"
 dependencies = [
- "axum",
+ "axum 0.6.20",
  "chrono",
  "database-common",
  "database-common-macros",
@@ -5264,6 +5697,7 @@ dependencies = [
  "kamu-core",
  "messaging-outbox",
  "opendatafabric",
+ "pretty_assertions",
  "quick-xml",
  "reqwest 0.11.27",
  "serde",
@@ -5356,7 +5790,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-axum",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "axum-extra",
  "cfg-if",
  "chrono",
@@ -5450,8 +5884,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
- "tower",
+ "tonic 0.12.2",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -5642,12 +6076,15 @@ version = "0.201.0"
 dependencies = [
  "arrow",
  "async-trait",
- "aws-config",
- "aws-credential-types",
+ "aws-config 1.5.6",
+ "aws-credential-types 1.2.1",
+ "aws-sdk-sso 1.43.0",
+ "aws-sdk-ssooidc 1.44.0",
+ "aws-sdk-sts 1.43.0",
  "clap",
  "datafusion",
- "datafusion-common",
  "dirs",
+ "env_logger",
  "futures",
  "object_store",
  "parking_lot",
@@ -5961,7 +6398,6 @@ dependencies = [
  "internal-error",
  "kamu-core",
  "kamu-data-utils",
- "object_store",
  "opendatafabric",
  "pretty_assertions",
  "rand",
@@ -6762,12 +7198,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "cfg-if",
+ "cfg_aliases 0.1.1",
  "libc",
 ]
 
@@ -6779,7 +7216,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -6981,9 +7418,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
+checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7015,7 +7452,7 @@ name = "observability"
 version = "0.201.0"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "dill",
  "http 0.2.12",
  "opentelemetry",
@@ -7026,7 +7463,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -7073,7 +7510,7 @@ dependencies = [
  "internal-error",
  "like",
  "multiformats",
- "prost",
+ "prost 0.12.6",
  "rand",
  "serde",
  "serde_with",
@@ -7081,7 +7518,7 @@ dependencies = [
  "sha3",
  "sqlx",
  "thiserror",
- "tonic",
+ "tonic 0.11.0",
  "url",
 ]
 
@@ -7139,10 +7576,10 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.12.6",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -7153,8 +7590,8 @@ checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -7313,9 +7750,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e977b9066b4d3b03555c22bdc442f3fadebd96a39111249113087d0edb2691cd"
+checksum = "f0fbf928021131daaa57d334ca8e3904fe9ae22f73c56244fc7db9b04eedc3d8"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -7811,6 +8248,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7860,7 +8319,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.2",
 ]
 
 [[package]]
@@ -7877,12 +8346,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.12.6"
+name = "prost-derive"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
- "prost",
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
+dependencies = [
+ "prost 0.13.2",
 ]
 
 [[package]]
@@ -8103,6 +8585,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -8340,20 +8828,20 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rumqttc"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8941c6791801b667d52bfe9ff4fc7c968d4f3f9ae8ae7abdaaa1c966feafc8"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
 dependencies = [
  "bytes",
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs 0.6.3",
- "rustls-pemfile 1.0.4",
- "rustls-webpki 0.101.7",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.1.3",
+ "rustls-webpki 0.102.8",
  "thiserror",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
 ]
 
 [[package]]
@@ -8451,6 +8939,20 @@ dependencies = [
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -8571,25 +9073,24 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "11.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "cfg-if",
  "clipboard-win",
- "dirs-next",
  "fd-lock",
+ "home",
  "libc",
  "log",
  "memchr",
- "nix 0.26.4",
+ "nix 0.28.0",
  "radix_trie",
- "scopeguard",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9002,24 +9503,23 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
 dependencies = [
- "doc-comment",
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9079,9 +9579,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
+checksum = "b2e5b515a2bd5168426033e9efbfd05500114833916f1d5c268f938b4ee130ac"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -9310,12 +9810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9432,9 +9926,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
+checksum = "4b95156f8b577cb59dc0b1df15c6f29a10afc5f8a7ac9786b0b5c68c19149278"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -9759,6 +10253,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
@@ -9878,20 +10383,50 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.6",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.5",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.2",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9915,6 +10450,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -11057,9 +11606,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,13 +255,13 @@ incremental = false
 debug = "line-tables-only"
 
 
-# Use this section to test or apply emergency overides to dependencies
+# Use this section to test or apply emergency overrides to dependencies
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 [patch.crates-io]
-# datafusion = { git = 'https://github.com/apache/datafusion.git', tag = '41.0.0-rc1' }
-# datafusion-common = { git = 'https://github.com/apache/datafusion.git', tag = '41.0.0-rc1' }
-# datafusion-execution = { git = 'https://github.com/apache/datafusion.git', tag = '41.0.0-rc1' }
-# datafusion-expr = { git = 'https://github.com/apache/datafusion.git', tag = '41.0.0-rc1' }
-datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = '41.0.0-axum-0.6' }
-# datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", tag = "41.0.0" }
+# datafusion = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
+# datafusion-common = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
+# datafusion-execution = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
+# datafusion-expr = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
+datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = '42.0.0-axum-0.6' }
+# datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", tag = "42.0.0" }
 # object_store = { git = 'https://github.com/s373r/arrow-rs', branch = 'add-debug-logs', package = "object_store" }

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ lint:
 	$(foreach crate,$(ALL_DATABASE_CRATES),(cd $(crate) && cargo sqlx prepare --check);)
 
 
+.PHONY: clippy
+clippy:
+	cargo clippy --workspace --all-targets -- -D warnings
+
 ###############################################################################
 # Lint (with fixes)
 ###############################################################################

--- a/src/adapter/flight-sql/Cargo.toml
+++ b/src/adapter/flight-sql/Cargo.toml
@@ -22,15 +22,15 @@ doctest = false
 
 
 [dependencies]
-arrow-flight = { version = "52", features = ["flight-sql-experimental"] }
+arrow-flight = { version = "53", features = ["flight-sql-experimental"] }
 async-trait = { version = "0.1", default-features = false }
 base64 = { version = "0.22", default-features = false }
 dashmap = { version = "6", default-features = false }
-datafusion = { version = "41", default-features = false }
+datafusion = { version = "42", default-features = false }
 futures = "0.3"
 like = { version = "0.3", default-features = false }
-prost = { version = "0.12", default-features = false }
-tonic = { version = "0.11", default-features = false }
+prost = { version = "0.13", default-features = false }
+tonic = { version = "0.12", default-features = false }
 tracing = { version = "0.1", default-features = false }
 uuid = { version = "1", default-features = false }
 

--- a/src/adapter/flight-sql/src/service.rs
+++ b/src/adapter/flight-sql/src/service.rs
@@ -138,6 +138,7 @@ impl KamuFlightSqlService {
             .map_err(|e| Status::internal(format!("Error: {e}")))
     }
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     fn get_catalogs(
         &self,
         ctx: &SessionContext,

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -45,7 +45,7 @@ async-graphql = { version = "6", features = [
 async-trait = { version = "0.1", default-features = false }
 cron = { version = "0.12", default-features = false }
 chrono = "0.4"
-datafusion = { version = "41", default-features = false, features = [
+datafusion = { version = "42", default-features = false, features = [
     "serde",
 ] } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.9"

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -43,7 +43,7 @@ base64 = { version = "0.22", default-features = false }
 bytes = "1"
 canonical_json = { version = "0.5.0", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
-datafusion = { version = "41", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
+datafusion = { version = "42", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.9"
 ed25519-dalek = { version = "2", default-features = false, features = [
     "std",

--- a/src/adapter/http/tests/tests/test_data_ingest.rs
+++ b/src/adapter/http/tests/tests/test_data_ingest.rs
@@ -73,7 +73,7 @@ async fn test_data_push_ingest_handler() {
                 indoc!(
                     r#"
                     message arrow_schema {
-                      OPTIONAL INT64 offset;
+                      REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -184,7 +184,7 @@ async fn test_data_push_ingest_handler() {
                 indoc!(
                     r#"
                     message arrow_schema {
-                      OPTIONAL INT64 offset;
+                      REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -245,7 +245,7 @@ async fn test_data_push_ingest_handler() {
                 indoc!(
                     r#"
                     message arrow_schema {
-                      OPTIONAL INT64 offset;
+                      REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -329,7 +329,7 @@ async fn test_data_push_ingest_upload_token_no_initial_source() {
                 indoc!(
                     r#"
                     message arrow_schema {
-                      OPTIONAL INT64 offset;
+                      REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -416,7 +416,7 @@ async fn test_data_push_ingest_upload_token_with_initial_source() {
                 indoc!(
                     r#"
                     message arrow_schema {
-                      OPTIONAL INT64 offset;
+                      REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -495,7 +495,7 @@ async fn test_data_push_ingest_upload_content_type_not_specified() {
                 indoc!(
                     r#"
                     message arrow_schema {
-                      OPTIONAL INT64 offset;
+                      REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));

--- a/src/adapter/http/tests/tests/test_data_query.rs
+++ b/src/adapter/http/tests/tests/test_data_query.rs
@@ -295,7 +295,7 @@ async fn test_data_query_handler_full() {
             .error_for_status()
             .unwrap();
 
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             res.json::<serde_json::Value>().await.unwrap(),
             json!({
                 "data": [{
@@ -307,7 +307,7 @@ async fn test_data_query_handler_full() {
                     "offset": 0,
                     "population": 100,
                 }],
-                "schema": "{\"fields\":[{\"name\":\"offset\",\"data_type\":\"Int64\",\"nullable\":true,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}},{\"name\":\"city\",\"data_type\":\"Utf8\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}},{\"name\":\"population\",\"data_type\":\"UInt64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}}],\"metadata\":{}}",
+                "schema": "{\"fields\":[{\"name\":\"offset\",\"data_type\":\"Int64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}},{\"name\":\"city\",\"data_type\":\"Utf8\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}},{\"name\":\"population\",\"data_type\":\"UInt64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}}],\"metadata\":{}}",
                 "dataHash": "f9680c001200b3483eecc3d5c6b50ee6b8cba11b51c08f89ea1f53d3a334c743199f5fe656e",
                 "state": {
                     "inputs": [{
@@ -465,14 +465,14 @@ async fn test_data_query_handler_v2() {
                 },
                 "subQueries": [],
                 "commitment": {
-                    "inputHash": "f1620a34bf5f8e0dbbe4ae6aefb60a3709d4eaaebd99173c90a0582c1b0011305a752",
-                    "outputHash": "f1620ba3be8f1b2ff3d37efc7051b43a1a78f635bb657874326ac394f99e486c6569d",
+                    "inputHash": "f1620986f955571b81e8f4c3753203fe08a9af520b84ec9079fd1351014d9fd24468a",
+                    "outputHash": "f16208d66e08ce876ba35ce00ea56f02faf83dbc086f877c443e3d493427ccad133f1",
                     "subQueriesHash": "f1620ca4510738395af1429224dd785675309c344b2b549632e20275c69b15ed1d210",
                 },
                 "proof": {
                     "type": "Ed25519Signature2020",
                     "verificationMethod": "did:key:z6Mko2nqhQ9wYSTS5Giab2j1aHzGnxHimqwmFeEVY8aNsVnN",
-                    "proofValue": "u2FwMK6jHGML0EBQ8X3Q7gfwUGLzZBe6jJeYRug6jDoZM8lvEqM_fUk9itia0htm7vRZ8MD_fezG2sgBCc8e-Bw",
+                    "proofValue": "uU6WTHFxAE2eMY4k0HGN8m-OGG9EkZSvjYa8-I8xWXVJBuMHWiUwtSeGCEjeFrCGn1ErYCs53t-8r0PHWxa2mDg",
                 }
             })
         );
@@ -619,14 +619,14 @@ async fn test_data_verify_handler() {
                 },
                 "subQueries": [],
                 "commitment": {
-                    "inputHash": "f1620c3e929e13d3f0f55ce24e7579919e01b356e79b4212a622b4fc2e7b0acb10d0d",
+                    "inputHash": "f1620deb55f2b02c11c74aba9a8b6c3cc740d7385c2ba3eb1d4b62a3b30ccfe116ec2",
                     "outputHash": "f1620ff7f5beaf16900218a3ac4aae82cdccf764816986c7c739c716cf7dc03112a2c",
                     "subQueriesHash": "f1620ca4510738395af1429224dd785675309c344b2b549632e20275c69b15ed1d210",
                 },
                 "proof": {
                     "type": "Ed25519Signature2020",
                     "verificationMethod": "did:key:z6Mko2nqhQ9wYSTS5Giab2j1aHzGnxHimqwmFeEVY8aNsVnN",
-                    "proofValue": "uZbm7fFcWc4l6iyvaKe_txdKntL3h3kvsGHOaKIbPV6c42PH1VnSmpYHMopv4TU67syzgoEdcS26AvpkSQb9dBQ",
+                    "proofValue": "u9rZLu4l6qisJUK8YlPNx3DCKy3jHFyOaFg5pheHrVdGt4ThdwCiWIwPjY5vE7GycGKy8axK7r8UEH-iGB2GtAQ",
                 }
             })
         );
@@ -1188,7 +1188,7 @@ async fn test_data_query_handler_schema_formats() {
             res.json::<serde_json::Value>().await.unwrap()["schema"]
                 .as_str()
                 .unwrap(),
-            r#"{"fields":[{"name":"offset","data_type":"Int64","nullable":true,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"city","data_type":"Utf8","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"population","data_type":"UInt64","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}}],"metadata":{}}"#
+            r#"{"fields":[{"name":"offset","data_type":"Int64","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"city","data_type":"Utf8","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"population","data_type":"UInt64","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}}],"metadata":{}}"#
         );
 
         let res = cl
@@ -1210,7 +1210,7 @@ async fn test_data_query_handler_schema_formats() {
             res.json::<serde_json::Value>().await.unwrap()["schema"]
                 .as_str()
                 .unwrap(),
-            r#"{"fields":[{"name":"offset","data_type":"Int64","nullable":true,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"city","data_type":"Utf8","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"population","data_type":"UInt64","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}}],"metadata":{}}"#
+            r#"{"fields":[{"name":"offset","data_type":"Int64","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"city","data_type":"Utf8","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}},{"name":"population","data_type":"UInt64","nullable":false,"dict_id":0,"dict_is_ordered":false,"metadata":{}}],"metadata":{}}"#
         );
 
         let res = cl
@@ -1234,7 +1234,7 @@ async fn test_data_query_handler_schema_formats() {
                 .unwrap(),
             indoc::indoc!(
                 r#"message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED BYTE_ARRAY city (STRING);
                   REQUIRED INT64 population (INTEGER(64,false));
                 }
@@ -1261,7 +1261,7 @@ async fn test_data_query_handler_schema_formats() {
             res.json::<serde_json::Value>().await.unwrap()["schema"]
                 .as_str()
                 .unwrap(),
-            r#"{"name": "arrow_schema", "type": "struct", "fields": [{"name": "offset", "repetition": "OPTIONAL", "type": "INT64"}, {"name": "city", "repetition": "REQUIRED", "type": "BYTE_ARRAY", "logicalType": "STRING"}, {"name": "population", "repetition": "REQUIRED", "type": "INT64", "logicalType": "INTEGER(64,false)"}]}"#
+            r#"{"name": "arrow_schema", "type": "struct", "fields": [{"name": "offset", "repetition": "REQUIRED", "type": "INT64"}, {"name": "city", "repetition": "REQUIRED", "type": "BYTE_ARRAY", "logicalType": "STRING"}, {"name": "population", "repetition": "REQUIRED", "type": "INT64", "logicalType": "INTEGER(64,false)"}]}"#
         );
     };
 
@@ -1404,7 +1404,7 @@ async fn test_metadata_handler_schema_formats() {
                                 "dict_is_ordered": false,
                                 "metadata": {},
                                 "name": "offset",
-                                "nullable": true
+                                "nullable": false
                             },
                             {
                                 "data_type": "Int32",
@@ -1484,7 +1484,7 @@ async fn test_metadata_handler_schema_formats() {
                         "fields": [
                             {
                                 "name": "offset",
-                                "repetition": "OPTIONAL",
+                                "repetition": "REQUIRED",
                                 "type": "INT64"
                             },
                             {
@@ -1537,7 +1537,7 @@ async fn test_metadata_handler_schema_formats() {
             json!({
                 "output": {
                     "schemaFormat": "Parquet",
-                    "schema": "message arrow_schema {\n  OPTIONAL INT64 offset;\n  REQUIRED INT32 op;\n  REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));\n  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));\n  REQUIRED BYTE_ARRAY city (STRING);\n  REQUIRED INT64 population (INTEGER(64,false));\n}\n",
+                    "schema": "message arrow_schema {\n  REQUIRED INT64 offset;\n  REQUIRED INT32 op;\n  REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));\n  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));\n  REQUIRED BYTE_ARRAY city (STRING);\n  REQUIRED INT64 population (INTEGER(64,false));\n}\n",
                 }
             })
         );

--- a/src/adapter/odata/Cargo.toml
+++ b/src/adapter/odata/Cargo.toml
@@ -32,8 +32,8 @@ opendatafabric = { workspace = true }
 
 axum = { version = "0.6", features = ["headers"] }
 chrono = { version = "0.4", default-features = false }
-datafusion = { version = "41", default-features = false }
-datafusion-odata = { version = "41", default-features = false }
+datafusion = { version = "42", default-features = false }
+datafusion-odata = { version = "42", default-features = false }
 dill = { version = "0.9" }
 futures = { version = "0.3", default-features = false }
 http = "0.2"
@@ -49,6 +49,7 @@ time-source = { workspace = true }
 hyper = { version = "0.14", default-features = false }
 indoc = { version = "2" }
 kamu = { workspace = true }
+pretty_assertions = { version = "1" }
 reqwest = { version = "0.11", default-features = false }
 tempfile = { version = "3" }
 test-group = { version = "1" }

--- a/src/adapter/odata/src/context.rs
+++ b/src/adapter/odata/src/context.rs
@@ -24,6 +24,7 @@ use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::dataframe::DataFrame;
 use datafusion_odata::collection::{CollectionAddr, QueryParams};
 use datafusion_odata::context::{CollectionContext, OnUnsupported, ServiceContext};
+use datafusion_odata::error::ODataError;
 use dill::Catalog;
 use internal_error::ResultIntoInternal;
 use kamu_core::*;
@@ -64,7 +65,7 @@ impl ServiceContext for ODataServiceContext {
         self.service_base_url.clone()
     }
 
-    async fn list_collections(&self) -> Vec<Arc<dyn CollectionContext>> {
+    async fn list_collections(&self) -> Result<Vec<Arc<dyn CollectionContext>>, ODataError> {
         use futures::TryStreamExt;
 
         let repo: Arc<dyn DatasetRepository> = self.catalog.get_one().unwrap();
@@ -93,7 +94,7 @@ impl ServiceContext for ODataServiceContext {
             }));
         }
 
-        collections
+        Ok(collections)
     }
 
     fn on_unsupported_feature(&self) -> OnUnsupported {
@@ -133,24 +134,28 @@ impl ODataCollectionContext {
 
 #[async_trait]
 impl CollectionContext for ODataCollectionContext {
-    fn addr(&self) -> &CollectionAddr {
-        &self.addr
+    fn addr(&self) -> Result<&CollectionAddr, ODataError> {
+        Ok(&self.addr)
     }
 
-    fn service_base_url(&self) -> String {
-        self.service_base_url.clone()
+    fn service_base_url(&self) -> Result<String, ODataError> {
+        Ok(self.service_base_url.clone())
     }
 
-    fn collection_base_url(&self) -> String {
-        format!("{}/{}", self.service_base_url(), self.collection_name())
+    fn collection_base_url(&self) -> Result<String, ODataError> {
+        Ok(format!(
+            "{}/{}",
+            self.service_base_url()?,
+            self.collection_name()?
+        ))
     }
 
-    fn collection_namespace(&self) -> String {
-        datafusion_odata::context::DEFAULT_NAMESPACE.to_string()
+    fn collection_namespace(&self) -> Result<String, ODataError> {
+        Ok(datafusion_odata::context::DEFAULT_NAMESPACE.to_string())
     }
 
-    fn collection_name(&self) -> String {
-        self.dataset_handle.alias.dataset_name.to_string()
+    fn collection_name(&self) -> Result<String, ODataError> {
+        Ok(self.dataset_handle.alias.dataset_name.to_string())
     }
 
     async fn last_updated_time(&self) -> DateTime<Utc> {
@@ -168,7 +173,7 @@ impl CollectionContext for ODataCollectionContext {
         last_block.system_time
     }
 
-    async fn schema(&self) -> SchemaRef {
+    async fn schema(&self) -> Result<SchemaRef, ODataError> {
         // TODO: Use QueryService after arrow schema is exposed
         // See: https://github.com/kamu-data/kamu-cli/issues/306
 
@@ -187,13 +192,13 @@ impl CollectionContext for ODataCollectionContext {
             .unwrap();
 
         if let Some(set_schema) = set_data_schema {
-            set_schema.schema_as_arrow().unwrap()
+            set_schema.schema_as_arrow().map_err(ODataError::internal)
         } else {
-            Arc::new(Schema::empty())
+            Ok(Arc::new(Schema::empty()))
         }
     }
 
-    async fn query(&self, query: QueryParams) -> datafusion::error::Result<DataFrame> {
+    async fn query(&self, query: QueryParams) -> Result<DataFrame, ODataError> {
         // TODO: Convert into config value
         let default_records_per_page: usize = std::env::var("KAMU_ODATA_DEFAULT_RECORDS_PER_PAGE")
             .ok()
@@ -205,7 +210,7 @@ impl CollectionContext for ODataCollectionContext {
             .as_metadata_chain()
             .accept_one(SearchSetVocabVisitor::new())
             .await
-            .map_err(|e| datafusion::error::DataFusionError::External(e.into()))?
+            .map_err(ODataError::internal)?
             .into_event()
             .map(Into::into)
             .unwrap_or_default();
@@ -217,14 +222,16 @@ impl CollectionContext for ODataCollectionContext {
             .await
             .unwrap();
 
-        query.apply(
-            df,
-            &self.addr,
-            &vocab.offset_column,
-            KEY_COLUMN_ALIAS,
-            default_records_per_page,
-            MAX_RECORDS_PER_PAGE,
-        )
+        query
+            .apply(
+                df,
+                &self.addr,
+                &vocab.offset_column,
+                KEY_COLUMN_ALIAS,
+                default_records_per_page,
+                MAX_RECORDS_PER_PAGE,
+            )
+            .map_err(ODataError::internal)
     }
 
     fn on_unsupported_feature(&self) -> OnUnsupported {

--- a/src/adapter/odata/tests/tests/test_handlers.rs
+++ b/src/adapter/odata/tests/tests/test_handlers.rs
@@ -56,7 +56,7 @@ async fn test_service_handler() {
         );
 
         let body = res.text().await.unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             body,
             indoc!(
                 r#"
@@ -101,7 +101,7 @@ async fn test_metadata_handler() {
         );
 
         let body = res.text().await.unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             body,
             indoc!(
                 r#"
@@ -110,8 +110,8 @@ async fn test_metadata_handler() {
                 <edmx:DataServices xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" m:DataServiceVersion="3.0" m:MaxDataServiceVersion="3.0">
                 <Schema Namespace="default" xmlns="http://schemas.microsoft.com/ado/2009/11/edm">
                 <EntityType Name="foo.bar">
-                <Key><PropertyRef Name="foo.bar"/></Key>
-                <Property Name="offset" Type="Edm.Int64" Nullable="true"/>
+                <Key><PropertyRef Name="offset"/></Key>
+                <Property Name="offset" Type="Edm.Int64" Nullable="false"/>
                 <Property Name="op" Type="Edm.Int32" Nullable="false"/>
                 <Property Name="system_time" Type="Edm.DateTime" Nullable="false"/>
                 <Property Name="date" Type="Edm.DateTime" Nullable="true"/>
@@ -154,7 +154,7 @@ async fn test_collection_handler() {
         );
 
         let body = res.text().await.unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             body,
             indoc!(
                 r#"
@@ -253,7 +253,7 @@ async fn test_collection_handler_by_id() {
         );
 
         let body = res.text().await.unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             body,
             indoc!(
                 r#"

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -29,13 +29,14 @@ doctest = false
 
 
 [features]
-default = ["kamu/ingest-evm", "kamu/ingest-mqtt", "kamu/query-extensions-json"]
+default = ["flight-sql", "ingest-evm", "ingest-mqtt", "query-extensions-json"]
 
-web-ui = ["rust-embed"]
+flight-sql = ["dep:kamu-adapter-flight-sql"]
 ingest-evm = ["kamu/ingest-evm"]
 ingest-ftp = ["kamu/ingest-ftp"]
 ingest-mqtt = ["kamu/ingest-mqtt"]
 query-extensions-json = ["kamu/query-extensions-json"]
+web-ui = ["rust-embed"]
 
 
 [dependencies]
@@ -52,7 +53,7 @@ kamu = { workspace = true }
 kamu-data-utils = { workspace = true }
 
 kamu-adapter-auth-oso = { workspace = true }
-kamu-adapter-flight-sql = { workspace = true }
+kamu-adapter-flight-sql = { optional = true, workspace = true }
 kamu-adapter-graphql = { workspace = true }
 kamu-adapter-http = { workspace = true }
 kamu-adapter-oauth = { workspace = true }
@@ -108,7 +109,7 @@ read_input = "0.8"                                                # Basic user i
 webbrowser = "0.8"                                                # For opening URLs in default system browser
 
 # APIs
-arrow-flight = { version = "52", features = ["flight-sql-experimental"] }
+arrow-flight = { version = "53", features = ["flight-sql-experimental"] }
 async-graphql = { version = "6", features = [
     "chrono",
     "url",
@@ -121,7 +122,7 @@ http = "0.2"
 hyper = "0.14"
 reqwest = { version = "0.11", default-features = false, features = [] }
 serde_json = "1"
-tonic = { version = "0.11", default-features = false }
+tonic = { version = "0.12", default-features = false }
 tower = "0.4"
 tower-http = { version = "0.4", features = ["trace", "cors"] }
 
@@ -158,7 +159,7 @@ tracing-bunyan-formatter = "0.3"
 async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1" # Conditional compilation
-datafusion = { version = "41", default-features = false, features = [
+datafusion = { version = "42", default-features = false, features = [
     "crypto_expressions",
     "encoding_expressions",
     "parquet",

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -368,11 +368,17 @@ pub fn get_command(
                         sc.port,
                     ))
                 } else if sc.flight_sql {
-                    Box::new(SqlServerFlightSqlCommand::new(
-                        sc.address,
-                        sc.port,
-                        cli_catalog.get_one()?,
-                    ))
+                    cfg_if::cfg_if! {
+                        if #[cfg(feature = "flight-sql")] {
+                            Box::new(SqlServerFlightSqlCommand::new(
+                                sc.address,
+                                sc.port,
+                                cli_catalog.get_one()?,
+                            ))
+                        } else {
+                            return Err(CLIError::usage_error("Kamu was compiled without Flight SQL support"))
+                        }
+                    }
                 } else {
                     Box::new(SqlServerCommand::new(
                         cli_catalog.get_one()?,

--- a/src/app/cli/src/commands/mod.rs
+++ b/src/app/cli/src/commands/mod.rs
@@ -41,6 +41,7 @@ mod reset_command;
 mod search_command;
 mod set_watermark_command;
 mod sql_server_command;
+#[cfg(feature = "flight-sql")]
 mod sql_server_flightsql_command;
 mod sql_server_livy_command;
 mod sql_shell_command;
@@ -91,6 +92,7 @@ pub use reset_command::*;
 pub use search_command::*;
 pub use set_watermark_command::*;
 pub use sql_server_command::*;
+#[cfg(feature = "flight-sql")]
 pub use sql_server_flightsql_command::*;
 pub use sql_server_livy_command::*;
 pub use sql_shell_command::*;

--- a/src/app/cli/src/commands/sql_server_flightsql_command.rs
+++ b/src/app/cli/src/commands/sql_server_flightsql_command.rs
@@ -100,7 +100,7 @@ struct SessionFactoryImpl {
 impl SessionFactory for SessionFactoryImpl {
     async fn authenticate(&self, username: &str, password: &str) -> Result<Token, Status> {
         if username == "kamu" && password == "kamu" {
-            Ok(String::new())
+            Ok(Token::new())
         } else {
             Err(Status::unauthenticated("Invalid credentials!"))
         }

--- a/src/domain/core/Cargo.toml
+++ b/src/domain/core/Cargo.toml
@@ -45,10 +45,10 @@ tracing = { version = "0.1", default-features = false }
 url = { version = "2", default-features = false, features = ["serde"] }
 
 # TODO: Avoid this dependency or depend on sub-crates
-datafusion = { version = "41", default-features = false, features = [
+datafusion = { version = "42", default-features = false, features = [
     "parquet",
 ] }
-object_store = { version = "0.10", default-features = false }
+object_store = { version = "0.11", default-features = false }
 
 # TODO: Make serde optional
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/src/domain/core/src/services/ingest/merge_strategy.rs
+++ b/src/domain/core/src/services/ingest/merge_strategy.rs
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use datafusion::prelude::{DataFrame, Expr};
+use datafusion::logical_expr::SortExpr;
+use datafusion::prelude::DataFrame;
 use internal_error::InternalError;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -38,7 +39,7 @@ pub trait MergeStrategy: Send + Sync {
 
     /// Returns the sort expression best suited for the output of this strategy
     /// to perform before writing the final result.
-    fn sort_order(&self) -> Vec<Expr>;
+    fn sort_order(&self) -> Vec<SortExpr>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/flow-system/domain/Cargo.toml
+++ b/src/domain/flow-system/domain/Cargo.toml
@@ -51,4 +51,4 @@ serde_with = { version = "3", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-datafusion = { version = "41", default-features = false }
+datafusion = { version = "42", default-features = false }

--- a/src/domain/opendatafabric/Cargo.toml
+++ b/src/domain/opendatafabric/Cargo.toml
@@ -68,7 +68,7 @@ prost = "0.12"
 tonic = "0.11"
 
 # Optional
-arrow = { optional = true, version = "52", default-features = false, features = [
+arrow = { optional = true, version = "53", default-features = false, features = [
     "ipc",
 ] }
 sqlx = { optional = true, version = "0.8", default-features = false }

--- a/src/e2e/app/cli/repo-tests/src/commands/test_ingest_command.rs
+++ b/src/e2e/app/cli/repo-tests/src/commands/test_ingest_command.rs
@@ -72,7 +72,7 @@ pub async fn test_push_ingest_from_file_ledger(mut kamu: KamuCliPuppet) {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -154,7 +154,7 @@ pub async fn test_push_ingest_from_file_snapshot_with_event_time(mut kamu: KamuC
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -68,9 +68,9 @@ secrecy = "0.8"
 zip = "0.6"
 
 # Data
-datafusion = { version = "41", default-features = false }
+datafusion = { version = "42", default-features = false }
 digest = "0.10"
-object_store = { version = "0.10", features = ["aws"] }
+object_store = { version = "0.11", features = ["aws"] }
 parking_lot = { version = "0.12" }
 sha3 = "0.10"
 
@@ -125,7 +125,7 @@ tower-http = { version = "0.4", features = ["fs", "trace"] }
 axum = "0.6"
 
 # Optional dependencies
-alloy = { optional = true, version = "0.2", default-features = false, features = [
+alloy = { optional = true, version = "0.3", default-features = false, features = [
     "std",
     "provider-http",
     "provider-ws",
@@ -138,9 +138,9 @@ curl = { optional = true, version = "0.4", features = [
     "static-ssl",
 ] }
 curl-sys = { optional = true, version = "0.4" }
-datafusion-ethers = { optional = true, version = "41" }
-datafusion-functions-json = { optional = true, version = "0.41" }
-rumqttc = { optional = true, version = "0.23" }
+datafusion-ethers = { optional = true, version = "42" }
+datafusion-functions-json = { optional = true, version = "0.42" }
+rumqttc = { optional = true, version = "0.24" }
 
 
 [target.'cfg(unix)'.dependencies]
@@ -154,7 +154,7 @@ kamu-accounts-services = { workspace = true }
 kamu-datasets-services = { workspace = true }
 
 criterion = { version = "0.5", features = ["async_tokio"] }
-datafusion = { version = "41", default-features = false, features = [
+datafusion = { version = "42", default-features = false, features = [
     "parquet",
 ] }
 filetime = "0.2"

--- a/src/infra/core/src/ingest/fetch_service/evm.rs
+++ b/src/infra/core/src/ingest/fetch_service/evm.rs
@@ -273,8 +273,7 @@ impl FetchService {
         Ok(FetchResult::Updated(FetchResultUpdated {
             source_state: Some(PollingSourceState::ETag(format!(
                 "{}@{:x}",
-                last_seen_block.header.number.unwrap(),
-                last_seen_block.header.hash.unwrap(),
+                last_seen_block.header.number, last_seen_block.header.hash,
             ))),
             source_event_time: None,
             has_more,

--- a/src/infra/core/src/query/mod.rs
+++ b/src/infra/core/src/query/mod.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -512,7 +513,7 @@ impl TableProvider for KamuTable {
         None
     }
 
-    fn get_logical_plan(&self) -> Option<&LogicalPlan> {
+    fn get_logical_plan(&self) -> Option<Cow<LogicalPlan>> {
         None
     }
 

--- a/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
@@ -121,7 +121,7 @@ async fn test_ingest_polling_snapshot() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -294,7 +294,7 @@ async fn test_ingest_polling_ledger() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -566,7 +566,7 @@ async fn test_ingest_polling_event_time_as_date() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT32 date (DATE);
@@ -721,7 +721,7 @@ async fn test_ingest_polling_bad_column_names_preserve() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   REQUIRED INT32 Date (UTC) (DATE);
@@ -814,7 +814,7 @@ async fn test_ingest_polling_bad_column_names_rename() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -906,7 +906,7 @@ async fn test_ingest_polling_preprocess_with_spark() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -998,7 +998,7 @@ async fn test_ingest_polling_preprocess_with_flink() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));

--- a/src/infra/core/tests/tests/ingest/test_push_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_push_ingest.rs
@@ -92,7 +92,7 @@ async fn test_ingest_push_url_stream() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -240,7 +240,7 @@ async fn test_ingest_push_media_type_override() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -293,7 +293,7 @@ async fn test_ingest_push_media_type_override() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -348,7 +348,7 @@ async fn test_ingest_push_media_type_override() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -528,7 +528,7 @@ async fn test_ingest_inference_automatic_coercion_of_event_time_from_string() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -608,7 +608,7 @@ async fn test_ingest_inference_automatic_coercion_of_event_time_from_unixtime() 
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -688,7 +688,7 @@ async fn test_ingest_inference_automatic_renaming_of_conflicting_columns() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -783,7 +783,7 @@ async fn test_ingest_sql_case_sensitivity() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));

--- a/src/infra/core/tests/tests/ingest/test_writer.rs
+++ b/src/infra/core/tests/tests/ingest/test_writer.rs
@@ -68,7 +68,7 @@ async fn test_data_writer_happy_path() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -133,7 +133,7 @@ async fn test_data_writer_happy_path() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -259,7 +259,7 @@ async fn test_data_writer_rejects_incompatible_schema() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -310,7 +310,7 @@ async fn test_data_writer_rejects_incompatible_schema() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -391,7 +391,7 @@ async fn test_data_writer_rejects_incompatible_schema() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -450,7 +450,7 @@ async fn test_data_writer_ledger_orders_by_event_time() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT32 event_time (DATE);
@@ -525,7 +525,7 @@ async fn test_data_writer_snapshot_orders_by_pk_and_operation_type() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -589,7 +589,7 @@ async fn test_data_writer_snapshot_orders_by_pk_and_operation_type() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
@@ -664,7 +664,7 @@ async fn test_data_writer_normalizes_timestamps_to_utc_millis() {
         indoc!(
             r#"
             message arrow_schema {
-              OPTIONAL INT64 offset;
+              REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));

--- a/src/infra/core/tests/tests/test_compact_service_impl.rs
+++ b/src/infra/core/tests/tests/test_compact_service_impl.rs
@@ -133,7 +133,7 @@ async fn test_dataset_compact() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -398,7 +398,7 @@ async fn test_dataset_compaction_watermark_only_blocks() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -562,7 +562,7 @@ async fn test_dataset_compaction_limits() {
                 indoc!(
                     r#"
                     message arrow_schema {
-                      OPTIONAL INT64 offset;
+                      REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -719,7 +719,7 @@ async fn test_dataset_compaction_keep_all_non_data_blocks() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -820,7 +820,7 @@ async fn test_large_dataset_compact() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
@@ -872,7 +872,7 @@ async fn test_large_dataset_compact() {
             indoc!(
                 r#"
                 message arrow_schema {
-                  OPTIONAL INT64 offset;
+                  REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));

--- a/src/infra/ingest-datafusion/Cargo.toml
+++ b/src/infra/ingest-datafusion/Cargo.toml
@@ -27,14 +27,13 @@ opendatafabric = { workspace = true, features = ["arrow"] }
 kamu-core = { workspace = true }
 kamu-data-utils = { workspace = true }
 
-datafusion = { version = "41", default-features = false }
+datafusion = { version = "42", default-features = false }
 digest = "0.10"
 geo-types = { version = "0.7", default-features = false, features = [] }
 geojson = { version = "0.24", default-features = false, features = [
     "geo-types",
 ] }
 glob = "0.3"
-object_store = { version = "0.10", features = ["aws"] }
 serde = { version = "1" }
 serde_json = "1"
 sha3 = "0.10"

--- a/src/infra/ingest-datafusion/src/merge_strategies/append.rs
+++ b/src/infra/ingest-datafusion/src/merge_strategies/append.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use datafusion::logical_expr::SortExpr;
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_data_utils::data::dataframe_ext::DataFrameExt;
@@ -43,7 +44,7 @@ impl MergeStrategy for MergeStrategyAppend {
         Ok(df)
     }
 
-    fn sort_order(&self) -> Vec<Expr> {
+    fn sort_order(&self) -> Vec<SortExpr> {
         vec![col(Column::from_name(&self.vocab.event_time_column)).sort(true, true)]
     }
 }

--- a/src/infra/ingest-datafusion/src/merge_strategies/ledger.rs
+++ b/src/infra/ingest-datafusion/src/merge_strategies/ledger.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use datafusion::logical_expr::SortExpr;
 use datafusion::prelude::*;
 use internal_error::*;
 use kamu_data_utils::data::dataframe_ext::DataFrameExt;
@@ -75,7 +76,7 @@ impl MergeStrategy for MergeStrategyLedger {
         Ok(res)
     }
 
-    fn sort_order(&self) -> Vec<Expr> {
+    fn sort_order(&self) -> Vec<SortExpr> {
         vec![col(Column::from_name(&self.vocab.event_time_column)).sort(true, true)]
     }
 }

--- a/src/infra/ingest-datafusion/src/readers/csv.rs
+++ b/src/infra/ingest-datafusion/src/readers/csv.rs
@@ -108,6 +108,7 @@ impl Reader for ReaderCsv {
         let options = CsvReadOptions {
             schema: self.schema.as_deref(),
             delimiter,
+            terminator: None,
             comment: None,
             has_header: self.conf.header.unwrap_or(false),
             schema_infer_max_records: if self.conf.infer_schema.unwrap_or(false) {

--- a/src/utils/data-utils/Cargo.toml
+++ b/src/utils/data-utils/Cargo.toml
@@ -25,10 +25,10 @@ doctest = false
 opendatafabric = { workspace = true }
 
 async-trait = "0.1"
-arrow = { version = "52", default-features = false }
-arrow-json = { version = "52", default-features = false }
-arrow-digest = { version = "52", default-features = false }
-datafusion = { version = "41", default-features = false, features = [
+arrow = { version = "53", default-features = false }
+arrow-json = { version = "53", default-features = false }
+arrow-digest = { version = "53", default-features = false }
+datafusion = { version = "42", default-features = false, features = [
     "parquet",
     "serde",
 ] }

--- a/src/utils/datafusion-cli/Cargo.toml
+++ b/src/utils/datafusion-cli/Cargo.toml
@@ -30,12 +30,15 @@ edition = { workspace = true }
 publish = { workspace = true }
 
 [dependencies]
-arrow = { version = "52" }
-async-trait = "0.1"
-aws-config = "0.57"
-aws-credential-types = "0.57"
+arrow = { version = "53" }
+async-trait = "0.1.73"
+aws-config = "1.5.5"
+aws-sdk-sso = "1"
+aws-sdk-ssooidc = "1"
+aws-sdk-sts = "1"
+aws-credential-types = "1.2.0"
 clap = { version = "4", features = ["derive"] }
-datafusion = { version = "41", features = [
+datafusion = { version = "42", features = [
     "crypto_expressions",
     "datetime_expressions",
     "encoding_expressions",
@@ -44,14 +47,14 @@ datafusion = { version = "41", features = [
     "unicode_expressions",
     "compression",
 ] }
-datafusion-common = { version = "41", default-features = false }
-dirs = "5"
+dirs = "5.0.1"
+env_logger = "0.11"
 futures = "0.3"
-object_store = { version = "0.10.1", features = ["aws", "gcp", "http"] }
+object_store = { version = "0.11", features = ["aws", "gcp", "http"] }
 parking_lot = { version = "0.12" }
-parquet = { version = "52", default-features = false }
-regex = "1"
-rustyline = "11"
+parquet = { version = "53", default-features = false }
+regex = "1.8"
+rustyline = "14.0"
 tokio = { version = "1", features = [
     "macros",
     "rt",
@@ -60,4 +63,4 @@ tokio = { version = "1", features = [
     "parking_lot",
     "signal",
 ] }
-url = { version = "2" }
+url = "2"

--- a/src/utils/datafusion-cli/src/exec.rs
+++ b/src/utils/datafusion-cli/src/exec.rs
@@ -68,6 +68,9 @@ pub async fn exec_from_lines(
 
     for line in reader.lines() {
         match line {
+            Ok(line) if line.starts_with("#!") => {
+                continue;
+            }
             Ok(line) if line.starts_with("--") => {
                 continue;
             }

--- a/src/utils/datafusion-cli/src/functions.rs
+++ b/src/utils/datafusion-cli/src/functions.rs
@@ -36,6 +36,7 @@ use datafusion::physical_plan::memory::MemoryExec;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::scalar::ScalarValue;
 use parquet::basic::ConvertedType;
+use parquet::data_type::{ByteArray, FixedLenByteArray};
 use parquet::file::reader::FileReader;
 use parquet::file::serialized_reader::SerializedFileReader;
 use parquet::file::statistics::Statistics;
@@ -250,45 +251,67 @@ impl TableProvider for ParquetMetadataTable {
 fn convert_parquet_statistics(
     value: &Statistics,
     converted_type: ConvertedType,
-) -> (String, String) {
+) -> (Option<String>, Option<String>) {
     match (value, converted_type) {
-        (Statistics::Boolean(val), _) => (val.min().to_string(), val.max().to_string()),
-        (Statistics::Int32(val), _) => (val.min().to_string(), val.max().to_string()),
-        (Statistics::Int64(val), _) => (val.min().to_string(), val.max().to_string()),
-        (Statistics::Int96(val), _) => (val.min().to_string(), val.max().to_string()),
-        (Statistics::Float(val), _) => (val.min().to_string(), val.max().to_string()),
-        (Statistics::Double(val), _) => (val.min().to_string(), val.max().to_string()),
-        (Statistics::ByteArray(val), ConvertedType::UTF8) => {
-            let min_bytes = val.min();
-            let max_bytes = val.max();
-            let min = min_bytes
-                .as_utf8()
-                .map(|v| v.to_string())
-                .unwrap_or_else(|_| min_bytes.to_string());
-
-            let max = max_bytes
-                .as_utf8()
-                .map(|v| v.to_string())
-                .unwrap_or_else(|_| max_bytes.to_string());
-            (min, max)
-        }
-        (Statistics::ByteArray(val), _) => (val.min().to_string(), val.max().to_string()),
-        (Statistics::FixedLenByteArray(val), ConvertedType::UTF8) => {
-            let min_bytes = val.min();
-            let max_bytes = val.max();
-            let min = min_bytes
-                .as_utf8()
-                .map(|v| v.to_string())
-                .unwrap_or_else(|_| min_bytes.to_string());
-
-            let max = max_bytes
-                .as_utf8()
-                .map(|v| v.to_string())
-                .unwrap_or_else(|_| max_bytes.to_string());
-            (min, max)
-        }
-        (Statistics::FixedLenByteArray(val), _) => (val.min().to_string(), val.max().to_string()),
+        (Statistics::Boolean(val), _) => (
+            val.min_opt().map(|v| v.to_string()),
+            val.max_opt().map(|v| v.to_string()),
+        ),
+        (Statistics::Int32(val), _) => (
+            val.min_opt().map(|v| v.to_string()),
+            val.max_opt().map(|v| v.to_string()),
+        ),
+        (Statistics::Int64(val), _) => (
+            val.min_opt().map(|v| v.to_string()),
+            val.max_opt().map(|v| v.to_string()),
+        ),
+        (Statistics::Int96(val), _) => (
+            val.min_opt().map(|v| v.to_string()),
+            val.max_opt().map(|v| v.to_string()),
+        ),
+        (Statistics::Float(val), _) => (
+            val.min_opt().map(|v| v.to_string()),
+            val.max_opt().map(|v| v.to_string()),
+        ),
+        (Statistics::Double(val), _) => (
+            val.min_opt().map(|v| v.to_string()),
+            val.max_opt().map(|v| v.to_string()),
+        ),
+        (Statistics::ByteArray(val), ConvertedType::UTF8) => (
+            byte_array_to_string(val.min_opt()),
+            byte_array_to_string(val.max_opt()),
+        ),
+        (Statistics::ByteArray(val), _) => (
+            val.min_opt().map(|v| v.to_string()),
+            val.max_opt().map(|v| v.to_string()),
+        ),
+        (Statistics::FixedLenByteArray(val), ConvertedType::UTF8) => (
+            fixed_len_byte_array_to_string(val.min_opt()),
+            fixed_len_byte_array_to_string(val.max_opt()),
+        ),
+        (Statistics::FixedLenByteArray(val), _) => (
+            val.min_opt().map(|v| v.to_string()),
+            val.max_opt().map(|v| v.to_string()),
+        ),
     }
+}
+
+/// Convert to a string if it has utf8 encoding, otherwise print bytes directly
+fn byte_array_to_string(val: Option<&ByteArray>) -> Option<String> {
+    val.map(|v| {
+        v.as_utf8()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|_e| v.to_string())
+    })
+}
+
+/// Convert to a string if it has utf8 encoding, otherwise print bytes directly
+fn fixed_len_byte_array_to_string(val: Option<&FixedLenByteArray>) -> Option<String> {
+    val.map(|v| {
+        v.as_utf8()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|_e| v.to_string())
+    })
 }
 
 pub struct ParquetMetadataFunc {}
@@ -376,16 +399,11 @@ impl TableFunctionImpl for ParquetMetadataFunc {
                 let converted_type = column.column_descr().converted_type();
 
                 if let Some(s) = column.statistics() {
-                    let (min_val, max_val) = if s.has_min_max_set() {
-                        let (min_val, max_val) = convert_parquet_statistics(s, converted_type);
-                        (Some(min_val), Some(max_val))
-                    } else {
-                        (None, None)
-                    };
+                    let (min_val, max_val) = convert_parquet_statistics(s, converted_type);
                     stats_min_arr.push(min_val.clone());
                     stats_max_arr.push(max_val.clone());
-                    stats_null_count_arr.push(Some(s.null_count() as i64));
-                    stats_distinct_count_arr.push(s.distinct_count().map(|c| c as i64));
+                    stats_null_count_arr.push(s.null_count_opt().map(|c| c as i64));
+                    stats_distinct_count_arr.push(s.distinct_count_opt().map(|c| c as i64));
                     stats_min_value_arr.push(min_val);
                     stats_max_value_arr.push(max_val);
                 } else {

--- a/src/utils/datafusion-cli/src/helper.rs
+++ b/src/utils/datafusion-cli/src/helper.rs
@@ -118,8 +118,8 @@ impl Highlighter for CliHelper {
         self.highlighter.highlight(line, pos)
     }
 
-    fn highlight_char(&self, line: &str, pos: usize) -> bool {
-        self.highlighter.highlight_char(line, pos)
+    fn highlight_char(&self, line: &str, pos: usize, forced: bool) -> bool {
+        self.highlighter.highlight_char(line, pos, forced)
     }
 }
 

--- a/src/utils/datafusion-cli/src/highlighter.rs
+++ b/src/utils/datafusion-cli/src/highlighter.rs
@@ -68,7 +68,7 @@ impl Highlighter for SyntaxHighlighter {
         }
     }
 
-    fn highlight_char(&self, line: &str, _: usize) -> bool {
+    fn highlight_char(&self, line: &str, _pos: usize, _forced: bool) -> bool {
         !line.is_empty()
     }
 }

--- a/src/utils/datafusion-cli/src/object_storage.rs
+++ b/src/utils/datafusion-cli/src/object_storage.rs
@@ -20,6 +20,7 @@ use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use aws_config::BehaviorVersion;
 use aws_credential_types::provider::ProvideCredentials;
 use datafusion::common::config::{
     ConfigEntry,
@@ -63,7 +64,7 @@ pub async fn get_s3_object_store_builder(
             builder = builder.with_token(session_token);
         }
     } else {
-        let config = aws_config::from_env().load().await;
+        let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
         if let Some(region) = config.region() {
             builder = builder.with_region(region.to_string());
         }

--- a/src/utils/datafusion-cli/src/pool_type.rs
+++ b/src/utils/datafusion-cli/src/pool_type.rs
@@ -18,7 +18,7 @@
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum PoolType {
     Greedy,
     Fair,

--- a/src/utils/kamu-cli-puppet/Cargo.toml
+++ b/src/utils/kamu-cli-puppet/Cargo.toml
@@ -46,7 +46,7 @@ kamu-data-utils = { optional = true, workspace = true }
 opendatafabric = { optional = true, workspace = true }
 
 async-trait = { optional = true, version = "0.1" }
-datafusion = { optional = true, version = "41", default-features = false }
+datafusion = { optional = true, version = "42", default-features = false }
 serde = { optional = true, version = "1", default-features = false, features = [
     "derive",
 ] }


### PR DESCRIPTION
This branch tries to get DF 42 upgrade into a consistent state, but we might not want to merge it even if tests pass, because:
- `arrow-flight` is using newer `tonic` than `opendatafabric`, leading to duplication
- `object_store` is using new `http` stack
- `datafusion-cli` is using v1 of `aws-sdk`, leading to massive duplication
