### PR TITLE
kamu-cli#834: failed flows should still propagate `finishedAt` time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!--- - Changed -->
 <!--- - Fixed -->
 
+## [Unreleased]
+### Fixed
+- Failed flows should still propagate `finishedAt` time
+
 ## [0.201.0] - 2024-09-18
 ### Added
 - REST API: New `/verify` endpoint allows verification of query commitment as per [documentation](https://docs.kamu.dev/node/commitments/#dispute-resolution) (#831)

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_flow_runs.rs
@@ -2932,7 +2932,7 @@ async fn test_execute_transfrom_flow_error_after_compaction() {
                                         "timing": {
                                             "awaitingExecutorSince": schedule_time.to_rfc3339(),
                                             "runningSince": running_time.to_rfc3339(),
-                                            "finishedAt": null,
+                                            "finishedAt": complete_time.to_rfc3339(),
                                         },
                                         "tasks": [
                                             {

--- a/src/domain/flow-system/domain/src/entities/flow/flow_state.rs
+++ b/src/domain/flow-system/domain/src/entities/flow/flow_state.rs
@@ -207,26 +207,25 @@ impl Projection for FlowState {
                             // Ignore for idempotence motivation
                             Ok(s)
                         } else {
+                            let timing = FlowTimingRecords {
+                                finished_at: Some(event_time),
+                                ..s.timing
+                            };
                             match task_outcome {
                                 ts::TaskOutcome::Success(task_result) => Ok(FlowState {
                                     outcome: Some(FlowOutcome::Success(task_result.clone().into())),
-                                    timing: FlowTimingRecords {
-                                        finished_at: Some(event_time),
-                                        ..s.timing
-                                    },
+                                    timing,
                                     ..s
                                 }),
                                 ts::TaskOutcome::Cancelled => Ok(FlowState {
                                     outcome: Some(FlowOutcome::Aborted),
-                                    timing: FlowTimingRecords {
-                                        finished_at: Some(event_time),
-                                        ..s.timing
-                                    },
+                                    timing,
                                     ..s
                                 }),
                                 // TODO: support retries
                                 ts::TaskOutcome::Failed(task_error) => Ok(FlowState {
                                     outcome: Some(FlowOutcome::Failed(task_error.into())),
+                                    timing,
                                     ..s
                                 }),
                             }


### PR DESCRIPTION
## Description

Closes: #834.


## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅ 
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will node need to be updated with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