### PR TITLE
JSON encoding of lists and structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Added
+- Support `List` and `Struct` arrow types in `json` and `json-aoa` encodings
+
 ## [0.202.1] - 2024-09-20
 ### Fixed
 - Open Telemetry integration fixes

--- a/src/utils/data-utils/src/data/format/csv.rs
+++ b/src/utils/data-utils/src/data/format/csv.rs
@@ -1,0 +1,450 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::io::Write;
+
+use arrow::array::AsArray;
+use arrow::datatypes::DataType;
+use datafusion::arrow::record_batch::RecordBatch;
+
+use super::*;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug)]
+pub struct CsvWriterOptions {
+    /// Whether to write column names as file headers. Defaults to `true`
+    pub header: bool,
+    /// Optional column delimiter. Defaults to `b','`
+    pub delimiter: u8,
+    /// Optional quote character. Defaults to `b'"'`
+    pub quote: u8,
+}
+
+impl Default for CsvWriterOptions {
+    fn default() -> Self {
+        Self {
+            header: true,
+            delimiter: b',',
+            quote: b'"',
+        }
+    }
+}
+
+pub struct CsvWriter<W> {
+    writer: W,
+    options: CsvWriterOptions,
+    rows_written: usize,
+}
+
+impl<W> CsvWriter<W> {
+    pub fn new(writer: W, options: CsvWriterOptions) -> Self {
+        Self {
+            writer,
+            options,
+            rows_written: 0,
+        }
+    }
+}
+
+impl<W: Write> RecordsWriter for CsvWriter<W> {
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), WriterError> {
+        if self.rows_written == 0 && self.options.header {
+            for (i, field) in batch.schema_ref().fields().iter().enumerate() {
+                if i != 0 {
+                    self.writer.write_all(&[self.options.delimiter])?;
+                }
+                // TODO: quote / escape
+                CsvEscapeStringEncoder::write_escaped(
+                    &mut self.writer,
+                    field.name(),
+                    &self.options,
+                )?;
+            }
+            self.rows_written += 1;
+        }
+
+        let mut encoders = Vec::new();
+        for (f, c) in batch.schema_ref().fields().iter().zip(batch.columns()) {
+            encoders.push(encoder_for(f.data_type(), c, &self.options));
+        }
+
+        for idx in 0..batch.num_rows() {
+            if self.rows_written != 0 {
+                self.writer.write_all(b"\n")?;
+            }
+
+            for (i, e) in encoders.iter_mut().enumerate() {
+                if i != 0 {
+                    self.writer.write_all(&[self.options.delimiter])?;
+                }
+                e.encode(idx, &mut self.writer)?;
+            }
+
+            self.rows_written += 1;
+        }
+
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn encoder_for<'a>(
+    dt: &'a DataType,
+    c: &'a dyn arrow::array::Array,
+    opts: &'a CsvWriterOptions,
+) -> Box<dyn Encoder + 'a> {
+    use arrow::datatypes as dts;
+    match dt {
+        DataType::Null => Box::new(CsvNullEncoder),
+        DataType::Boolean => Box::new(CsvNullableEncoder(c, BooleanEncoder(c.as_boolean()))),
+        DataType::Int8 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int8Type>()),
+        )),
+        DataType::Int16 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int16Type>()),
+        )),
+        DataType::Int32 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int32Type>()),
+        )),
+        DataType::Int64 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::Int64Type>()),
+        )),
+        DataType::UInt8 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt8Type>()),
+        )),
+        DataType::UInt16 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt16Type>()),
+        )),
+        DataType::UInt32 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt32Type>()),
+        )),
+        DataType::UInt64 => Box::new(CsvNullableEncoder(
+            c,
+            IntegerEncoder(c.as_primitive::<dts::UInt64Type>()),
+        )),
+        DataType::Float16 => Box::new(CsvNullableEncoder(c, Float16Encoder(c.as_primitive()))),
+        DataType::Float32 => Box::new(CsvNullableEncoder(c, Float32Encoder(c.as_primitive()))),
+        DataType::Float64 => Box::new(CsvNullableEncoder(c, Float64Encoder(c.as_primitive()))),
+        DataType::Decimal128(_, _) => {
+            Box::new(CsvNullableEncoder(c, Decimal128Encoder(c.as_primitive())))
+        }
+        DataType::Decimal256(_, _) => {
+            Box::new(CsvNullableEncoder(c, Decimal256Encoder(c.as_primitive())))
+        }
+        DataType::Utf8 => Box::new(CsvNullableEncoder(
+            c,
+            CsvEscapeStringEncoder::new(StringEncoder(c.as_string::<i32>()), opts),
+        )),
+        DataType::LargeUtf8 => Box::new(CsvNullableEncoder(
+            c,
+            CsvEscapeStringEncoder::new(StringEncoder(c.as_string::<i64>()), opts),
+        )),
+        DataType::Timestamp(_, _)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Duration(_)
+        | DataType::Interval(_) => {
+            let options = arrow::util::display::FormatOptions::new().with_display_error(true);
+            let formatter = arrow::util::display::ArrayFormatter::try_new(c, &options).unwrap();
+            Box::new(CsvNullableEncoder(c, ArrowEncoder(formatter)))
+        }
+        DataType::Binary => Box::new(CsvNullableEncoder(
+            c,
+            BinaryHexEncoder(c.as_binary::<i32>()),
+        )),
+        DataType::LargeBinary => Box::new(CsvNullableEncoder(
+            c,
+            BinaryHexEncoder(c.as_binary::<i64>()),
+        )),
+        DataType::FixedSizeBinary(_) => Box::new(CsvNullableEncoder(
+            c,
+            BinaryFixedHexEncoder(c.as_fixed_size_binary()),
+        )),
+        DataType::List(_)
+        | DataType::ListView(_)
+        | DataType::FixedSizeList(_, _)
+        | DataType::LargeList(_)
+        | DataType::LargeListView(_)
+        | DataType::Struct(_) => Box::new(CsvNullableEncoder(
+            c,
+            CsvEscapeStringEncoder::new(
+                super::json::encoder_for(dt, c, &|f, e| {
+                    Box::new(super::json::JsonStructAoSEncoder(f, e))
+                }),
+                opts,
+            ),
+        )),
+        DataType::BinaryView
+        | DataType::Utf8View
+        | DataType::Union(_, _)
+        | DataType::Dictionary(_, _)
+        | DataType::Map(_, _)
+        | DataType::RunEndEncoded(_, _) => {
+            unimplemented!("CSV encoding is not yet supported for {}", dt)
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct CsvEscapeStringEncoder<'a, E: Encoder>(E, &'a CsvWriterOptions, Vec<u8>);
+impl<'a, E: Encoder> CsvEscapeStringEncoder<'a, E> {
+    fn new(e: E, opts: &'a CsvWriterOptions) -> Self {
+        Self(e, opts, Vec::new())
+    }
+}
+
+impl CsvEscapeStringEncoder<'static, CsvNullEncoder> {
+    fn write_escaped(
+        buf: &mut dyn std::io::Write,
+        s: &str,
+        opts: &CsvWriterOptions,
+    ) -> Result<(), WriterError> {
+        if !s.contains([
+            char::from(opts.delimiter),
+            char::from(opts.quote),
+            '\n',
+            '\r',
+        ]) {
+            buf.write_all(s.as_bytes())?;
+        } else {
+            buf.write_all(&[opts.quote])?;
+            let double_quote = [opts.quote, opts.quote];
+            let s = s.replace(
+                char::from(opts.quote),
+                std::str::from_utf8(&double_quote).unwrap(),
+            );
+            buf.write_all(s.as_bytes())?;
+            buf.write_all(&[opts.quote])?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a, E: Encoder> Encoder for CsvEscapeStringEncoder<'a, E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        self.0.encode(idx, &mut self.2)?;
+        CsvEscapeStringEncoder::write_escaped(buf, std::str::from_utf8(&self.2).unwrap(), self.1)?;
+        self.2.clear();
+        Ok(())
+    }
+}
+
+struct CsvNullEncoder;
+impl Encoder for CsvNullEncoder {
+    fn encode(&mut self, _idx: usize, _buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        Ok(())
+    }
+}
+
+struct CsvNullableEncoder<'a, E: Encoder + 'a>(&'a dyn arrow::array::Array, E);
+impl<'a, E: Encoder + 'a> Encoder for CsvNullableEncoder<'a, E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        if self.0.is_null(idx) {
+            CsvNullEncoder.encode(idx, buf)
+        } else {
+            self.1.encode(idx, buf)
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::*;
+    use arrow::datatypes::*;
+
+    use super::*;
+
+    #[test_log::test]
+    fn test_csv_empty() {
+        let batch = get_empty_batch();
+        assert_csv_output(
+            batch.clone(),
+            CsvWriterOptions::default(),
+            "nullable,uint64,decimal,utf8,utf8_special,bin,bin_fixed,ts_milli",
+        );
+        assert_csv_output(
+            batch,
+            CsvWriterOptions {
+                header: false,
+                ..Default::default()
+            },
+            "",
+        );
+    }
+
+    #[test_log::test]
+    fn test_csv_simple() {
+        let batch = get_sample_batch();
+        assert_csv_output(
+            batch,
+            CsvWriterOptions::default(),
+            indoc::indoc!(
+                r#"
+                nullable,uint64,decimal,utf8,utf8_special,bin,bin_fixed,ts_milli
+                1,100,5789604461865809771178549250434395392663499233282028201972879200395656481996,foo,"sep,quotes'"",newline
+                fin",666f6f,0102,2020-01-01T12:00:00Z
+                ,200,-5789604461865809771178549250434395392663499233282028201972879200395656481996,bar,,626172,0304,2020-01-01T12:01:00Z
+                "#
+            )
+            .trim(),
+        );
+    }
+
+    #[test_log::test]
+    fn test_csv_nested() {
+        let batch = get_nested_batch();
+        assert_csv_output(
+            batch,
+            CsvWriterOptions::default(),
+            indoc::indoc!(
+                r#"
+                list_fixed_i32,list_str
+                ,
+                "[1,2]",[]
+                ,"[""foo"",""bar""]"
+                ,"[""baz"",null]"
+                "#
+            )
+            .trim(),
+        );
+    }
+
+    fn get_empty_batch() -> RecordBatch {
+        RecordBatch::new_empty(Arc::new(Schema::new(vec![
+            Field::new("nullable", DataType::UInt64, true),
+            Field::new("uint64", DataType::UInt64, false),
+            Field::new("decimal", DataType::Decimal256(76, 0), false),
+            Field::new("utf8", DataType::Utf8, false),
+            Field::new("utf8_special", DataType::Utf8, true),
+            Field::new("bin", DataType::Binary, false),
+            Field::new("bin_fixed", DataType::FixedSizeBinary(2), false),
+            Field::new(
+                "ts_milli",
+                DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("UTC"))),
+                false,
+            ),
+        ])))
+    }
+
+    fn get_sample_batch() -> RecordBatch {
+        RecordBatch::try_new(
+            get_empty_batch().schema(),
+            vec![
+                Arc::new(UInt64Array::from(vec![Some(1), None])),
+                Arc::new(UInt64Array::from(vec![100, 200])),
+                Arc::new(
+                    Decimal256Array::from(vec![i256::MAX, i256::MIN])
+                        .with_precision_and_scale(76, 0)
+                        .unwrap(),
+                ),
+                Arc::new(StringArray::from(vec![
+                    "foo".to_string(),
+                    "bar".to_string(),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("sep,quotes'\",newline\nfin".to_string()),
+                    None,
+                ])),
+                Arc::new(BinaryArray::from(vec![&b"foo"[..], &b"bar"[..]])),
+                Arc::new({
+                    let v = vec![vec![1, 2], vec![3, 4]];
+                    FixedSizeBinaryArray::try_from_iter(v.into_iter()).unwrap()
+                }),
+                Arc::new(
+                    TimestampMillisecondArray::from(vec![
+                        // 2020-01-01T12:00:00Z
+                        1_577_880_000_000,
+                        // 2020-01-01T12:01:00Z
+                        1_577_880_060_000,
+                    ])
+                    .with_timezone(Arc::from("UTC")),
+                ),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn get_nested_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "list_fixed_i32",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int32, true)), 2),
+                true,
+            ),
+            Field::new(
+                "list_str",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            ),
+        ]));
+
+        let mut list_fixed_i32 = FixedSizeListBuilder::new(Int32Builder::new(), 2);
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.append(false); // null
+        list_fixed_i32.values().append_value(1);
+        list_fixed_i32.values().append_value(2);
+        list_fixed_i32.append(true); // [1, 2]
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.append(false); // null
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.append(false); // null
+
+        let mut list_str = ListBuilder::new(StringBuilder::new());
+        list_str.append(false); // null
+        list_str.append(true); // []
+        list_str.values().append_value("foo");
+        list_str.values().append_value("bar");
+        list_str.append(true); // ["foo", "bar"]
+        list_str.values().append_value("baz");
+        list_str.values().append_null();
+        list_str.append(true); // [null]
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(list_fixed_i32.finish()),
+                Arc::new(list_str.finish()),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn assert_csv_output(batch: RecordBatch, opts: CsvWriterOptions, expected: &str) {
+        let mut buf = Vec::new();
+        {
+            let mut writer = CsvWriter::new(&mut buf, opts);
+            writer.write_batch(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+        let actual = std::str::from_utf8(&buf).unwrap();
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+}

--- a/src/utils/data-utils/src/data/format/json.rs
+++ b/src/utils/data-utils/src/data/format/json.rs
@@ -7,144 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::io::{BufWriter, ErrorKind, Write};
+use std::io::Write;
 
 use arrow::array::{AsArray, OffsetSizeTrait};
-use arrow::datatypes::{ArrowPrimitiveType, DataType, SchemaRef};
-use arrow::error::ArrowError;
+use arrow::datatypes::{DataType, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use serde::ser::Serializer;
-use thiserror::Error;
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// RecordsWriter
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-pub trait RecordsWriter {
-    fn write_batch(&mut self, records: &RecordBatch) -> Result<(), WriterError>;
-
-    fn write_batches(&mut self, record_batches: &[RecordBatch]) -> Result<(), WriterError> {
-        for records in record_batches {
-            self.write_batch(records)?;
-        }
-        Ok(())
-    }
-
-    fn finish(&mut self) -> Result<(), WriterError> {
-        Ok(())
-    }
-
-    fn handle_writer_result(
-        &self,
-        writer_result: Result<(), ArrowError>,
-    ) -> Result<(), WriterError> {
-        if let Err(err) = writer_result {
-            match err {
-                ArrowError::IoError(_, io_err) => match io_err.kind() {
-                    ErrorKind::BrokenPipe => (),
-                    _ => return Err(WriterError::IoError(io_err)),
-                },
-                err => return Err(WriterError::ArrowError(err)),
-            };
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum WriterError {
-    #[error(transparent)]
-    DataTooLarge(#[from] DataTooLarge),
-    #[error(transparent)]
-    IoError(#[from] std::io::Error),
-    #[error(transparent)]
-    ArrowError(#[from] ArrowError),
-}
-
-#[derive(Debug, Error)]
-#[error("Data is too large to fit in the defined serialization buffer")]
-pub struct DataTooLarge;
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// CSV
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#[derive(Debug)]
-pub struct CsvWriterOptions {
-    /// Whether to write column names as file headers. Defaults to `true`
-    pub header: bool,
-    /// Optional column delimiter. Defaults to `b','`
-    pub delimiter: u8,
-    /// Optional quote character. Defaults to `b'"'`
-    pub quote: u8,
-}
-
-impl Default for CsvWriterOptions {
-    fn default() -> Self {
-        Self {
-            header: true,
-            delimiter: b',',
-            quote: b'"',
-        }
-    }
-}
-
-pub struct CsvWriter<W> {
-    writer: W,
-    options: CsvWriterOptions,
-    rows_written: usize,
-}
-
-impl<W> CsvWriter<W> {
-    pub fn new(writer: W, options: CsvWriterOptions) -> Self {
-        Self {
-            writer,
-            options,
-            rows_written: 0,
-        }
-    }
-}
-
-impl<W: Write> RecordsWriter for CsvWriter<W> {
-    fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), WriterError> {
-        if self.rows_written == 0 && self.options.header {
-            for (i, field) in batch.schema_ref().fields().iter().enumerate() {
-                if i != 0 {
-                    self.writer.write_all(&[self.options.delimiter])?;
-                }
-                // TODO: quote / escape
-                CsvEscapeStringEncoder::write_escaped(
-                    &mut self.writer,
-                    field.name(),
-                    &self.options,
-                )?;
-            }
-            self.rows_written += 1;
-        }
-
-        let mut encoders = Vec::new();
-        for (f, c) in batch.schema_ref().fields().iter().zip(batch.columns()) {
-            encoders.push(encoder_for_csv(f.data_type(), c, &self.options));
-        }
-
-        for idx in 0..batch.num_rows() {
-            if self.rows_written != 0 {
-                self.writer.write_all(b"\n")?;
-            }
-
-            for (i, e) in encoders.iter_mut().enumerate() {
-                if i != 0 {
-                    self.writer.write_all(&[self.options.delimiter])?;
-                }
-                e.encode(idx, &mut self.writer)?;
-            }
-
-            self.rows_written += 1;
-        }
-
-        Ok(())
-    }
-}
+use super::*;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // JSON Array-of-Structures
@@ -167,36 +37,22 @@ impl<W: std::io::Write> JsonArrayOfStructsWriter<W> {
 
 impl<W: Write> RecordsWriter for JsonArrayOfStructsWriter<W> {
     fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), WriterError> {
-        let mut encoders = Vec::new();
-        for (f, c) in batch.schema_ref().fields().iter().zip(batch.columns()) {
-            encoders.push(encoder_for_json(f.data_type(), c));
+        if batch.num_rows() == 0 {
+            return Ok(());
         }
+
+        let struct_array: arrow::array::StructArray = batch.clone().into();
+        let struct_array_data_type = DataType::Struct(struct_array.fields().clone());
+        let mut encoder = encoder_for(&struct_array_data_type, &struct_array, &|f, e| {
+            Box::new(JsonStructAoSEncoder(f, e))
+        });
 
         for idx in 0..batch.num_rows() {
             if !self.empty {
                 self.writer.write_all(b",")?;
             }
 
-            self.writer.write_all(b"{")?;
-
-            for (i, (e, f)) in encoders
-                .iter_mut()
-                .zip(batch.schema_ref().fields().iter())
-                .enumerate()
-            {
-                if i != 0 {
-                    self.writer.write_all(b",")?;
-                }
-
-                {
-                    let mut serializer = serde_json::Serializer::new(&mut self.writer);
-                    serializer.serialize_str(f.name()).unwrap();
-                }
-                self.writer.write_all(b":")?;
-                e.encode(idx, &mut self.writer)?;
-            }
-
-            self.writer.write_all(b"}")?;
+            encoder.encode(idx, &mut self.writer)?;
             self.empty = false;
         }
 
@@ -229,36 +85,22 @@ impl<W: std::io::Write> JsonLineDelimitedWriter<W> {
 
 impl<W: Write> RecordsWriter for JsonLineDelimitedWriter<W> {
     fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), WriterError> {
-        let mut encoders = Vec::new();
-        for (f, c) in batch.schema_ref().fields().iter().zip(batch.columns()) {
-            encoders.push(encoder_for_json(f.data_type(), c));
+        if batch.num_rows() == 0 {
+            return Ok(());
         }
+
+        let struct_array: arrow::array::StructArray = batch.clone().into();
+        let struct_array_data_type = DataType::Struct(struct_array.fields().clone());
+        let mut encoder = encoder_for(&struct_array_data_type, &struct_array, &|f, e| {
+            Box::new(JsonStructAoSEncoder(f, e))
+        });
 
         for idx in 0..batch.num_rows() {
             if !self.empty {
                 self.writer.write_all(b"\n")?;
             }
 
-            self.writer.write_all(b"{")?;
-
-            for (i, (e, f)) in encoders
-                .iter_mut()
-                .zip(batch.schema_ref().fields().iter())
-                .enumerate()
-            {
-                if i != 0 {
-                    self.writer.write_all(b",")?;
-                }
-
-                {
-                    let mut serializer = serde_json::Serializer::new(&mut self.writer);
-                    serializer.serialize_str(f.name()).unwrap();
-                }
-                self.writer.write_all(b":")?;
-                e.encode(idx, &mut self.writer)?;
-            }
-
-            self.writer.write_all(b"}")?;
+            encoder.encode(idx, &mut self.writer)?;
             self.empty = false;
         }
 
@@ -276,7 +118,7 @@ impl<W: Write> RecordsWriter for JsonLineDelimitedWriter<W> {
 
 pub struct JsonArrayOfArraysWriter<W> {
     writer: W,
-    started: bool,
+    empty: bool,
 }
 
 impl<W: std::io::Write> JsonArrayOfArraysWriter<W> {
@@ -284,7 +126,7 @@ impl<W: std::io::Write> JsonArrayOfArraysWriter<W> {
         writer.write_all(b"[").unwrap();
         Self {
             writer,
-            started: false,
+            empty: true,
         }
     }
 
@@ -299,30 +141,19 @@ impl<W: std::io::Write> RecordsWriter for JsonArrayOfArraysWriter<W> {
             return Ok(());
         }
 
-        let mut buf: BufWriter<&mut dyn std::io::Write> =
-            BufWriter::with_capacity(16 * 1024, &mut self.writer);
-
-        let mut encoders = Vec::new();
-        for (f, c) in batch.schema().fields().iter().zip(batch.columns()) {
-            encoders.push(encoder_for_json(f.data_type(), c));
-        }
+        let struct_array: arrow::array::StructArray = batch.clone().into();
+        let struct_array_data_type = DataType::Struct(struct_array.fields().clone());
+        let mut encoder = encoder_for(&struct_array_data_type, &struct_array, &|f, e| {
+            Box::new(JsonStructAoAEncoder(f, e))
+        });
 
         for idx in 0..batch.num_rows() {
-            if self.started {
-                write!(&mut buf, ",")?;
+            if !self.empty {
+                self.writer.write_all(b",")?;
             }
-            self.started = true;
+            self.empty = false;
 
-            write!(&mut buf, "[")?;
-            let mut first = true;
-            for e in &mut encoders {
-                if !first {
-                    write!(&mut buf, ",")?;
-                }
-                e.encode(idx, &mut buf)?;
-                first = false;
-            }
-            write!(&mut buf, "]")?;
+            encoder.encode(idx, &mut self.writer)?;
         }
 
         Ok(())
@@ -382,7 +213,9 @@ impl<W: std::io::Write> RecordsWriter for JsonStructOfArraysWriter<W> {
         {
             let buf_start_len = buf.len();
 
-            let mut encoder = encoder_for_json(f.data_type(), c);
+            let mut encoder = encoder_for(f.data_type(), c, &|_, _| {
+                unimplemented!("SoA encoding for struct types is not yet supported")
+            });
             for idx in 0..c.len() {
                 if buf.len() > 1 {
                     buf.push(b',');
@@ -424,16 +257,15 @@ impl<W: std::io::Write> RecordsWriter for JsonStructOfArraysWriter<W> {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Row-wise encoders
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-trait Encoder {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError>;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-fn encoder_for_json<'a>(dt: &DataType, c: &'a dyn arrow::array::Array) -> Box<dyn Encoder + 'a> {
+pub fn encoder_for<'a>(
+    dt: &'a DataType,
+    c: &'a dyn arrow::array::Array,
+    nested: &dyn Fn(
+        &'a arrow::datatypes::Fields,
+        Vec<Box<dyn Encoder + 'a>>,
+    ) -> Box<dyn Encoder + 'a>,
+) -> Box<dyn Encoder + 'a> {
     use arrow::datatypes as dts;
     match dt {
         DataType::Null => Box::new(JsonNullEncoder),
@@ -515,196 +347,47 @@ fn encoder_for_json<'a>(dt: &DataType, c: &'a dyn arrow::array::Array) -> Box<dy
             c,
             JsonSafeStringEncoder(BinaryFixedHexEncoder(c.as_fixed_size_binary())),
         )),
+        DataType::List(field) => {
+            let list = c.as_list::<i32>();
+            let item_encoder = encoder_for(field.data_type(), list.values(), nested);
+            Box::new(JsonNullableEncoder(c, JsonListEncoder(list, item_encoder)))
+        }
+        DataType::LargeList(field) => {
+            let list = c.as_list::<i64>();
+            let item_encoder = encoder_for(field.data_type(), list.values(), nested);
+            Box::new(JsonNullableEncoder(c, JsonListEncoder(list, item_encoder)))
+        }
+        DataType::FixedSizeList(field, len) => {
+            let list = c.as_fixed_size_list();
+            let item_encoder = encoder_for(field.data_type(), list.values(), nested);
+            Box::new(JsonNullableEncoder(
+                c,
+                JsonFixedSizeListEncoder(usize::try_from(*len).unwrap(), item_encoder),
+            ))
+        }
+        DataType::Struct(fields) => {
+            let arr = c.as_struct();
+            let encoders = fields
+                .iter()
+                .zip(arr.columns())
+                .map(|(f, a)| encoder_for(f.data_type(), a, nested))
+                .collect();
+            Box::new(JsonNullableEncoder(c, nested(fields, encoders)))
+        }
         DataType::BinaryView
         | DataType::Utf8View
-        | DataType::List(_)
         | DataType::ListView(_)
-        | DataType::FixedSizeList(_, _)
-        | DataType::LargeList(_)
         | DataType::LargeListView(_)
-        | DataType::Struct(_)
         | DataType::Union(_, _)
         | DataType::Dictionary(_, _)
         | DataType::Map(_, _)
         | DataType::RunEndEncoded(_, _) => {
-            unimplemented!("Array-of-Arrays encoding is not yet supported for {}", dt)
+            unimplemented!("JSON encoding is not yet supported for {}", dt)
         }
     }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-fn encoder_for_csv<'a>(
-    dt: &DataType,
-    c: &'a dyn arrow::array::Array,
-    opts: &'a CsvWriterOptions,
-) -> Box<dyn Encoder + 'a> {
-    use arrow::datatypes as dts;
-    match dt {
-        DataType::Null => Box::new(CsvNullEncoder),
-        DataType::Boolean => Box::new(CsvNullableEncoder(c, BooleanEncoder(c.as_boolean()))),
-        DataType::Int8 => Box::new(CsvNullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::Int8Type>()),
-        )),
-        DataType::Int16 => Box::new(CsvNullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::Int16Type>()),
-        )),
-        DataType::Int32 => Box::new(CsvNullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::Int32Type>()),
-        )),
-        DataType::Int64 => Box::new(CsvNullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::Int64Type>()),
-        )),
-        DataType::UInt8 => Box::new(CsvNullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::UInt8Type>()),
-        )),
-        DataType::UInt16 => Box::new(CsvNullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::UInt16Type>()),
-        )),
-        DataType::UInt32 => Box::new(CsvNullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::UInt32Type>()),
-        )),
-        DataType::UInt64 => Box::new(CsvNullableEncoder(
-            c,
-            IntegerEncoder(c.as_primitive::<dts::UInt64Type>()),
-        )),
-        DataType::Float16 => Box::new(CsvNullableEncoder(c, Float16Encoder(c.as_primitive()))),
-        DataType::Float32 => Box::new(CsvNullableEncoder(c, Float32Encoder(c.as_primitive()))),
-        DataType::Float64 => Box::new(CsvNullableEncoder(c, Float64Encoder(c.as_primitive()))),
-        DataType::Decimal128(_, _) => {
-            Box::new(CsvNullableEncoder(c, Decimal128Encoder(c.as_primitive())))
-        }
-        DataType::Decimal256(_, _) => {
-            Box::new(CsvNullableEncoder(c, Decimal256Encoder(c.as_primitive())))
-        }
-        DataType::Utf8 => Box::new(CsvNullableEncoder(
-            c,
-            CsvEscapeStringEncoder::new(StringEncoder(c.as_string::<i32>()), opts),
-        )),
-        DataType::LargeUtf8 => Box::new(CsvNullableEncoder(
-            c,
-            CsvEscapeStringEncoder::new(StringEncoder(c.as_string::<i64>()), opts),
-        )),
-        DataType::Timestamp(_, _)
-        | DataType::Date32
-        | DataType::Date64
-        | DataType::Time32(_)
-        | DataType::Time64(_)
-        | DataType::Duration(_)
-        | DataType::Interval(_) => {
-            let options = arrow::util::display::FormatOptions::new().with_display_error(true);
-            let formatter = arrow::util::display::ArrayFormatter::try_new(c, &options).unwrap();
-            Box::new(CsvNullableEncoder(c, ArrowEncoder(formatter)))
-        }
-        DataType::Binary => Box::new(CsvNullableEncoder(
-            c,
-            BinaryHexEncoder(c.as_binary::<i32>()),
-        )),
-        DataType::LargeBinary => Box::new(CsvNullableEncoder(
-            c,
-            BinaryHexEncoder(c.as_binary::<i64>()),
-        )),
-        DataType::FixedSizeBinary(_) => Box::new(CsvNullableEncoder(
-            c,
-            BinaryFixedHexEncoder(c.as_fixed_size_binary()),
-        )),
-        DataType::BinaryView
-        | DataType::Utf8View
-        | DataType::List(_)
-        | DataType::ListView(_)
-        | DataType::FixedSizeList(_, _)
-        | DataType::LargeList(_)
-        | DataType::LargeListView(_)
-        | DataType::Struct(_)
-        | DataType::Union(_, _)
-        | DataType::Dictionary(_, _)
-        | DataType::Map(_, _)
-        | DataType::RunEndEncoded(_, _) => {
-            unimplemented!("Array-of-Arrays encoding is not yet supported for {}", dt)
-        }
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct JsonEscapeStringEncoder<E: Encoder>(E, Vec<u8>);
-impl<E: Encoder> JsonEscapeStringEncoder<E> {
-    fn new(e: E) -> Self {
-        Self(e, Vec::new())
-    }
-}
-impl<E: Encoder> Encoder for JsonEscapeStringEncoder<E> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        self.0.encode(idx, &mut self.1)?;
-        let mut serializer = serde_json::Serializer::new(buf);
-        serializer
-            .serialize_str(std::str::from_utf8(&self.1).unwrap())
-            .unwrap();
-
-        self.1.clear();
-        Ok(())
-    }
-}
-
-struct JsonSafeStringEncoder<E: Encoder>(E);
-impl<E: Encoder> Encoder for JsonSafeStringEncoder<E> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        write!(buf, "\"")?;
-        self.0.encode(idx, buf)?;
-        write!(buf, "\"")?;
-        Ok(())
-    }
-}
-
-struct CsvEscapeStringEncoder<'a, E: Encoder>(E, &'a CsvWriterOptions, Vec<u8>);
-impl<'a, E: Encoder> CsvEscapeStringEncoder<'a, E> {
-    fn new(e: E, opts: &'a CsvWriterOptions) -> Self {
-        Self(e, opts, Vec::new())
-    }
-}
-
-impl CsvEscapeStringEncoder<'static, CsvNullEncoder> {
-    fn write_escaped(
-        buf: &mut dyn std::io::Write,
-        s: &str,
-        opts: &CsvWriterOptions,
-    ) -> Result<(), WriterError> {
-        if !s.contains([
-            char::from(opts.delimiter),
-            char::from(opts.quote),
-            '\n',
-            '\r',
-        ]) {
-            buf.write_all(s.as_bytes())?;
-        } else {
-            buf.write_all(&[opts.quote])?;
-            let double_quote = [opts.quote, opts.quote];
-            let s = s.replace(
-                char::from(opts.quote),
-                std::str::from_utf8(&double_quote).unwrap(),
-            );
-            buf.write_all(s.as_bytes())?;
-            buf.write_all(&[opts.quote])?;
-        }
-        Ok(())
-    }
-}
-
-impl<'a, E: Encoder> Encoder for CsvEscapeStringEncoder<'a, E> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        self.0.encode(idx, &mut self.2)?;
-        CsvEscapeStringEncoder::write_escaped(buf, std::str::from_utf8(&self.2).unwrap(), self.1)?;
-        self.2.clear();
-        Ok(())
-    }
-}
 
 struct JsonNullEncoder;
 impl Encoder for JsonNullEncoder {
@@ -725,132 +408,124 @@ impl<'a, E: Encoder + 'a> Encoder for JsonNullableEncoder<'a, E> {
     }
 }
 
