### PR TITLE
Generalize CLI confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Changed
+- CLI command tweaks:
+  - Make `--yes / -y` flag global
+  - Add confirmation step to `system compact` command
+  - Add support for patterns to `system compact` to process multiple datasets at once
+  - Fixed argument parsing error in `kamu system compact` command
+
 ## [0.204.3] - 2024-09-26
 ### Fixed
 - Dataset creation with unique alias but with existing id for FS dataset storage mode

--- a/resources/cli-reference.md
+++ b/resources/cli-reference.md
@@ -42,6 +42,7 @@ To regenerate this schema from existing code, use the following command:
 * `-v` — Sets the level of verbosity (repeat for more)
 * `--no-color` — Disable color output in the terminal
 * `-q`, `--quiet` — Suppress all non-essential output
+* `-y`, `--yes` — Do not ask for confirmation and assume the 'yes' answer
 * `--trace` — Record and visualize the command execution as perfetto.dev trace
 * `--metrics` — Dump all metrics at the end of command execution
 
@@ -233,7 +234,6 @@ Delete a dataset
 
 * `-a`, `--all` — Delete all datasets in the workspace
 * `-r`, `--recursive` — Also delete all transitive dependencies of specified datasets
-* `-y`, `--yes` — Don't ask for confirmation
 
 This command deletes the dataset from your workspace, including both metadata and the raw data.
 
@@ -769,16 +769,12 @@ Renaming is often useful when you pull a remote dataset by URL, and it gets auto
 
 Revert the dataset back to the specified state
 
-**Usage:** `kamu reset [OPTIONS] <DATASET> <HASH>`
+**Usage:** `kamu reset <DATASET> <HASH>`
 
 **Arguments:**
 
 * `<DATASET>` — Dataset reference
 * `<HASH>` — Hash of the block to reset to
-
-**Options:**
-
-* `-y`, `--yes` — Don't ask for confirmation
 
 Resetting a dataset to the specified block erases all metadata blocks that followed it and deletes all data added since that point. This can sometimes be useful to resolve conflicts, but otherwise should be used with care.
 
@@ -858,7 +854,6 @@ Deletes a reference to repository
 **Options:**
 
 * `-a`, `--all` — Delete all known repositories
-* `-y`, `--yes` — Don't ask for confirmation
 
 
 
@@ -942,7 +937,7 @@ Adds a remote alias to a dataset
 
 Deletes a remote alias associated with a dataset
 
-**Usage:** `kamu repo alias delete [OPTIONS] <DATASET> [ALIAS]`
+**Usage:** `kamu repo alias delete [OPTIONS] [DATASET] [ALIAS]`
 
 **Arguments:**
 
@@ -1194,11 +1189,11 @@ Prints the GraphQL schema
 
 Compact a dataset
 
-**Usage:** `kamu system compact [OPTIONS] <DATASET>`
+**Usage:** `kamu system compact [OPTIONS] [DATASET]...`
 
 **Arguments:**
 
-* `<DATASET>` — Local dataset reference
+* `<DATASET>` — Local dataset references
 
 **Options:**
 

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -158,6 +158,8 @@ pub async fn run(workspace_layout: WorkspaceLayout, args: cli::Cli) -> Result<()
             .add_value(dependencies_graph_repository)
             .bind::<dyn DependencyGraphRepository, DependencyGraphRepositoryInMemory>();
 
+        base_catalog_builder.add_value(Interact::new(args.yes));
+
         let output_config = configure_output_format(&args, &workspace_svc);
         base_catalog_builder.add_value(output_config.clone());
 

