### PR TITLE
Extend output formats of `repo alias list` command (cont.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Changed
+- `kamu repo alias list`: added JSON output alongside with other formats mentioned in the command's help
+
 ## [0.204.4] - 2024-09-30
 ### Changed
 - CLI command tweaks:

--- a/examples/covid/init-odf.sh
+++ b/examples/covid/init-odf.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Downloads cached root datasets from ODF node for faster experimentation and testing
+set -e
+
+BASE_URL="odf+https://node.demo.kamu.dev/kamu/"
+
+kamu init || true
+
+kamu pull "${BASE_URL}covid19.alberta.case-details"
+kamu pull "${BASE_URL}covid19.british-columbia.case-details"
+kamu pull "${BASE_URL}covid19.ontario.case-details"
+kamu pull "${BASE_URL}covid19.quebec.case-details"
+
+kamu add -r .

--- a/src/e2e/app/cli/repo-tests/src/commands/test_repo_alias_command.rs
+++ b/src/e2e/app/cli/repo-tests/src/commands/test_repo_alias_command.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use kamu_cli_puppet::extensions::KamuCliPuppetExt;
+use kamu_cli_puppet::extensions::{KamuCliPuppetExt, RepoAlias};
 use kamu_cli_puppet::KamuCliPuppet;
 use opendatafabric::*;
 
@@ -38,41 +38,53 @@ pub async fn test_repository_pull_aliases_commands(kamu: KamuCliPuppet) {
     .await;
 
     let dataset_aliases = vec![
-        "http://pull.example.com/".to_string(),
-        "http://pull.example1.com/".to_string(),
-        "http://pull.example2.com/".to_string(),
+        RepoAlias {
+            dataset: "foo".parse().unwrap(),
+            kind: "Pull".to_string(),
+            alias: "http://pull.example.com/".to_string(),
+        },
+        RepoAlias {
+            dataset: "foo".parse().unwrap(),
+            kind: "Pull".to_string(),
+            alias: "http://pull.example1.com/".to_string(),
+        },
+        RepoAlias {
+            dataset: "foo".parse().unwrap(),
+            kind: "Pull".to_string(),
+            alias: "http://pull.example2.com/".to_string(),
+        },
     ];
 
-    for dataset_alias in &dataset_aliases {
-        kamu.execute(["repo", "alias", "add", "foo", dataset_alias, "--pull"])
+    for repo_alias in &dataset_aliases {
+        kamu.execute(["repo", "alias", "add", "foo", &repo_alias.alias, "--pull"])
             .await
             .success();
     }
 
-    let (pull_aliases, _push_aliases) = kamu
+    let aliases = kamu
         .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
         .await;
-    assert_eq!(pull_aliases, dataset_aliases);
+    assert_eq!(aliases, dataset_aliases);
 
     // Test remove single pull alias
-    kamu.execute(["repo", "alias", "rm", "foo", dataset_aliases[2].as_str()])
+    kamu.execute(["repo", "alias", "rm", "foo", &dataset_aliases[2].alias])
         .await
         .success();
 
-    let (pull_aliases, _push_aliases) = kamu
+    let aliases = kamu
         .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
         .await;
-    assert_eq!(pull_aliases, dataset_aliases[..2]);
+    assert_eq!(aliases, dataset_aliases[..2]);
 
     // Test remove all pull aliases
     kamu.execute(["repo", "alias", "rm", "--all", "foo"])
         .await
         .success();
 
-    let (pull_aliases, _push_aliases) = kamu
+    let aliases = kamu
         .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
         .await;
-    assert!(pull_aliases.is_empty());
+    assert!(aliases.is_empty());
 }
 
 pub async fn test_repository_push_aliases_commands(kamu: KamuCliPuppet) {
@@ -100,40 +112,52 @@ pub async fn test_repository_push_aliases_commands(kamu: KamuCliPuppet) {
     .await;
 
     let dataset_aliases = vec![
-        "http://push.example.com/".to_string(),
-        "http://push.example1.com/".to_string(),
-        "http://push.example2.com/".to_string(),
+        RepoAlias {
+            dataset: "foo".parse().unwrap(),
+            kind: "Push".to_string(),
+            alias: "http://push.example.com/".to_string(),
+        },
+        RepoAlias {
+            dataset: "foo".parse().unwrap(),
+            kind: "Push".to_string(),
+            alias: "http://push.example1.com/".to_string(),
+        },
+        RepoAlias {
+            dataset: "foo".parse().unwrap(),
+            kind: "Push".to_string(),
+            alias: "http://push.example2.com/".to_string(),
+        },
     ];
 
-    for dataset_alias in &dataset_aliases {
-        kamu.execute(["repo", "alias", "add", "foo", dataset_alias, "--push"])
+    for repo_alias in &dataset_aliases {
+        kamu.execute(["repo", "alias", "add", "foo", &repo_alias.alias, "--push"])
             .await
             .success();
     }
 
-    let (_pull_aliases, push_aliases) = kamu
+    let aliases = kamu
         .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
         .await;
-    assert_eq!(push_aliases, dataset_aliases);
+    assert_eq!(aliases, dataset_aliases);
 
     // Test remove single push alias
-    kamu.execute(["repo", "alias", "rm", "foo", dataset_aliases[2].as_str()])
+    kamu.execute(["repo", "alias", "rm", "foo", &dataset_aliases[2].alias])
         .await
         .success();
 
-    let (_pull_aliases, push_aliases) = kamu
+    let aliases = kamu
         .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
         .await;
-    assert_eq!(push_aliases, dataset_aliases[..2]);
+    assert_eq!(aliases, dataset_aliases[..2]);
     // Test remove all push aliases
     kamu.execute(["repo", "alias", "rm", "--all", "foo"])
         .await
         .success();
 
-    let (_pull_aliases, push_aliases) = kamu
+    let aliases = kamu
         .get_list_of_repo_aliases(&DatasetRef::from(DatasetName::new_unchecked("foo")))
         .await;
-    assert!(push_aliases.is_empty());
+    assert!(aliases.is_empty());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes: #751

This is a continuation of PR #866 by @demusdev

I have tested the changes and added just one commit to convert our E2E test from manual CSV parser to serde, so we could fully address the scope of #751 and close it.