### PR TITLE
kamu init: fixed regression in case of using exists_ok flag + Release (patch): 0.204.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
-## [Unreleased]
+## [0.204.3] - 2024-09-26
 ### Fixed
 - Dataset creation with unique alias but with existing id for FS dataset storage mode
+- `kamu init`: fixed regression in case of using `exists_ok` flag... finally
 
 ## [0.204.2] - 2024-09-26
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "async-utils"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
 ]
@@ -2443,7 +2443,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2873,7 +2873,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "quote",
  "syn 2.0.77",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.204.2"
+version = "0.204.3"
 
 [[package]]
 name = "env_filter"
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "quote",
  "syn 2.0.77",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "axum",
  "http 1.1.0",
@@ -4815,7 +4815,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "thiserror",
 ]
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -5050,7 +5050,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "base32",
@@ -5076,7 +5076,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "argon2",
  "chrono",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5202,7 +5202,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "dill",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5247,7 +5247,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "axum",
  "chrono",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-repo-tests"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "dill",
  "kamu-auth-rebac",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "dill",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5488,7 +5488,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -5607,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "chrono",
  "indoc 2.0.5",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "quote",
  "syn 2.0.77",
@@ -5635,7 +5635,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-inmem"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5676,7 +5676,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "chrono",
  "indoc 2.0.5",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5843,7 +5843,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-repo-tests"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "chrono",
  "database-common",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5900,7 +5900,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6007,7 +6007,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "chrono",
  "database-common",
@@ -6020,7 +6020,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6063,7 +6063,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6143,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6166,7 +6166,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-repo-tests"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "chrono",
  "database-common",
@@ -6180,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "chrono",
  "clap",
@@ -6217,7 +6217,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6254,7 +6254,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "chrono",
  "database-common",
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6316,7 +6316,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6713,7 +6713,7 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6841,7 +6841,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7166,7 +7166,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -7224,7 +7224,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "rand",
 ]
@@ -9755,7 +9755,7 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10169,7 +10169,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.204.2"
+version = "0.204.3"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,93 +90,93 @@ resolver = "2"
 [workspace.dependencies]
 
 # Apps