-struct CsvNullEncoder;
-impl Encoder for CsvNullEncoder {
-    fn encode(&mut self, _idx: usize, _buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::unnecessary_wraps)]
+fn write_string_quoted_escaped(s: &str, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+    let mut serializer = serde_json::Serializer::new(buf);
+    serializer.serialize_str(s).unwrap();
+    Ok(())
+}
+
+struct JsonEscapeStringEncoder<E: Encoder>(E, Vec<u8>);
+impl<E: Encoder> JsonEscapeStringEncoder<E> {
+    fn new(e: E) -> Self {
+        Self(e, Vec::new())
+    }
+}
+impl<E: Encoder> Encoder for JsonEscapeStringEncoder<E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        self.0.encode(idx, &mut self.1)?;
+        write_string_quoted_escaped(std::str::from_utf8(&self.1).unwrap(), buf)?;
+        self.1.clear();
         Ok(())
     }
 }
 
-struct CsvNullableEncoder<'a, E: Encoder + 'a>(&'a dyn arrow::array::Array, E);
-impl<'a, E: Encoder + 'a> Encoder for CsvNullableEncoder<'a, E> {
+struct JsonSafeStringEncoder<E: Encoder>(E);
+impl<E: Encoder> Encoder for JsonSafeStringEncoder<E> {
     fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        if self.0.is_null(idx) {
-            CsvNullEncoder.encode(idx, buf)
-        } else {
-            self.1.encode(idx, buf)
-        }
-    }
-}
-
-struct BooleanEncoder<'a>(&'a arrow::array::BooleanArray);
-impl<'a> Encoder for BooleanEncoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        if self.0.value(idx) {
-            write!(buf, "true")?;
-        } else {
-            write!(buf, "false")?;
-        }
+        write!(buf, "\"")?;
+        self.0.encode(idx, buf)?;
+        write!(buf, "\"")?;
         Ok(())
     }
 }
 
