### PR TITLE
Delete respects graph order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Added
+- `kamu delete` command will respect dependency graph ordering allowing to delete multiple datasets without encountering dangling reference errors
+
 ## [0.203.0] - 2024-09-22
 ### Added
 - Support `List` and `Struct` arrow types in `json` and `json-aoa` encodings

--- a/src/domain/core/src/services/dependency_graph_service.rs
+++ b/src/domain/core/src/services/dependency_graph_service.rs
@@ -50,11 +50,28 @@ pub trait DependencyGraphService: Sync + Send {
         &self,
         dataset_ids: Vec<DatasetID>,
     ) -> Result<DatasetIDStream, GetDependenciesError>;
+
+    /// Given a set of dataset IDs this will sort them in depth-first or
+    /// breadth-first graph traversal order which is useful for operations that
+    /// require upstream datasets to be processed before downstream or vice
+    /// versa
+    async fn in_dependency_order(
+        &self,
+        dataset_ids: Vec<DatasetID>,
+        order: DependencyOrder,
+    ) -> Result<Vec<DatasetID>, GetDependenciesError>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 pub type DatasetIDStream<'a> = std::pin::Pin<Box<dyn Stream<Item = DatasetID> + Send + 'a>>;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub enum DependencyOrder {
+    BreadthFirst,
+    DepthFirst,
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
## Description

Closes: #843

`kamu delete` command will respect dependency graph ordering allowing to delete multiple datasets without encountering dangling reference errors

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)