-kamu-cli = { version = "0.204.2", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.204.3", path = "src/app/cli", default-features = false }
 
 # Utils
-async-utils = { version = "0.204.2", path = "src/utils/async-utils", default-features = false }
-container-runtime = { version = "0.204.2", path = "src/utils/container-runtime", default-features = false }
-database-common = { version = "0.204.2", path = "src/utils/database-common", default-features = false }
-database-common-macros = { version = "0.204.2", path = "src/utils/database-common-macros", default-features = false }
-enum-variants = { version = "0.204.2", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.204.2", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.204.2", path = "src/utils/event-sourcing-macros", default-features = false }
-http-common = { version = "0.204.2", path = "src/utils/http-common", default-features = false }
-internal-error = { version = "0.204.2", path = "src/utils/internal-error", default-features = false }
-kamu-cli-puppet = { version = "0.204.2", path = "src/utils/kamu-cli-puppet", default-features = false }
-kamu-data-utils = { version = "0.204.2", path = "src/utils/data-utils", default-features = false }
-kamu-datafusion-cli = { version = "0.204.2", path = "src/utils/datafusion-cli", default-features = false }
-messaging-outbox = { version = "0.204.2", path = "src/utils/messaging-outbox", default-features = false }
-multiformats = { version = "0.204.2", path = "src/utils/multiformats", default-features = false }
-observability = { version = "0.204.2", path = "src/utils/observability", default-features = false }
-random-names = { version = "0.204.2", path = "src/utils/random-names", default-features = false }
-time-source = { version = "0.204.2", path = "src/utils/time-source", default-features = false }
-tracing-perfetto = { version = "0.204.2", path = "src/utils/tracing-perfetto", default-features = false }
+async-utils = { version = "0.204.3", path = "src/utils/async-utils", default-features = false }
+container-runtime = { version = "0.204.3", path = "src/utils/container-runtime", default-features = false }
+database-common = { version = "0.204.3", path = "src/utils/database-common", default-features = false }
+database-common-macros = { version = "0.204.3", path = "src/utils/database-common-macros", default-features = false }
+enum-variants = { version = "0.204.3", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.204.3", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.204.3", path = "src/utils/event-sourcing-macros", default-features = false }
+http-common = { version = "0.204.3", path = "src/utils/http-common", default-features = false }
+internal-error = { version = "0.204.3", path = "src/utils/internal-error", default-features = false }
+kamu-cli-puppet = { version = "0.204.3", path = "src/utils/kamu-cli-puppet", default-features = false }
+kamu-data-utils = { version = "0.204.3", path = "src/utils/data-utils", default-features = false }
+kamu-datafusion-cli = { version = "0.204.3", path = "src/utils/datafusion-cli", default-features = false }
+messaging-outbox = { version = "0.204.3", path = "src/utils/messaging-outbox", default-features = false }
+multiformats = { version = "0.204.3", path = "src/utils/multiformats", default-features = false }
+observability = { version = "0.204.3", path = "src/utils/observability", default-features = false }
+random-names = { version = "0.204.3", path = "src/utils/random-names", default-features = false }
+time-source = { version = "0.204.3", path = "src/utils/time-source", default-features = false }
+tracing-perfetto = { version = "0.204.3", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-kamu-accounts = { version = "0.204.2", path = "src/domain/accounts/domain", default-features = false }
-kamu-auth-rebac = { version = "0.204.2", path = "src/domain/auth-rebac/domain", default-features = false }
-kamu-core = { version = "0.204.2", path = "src/domain/core", default-features = false }
-kamu-datasets = { version = "0.204.2", path = "src/domain/datasets/domain", default-features = false }
-kamu-flow-system = { version = "0.204.2", path = "src/domain/flow-system/domain", default-features = false }
-kamu-task-system = { version = "0.204.2", path = "src/domain/task-system/domain", default-features = false }
-opendatafabric = { version = "0.204.2", path = "src/domain/opendatafabric", default-features = false }
+kamu-accounts = { version = "0.204.3", path = "src/domain/accounts/domain", default-features = false }
+kamu-auth-rebac = { version = "0.204.3", path = "src/domain/auth-rebac/domain", default-features = false }
+kamu-core = { version = "0.204.3", path = "src/domain/core", default-features = false }
+kamu-datasets = { version = "0.204.3", path = "src/domain/datasets/domain", default-features = false }
+kamu-flow-system = { version = "0.204.3", path = "src/domain/flow-system/domain", default-features = false }
+kamu-task-system = { version = "0.204.3", path = "src/domain/task-system/domain", default-features = false }
+opendatafabric = { version = "0.204.3", path = "src/domain/opendatafabric", default-features = false }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.204.2", path = "src/domain/accounts/services", default-features = false }
-kamu-auth-rebac-services = { version = "0.204.2", path = "src/domain/auth-rebac/services", default-features = false }
-kamu-datasets-services = { version = "0.204.2", path = "src/domain/datasets/services", default-features = false }
-kamu-flow-system-services = { version = "0.204.2", path = "src/domain/flow-system/services", default-features = false }
-kamu-task-system-services = { version = "0.204.2", path = "src/domain/task-system/services", default-features = false }
+kamu-accounts-services = { version = "0.204.3", path = "src/domain/accounts/services", default-features = false }
+kamu-auth-rebac-services = { version = "0.204.3", path = "src/domain/auth-rebac/services", default-features = false }
+kamu-datasets-services = { version = "0.204.3", path = "src/domain/datasets/services", default-features = false }
+kamu-flow-system-services = { version = "0.204.3", path = "src/domain/flow-system/services", default-features = false }
+kamu-task-system-services = { version = "0.204.3", path = "src/domain/task-system/services", default-features = false }
 
 # Infra
-kamu = { version = "0.204.2", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.204.2", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.204.3", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.204.3", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.204.2", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.204.2", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.204.2", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.204.2", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.204.3", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.204.3", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.204.3", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.204.3", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.204.2", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.204.2", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.204.2", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.204.2", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.204.2", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.204.3", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.204.3", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.204.3", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.204.3", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.204.3", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Datasets
-kamu-datasets-inmem = { version = "0.204.2", path = "src/infra/datasets/inmem", default-features = false }
-kamu-datasets-postgres = { version = "0.204.2", path = "src/infra/datasets/postgres", default-features = false }
-kamu-datasets-sqlite = { version = "0.204.2", path = "src/infra/datasets/sqlite", default-features = false }
-kamu-datasets-repo-tests = { version = "0.204.2", path = "src/infra/datasets/repo-tests", default-features = false }
+kamu-datasets-inmem = { version = "0.204.3", path = "src/infra/datasets/inmem", default-features = false }
+kamu-datasets-postgres = { version = "0.204.3", path = "src/infra/datasets/postgres", default-features = false }
+kamu-datasets-sqlite = { version = "0.204.3", path = "src/infra/datasets/sqlite", default-features = false }
+kamu-datasets-repo-tests = { version = "0.204.3", path = "src/infra/datasets/repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.204.2", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.204.2", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.204.2", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.204.2", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.204.3", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.204.3", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.204.3", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.204.3", path = "src/infra/task-system/repo-tests", default-features = false }
 ## ReBAC
-kamu-auth-rebac-inmem = { version = "0.204.2", path = "src/infra/auth-rebac/inmem", default-features = false }
-kamu-auth-rebac-repo-tests = { version = "0.204.2", path = "src/infra/auth-rebac/repo-tests", default-features = false }
-kamu-auth-rebac-sqlite = { version = "0.204.2", path = "src/infra/auth-rebac/sqlite", default-features = false }
+kamu-auth-rebac-inmem = { version = "0.204.3", path = "src/infra/auth-rebac/inmem", default-features = false }
+kamu-auth-rebac-repo-tests = { version = "0.204.3", path = "src/infra/auth-rebac/repo-tests", default-features = false }
+kamu-auth-rebac-sqlite = { version = "0.204.3", path = "src/infra/auth-rebac/sqlite", default-features = false }
 ## Outbox
-kamu-messaging-outbox-inmem = { version = "0.204.2", path = "src/infra/messaging-outbox/inmem", default-features = false }
-kamu-messaging-outbox-postgres = { version = "0.204.2", path = "src/infra/messaging-outbox/postgres", default-features = false }
-kamu-messaging-outbox-sqlite = { version = "0.204.2", path = "src/infra/messaging-outbox/sqlite", default-features = false }
-kamu-messaging-outbox-repo-tests = { version = "0.204.2", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
+kamu-messaging-outbox-inmem = { version = "0.204.3", path = "src/infra/messaging-outbox/inmem", default-features = false }
+kamu-messaging-outbox-postgres = { version = "0.204.3", path = "src/infra/messaging-outbox/postgres", default-features = false }
+kamu-messaging-outbox-sqlite = { version = "0.204.3", path = "src/infra/messaging-outbox/sqlite", default-features = false }
+kamu-messaging-outbox-repo-tests = { version = "0.204.3", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso = { version = "0.204.2", path = "src/adapter/auth-oso", default-features = false }
-kamu-adapter-flight-sql = { version = "0.204.2", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.204.2", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.204.2", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.204.2", path = "src/adapter/odata", default-features = false }
-kamu-adapter-oauth = { version = "0.204.2", path = "src/adapter/oauth", default-features = false }
+kamu-adapter-auth-oso = { version = "0.204.3", path = "src/adapter/auth-oso", default-features = false }
+kamu-adapter-flight-sql = { version = "0.204.3", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.204.3", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.204.3", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.204.3", path = "src/adapter/odata", default-features = false }
+kamu-adapter-oauth = { version = "0.204.3", path = "src/adapter/oauth", default-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.204.2", path = "src/e2e/app/cli/common", default-features = false }
-kamu-cli-e2e-common-macros = { version = "0.204.2", path = "src/e2e/app/cli/common-macros", default-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.204.2", path = "src/e2e/app/cli/repo-tests", default-features = false }
+kamu-cli-e2e-common = { version = "0.204.3", path = "src/e2e/app/cli/common", default-features = false }
+kamu-cli-e2e-common-macros = { version = "0.204.3", path = "src/e2e/app/cli/common-macros", default-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.204.3", path = "src/e2e/app/cli/repo-tests", default-features = false }
 
 [workspace.package]
-version = "0.204.2"
+version = "0.204.3"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.204.2
+Licensed Work:             Kamu CLI Version 0.204.3
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -114,11 +114,12 @@ pub async fn run(workspace_layout: WorkspaceLayout, args: cli::Cli) -> Result<()
 
     prepare_run_dir(&workspace_layout.run_info_dir);
 
+    let is_init_command = maybe_init_command.is_some();
     let app_database_config = get_app_database_config(
         &workspace_layout,
         &config,
         is_multi_tenant_workspace,
-        maybe_init_command,
+        is_init_command,
     );
     let (database_config, maybe_temp_database_path) = app_database_config.into_inner();
     let maybe_db_connection_settings = database_config

--- a/src/e2e/app/cli/inmem/tests/tests/commands/test_init_command.rs
+++ b/src/e2e/app/cli/inmem/tests/tests/commands/test_init_command.rs
@@ -21,6 +21,15 @@ kamu_cli_execute_command_e2e_test!(
 
 kamu_cli_execute_command_e2e_test!(
     storage = inmem,
+    fixture =
+        kamu_cli_e2e_repo_tests::test_init_multi_tenant_with_exists_ok_flag_creates_sqlite_database,
+    options = Options::default().with_no_workspace()
+);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+kamu_cli_execute_command_e2e_test!(
+    storage = inmem,
     fixture = kamu_cli_e2e_repo_tests::test_init_exist_ok_st,
     options = Options::default().with_no_workspace()
 );

--- a/src/e2e/app/cli/repo-tests/src/commands/test_init_command.rs
+++ b/src/e2e/app/cli/repo-tests/src/commands/test_init_command.rs
@@ -27,6 +27,25 @@ pub async fn test_init_multi_tenant_creates_sqlite_database(mut kamu: KamuCliPup
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+pub async fn test_init_multi_tenant_with_exists_ok_flag_creates_sqlite_database(
+    mut kamu: KamuCliPuppet,
+) {
+    kamu.set_workspace_path_in_tmp_dir();
+
+    kamu.execute(["init", "--multi-tenant", "--exists-ok"])
+        .await
+        .success();
+
+    let expected_database_path = kamu
+        .workspace_path()
+        .join(KAMU_WORKSPACE_DIR_NAME)
+        .join(DEFAULT_MULTI_TENANT_SQLITE_DATABASE_NAME);
+
+    assert!(expected_database_path.exists());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 pub async fn test_init_exist_ok_st(mut kamu: KamuCliPuppet) {
     kamu.set_workspace_path_in_tmp_dir();
 


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: https://github.com/kamu-data/kamu-cli/issues/853

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

### Fixed
- `kamu init`: fixed regression in case of using `exists_ok` flag... finally

## Checklist before requesting a review

- [x] Unit and integration tests added ✅
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability: 
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ❌ not needed
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ❌ not needed
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ❌ not needed
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌ not needed
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ❌ not needed
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1) ❌ not needed