-struct IntegerEncoder<'a, T: ArrowPrimitiveType>(&'a arrow::array::PrimitiveArray<T>);
-impl<'a, T: ArrowPrimitiveType> Encoder for IntegerEncoder<'a, T>
-where
-    <T as ArrowPrimitiveType>::Native: std::fmt::Display,
-{
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        write!(buf, "{}", self.0.value(idx))?;
-        Ok(())
-    }
-}
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct Float16Encoder<'a>(&'a arrow::array::Float16Array);
-impl<'a> Encoder for Float16Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        let mut serializer = serde_json::Serializer::new(buf);
-        serializer
-            .serialize_f32(self.0.value(idx).to_f32())
-            .unwrap();
-        Ok(())
-    }
-}
-
-struct Float32Encoder<'a>(&'a arrow::array::Float32Array);
-impl<'a> Encoder for Float32Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        let mut serializer = serde_json::Serializer::new(buf);
-        serializer.serialize_f32(self.0.value(idx)).unwrap();
-        Ok(())
-    }
-}
-
-struct Float64Encoder<'a>(&'a arrow::array::Float64Array);
-impl<'a> Encoder for Float64Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        let mut serializer = serde_json::Serializer::new(buf);
-        serializer.serialize_f64(self.0.value(idx)).unwrap();
-        Ok(())
-    }
-}
-
-struct Decimal128Encoder<'a>(&'a arrow::array::Decimal128Array);
-impl<'a> Encoder for Decimal128Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        // TODO: PERF: Avoid allocation
-        write!(buf, "{}", self.0.value_as_string(idx))?;
-        Ok(())
-    }
-}
-
-struct Decimal256Encoder<'a>(&'a arrow::array::Decimal256Array);
-impl<'a> Encoder for Decimal256Encoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        // TODO: PERF: Avoid allocation
-        write!(buf, "{}", self.0.value_as_string(idx))?;
-        Ok(())
-    }
-}
-
-struct StringEncoder<'a, OffsetSize: OffsetSizeTrait>(
-    &'a arrow::array::GenericStringArray<OffsetSize>,
+struct JsonListEncoder<'a, OffsetSize: OffsetSizeTrait, E: Encoder>(
+    &'a arrow::array::GenericListArray<OffsetSize>,
+    E,
 );