--- a/src/app/cli/src/cli.rs
+++ b/src/app/cli/src/cli.rs
@@ -45,6 +45,10 @@ pub struct Cli {
     #[arg(long, short = 'q')]
     pub quiet: bool,
 
+    /// Do not ask for confirmation and assume the 'yes' answer
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+
     /// Record and visualize the command execution as perfetto.dev trace
     #[arg(long)]
     pub trace: bool,
@@ -358,10 +362,6 @@ pub struct Delete {
     /// Also delete all transitive dependencies of specified datasets
     #[arg(long, short = 'r')]
     pub recursive: bool,
-
-    /// Don't ask for confirmation
-    #[arg(long, short = 'y')]
-    pub yes: bool,
 
     /// Local dataset reference(s)
     #[arg(value_parser = parsers::dataset_ref_pattern)]
@@ -955,10 +955,6 @@ Resetting a dataset to the specified block erases all metadata blocks that follo
 Keep in mind that blocks that were pushed to a repository could've been already observed by other people, so resetting the history will not let you take that data back and instead create conflicts for the downstream consumers of your data.
 "#)]
 pub struct Reset {
-    /// Don't ask for confirmation
-    #[arg(long, short = 'y')]
-    pub yes: bool,
-
     /// Dataset reference
     #[arg(index = 1, value_parser = parsers::dataset_ref)]
     pub dataset: odf::DatasetRef,
@@ -1024,7 +1020,7 @@ pub struct RepoAdd {
 
     /// URL of the repository
     #[arg(index = 2)]
-    pub url: String,
+    pub url: url::Url,
 }
 
 /// Deletes a reference to repository
@@ -1034,10 +1030,6 @@ pub struct RepoDelete {
     /// Delete all known repositories
     #[arg(long, short = 'a')]
     pub all: bool,
-
-    /// Don't ask for confirmation
-    #[arg(long, short = 'y')]
-    pub yes: bool,
 
     /// Repository name(s)
     #[arg(value_parser = parsers::repo_name)]
@@ -1122,7 +1114,7 @@ pub struct RepoAliasDelete {
 
     /// Local dataset reference
     #[arg(index = 1, value_parser = parsers::dataset_ref)]
-    pub dataset: odf::DatasetRef,
+    pub dataset: Option<odf::DatasetRef>,
 
     /// Remote dataset name
     #[arg(index = 2, value_parser = parsers::dataset_ref_remote)]
@@ -1378,9 +1370,9 @@ pub struct SystemCompact {
     #[arg(long)]
     pub verify: bool,
 
-    /// Local dataset reference
-    #[arg(value_parser = parsers::repo_name)]
-    pub dataset: odf::DatasetRef,
+    /// Local dataset references
+    #[arg(value_parser = parsers::dataset_ref_pattern)]
+    pub dataset: Vec<odf::DatasetRefPattern>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/app/cli/src/cli_commands.rs
+++ b/src/app/cli/src/cli_commands.rs
@@ -28,6 +28,7 @@ pub fn get_command(
             work_catalog.get_one()?,
             work_catalog.get_one()?,
             work_catalog.get_one()?,
+            work_catalog.get_one()?,
             c.manifest,
             c.name,
             c.recursive,
@@ -88,11 +89,11 @@ pub fn get_command(
         cli::Command::Delete(c) => Box::new(DeleteCommand::new(
             work_catalog.get_one()?,
             work_catalog.get_one()?,
+            work_catalog.get_one()?,
             validate_many_dataset_patterns(work_catalog, c.dataset)?,
             work_catalog.get_one()?,
             c.all,
             c.recursive,
-            c.yes,
         )),
         cli::Command::Ingest(c) => Box::new(IngestCommand::new(
             work_catalog.get_one()?,
@@ -301,9 +302,9 @@ pub fn get_command(
             )),
             cli::RepoSubCommand::Delete(sc) => Box::new(RepositoryDeleteCommand::new(
                 work_catalog.get_one()?,
+                work_catalog.get_one()?,
                 sc.repository.unwrap_or_default(),
                 sc.all,
-                sc.yes,
             )),
             cli::RepoSubCommand::List(_) => Box::new(RepositoryListCommand::new(
                 work_catalog.get_one()?,
@@ -319,6 +320,7 @@ pub fn get_command(
                     ssc.push,
                 )),
                 cli::RepoAliasSubCommand::Delete(ssc) => Box::new(AliasDeleteCommand::new(
+                    work_catalog.get_one()?,
                     work_catalog.get_one()?,
                     ssc.dataset,
                     ssc.alias,
@@ -337,9 +339,9 @@ pub fn get_command(
         cli::Command::Reset(c) => Box::new(ResetCommand::new(
             work_catalog.get_one()?,
             work_catalog.get_one()?,
+            work_catalog.get_one()?,
             validate_dataset_ref(work_catalog, c.dataset)?,
             c.hash,
-            c.yes,
         )),
         cli::Command::Search(c) => Box::new(SearchCommand::new(
             work_catalog.get_one()?,
@@ -423,7 +425,8 @@ pub fn get_command(
                 work_catalog.get_one()?,
                 work_catalog.get_one()?,
                 work_catalog.get_one()?,
-                validate_dataset_ref(work_catalog, sc.dataset)?,
+                work_catalog.get_one()?,
+                validate_many_dataset_patterns(work_catalog, sc.dataset)?,
                 sc.max_slice_size,
                 sc.max_slice_records,
                 sc.hard,

--- a/src/app/cli/src/commands/common.rs
+++ b/src/app/cli/src/commands/common.rs
@@ -14,20 +14,6 @@ use kamu::domain::PullImageListener;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-pub fn prompt_yes_no(msg: &str) -> bool {
-    use read_input::prelude::*;
-
-    let answer: String = input()
-        .repeat_msg(msg)
-        .default("n".to_owned())
-        .add_test(|v| matches!(v.as_ref(), "n" | "N" | "no" | "y" | "Y" | "yes"))
-        .get();
-
-    !matches!(answer.as_ref(), "n" | "N" | "no")
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 pub struct PullImageProgress {
     image_purpose: &'static str,
     progress_bar: Mutex<Option<indicatif::ProgressBar>>,

--- a/src/app/cli/src/commands/repository_add_command.rs
+++ b/src/app/cli/src/commands/repository_add_command.rs
@@ -18,22 +18,19 @@ use super::{CLIError, Command};
 pub struct RepositoryAddCommand {
     remote_repo_reg: Arc<dyn RemoteRepositoryRegistry>,
     name: RepoName,
-    url: String,
+    url: Url,
 }
 
 impl RepositoryAddCommand {
-    pub fn new<S>(
+    pub fn new(
         remote_repo_reg: Arc<dyn RemoteRepositoryRegistry>,
         name: RepoName,
-        url: S,
-    ) -> Self
-    where
-        S: Into<String>,
-    {
+        url: Url,
+    ) -> Self {
         Self {
             remote_repo_reg,
             name,
-            url: url.into(),
+            url,
         }
     }
 }
@@ -41,13 +38,8 @@ impl RepositoryAddCommand {
 #[async_trait::async_trait(?Send)]
 impl Command for RepositoryAddCommand {
     async fn run(&mut self) -> Result<(), CLIError> {
-        let url = Url::parse(&self.url).map_err(|e| {
-            eprintln!("{}: {}", console::style("Invalid URL").red(), e);
-            CLIError::Aborted
-        })?;
-
         self.remote_repo_reg
-            .add_repository(&self.name, url)
+            .add_repository(&self.name, self.url.clone())
             .map_err(CLIError::failure)?;
 
         eprintln!("{}: {}", console::style("Added").green(), &self.name);

--- a/src/app/cli/src/commands/reset_command.rs
+++ b/src/app/cli/src/commands/reset_command.rs
@@ -12,30 +12,31 @@ use std::sync::Arc;
 use kamu::domain::*;
 use opendatafabric::*;
 
-use super::{common, CLIError, Command};
+use super::{CLIError, Command};
+use crate::Interact;
 
 pub struct ResetCommand {
+    interact: Arc<Interact>,
     dataset_repo: Arc<dyn DatasetRepository>,
     reset_svc: Arc<dyn ResetService>,
     dataset_ref: DatasetRef,
     block_hash: Multihash,
-    no_confirmation: bool,
 }
 
 impl ResetCommand {
     pub fn new(
+        interact: Arc<Interact>,
         dataset_repo: Arc<dyn DatasetRepository>,
         reset_svc: Arc<dyn ResetService>,
         dataset_ref: DatasetRef,
         block_hash: Multihash,
-        no_confirmation: bool,
     ) -> Self {
         Self {
+            interact,
             dataset_repo,
             reset_svc,
             dataset_ref,
             block_hash,
-            no_confirmation,
         }
     }
 }
@@ -48,25 +49,19 @@ impl Command for ResetCommand {
             .resolve_dataset_ref(&self.dataset_ref)
             .await?;
 
-        let confirmed = if self.no_confirmation {
-            true
-        } else {
-            common::prompt_yes_no(&format!(
-                "{}: {}\n{}\nDo you wish to continue? [y/N]: ",
-                console::style("You are about to reset the following dataset").yellow(),
-                self.dataset_ref,
-                console::style("This operation is irreversible!").yellow(),
-            ))
-        };
-
-        if !confirmed {
-            return Err(CLIError::Aborted);
-        }
+        self.interact.require_confirmation(format!(
+            "{}: {}\n{}",
+            console::style("You are about to reset the following dataset").yellow(),
+            self.dataset_ref,
+            console::style("This operation is irreversible!").yellow(),
+        ))?;
 
         self.reset_svc
             .reset_dataset(&dataset_handle, Some(&self.block_hash), None)
             .await
             .map_err(CLIError::failure)?;
+
+        eprintln!("{}", console::style("Dataset was reset").green().bold());
 
         Ok(())
     }

--- a/src/app/cli/src/output/interact.rs
+++ b/src/app/cli/src/output/interact.rs
@@ -1,0 +1,40 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::CLIError;
+
+#[derive(Debug, Clone)]
+pub struct Interact {
+    /// Don't ask user for confirmation and assume 'yes'
+    pub assume_yes: bool,
+}
+
+impl Interact {
+    pub fn new(assume_yes: bool) -> Self {
+        Self { assume_yes }
+    }
+
+    pub fn require_confirmation(&self, prompt: impl std::fmt::Display) -> Result<(), CLIError> {
+        use read_input::prelude::*;
+
+        let prompt = format!("{prompt}\nDo you wish to continue? [y/N]: ");
+
+        let answer: String = input()
+            .repeat_msg(prompt)
+            .default("n".to_owned())
+            .add_test(|v| matches!(v.as_ref(), "n" | "N" | "no" | "y" | "Y" | "yes"))
+            .get();
+
+        if !matches!(answer.as_ref(), "n" | "N" | "no") {
+            Ok(())
+        } else {
+            Err(CLIError::Aborted)
+        }
+    }
+}

--- a/src/app/cli/src/output/mod.rs
+++ b/src/app/cli/src/output/mod.rs
@@ -8,10 +8,12 @@
 // by the Apache License, Version 2.0.
 
 mod compact_progress;
+mod interact;
 mod output_config;
 mod verify_progress;
 
 pub use compact_progress::*;
+pub use interact::*;
 pub use output_config::*;
 pub use verify_progress::*;
 


### PR DESCRIPTION
## Description

- Make `--yes / -y` flag global
- Introduces `Interact` object that can be used to ask for action confirmations
  - In future I'd like all messages, progress bars etc. to go through this object so we could automatically adjust the output based on verbosity level and whether we're under TTY, instead of individual commands handling flags like `verbose` and `quiet`
- Fixes a parsing error in SystemCompact command (turns out you still can have dynamic errors with clap derive)
- Adds confirmation to `system compact` command
- Allows `system compact` process multiple datasets at once

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)