-impl<'a, OffsetSize: OffsetSizeTrait> Encoder for StringEncoder<'a, OffsetSize> {
+impl<'a, OffsetSize: OffsetSizeTrait, E: Encoder> Encoder for JsonListEncoder<'a, OffsetSize, E> {
     fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        write!(buf, "{}", self.0.value(idx))?;
+        write!(buf, "[")?;
+        let start = self.0.value_offsets()[idx].as_usize();
+        let end = self.0.value_offsets()[idx + 1].as_usize();
+        for slice_idx in start..end {
+            if slice_idx != start {
+                write!(buf, ",")?;
+            }
+            self.1.encode(slice_idx, buf)?;
+        }
+        write!(buf, "]")?;
         Ok(())
     }
 }
 
-struct BinaryHexEncoder<'a, OffsetSize: OffsetSizeTrait>(
-    &'a arrow::array::GenericBinaryArray<OffsetSize>,
+struct JsonFixedSizeListEncoder<E: Encoder>(usize, E);
+impl<E: Encoder> Encoder for JsonFixedSizeListEncoder<E> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "[")?;
+        let start = idx * self.0;
+        let end = start + self.0;
+        for slice_idx in start..end {
+            if slice_idx != start {
+                write!(buf, ",")?;
+            }
+            self.1.encode(slice_idx, buf)?;
+        }
+        write!(buf, "]")?;
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct JsonStructAoSEncoder<'a>(
+    pub &'a arrow::datatypes::Fields,
+    pub Vec<Box<dyn Encoder + 'a>>,
 );
-impl<'a, OffsetSize: OffsetSizeTrait> Encoder for BinaryHexEncoder<'a, OffsetSize> {
+impl<'a> Encoder for JsonStructAoSEncoder<'a> {
     fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        let hex_str = hex::encode(self.0.value(idx));
-        write!(buf, "{hex_str}")?;
+        buf.write_all(b"{")?;
+
+        for (i, (e, f)) in self.1.iter_mut().zip(self.0.iter()).enumerate() {
+            if i != 0 {
+                buf.write_all(b",")?;
+            }
+
+            write_string_quoted_escaped(f.name(), buf)?;
+            buf.write_all(b":")?;
+            e.encode(idx, buf)?;
+        }
+
+        buf.write_all(b"}")?;
+
         Ok(())
     }
 }
 
-struct BinaryFixedHexEncoder<'a>(&'a arrow::array::FixedSizeBinaryArray);
-impl<'a> Encoder for BinaryFixedHexEncoder<'a> {
+pub struct JsonStructAoAEncoder<'a>(
+    pub &'a arrow::datatypes::Fields,
+    pub Vec<Box<dyn Encoder + 'a>>,
+);
+impl<'a> Encoder for JsonStructAoAEncoder<'a> {
     fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        let hex_str = hex::encode(self.0.value(idx));
-        write!(buf, "{hex_str}")?;
-        Ok(())
-    }
-}
+        write!(buf, "[")?;
 
-/// This encoder uses default arrow representation as determined by
-/// [`arrow::util::display::ArrayFormatter`]. When using this encoder you have
-/// to be absolutely sure that result does not include symbols that have special
-/// meaning within a JSON string.
-struct ArrowEncoder<'a>(arrow::util::display::ArrayFormatter<'a>);
-impl<'a> Encoder for ArrowEncoder<'a> {
-    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
-        write!(buf, "{}", self.0.value(idx))?;
+        let mut first = true;
+        for e in &mut self.1 {
+            if !first {
+                write!(buf, ",")?;
+            }
+            first = false;
+
+            e.encode(idx, buf)?;
+        }
+        write!(buf, "]")?;
+
         Ok(())
     }
 }
@@ -866,7 +541,6 @@ mod tests {
 
     use arrow::array::*;
     use arrow::datatypes::*;
-    use arrow_json::ArrayWriter;
     use serde_json::json;
 
     use super::*;
@@ -881,7 +555,7 @@ mod tests {
 
         let mut buf = Vec::new();
         {
-            let mut writer = ArrayWriter::new(&mut buf);
+            let mut writer = arrow_json::ArrayWriter::new(&mut buf);
             writer.write(&batch).unwrap();
             writer.finish().unwrap();
         }
@@ -926,6 +600,51 @@ mod tests {
         );
     }
 
+    #[test_log::test]
+    fn test_json_aos_lists() {
+        let batch = get_batch_lists();
+        assert_aos_output(
+            batch,
+            json!([
+                {
+                    "list_fixed_i32": null,
+                    "list_str": null,
+                },
+                {
+                    "list_fixed_i32": [1, 2],
+                    "list_str": [],
+                },
+                {
+                    "list_fixed_i32": null,
+                    "list_str": ["foo", "bar"],
+                },
+                {
+                    "list_fixed_i32": null,
+                    "list_str": ["baz", null],
+                },
+            ]),
+        );
+    }
+
+    #[test_log::test]
+    fn test_json_aos_structs() {
+        let batch = get_batch_structs();
+        assert_aos_output(
+            batch,
+            json!([
+                {
+                    "struct": {"a": "foo", "b": "baz"},
+                },
+                {
+                    "struct": {"a": "bar", "b": null},
+                },
+                {
+                    "struct": null,
+                },
+            ]),
+        );
+    }
+
     // AoA
     #[test_log::test]
     fn test_json_aoa_empty() {
@@ -961,6 +680,26 @@ mod tests {
                 ],
             ]),
         );
+    }
+
+    #[test_log::test]
+    fn test_json_aoa_lists() {
+        let batch = get_batch_lists();
+        assert_aoa_output(
+            batch,
+            json!([
+                [null, null],
+                [[1, 2], []],
+                [null, ["foo", "bar"]],
+                [null, ["baz", null]]
+            ]),
+        );
+    }
+
+    #[test_log::test]
+    fn test_json_aoa_structs() {
+        let batch = get_batch_structs();
+        assert_aoa_output(batch, json!([[["foo", "baz"]], [["bar", null]], [null]]));
     }
 
     // SoA
@@ -999,6 +738,18 @@ mod tests {
                 "uint64": [100, 200],
                 "utf8": ["foo", "bar"],
                 "utf8_special": ["sep,quotes'\",newline\nfin", null],
+            }),
+        );
+    }
+
+    #[test_log::test]
+    fn test_json_soa_lists() {
+        let batch = get_batch_lists();
+        assert_soa_output(
+            batch,
+            json!({
+                "list_fixed_i32": [null, [1, 2], null, null],
+                "list_str": [null, [], ["foo", "bar"], ["baz", null]],
             }),
         );
     }
@@ -1052,43 +803,6 @@ mod tests {
         );
     }
 
-    // CSV
-    #[test_log::test]
-    fn test_csv_empty() {
-        let batch = get_empty_batch();
-        assert_csv_output(
-            batch.clone(),
-            CsvWriterOptions::default(),
-            "nullable,uint64,decimal,utf8,utf8_special,bin,bin_fixed,ts_milli",
-        );
-        assert_csv_output(
-            batch,
-            CsvWriterOptions {
-                header: false,
-                ..Default::default()
-            },
-            "",
-        );
-    }
-
-    #[test_log::test]
-    fn test_csv_simple() {
-        let batch = get_sample_batch();
-        assert_csv_output(
-            batch,
-            CsvWriterOptions::default(),
-            indoc::indoc!(
-                r#"
-                nullable,uint64,decimal,utf8,utf8_special,bin,bin_fixed,ts_milli
-                1,100,5789604461865809771178549250434395392663499233282028201972879200395656481996,foo,"sep,quotes'"",newline
-                fin",666f6f,0102,2020-01-01T12:00:00Z
-                ,200,-5789604461865809771178549250434395392663499233282028201972879200395656481996,bar,,626172,0304,2020-01-01T12:01:00Z
-                "#
-            )
-            .trim(),
-        );
-    }
-
     fn get_empty_batch() -> RecordBatch {
         RecordBatch::new_empty(Arc::new(Schema::new(vec![
             Field::new("nullable", DataType::UInt64, true),
@@ -1117,12 +831,9 @@ mod tests {
                         .with_precision_and_scale(76, 0)
                         .unwrap(),
                 ),
+                Arc::new(StringArray::from(vec!["foo", "bar"])),
                 Arc::new(StringArray::from(vec![
-                    "foo".to_string(),
-                    "bar".to_string(),
-                ])),
-                Arc::new(StringArray::from(vec![
-                    Some("sep,quotes'\",newline\nfin".to_string()),
+                    Some("sep,quotes'\",newline\nfin"),
                     None,
                 ])),
                 Arc::new(BinaryArray::from(vec![&b"foo"[..], &b"bar"[..]])),
@@ -1144,6 +855,83 @@ mod tests {
         .unwrap()
     }
 
+    fn get_batch_lists() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "list_fixed_i32",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int32, true)), 2),
+                true,
+            ),
+            Field::new(
+                "list_str",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            ),
+        ]));
+
+        let mut list_fixed_i32 = FixedSizeListBuilder::new(Int32Builder::new(), 2);
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.append(false); // null
+        list_fixed_i32.values().append_value(1);
+        list_fixed_i32.values().append_value(2);
+        list_fixed_i32.append(true); // [1, 2]
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.append(false); // null
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.values().append_null();
+        list_fixed_i32.append(false); // null
+
+        let mut list_str = ListBuilder::new(StringBuilder::new());
+        list_str.append(false); // null
+        list_str.append(true); // []
+        list_str.values().append_value("foo");
+        list_str.values().append_value("bar");
+        list_str.append(true); // ["foo", "bar"]
+        list_str.values().append_value("baz");
+        list_str.values().append_null();
+        list_str.append(true); // [null]
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(list_fixed_i32.finish()),
+                Arc::new(list_str.finish()),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn get_batch_structs() -> RecordBatch {
+        let struct_fields = Fields::from(vec![
+            Arc::new(Field::new("a", DataType::Utf8, true)),
+            Arc::new(Field::new("b", DataType::Utf8, true)),
+        ]);
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "struct",
+            DataType::Struct(struct_fields.clone()),
+            true,
+        )]));
+
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(
+                StructArray::try_new(
+                    struct_fields,
+                    vec![
+                        Arc::new(StringArray::from(vec![Some("foo"), Some("bar"), None])),
+                        Arc::new(StringArray::from(vec![Some("baz"), None, None])),
+                    ],
+                    Some(vec![true, true, false].into()),
+                )
+                .unwrap(),
+            )],
+        )
+        .unwrap()
+    }
+
     #[allow(clippy::needless_pass_by_value)]
     fn assert_aos_output(batch: RecordBatch, expected: serde_json::Value) {
         let mut buf = Vec::new();
@@ -1155,7 +943,7 @@ mod tests {
         tracing::debug!("Raw result:\n{}", std::str::from_utf8(&buf).unwrap());
 
         let actual: serde_json::Value = serde_json::from_slice(&buf).unwrap();
-        assert_eq!(actual, expected);
+        pretty_assertions::assert_eq!(actual, expected);
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -1169,7 +957,7 @@ mod tests {
         tracing::debug!("Raw result:\n{}", std::str::from_utf8(&buf).unwrap());
 
         let actual: serde_json::Value = serde_json::from_slice(&buf).unwrap();
-        assert_eq!(actual, expected);
+        pretty_assertions::assert_eq!(actual, expected);
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -1183,7 +971,7 @@ mod tests {
         tracing::debug!("Raw result:\n{}", std::str::from_utf8(&buf).unwrap());
 
         let actual: serde_json::Value = serde_json::from_slice(&buf).unwrap();
-        assert_eq!(actual, expected);
+        pretty_assertions::assert_eq!(actual, expected);
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -1205,18 +993,6 @@ mod tests {
                 .collect()
         };
 
-        assert_eq!(actual, expected);
-    }
-
-    #[allow(clippy::needless_pass_by_value)]
-    fn assert_csv_output(batch: RecordBatch, opts: CsvWriterOptions, expected: &str) {
-        let mut buf = Vec::new();
-        {
-            let mut writer = CsvWriter::new(&mut buf, opts);
-            writer.write_batch(&batch).unwrap();
-            writer.finish().unwrap();
-        }
-        let actual = std::str::from_utf8(&buf).unwrap();
         pretty_assertions::assert_eq!(actual, expected);
     }
 }

--- a/src/utils/data-utils/src/data/format/mod.rs
+++ b/src/utils/data-utils/src/data/format/mod.rs
@@ -1,0 +1,18 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod csv;
+pub mod json;
+pub mod text;
+pub mod traits;
+
+pub use csv::*;
+pub use json::*;
+pub use text::*;
+pub use traits::*;

--- a/src/utils/data-utils/src/data/format/text.rs
+++ b/src/utils/data-utils/src/data/format/text.rs
@@ -1,0 +1,130 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use arrow::array::OffsetSizeTrait;
+use arrow::datatypes::ArrowPrimitiveType;
+use serde::ser::Serializer;
+
+use super::traits::*;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct BooleanEncoder<'a>(pub &'a arrow::array::BooleanArray);
+impl<'a> Encoder for BooleanEncoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        if self.0.value(idx) {
+            write!(buf, "true")?;
+        } else {
+            write!(buf, "false")?;
+        }
+        Ok(())
+    }
+}
+
+pub struct IntegerEncoder<'a, T: ArrowPrimitiveType>(pub &'a arrow::array::PrimitiveArray<T>);
+impl<'a, T: ArrowPrimitiveType> Encoder for IntegerEncoder<'a, T>
+where
+    <T as ArrowPrimitiveType>::Native: std::fmt::Display,
+{
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "{}", self.0.value(idx))?;
+        Ok(())
+    }
+}
+
+pub struct Float16Encoder<'a>(pub &'a arrow::array::Float16Array);
+impl<'a> Encoder for Float16Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let mut serializer = serde_json::Serializer::new(buf);
+        serializer
+            .serialize_f32(self.0.value(idx).to_f32())
+            .unwrap();
+        Ok(())
+    }
+}
+
+pub struct Float32Encoder<'a>(pub &'a arrow::array::Float32Array);
+impl<'a> Encoder for Float32Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let mut serializer = serde_json::Serializer::new(buf);
+        serializer.serialize_f32(self.0.value(idx)).unwrap();
+        Ok(())
+    }
+}
+
+pub struct Float64Encoder<'a>(pub &'a arrow::array::Float64Array);
+impl<'a> Encoder for Float64Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let mut serializer = serde_json::Serializer::new(buf);
+        serializer.serialize_f64(self.0.value(idx)).unwrap();
+        Ok(())
+    }
+}
+
+pub struct Decimal128Encoder<'a>(pub &'a arrow::array::Decimal128Array);
+impl<'a> Encoder for Decimal128Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        // TODO: PERF: Avoid allocation
+        write!(buf, "{}", self.0.value_as_string(idx))?;
+        Ok(())
+    }
+}
+
+pub struct Decimal256Encoder<'a>(pub &'a arrow::array::Decimal256Array);
+impl<'a> Encoder for Decimal256Encoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        // TODO: PERF: Avoid allocation
+        write!(buf, "{}", self.0.value_as_string(idx))?;
+        Ok(())
+    }
+}
+
+pub struct StringEncoder<'a, OffsetSize: OffsetSizeTrait>(
+    pub &'a arrow::array::GenericStringArray<OffsetSize>,
+);
+impl<'a, OffsetSize: OffsetSizeTrait> Encoder for StringEncoder<'a, OffsetSize> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "{}", self.0.value(idx))?;
+        Ok(())
+    }
+}
+
+pub struct BinaryHexEncoder<'a, OffsetSize: OffsetSizeTrait>(
+    pub &'a arrow::array::GenericBinaryArray<OffsetSize>,
+);
+impl<'a, OffsetSize: OffsetSizeTrait> Encoder for BinaryHexEncoder<'a, OffsetSize> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let hex_str = hex::encode(self.0.value(idx));
+        write!(buf, "{hex_str}")?;
+        Ok(())
+    }
+}
+
+pub struct BinaryFixedHexEncoder<'a>(pub &'a arrow::array::FixedSizeBinaryArray);
+impl<'a> Encoder for BinaryFixedHexEncoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        let hex_str = hex::encode(self.0.value(idx));
+        write!(buf, "{hex_str}")?;
+        Ok(())
+    }
+}
+
+/// This encoder uses default arrow representation as determined by
+/// [`arrow::util::display::ArrayFormatter`]. When using this encoder you have
+/// to be absolutely sure that result does not include symbols that have special
+/// meaning within a JSON string.
+pub struct ArrowEncoder<'a>(pub arrow::util::display::ArrayFormatter<'a>);
+impl<'a> Encoder for ArrowEncoder<'a> {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        write!(buf, "{}", self.0.value(idx))?;
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/data-utils/src/data/format/traits.rs
+++ b/src/utils/data-utils/src/data/format/traits.rs
@@ -1,0 +1,83 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::io::ErrorKind;
+
+use arrow::error::ArrowError;
+use datafusion::arrow::record_batch::RecordBatch;
+use thiserror::Error;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// RecordsWriter
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub trait RecordsWriter {
+    fn write_batch(&mut self, records: &RecordBatch) -> Result<(), WriterError>;
+
+    fn write_batches(&mut self, record_batches: &[RecordBatch]) -> Result<(), WriterError> {
+        for records in record_batches {
+            self.write_batch(records)?;
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<(), WriterError> {
+        Ok(())
+    }
+
+    fn handle_writer_result(
+        &self,
+        writer_result: Result<(), ArrowError>,
+    ) -> Result<(), WriterError> {
+        if let Err(err) = writer_result {
+            match err {
+                ArrowError::IoError(_, io_err) => match io_err.kind() {
+                    ErrorKind::BrokenPipe => (),
+                    _ => return Err(WriterError::IoError(io_err)),
+                },
+                err => return Err(WriterError::ArrowError(err)),
+            };
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum WriterError {
+    #[error(transparent)]
+    DataTooLarge(#[from] DataTooLarge),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    ArrowError(#[from] ArrowError),
+}
+
+#[derive(Debug, Error)]
+#[error("Data is too large to fit in the defined serialization buffer")]
+pub struct DataTooLarge;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Row-wise encoders
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub trait Encoder {
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError>;
+}
+
+impl<T> Encoder for Box<T>
+where
+    T: Encoder,
+    T: ?Sized,
+{
+    fn encode(&mut self, idx: usize, buf: &mut dyn std::io::Write) -> Result<(), WriterError> {
+        self.as_mut().encode(idx, buf)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Adds JSON encoding of lists and structs (as required for a customer dataset).

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)