### PR TITLE
Add OpenAPI schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Recommendation: for ease of reading, use the following order:
 
 ## [Unreleased]
 ### Added
+- Introduced OpenAPI spec generation
+  - `/openapi.json` endpoint now returns the generated spec
+  - `/swagger` endpoint serves an embedded Swagger UI for viewing the spec directly in the running server
+  - OpenAPI schema is available in the repo `resources/openapi.json` beside its multi-tenant version
 - Added (or expanded) E2E tests for:
   - `kamu config` command
   - `kamu init` command
@@ -35,6 +39,9 @@ Recommendation: for ease of reading, use the following order:
   - `kamu pull` command
 - E2E: HTTP middleware is implemented, which improves stability of E2E tests
 - Added endpoint to read a recently uploaded file (`GET /platform/file/upload/{upload_token}`)
+### Changed
+- Removed support for deprecated V1 `/query` endpoint format
+- The `/tail` endpoint was updated to better match V2 `/query` endpoint
 ### Fixed
 - `kamu add`: fixed behavior when using `--stdin` and `--name` arguments
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,12 +28,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,15 +2511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,12 +2847,6 @@ dependencies = [
  "quote",
  "syn 2.0.79",
 ]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "dashmap"
@@ -4752,29 +4731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include-flate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df49c16750695486c1f34de05da5b7438096156466e7f76c38fcdf285cf0113e"
-dependencies = [
- "include-flate-codegen",
- "lazy_static",
- "libflate",
-]
-
-[[package]]
-name = "include-flate-codegen"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5b246c6261be723b85c61ecf87804e8ea4a35cb68be0ff282ed84b95ffe7d7"
-dependencies = [
- "libflate",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5413,6 +5369,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "utoipa",
+ "utoipa-axum",
  "uuid",
 ]
 
@@ -5469,6 +5427,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
+ "utoipa",
+ "utoipa-axum",
 ]
 
 [[package]]
@@ -5675,6 +5635,9 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
+ "utoipa",
+ "utoipa-axum",
+ "utoipa-swagger-ui",
  "vergen",
  "webbrowser",
  "whoami",
@@ -5765,6 +5728,7 @@ dependencies = [
  "opendatafabric",
  "pretty_assertions",
  "reqwest",
+ "serde_json",
  "tokio",
  "tokio-retry",
 ]
@@ -6558,30 +6522,6 @@ name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
-
-[[package]]
-name = "libflate"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
-dependencies = [
- "core2",
- "hashbrown 0.14.5",
- "rle-decode-fast",
-]
 
 [[package]]
 name = "libm"
@@ -8497,12 +8437,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8586,7 +8520,6 @@ version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
- "include-flate",
  "rust-embed-impl",
  "rust-embed-utils",
  "walkdir",
@@ -10557,6 +10490,59 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8861811f7213bb866cd02319acb69a15b0ef8ca46874e805bd92d488c779036a"
+dependencies = [
+ "indexmap 2.6.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437ecfd6bbcdadb45dab6a63462ec9034fd9d3a926f471298f03aea749028419"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fadf94f07d67df4b15e6490dd9a9d59d7374849413e7f137eafe52fdcbd0db5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a551be0331bd01a1d39f2654409ca61cb955f02dfef0fc0f7aced8b2abbc88"
+dependencies = [
+ "axum",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
 
 [[package]]
 name = "uuid"

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -1,0 +1,1942 @@
+{
+  "components": {
+    "schemas": {
+      "AccountResponse": {
+        "properties": {
+          "accountName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "accountName"
+        ],
+        "type": "object"
+      },
+      "Commitment": {
+        "additionalProperties": false,
+        "properties": {
+          "inputHash": {
+            "description": "Hash of the \"input\" object in the [multihash](https://multiformats.io/multihash/) format",
+            "type": "string"
+          },
+          "outputHash": {
+            "description": "Hash of the \"output\" object in the [multihash](https://multiformats.io/multihash/) format",
+            "type": "string"
+          },
+          "subQueriesHash": {
+            "description": "Hash of the \"subQueries\" object in the [multihash](https://multiformats.io/multihash/) format",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputHash",
+          "outputHash",
+          "subQueriesHash"
+        ],
+        "type": "object"
+      },
+      "DataFormat": {
+        "enum": [
+          "JsonAoS",
+          "JsonSoA",
+          "JsonAoA"
+        ],
+        "type": "string"
+      },
+      "DatasetBlockNotFound": {
+        "properties": {
+          "block_hash": {
+            "type": "string"
+          },
+          "dataset_id": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "dataset_id",
+          "block_hash"
+        ],
+        "type": "object"
+      },
+      "DatasetInfoResponse": {
+        "properties": {
+          "datasetName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "owner": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DatasetOwnerInfo"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "datasetName"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "output": {
+            "$ref": "#/components/schemas/Output"
+          }
+        },
+        "required": [
+          "output"
+        ],
+        "type": "object"
+      },
+      "DatasetNotFound": {
+        "properties": {
+          "dataset_id": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "dataset_id"
+        ],
+        "type": "object"
+      },
+      "DatasetOwnerInfo": {
+        "properties": {
+          "accountId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "accountName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "accountName"
+        ],
+        "type": "object"
+      },
+      "DatasetState": {
+        "additionalProperties": false,
+        "properties": {
+          "alias": {
+            "description": "Alias to be used in the query",
+            "type": "string"
+          },
+          "blockHash": {
+            "description": "Last block hash of the input datasets that was or should be considered\nduring the query planning",
+            "type": "string"
+          },
+          "id": {
+            "description": "Globally unique identity of the dataset",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "alias"
+        ],
+        "type": "object"
+      },
+      "DatasetTailResponse": {
+        "properties": {
+          "data": {
+            "description": "Resulting data",
+            "type": "object"
+          },
+          "dataFormat": {
+            "$ref": "#/components/schemas/DataFormat",
+            "description": "How data is layed out in the response"
+          },
+          "schema": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Schema",
+                "description": "Schema of the resulting data"
+              }
+            ]
+          },
+          "schemaFormat": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaFormat",
+                "description": "What representation is used for the schema"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "dataFormat"
+        ],
+        "type": "object"
+      },
+      "Include": {
+        "enum": [
+          "Input",
+          "Proof",
+          "Schema"
+        ],
+        "type": "string"
+      },
+      "InvalidRequest": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvalidRequestInputHash"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "InvalidRequest::InputHash"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvalidRequestSubQueriesHash"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "InvalidRequest::SubQueriesHash"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvalidRequestBadSignature"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "InvalidRequest::BadSignature"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        ]
+      },
+      "InvalidRequestBadSignature": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "InvalidRequestInputHash": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "InvalidRequestSubQueriesHash": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "LoginRequestBody": {
+        "properties": {
+          "loginCredentialsJson": {
+            "type": "string"
+          },
+          "loginMethod": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "loginMethod",
+          "loginCredentialsJson"
+        ],
+        "type": "object"
+      },
+      "NodeInfoResponse": {
+        "properties": {
+          "isMultiTenant": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isMultiTenant"
+        ],
+        "type": "object"
+      },
+      "Output": {
+        "additionalProperties": false,
+        "properties": {
+          "attachments": {
+            "type": "object"
+          },
+          "info": {
+            "type": "object"
+          },
+          "license": {
+            "type": "object"
+          },
+          "refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "schema": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Schema"
+              }
+            ]
+          },
+          "schemaFormat": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaFormat"
+              }
+            ]
+          },
+          "seed": {
+            "type": "object"
+          },
+          "vocab": {
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "OutputMismatch": {
+        "properties": {
+          "actual_hash": {
+            "type": "string"
+          },
+          "expected_hash": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "expected_hash",
+          "actual_hash"
+        ],
+        "type": "object"
+      },
+      "Outputs": {
+        "properties": {
+          "data": {
+            "description": "Resulting data"
+          },
+          "dataFormat": {
+            "$ref": "#/components/schemas/DataFormat",
+            "description": "How data is layed out in the response"
+          },
+          "schema": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Schema",
+                "description": "Schema of the resulting data"
+              }
+            ]
+          },
+          "schemaFormat": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaFormat",
+                "description": "What representation is used for the schema"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "dataFormat"
+        ],
+        "type": "object"
+      },
+      "Proof": {
+        "additionalProperties": false,
+        "properties": {
+          "proofValue": {
+            "description": "Signature: `multibase(sign(canonicalize(commitment)))`",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ProofType",
+            "description": "Type of the proof provided"
+          },
+          "verificationMethod": {
+            "description": "DID (public key) of the node performing the computation",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "verificationMethod",
+          "proofValue"
+        ],
+        "type": "object"
+      },
+      "ProofType": {
+        "enum": [
+          "Ed25519Signature2020"
+        ],
+        "type": "string"
+      },
+      "QueryRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "dataFormat": {
+            "$ref": "#/components/schemas/DataFormat",
+            "description": "How data should be layed out in the response"
+          },
+          "datasets": {
+            "description": "Optional information used to affix an alias to the specific\n[`odf::DatasetID`] and reproduce the query at a specific state in time",
+            "items": {
+              "$ref": "#/components/schemas/DatasetState"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "include": {
+            "description": "What information to include",
+            "items": {
+              "$ref": "#/components/schemas/Include"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "limit": {
+            "description": "Pagination: limits number of records in response to N",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "query": {
+            "description": "Query string",
+            "type": "string"
+          },
+          "queryDialect": {
+            "description": "Dialect of the query",
+            "type": "string"
+          },
+          "schemaFormat": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaFormat",
+                "description": "What representation to use for the schema"
+              }
+            ]
+          },
+          "skip": {
+            "description": "Pagination: skips first N records",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "QueryResponse": {
+        "properties": {
+          "commitment": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Commitment",
+                "description": "Succinct commitment"
+              }
+            ]
+          },
+          "input": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/QueryRequest",
+                "description": "Inputs that can be used to fully reproduce the query"
+              }
+            ]
+          },
+          "output": {
+            "$ref": "#/components/schemas/Outputs",
+            "description": "Query results"
+          },
+          "proof": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Proof",
+                "description": "Signature block"
+              }
+            ]
+          },
+          "subQueries": {
+            "description": "Information about processing performed by other nodes as part of this\noperation",
+            "items": {
+              "$ref": "#/components/schemas/SubQuery"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "output"
+        ],
+        "type": "object"
+      },
+      "Schema": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/SchemaFormat"
+          },
+          "schema": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "schema",
+          "format"
+        ],
+        "type": "object"
+      },
+      "SchemaFormat": {
+        "enum": [
+          "ArrowJson",
+          "Parquet",
+          "ParquetJson"
+        ],
+        "type": "string"
+      },
+      "SubQuery": {
+        "additionalProperties": false,
+        "description": "Mirrors the structure of [`ResponseBody`] without the `outputs`",
+        "properties": {
+          "commitment": {
+            "$ref": "#/components/schemas/Commitment",
+            "description": "Succinct commitment"
+          },
+          "input": {
+            "$ref": "#/components/schemas/QueryRequest",
+            "description": "Inputs that can be used to fully reproduce the query"
+          },
+          "proof": {
+            "$ref": "#/components/schemas/Proof",
+            "description": "Signature block"
+          },
+          "subQueries": {
+            "description": "Information about processing performed by other nodes as part of this\noperation",
+            "type": "object"
+          }
+        },
+        "required": [
+          "input",
+          "subQueries",
+          "commitment",
+          "proof"
+        ],
+        "type": "object"
+      },
+      "UploadContext": {
+        "properties": {
+          "fields": {
+            "items": {
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "headers": {
+            "items": {
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "method": {
+            "type": "string"
+          },
+          "uploadToken": {
+            "type": "string"
+          },
+          "uploadUrl": {
+            "type": "string"
+          },
+          "useMultipart": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "uploadUrl",
+          "method",
+          "useMultipart",
+          "headers",
+          "fields",
+          "uploadToken"
+        ],
+        "type": "object"
+      },
+      "ValidationError": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/InvalidRequest"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationFailed"
+          }
+        ]
+      },
+      "VerificationFailed": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OutputMismatch"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "VerificationFailed::OutputMismatch"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetNotFound"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "VerificationFailed::DatasetNotFound"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetBlockNotFound"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "VerificationFailed::DatasetBlockNotFound"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        ]
+      },
+      "VerifyRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "commitment": {
+            "$ref": "#/components/schemas/Commitment",
+            "description": "Commitment createad by the original operation"
+          },
+          "input": {
+            "$ref": "#/components/schemas/QueryRequest",
+            "description": "Inputs that will be used to reproduce the query"
+          },
+          "proof": {
+            "$ref": "#/components/schemas/Proof",
+            "description": "Signature block"
+          },
+          "subQueries": {
+            "description": "Information about processing performed by other nodes as part of the\noriginal operation",
+            "items": {
+              "$ref": "#/components/schemas/SubQuery"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "input",
+          "subQueries",
+          "commitment",
+          "proof"
+        ],
+        "type": "object"
+      },
+      "VerifyResponse": {
+        "properties": {
+          "error": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ValidationError",
+                "description": "Will contain error details if validation was unsuccessufl"
+              }
+            ]
+          },
+          "ok": {
+            "description": "Whether validation was successful",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "bearerFormat": "AccessToken",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "dev@kamu.dev",
+      "name": "Kamu Data Inc."
+    },
+    "description": "Decentralized data management tool",
+    "license": {
+      "name": ""
+    },
+    "title": "kamu-cli",
+    "version": "0.205.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/accounts/me": {
+      "get": {
+        "operationId": "account_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get account information",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/datasets/{id}": {
+      "get": {
+        "operationId": "dataset_info_handler",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetInfoResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get dataset info by ID",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/info": {
+      "get": {
+        "operationId": "node_info_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodeInfoResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get ODF node description",
+        "tags": [
+          "odf-core"
+        ]
+      }
+    },
+    "/odata/{account_name}": {
+      "get": {
+        "operationId": "odata_service_handler_mt",
+        "parameters": [
+          {
+            "description": "Account name",
+            "in": "path",
+            "name": "account_name",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "OData root service description",
+        "tags": [
+          "kamu-odata"
+        ]
+      }
+    },
+    "/odata/{account_name}/$metadata": {
+      "get": {
+        "operationId": "odata_metadata_handler_mt",
+        "parameters": [
+          {
+            "description": "Account name",
+            "in": "path",
+            "name": "account_name",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "OData service metadata",
+        "tags": [
+          "kamu-odata"
+        ]
+      }
+    },
+    "/odata/{account_name}/{dataset_name}": {
+      "get": {
+        "operationId": "odata_collection_handler_mt",
+        "parameters": [
+          {
+            "description": "Account name",
+            "in": "path",
+            "name": "account_name",
+            "required": true
+          },
+          {
+            "description": "Dataset name",
+            "in": "path",
+            "name": "dataset_name",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "OData collection",
+        "tags": [
+          "kamu-odata"
+        ]
+      }
+    },
+    "/platform/file/upload/prepare": {
+      "post": {
+        "operationId": "platform_file_upload_prepare_post_handler",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "contentLength",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "contentType",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadContext"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Prepare file upload",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/platform/file/upload/{upload_token}": {
+      "get": {
+        "operationId": "platform_file_upload_get_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get file from temporary storage",
+        "tags": [
+          "kamu"
+        ]
+      },
+      "post": {
+        "operationId": "platform_file_upload_post_handler",
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadContext"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Upload file to temporary storage",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/platform/login": {
+      "post": {
+        "operationId": "platform_login_handler",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {}
+        ],
+        "summary": "Authenticate with the node",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/platform/token/validate": {
+      "get": {
+        "operationId": "platform_token_validate_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Validate auth token",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/query": {
+      "get": {
+        "operationId": "query_handler",
+        "parameters": [
+          {
+            "description": "Query to execute (e.g. SQL)",
+            "in": "path",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Dialect of the query",
+            "in": "path",
+            "name": "queryDialect",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of leading records to skip when returning result (used for\npagination)",
+            "in": "path",
+            "name": "skip",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (used for pagination)",
+            "in": "path",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "How the output data should be ecoded",
+            "in": "path",
+            "name": "dataFormat",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DataFormat"
+            }
+          },
+          {
+            "description": "How to encode the schema of the result",
+            "in": "path",
+            "name": "schemaFormat",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SchemaFormat"
+                }
+              ]
+            }
+          },
+          {
+            "description": "What information to include in the response",
+            "in": "path",
+            "name": "include",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Execute a batch query",
+        "tags": [
+          "odf-query"
+        ]
+      },
+      "post": {
+        "operationId": "query_handler_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Execute a batch query",
+        "tags": [
+          "odf-query"
+        ]
+      }
+    },
+    "/verify": {
+      "post": {
+        "description": "See [commitments documentation](https://docs.kamu.dev/node/commitments/) for details.",
+        "operationId": "verify_handler",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyResponse"
+                }
+              }
+            },
+            "description": ""
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Verify query commitment",
+        "tags": [
+          "odf-query"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/blocks/{block_hash}": {
+      "get": {
+        "operationId": "dataset_blocks_handler",
+        "parameters": [
+          {
+            "description": "Hash of the block",
+            "in": "path",
+            "name": "block_hash",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get block by hash",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/checkpoints/{physical_hash}": {
+      "get": {
+        "operationId": "dataset_checkpoints_get_handler",
+        "parameters": [
+          {
+            "description": "Physical hash of the checkpoint",
+            "in": "path",
+            "name": "physical_hash",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get checkpoint by hash",
+        "tags": [
+          "odf-transfer"
+        ]
+      },
+      "put": {
+        "operationId": "dataset_checkpoints_put_handler",
+        "parameters": [
+          {
+            "description": "Physical hash of the checkpoint",
+            "in": "path",
+            "name": "physical_hash",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Upload checkpoint",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/data/{physical_hash}": {
+      "get": {
+        "operationId": "dataset_data_get_handler",
+        "parameters": [
+          {
+            "description": "Physical hash of the data slice",
+            "in": "path",
+            "name": "physical_hash",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get data slice by hash",
+        "tags": [
+          "odf-transfer"
+        ]
+      },
+      "put": {
+        "operationId": "dataset_data_put_handler",
+        "parameters": [
+          {
+            "description": "Physical hash of the data slice",
+            "in": "path",
+            "name": "physical_hash",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Upload data slice",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/ingest": {
+      "post": {
+        "operationId": "dataset_ingest_handler",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sourceName",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "in": "path",
+            "name": "uploadToken",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Push data ingestion",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/metadata": {
+      "get": {
+        "operationId": "dataset_metadata_handler",
+        "parameters": [
+          {
+            "description": "What information to include in response",
+            "in": "path",
+            "name": "include",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "Format to return the schema in",
+            "in": "path",
+            "name": "schemaFormat",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SchemaFormat"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetMetadataResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Access dataset metadata chain",
+        "tags": [
+          "odf-query"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/pull": {
+      "get": {
+        "operationId": "dataset_pull_ws_upgrade_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Initiate pull via Smart Transfer Protocol",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/push": {
+      "get": {
+        "operationId": "dataset_push_ws_upgrade_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Initiate push via Smart Transfer Protocol",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/refs/{reference}": {
+      "get": {
+        "operationId": "dataset_refs_handler",
+        "parameters": [
+          {
+            "description": "Name of the reference",
+            "in": "path",
+            "name": "reference",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get named block reference",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{account_name}/{dataset_name}/tail": {
+      "get": {
+        "operationId": "dataset_tail_handler",
+        "parameters": [
+          {
+            "description": "Number of leading records to skip when returning result (used for\npagination)",
+            "in": "path",
+            "name": "skip",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (used for pagination)",
+            "in": "path",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "How the output data should be ecoded",
+            "in": "path",
+            "name": "dataFormat",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DataFormat"
+            }
+          },
+          {
+            "description": "How to encode the schema of the result",
+            "in": "path",
+            "name": "schemaFormat",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SchemaFormat"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetTailResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get a sample of latest events",
+        "tags": [
+          "odf-query"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Core ODF APIs",
+      "name": "odf-core"
+    },
+    {
+      "description": "ODF Data Transfer APIs",
+      "name": "odf-transfer"
+    },
+    {
+      "description": "ODF Data Query APIs",
+      "name": "odf-query"
+    },
+    {
+      "description": "General Node APIs",
+      "name": "kamu"
+    },
+    {
+      "description": "OData Adapter",
+      "name": "kamu-odata"
+    }
+  ]
+}

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -1,0 +1,1920 @@
+{
+  "components": {
+    "schemas": {
+      "AccountResponse": {
+        "properties": {
+          "accountName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "accountName"
+        ],
+        "type": "object"
+      },
+      "Commitment": {
+        "additionalProperties": false,
+        "properties": {
+          "inputHash": {
+            "description": "Hash of the \"input\" object in the [multihash](https://multiformats.io/multihash/) format",
+            "type": "string"
+          },
+          "outputHash": {
+            "description": "Hash of the \"output\" object in the [multihash](https://multiformats.io/multihash/) format",
+            "type": "string"
+          },
+          "subQueriesHash": {
+            "description": "Hash of the \"subQueries\" object in the [multihash](https://multiformats.io/multihash/) format",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputHash",
+          "outputHash",
+          "subQueriesHash"
+        ],
+        "type": "object"
+      },
+      "DataFormat": {
+        "enum": [
+          "JsonAoS",
+          "JsonSoA",
+          "JsonAoA"
+        ],
+        "type": "string"
+      },
+      "DatasetBlockNotFound": {
+        "properties": {
+          "block_hash": {
+            "type": "string"
+          },
+          "dataset_id": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "dataset_id",
+          "block_hash"
+        ],
+        "type": "object"
+      },
+      "DatasetInfoResponse": {
+        "properties": {
+          "datasetName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "owner": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DatasetOwnerInfo"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "datasetName"
+        ],
+        "type": "object"
+      },
+      "DatasetMetadataResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "output": {
+            "$ref": "#/components/schemas/Output"
+          }
+        },
+        "required": [
+          "output"
+        ],
+        "type": "object"
+      },
+      "DatasetNotFound": {
+        "properties": {
+          "dataset_id": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "dataset_id"
+        ],
+        "type": "object"
+      },
+      "DatasetOwnerInfo": {
+        "properties": {
+          "accountId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "accountName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "accountName"
+        ],
+        "type": "object"
+      },
+      "DatasetState": {
+        "additionalProperties": false,
+        "properties": {
+          "alias": {
+            "description": "Alias to be used in the query",
+            "type": "string"
+          },
+          "blockHash": {
+            "description": "Last block hash of the input datasets that was or should be considered\nduring the query planning",
+            "type": "string"
+          },
+          "id": {
+            "description": "Globally unique identity of the dataset",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "alias"
+        ],
+        "type": "object"
+      },
+      "DatasetTailResponse": {
+        "properties": {
+          "data": {
+            "description": "Resulting data",
+            "type": "object"
+          },
+          "dataFormat": {
+            "$ref": "#/components/schemas/DataFormat",
+            "description": "How data is layed out in the response"
+          },
+          "schema": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Schema",
+                "description": "Schema of the resulting data"
+              }
+            ]
+          },
+          "schemaFormat": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaFormat",
+                "description": "What representation is used for the schema"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "dataFormat"
+        ],
+        "type": "object"
+      },
+      "Include": {
+        "enum": [
+          "Input",
+          "Proof",
+          "Schema"
+        ],
+        "type": "string"
+      },
+      "InvalidRequest": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvalidRequestInputHash"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "InvalidRequest::InputHash"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvalidRequestSubQueriesHash"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "InvalidRequest::SubQueriesHash"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvalidRequestBadSignature"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "InvalidRequest::BadSignature"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        ]
+      },
+      "InvalidRequestBadSignature": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "InvalidRequestInputHash": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "InvalidRequestSubQueriesHash": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "LoginRequestBody": {
+        "properties": {
+          "loginCredentialsJson": {
+            "type": "string"
+          },
+          "loginMethod": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "loginMethod",
+          "loginCredentialsJson"
+        ],
+        "type": "object"
+      },
+      "NodeInfoResponse": {
+        "properties": {
+          "isMultiTenant": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isMultiTenant"
+        ],
+        "type": "object"
+      },
+      "Output": {
+        "additionalProperties": false,
+        "properties": {
+          "attachments": {
+            "type": "object"
+          },
+          "info": {
+            "type": "object"
+          },
+          "license": {
+            "type": "object"
+          },
+          "refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "schema": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Schema"
+              }
+            ]
+          },
+          "schemaFormat": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaFormat"
+              }
+            ]
+          },
+          "seed": {
+            "type": "object"
+          },
+          "vocab": {
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "OutputMismatch": {
+        "properties": {
+          "actual_hash": {
+            "type": "string"
+          },
+          "expected_hash": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "expected_hash",
+          "actual_hash"
+        ],
+        "type": "object"
+      },
+      "Outputs": {
+        "properties": {
+          "data": {
+            "description": "Resulting data"
+          },
+          "dataFormat": {
+            "$ref": "#/components/schemas/DataFormat",
+            "description": "How data is layed out in the response"
+          },
+          "schema": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Schema",
+                "description": "Schema of the resulting data"
+              }
+            ]
+          },
+          "schemaFormat": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaFormat",
+                "description": "What representation is used for the schema"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "dataFormat"
+        ],
+        "type": "object"
+      },
+      "Proof": {
+        "additionalProperties": false,
+        "properties": {
+          "proofValue": {
+            "description": "Signature: `multibase(sign(canonicalize(commitment)))`",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ProofType",
+            "description": "Type of the proof provided"
+          },
+          "verificationMethod": {
+            "description": "DID (public key) of the node performing the computation",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "verificationMethod",
+          "proofValue"
+        ],
+        "type": "object"
+      },
+      "ProofType": {
+        "enum": [
+          "Ed25519Signature2020"
+        ],
+        "type": "string"
+      },
+      "QueryRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "dataFormat": {
+            "$ref": "#/components/schemas/DataFormat",
+            "description": "How data should be layed out in the response"
+          },
+          "datasets": {
+            "description": "Optional information used to affix an alias to the specific\n[`odf::DatasetID`] and reproduce the query at a specific state in time",
+            "items": {
+              "$ref": "#/components/schemas/DatasetState"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "include": {
+            "description": "What information to include",
+            "items": {
+              "$ref": "#/components/schemas/Include"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "limit": {
+            "description": "Pagination: limits number of records in response to N",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "query": {
+            "description": "Query string",
+            "type": "string"
+          },
+          "queryDialect": {
+            "description": "Dialect of the query",
+            "type": "string"
+          },
+          "schemaFormat": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SchemaFormat",
+                "description": "What representation to use for the schema"
+              }
+            ]
+          },
+          "skip": {
+            "description": "Pagination: skips first N records",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "QueryResponse": {
+        "properties": {
+          "commitment": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Commitment",
+                "description": "Succinct commitment"
+              }
+            ]
+          },
+          "input": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/QueryRequest",
+                "description": "Inputs that can be used to fully reproduce the query"
+              }
+            ]
+          },
+          "output": {
+            "$ref": "#/components/schemas/Outputs",
+            "description": "Query results"
+          },
+          "proof": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Proof",
+                "description": "Signature block"
+              }
+            ]
+          },
+          "subQueries": {
+            "description": "Information about processing performed by other nodes as part of this\noperation",
+            "items": {
+              "$ref": "#/components/schemas/SubQuery"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "output"
+        ],
+        "type": "object"
+      },
+      "Schema": {
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/SchemaFormat"
+          },
+          "schema": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "schema",
+          "format"
+        ],
+        "type": "object"
+      },
+      "SchemaFormat": {
+        "enum": [
+          "ArrowJson",
+          "Parquet",
+          "ParquetJson"
+        ],
+        "type": "string"
+      },
+      "SubQuery": {
+        "additionalProperties": false,
+        "description": "Mirrors the structure of [`ResponseBody`] without the `outputs`",
+        "properties": {
+          "commitment": {
+            "$ref": "#/components/schemas/Commitment",
+            "description": "Succinct commitment"
+          },
+          "input": {
+            "$ref": "#/components/schemas/QueryRequest",
+            "description": "Inputs that can be used to fully reproduce the query"
+          },
+          "proof": {
+            "$ref": "#/components/schemas/Proof",
+            "description": "Signature block"
+          },
+          "subQueries": {
+            "description": "Information about processing performed by other nodes as part of this\noperation",
+            "type": "object"
+          }
+        },
+        "required": [
+          "input",
+          "subQueries",
+          "commitment",
+          "proof"
+        ],
+        "type": "object"
+      },
+      "UploadContext": {
+        "properties": {
+          "fields": {
+            "items": {
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "headers": {
+            "items": {
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "method": {
+            "type": "string"
+          },
+          "uploadToken": {
+            "type": "string"
+          },
+          "uploadUrl": {
+            "type": "string"
+          },
+          "useMultipart": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "uploadUrl",
+          "method",
+          "useMultipart",
+          "headers",
+          "fields",
+          "uploadToken"
+        ],
+        "type": "object"
+      },
+      "ValidationError": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/InvalidRequest"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationFailed"
+          }
+        ]
+      },
+      "VerificationFailed": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OutputMismatch"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "VerificationFailed::OutputMismatch"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetNotFound"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "VerificationFailed::DatasetNotFound"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetBlockNotFound"
+              },
+              {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "VerificationFailed::DatasetBlockNotFound"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        ]
+      },
+      "VerifyRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "commitment": {
+            "$ref": "#/components/schemas/Commitment",
+            "description": "Commitment createad by the original operation"
+          },
+          "input": {
+            "$ref": "#/components/schemas/QueryRequest",
+            "description": "Inputs that will be used to reproduce the query"
+          },
+          "proof": {
+            "$ref": "#/components/schemas/Proof",
+            "description": "Signature block"
+          },
+          "subQueries": {
+            "description": "Information about processing performed by other nodes as part of the\noriginal operation",
+            "items": {
+              "$ref": "#/components/schemas/SubQuery"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "input",
+          "subQueries",
+          "commitment",
+          "proof"
+        ],
+        "type": "object"
+      },
+      "VerifyResponse": {
+        "properties": {
+          "error": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ValidationError",
+                "description": "Will contain error details if validation was unsuccessufl"
+              }
+            ]
+          },
+          "ok": {
+            "description": "Whether validation was successful",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "bearerFormat": "AccessToken",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "dev@kamu.dev",
+      "name": "Kamu Data Inc."
+    },
+    "description": "Decentralized data management tool",
+    "license": {
+      "name": ""
+    },
+    "title": "kamu-cli",
+    "version": "0.205.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/accounts/me": {
+      "get": {
+        "operationId": "account_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get account information",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/datasets/{id}": {
+      "get": {
+        "operationId": "dataset_info_handler",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetInfoResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get dataset info by ID",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/info": {
+      "get": {
+        "operationId": "node_info_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodeInfoResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get ODF node description",
+        "tags": [
+          "odf-core"
+        ]
+      }
+    },
+    "/odata/": {
+      "get": {
+        "operationId": "odata_service_handler_st",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "OData root service description",
+        "tags": [
+          "kamu-odata"
+        ]
+      }
+    },
+    "/odata/$metadata": {
+      "get": {
+        "operationId": "odata_metadata_handler_st",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "OData service metadata",
+        "tags": [
+          "kamu-odata"
+        ]
+      }
+    },
+    "/odata/{dataset_name}": {
+      "get": {
+        "operationId": "odata_collection_handler_st",
+        "parameters": [
+          {
+            "description": "Dataset name",
+            "in": "path",
+            "name": "dataset_name",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "OData collection",
+        "tags": [
+          "kamu-odata"
+        ]
+      }
+    },
+    "/platform/file/upload/prepare": {
+      "post": {
+        "operationId": "platform_file_upload_prepare_post_handler",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "contentLength",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "contentType",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadContext"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Prepare file upload",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/platform/file/upload/{upload_token}": {
+      "get": {
+        "operationId": "platform_file_upload_get_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get file from temporary storage",
+        "tags": [
+          "kamu"
+        ]
+      },
+      "post": {
+        "operationId": "platform_file_upload_post_handler",
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadContext"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Upload file to temporary storage",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/platform/login": {
+      "post": {
+        "operationId": "platform_login_handler",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {}
+        ],
+        "summary": "Authenticate with the node",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/platform/token/validate": {
+      "get": {
+        "operationId": "platform_token_validate_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Validate auth token",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/query": {
+      "get": {
+        "operationId": "query_handler",
+        "parameters": [
+          {
+            "description": "Query to execute (e.g. SQL)",
+            "in": "path",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Dialect of the query",
+            "in": "path",
+            "name": "queryDialect",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of leading records to skip when returning result (used for\npagination)",
+            "in": "path",
+            "name": "skip",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (used for pagination)",
+            "in": "path",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "How the output data should be ecoded",
+            "in": "path",
+            "name": "dataFormat",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DataFormat"
+            }
+          },
+          {
+            "description": "How to encode the schema of the result",
+            "in": "path",
+            "name": "schemaFormat",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SchemaFormat"
+                }
+              ]
+            }
+          },
+          {
+            "description": "What information to include in the response",
+            "in": "path",
+            "name": "include",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Execute a batch query",
+        "tags": [
+          "odf-query"
+        ]
+      },
+      "post": {
+        "operationId": "query_handler_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Execute a batch query",
+        "tags": [
+          "odf-query"
+        ]
+      }
+    },
+    "/verify": {
+      "post": {
+        "description": "See [commitments documentation](https://docs.kamu.dev/node/commitments/) for details.",
+        "operationId": "verify_handler",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyResponse"
+                }
+              }
+            },
+            "description": ""
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Verify query commitment",
+        "tags": [
+          "odf-query"
+        ]
+      }
+    },
+    "/{dataset_name}/blocks/{block_hash}": {
+      "get": {
+        "operationId": "dataset_blocks_handler",
+        "parameters": [
+          {
+            "description": "Hash of the block",
+            "in": "path",
+            "name": "block_hash",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get block by hash",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{dataset_name}/checkpoints/{physical_hash}": {
+      "get": {
+        "operationId": "dataset_checkpoints_get_handler",
+        "parameters": [
+          {
+            "description": "Physical hash of the checkpoint",
+            "in": "path",
+            "name": "physical_hash",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get checkpoint by hash",
+        "tags": [
+          "odf-transfer"
+        ]
+      },
+      "put": {
+        "operationId": "dataset_checkpoints_put_handler",
+        "parameters": [
+          {
+            "description": "Physical hash of the checkpoint",
+            "in": "path",
+            "name": "physical_hash",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Upload checkpoint",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{dataset_name}/data/{physical_hash}": {
+      "get": {
+        "operationId": "dataset_data_get_handler",
+        "parameters": [
+          {
+            "description": "Physical hash of the data slice",
+            "in": "path",
+            "name": "physical_hash",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get data slice by hash",
+        "tags": [
+          "odf-transfer"
+        ]
+      },
+      "put": {
+        "operationId": "dataset_data_put_handler",
+        "parameters": [
+          {
+            "description": "Physical hash of the data slice",
+            "in": "path",
+            "name": "physical_hash",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Upload data slice",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{dataset_name}/ingest": {
+      "post": {
+        "operationId": "dataset_ingest_handler",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sourceName",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "in": "path",
+            "name": "uploadToken",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "items": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Push data ingestion",
+        "tags": [
+          "kamu"
+        ]
+      }
+    },
+    "/{dataset_name}/metadata": {
+      "get": {
+        "operationId": "dataset_metadata_handler",
+        "parameters": [
+          {
+            "description": "What information to include in response",
+            "in": "path",
+            "name": "include",
+            "required": true,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "Format to return the schema in",
+            "in": "path",
+            "name": "schemaFormat",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SchemaFormat"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetMetadataResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Access dataset metadata chain",
+        "tags": [
+          "odf-query"
+        ]
+      }
+    },
+    "/{dataset_name}/pull": {
+      "get": {
+        "operationId": "dataset_pull_ws_upgrade_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Initiate pull via Smart Transfer Protocol",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{dataset_name}/push": {
+      "get": {
+        "operationId": "dataset_push_ws_upgrade_handler",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": null
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Initiate push via Smart Transfer Protocol",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{dataset_name}/refs/{reference}": {
+      "get": {
+        "operationId": "dataset_refs_handler",
+        "parameters": [
+          {
+            "description": "Name of the reference",
+            "in": "path",
+            "name": "reference",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get named block reference",
+        "tags": [
+          "odf-transfer"
+        ]
+      }
+    },
+    "/{dataset_name}/tail": {
+      "get": {
+        "operationId": "dataset_tail_handler",
+        "parameters": [
+          {
+            "description": "Number of leading records to skip when returning result (used for\npagination)",
+            "in": "path",
+            "name": "skip",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return (used for pagination)",
+            "in": "path",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "How the output data should be ecoded",
+            "in": "path",
+            "name": "dataFormat",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DataFormat"
+            }
+          },
+          {
+            "description": "How to encode the schema of the result",
+            "in": "path",
+            "name": "schemaFormat",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/SchemaFormat"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetTailResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {},
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get a sample of latest events",
+        "tags": [
+          "odf-query"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Core ODF APIs",
+      "name": "odf-core"
+    },
+    {
+      "description": "ODF Data Transfer APIs",
+      "name": "odf-transfer"
+    },
+    {
+      "description": "ODF Data Query APIs",
+      "name": "odf-query"
+    },
+    {
+      "description": "General Node APIs",
+      "name": "kamu"
+    },
+    {
+      "description": "OData Adapter",
+      "name": "kamu-odata"
+    }
+  ]
+}

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -90,6 +90,8 @@ tokio-tungstenite = { version = "0.24", features = [
 tower = "0.5"
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }
+utoipa = { version = "5", default-features = false, features = [] }
+utoipa-axum = { version = "0.1", default-features = false, features = [] }
 uuid = { version = "1", default-features = false, features = ["v4"] }
 
 # Optional

--- a/src/adapter/http/src/data/query_handler.rs
+++ b/src/adapter/http/src/data/query_handler.rs
@@ -25,28 +25,27 @@ use internal_error::*;
 use kamu_core::*;
 use opendatafabric as odf;
 
-use super::query_types::*;
+use super::query_types::{QueryResponse, *};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Execute a batch query
+#[utoipa::path(
+    post,
+    path = "/query",
+    request_body = QueryRequest,
+    responses((status = OK, body = QueryResponse)),
+    tag = "odf-query",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 #[transactional_handler]
 pub async fn query_handler_post(
     Extension(catalog): Extension<Catalog>,
-    Json(body): Json<RequestBody>,
-) -> Result<Json<ResponseBody>, ApiError> {
-    match body {
-        RequestBody::V1(body) => query_handler_post_v1(catalog, body).await,
-        RequestBody::V2(body) => query_handler_post_v2(catalog, body).await,
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) async fn query_handler_post_v2(
-    catalog: Catalog,
-    mut body: RequestBodyV2,
-) -> Result<Json<ResponseBody>, ApiError> {
+    Json(mut body): Json<QueryRequest>,
+) -> Result<Json<QueryResponse>, ApiError> {
     tracing::debug!(request = ?body, "Query");
 
     // Automatically add `Input` if proof is requested, as proof depends on input
@@ -106,13 +105,19 @@ pub(crate) async fn query_handler_post_v2(
         if !body.include.contains(&Include::Input) && !body.include.contains(&Include::Proof) {
             None
         } else {
-            body.datasets = Some(RequestBodyV2::query_state_to_datasets(res.state));
+            body.datasets = Some(QueryRequest::query_state_to_datasets(res.state));
             body.schema_format = schema_format;
             Some(body)
         };
 
     let response = if !include_proof {
-        ResponseBody::V2(ResponseBodyV2 { input, output })
+        QueryResponse {
+            input,
+            output,
+            sub_queries: None,
+            commitment: None,
+            proof: None,
+        }
     } else if let Some(identity) = identity {
         use ed25519_dalek::Signer;
 
@@ -131,17 +136,17 @@ pub(crate) async fn query_handler_post_v2(
 
         let signature = identity.private_key.sign(&to_canonical_json(&commitment));
 
-        ResponseBody::V2Signed(ResponseBodyV2Signed {
-            input: input.unwrap(),
+        QueryResponse {
+            input,
             output,
-            sub_queries,
-            commitment,
-            proof: Proof {
+            sub_queries: Some(sub_queries),
+            commitment: Some(commitment),
+            proof: Some(Proof {
                 r#type: ProofType::Ed25519Signature2020,
                 verification_method: identity.did(),
                 proof_value: signature.into(),
-            },
-        })
+            }),
+        }
     } else {
         Err(ApiError::not_implemented(ResponseSigningNotConfigured))?
     };
@@ -151,71 +156,22 @@ pub(crate) async fn query_handler_post_v2(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[tracing::instrument(level = "info", skip_all)]
-async fn query_handler_post_v1(
-    catalog: Catalog,
-    body: RequestBodyV1,
-) -> Result<Json<ResponseBody>, ApiError> {
-    tracing::debug!(request = ?body, "Query");
-
-    let query_svc = catalog.get_one::<dyn QueryService>().unwrap();
-
-    let res = query_svc
-        .sql_statement(&body.query, body.to_options())
-        .await
-        .map_err(map_query_error)?;
-
-    // Apply pagination limits
-    let df = res
-        .df
-        .limit(
-            usize::try_from(body.skip).unwrap(),
-            Some(usize::try_from(body.limit).unwrap()),
-        )
-        .int_err()
-        .api_err()?;
-
-    let arrow_schema = df.schema().inner().clone();
-
-    let schema = if body.include_schema {
-        Some(serialize_schema(df.schema().as_arrow(), body.schema_format).api_err()?)
-    } else {
-        None
-    };
-
-    let state = if body.include_state {
-        Some(res.state.into())
-    } else {
-        None
-    };
-
-    let record_batches = df.collect().await.int_err().api_err()?;
-    let json = serialize_data(&record_batches, body.data_format).api_err()?;
-    let data = serde_json::value::RawValue::from_string(json).unwrap();
-
-    let data_hash = if body.include_data_hash {
-        Some(kamu_data_utils::data::hash::get_batches_logical_hash(
-            &arrow_schema,
-            &record_batches,
-        ))
-    } else {
-        None
-    };
-
-    Ok(Json(ResponseBody::V1(ResponseBodyV1 {
-        data,
-        schema,
-        state,
-        data_hash,
-    })))
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
+/// Execute a batch query
+#[utoipa::path(
+    get,
+    path = "/query",
+    params(QueryParams),
+    responses((status = OK, body = QueryResponse)),
+    tag = "odf-query",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn query_handler(
     catalog: Extension<Catalog>,
-    Query(params): Query<RequestParams>,
-) -> Result<Json<ResponseBody>, ApiError> {
+    Query(params): Query<QueryParams>,
+) -> Result<Json<QueryResponse>, ApiError> {
     query_handler_post(catalog, Json(params.into())).await
 }
 

--- a/src/adapter/http/src/data/router.rs
+++ b/src/adapter/http/src/data/router.rs
@@ -16,37 +16,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-pub fn root_router() -> axum::Router {
-    axum::Router::new()
-        .route(
-            "/query",
-            axum::routing::get(super::query_handler::query_handler)
-                .post(super::query_handler::query_handler_post),
-        )
-        .route(
-            "/verify",
-            axum::routing::post(super::verify_handler::verify_handler),
-        )
+pub fn root_router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(
+            super::query_handler::query_handler,
+            super::query_handler::query_handler_post
+        ))
+        .routes(routes!(super::verify_handler::verify_handler))
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-pub fn dataset_router() -> axum::Router {
-    axum::Router::new()
-        .route(
-            "/tail",
-            axum::routing::get(super::tail_handler::dataset_tail_handler),
-        )
-        .route(
-            "/metadata",
-            axum::routing::get(super::metadata_handler::dataset_metadata_handler),
-        )
-        .route(
-            "/ingest",
-            axum::routing::post(super::ingest_handler::dataset_ingest_handler),
-        )
+pub fn dataset_router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(super::tail_handler::dataset_tail_handler))
+        .routes(routes!(super::metadata_handler::dataset_metadata_handler))
+        .routes(routes!(super::ingest_handler::dataset_ingest_handler))
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/src/general/account_handler.rs
+++ b/src/adapter/http/src/general/account_handler.rs
@@ -26,10 +26,13 @@ use opendatafabric::{AccountID, AccountName};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountResponse {
+    #[schema(value_type = String)]
     pub id: AccountID,
+
+    #[schema(value_type = String)]
     pub account_name: AccountName,
 }
 
@@ -44,6 +47,17 @@ impl From<Account> for AccountResponse {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Get account information
+#[utoipa::path(
+    get,
+    path = "/accounts/me",
+    responses((status = OK, body = AccountResponse)),
+    tag = "kamu",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 #[transactional_handler]
 pub async fn account_handler(
     Extension(catalog): Extension<Catalog>,

--- a/src/adapter/http/src/general/node_info_handler.rs
+++ b/src/adapter/http/src/general/node_info_handler.rs
@@ -24,7 +24,7 @@ use kamu_core::DatasetRepository;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeInfoResponse {
     pub is_multi_tenant: bool,
@@ -32,6 +32,17 @@ pub struct NodeInfoResponse {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Get ODF node description
+#[utoipa::path(
+    get,
+    path = "/info",
+    responses((status = OK, body = NodeInfoResponse)),
+    tag = "odf-core",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn node_info_handler(
     Extension(catalog): Extension<Catalog>,
 ) -> Result<Json<NodeInfoResponse>, ApiError> {

--- a/src/adapter/http/src/general/router.rs
+++ b/src/adapter/http/src/general/router.rs
@@ -16,22 +16,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-pub fn root_router() -> axum::Router {
-    axum::Router::new()
-        .route(
-            "/info",
-            axum::routing::get(super::node_info_handler::node_info_handler),
-        )
-        .route(
-            "/accounts/me",
-            axum::routing::get(super::account_handler::account_handler),
-        )
-        .route(
-            "/datasets/:id",
-            axum::routing::get(super::dataset_info_handler::dataset_info_handler),
-        )
+pub fn root_router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(super::node_info_handler::node_info_handler))
+        .routes(routes!(super::account_handler::account_handler))
+        .routes(routes!(super::dataset_info_handler::dataset_info_handler))
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/http/src/simple_protocol/handlers.rs
+++ b/src/adapter/http/src/simple_protocol/handlers.rs
@@ -53,6 +53,20 @@ pub struct PhysicalHashFromPath {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Get named block reference
+#[utoipa::path(
+    get,
+    path = "/refs/{reference}",
+    params(
+        ("reference", description = "Name of the reference")
+    ),
+    responses((status = OK, body = String)),
+    tag = "odf-transfer",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn dataset_refs_handler(
     axum::extract::Extension(dataset): axum::extract::Extension<Arc<dyn Dataset>>,
     axum::extract::Path(ref_param): axum::extract::Path<RefFromPath>,
@@ -71,6 +85,20 @@ pub async fn dataset_refs_handler(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Get block by hash
+#[utoipa::path(
+    get,
+    path = "/blocks/{block_hash}",
+    params(
+        ("block_hash", description = "Hash of the block")
+    ),
+    responses((status = OK, body = Vec<u8>)),
+    tag = "odf-transfer",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn dataset_blocks_handler(
     axum::extract::Extension(dataset): axum::extract::Extension<Arc<dyn Dataset>>,
     axum::extract::Path(hash_param): axum::extract::Path<BlockHashFromPath>,
@@ -95,6 +123,20 @@ pub async fn dataset_blocks_handler(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Get data slice by hash
+#[utoipa::path(
+    get,
+    path = "/data/{physical_hash}",
+    params(
+        ("physical_hash", description = "Physical hash of the data slice")
+    ),
+    responses((status = OK, body = Vec<u8>)),
+    tag = "odf-transfer",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn dataset_data_get_handler(
     axum::extract::Extension(dataset): axum::extract::Extension<Arc<dyn Dataset>>,
     axum::extract::Path(hash_param): axum::extract::Path<PhysicalHashFromPath>,
@@ -104,6 +146,20 @@ pub async fn dataset_data_get_handler(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Get checkpoint by hash
+#[utoipa::path(
+    get,
+    path = "/checkpoints/{physical_hash}",
+    params(
+        ("physical_hash", description = "Physical hash of the checkpoint")
+    ),
+    responses((status = OK, body = Vec<u8>)),
+    tag = "odf-transfer",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn dataset_checkpoints_get_handler(
     axum::extract::Extension(dataset): axum::extract::Extension<Arc<dyn Dataset>>,
     axum::extract::Path(hash_param): axum::extract::Path<PhysicalHashFromPath>,
@@ -130,6 +186,21 @@ async fn dataset_get_object_common(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Upload data slice
+#[utoipa::path(
+    put,
+    path = "/data/{physical_hash}",
+    params(
+        ("physical_hash", description = "Physical hash of the data slice")
+    ),
+    request_body = Vec<u8>,
+    responses((status = OK, body = ())),
+    tag = "odf-transfer",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn dataset_data_put_handler(
     axum::extract::Extension(dataset): axum::extract::Extension<Arc<dyn Dataset>>,
     axum::extract::Path(hash_param): axum::extract::Path<PhysicalHashFromPath>,
@@ -147,6 +218,21 @@ pub async fn dataset_data_put_handler(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Upload checkpoint
+#[utoipa::path(
+    put,
+    path = "/checkpoints/{physical_hash}",
+    params(
+        ("physical_hash", description = "Physical hash of the checkpoint")
+    ),
+    request_body = Vec<u8>,
+    responses((status = OK, body = ())),
+    tag = "odf-transfer",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn dataset_checkpoints_put_handler(
     axum::extract::Extension(dataset): axum::extract::Extension<Arc<dyn Dataset>>,
     axum::extract::Path(hash_param): axum::extract::Path<PhysicalHashFromPath>,
@@ -189,6 +275,17 @@ async fn dataset_put_object_common(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Initiate push via Smart Transfer Protocol
+#[utoipa::path(
+    get,
+    path = "/push",
+    responses((status = OK, body = ())),
+    tag = "odf-transfer",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn dataset_push_ws_upgrade_handler(
     ws: axum::extract::ws::WebSocketUpgrade,
     axum::extract::Extension(dataset_ref): axum::extract::Extension<DatasetRef>,
@@ -241,6 +338,17 @@ pub async fn dataset_push_ws_upgrade_handler(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Initiate pull via Smart Transfer Protocol
+#[utoipa::path(
+    get,
+    path = "/pull",
+    responses((status = OK, body = ())),
+    tag = "odf-transfer",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 pub async fn dataset_pull_ws_upgrade_handler(
     ws: axum::extract::ws::WebSocketUpgrade,
     axum::extract::Extension(dataset): axum::extract::Extension<Arc<dyn Dataset>>,

--- a/src/adapter/http/src/upload/upload_service.rs
+++ b/src/adapter/http/src/upload/upload_service.rs
@@ -81,7 +81,7 @@ pub trait UploadService: Send + Sync {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct UploadContext {
     pub upload_url: String,
@@ -89,6 +89,8 @@ pub struct UploadContext {
     pub use_multipart: bool,
     pub headers: Vec<(String, String)>,
     pub fields: Vec<(String, String)>,
+
+    #[schema(value_type = String)]
     pub upload_token: UploadTokenBase64Json,
 }
 

--- a/src/adapter/odata/Cargo.toml
+++ b/src/adapter/odata/Cargo.toml
@@ -40,6 +40,8 @@ http = "1"
 quick-xml = { version = "0.36", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
+utoipa = { version = "5", default-features = false, features = [] }
+utoipa-axum = { version = "0.1", default-features = false, features = [] }
 
 
 [dev-dependencies]

--- a/src/adapter/odata/src/handler.rs
+++ b/src/adapter/odata/src/handler.rs
@@ -34,6 +34,17 @@ use crate::context::*;
 // TODO: Replace these variations with middleware
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// OData root service description
+#[utoipa::path(
+    get,
+    path = "/",
+    responses((status = OK, body = String)),
+    tag = "kamu-odata",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 #[transactional_handler]
 pub async fn odata_service_handler_st(
     Extension(catalog): Extension<Catalog>,
@@ -41,6 +52,20 @@ pub async fn odata_service_handler_st(
     odata_service_handler_common(catalog, None).await
 }
 
+/// OData root service description
+#[utoipa::path(
+    get,
+    path = "/{account_name}",
+    params(
+        ("account_name", description = "Account name")
+    ),
+    responses((status = OK, body = String)),
+    tag = "kamu-odata",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 #[transactional_handler]
 pub async fn odata_service_handler_mt(
     Extension(catalog): Extension<Catalog>,
@@ -51,6 +76,17 @@ pub async fn odata_service_handler_mt(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// OData service metadata
+#[utoipa::path(
+    get,
+    path = "/$metadata",
+    responses((status = OK, body = String)),
+    tag = "kamu-odata",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 #[transactional_handler]
 pub async fn odata_metadata_handler_st(
     Extension(catalog): Extension<Catalog>,
@@ -58,6 +94,20 @@ pub async fn odata_metadata_handler_st(
     odata_metadata_handler_common(catalog, None).await
 }
 
+/// OData service metadata
+#[utoipa::path(
+    get,
+    path = "/{account_name}/$metadata",
+    params(
+        ("account_name", description = "Account name")
+    ),
+    responses((status = OK, body = String)),
+    tag = "kamu-odata",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 #[transactional_handler]
 pub async fn odata_metadata_handler_mt(
     Extension(catalog): Extension<Catalog>,
@@ -68,6 +118,20 @@ pub async fn odata_metadata_handler_mt(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// OData collection
+#[utoipa::path(
+    get,
+    path = "/{dataset_name}",
+    params(
+        ("dataset_name", description = "Dataset name")
+    ),
+    responses((status = OK, body = String)),
+    tag = "kamu-odata",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 #[transactional_handler]
 pub async fn odata_collection_handler_st(
     Extension(catalog): Extension<Catalog>,
@@ -78,6 +142,21 @@ pub async fn odata_collection_handler_st(
     odata_collection_handler_common(catalog, None, collection_addr, headers, query).await
 }
 
+/// OData collection
+#[utoipa::path(
+    get,
+    path = "/{account_name}/{dataset_name}",
+    params(
+        ("account_name", description = "Account name"),
+        ("dataset_name", description = "Dataset name"),
+    ),
+    responses((status = OK, body = String)),
+    tag = "kamu-odata",
+    security(
+        (),
+        ("api_key" = [])
+    )
+)]
 #[transactional_handler]
 pub async fn odata_collection_handler_mt(
     Extension(catalog): Extension<Catalog>,

--- a/src/adapter/odata/src/router.rs
+++ b/src/adapter/odata/src/router.rs
@@ -16,34 +16,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
 use crate::handler::*;
 
-pub fn router_single_tenant() -> axum::Router {
-    axum::Router::new()
-        .route("/", axum::routing::get(odata_service_handler_st))
-        .route("/$metadata", axum::routing::get(odata_metadata_handler_st))
-        .route(
-            "/:dataset_name",
-            axum::routing::get(odata_collection_handler_st),
-        )
+pub fn router_single_tenant() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(odata_service_handler_st))
+        .routes(routes!(odata_metadata_handler_st))
+        .routes(routes!(odata_collection_handler_st))
 }
 
-pub fn router_multi_tenant() -> axum::Router {
-    axum::Router::new()
-        .route(
-            "/:account_name",
-            axum::routing::get(odata_service_handler_mt),
-        )
-        .route(
-            "/:account_name/",
-            axum::routing::get(odata_service_handler_mt),
-        )
-        .route(
-            "/:account_name/$metadata",
-            axum::routing::get(odata_metadata_handler_mt),
-        )
-        .route(
-            "/:account_name/:dataset_name",
-            axum::routing::get(odata_collection_handler_mt),
-        )
+pub fn router_multi_tenant() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(odata_service_handler_mt))
+        .routes(routes!(odata_metadata_handler_mt))
+        .routes(routes!(odata_collection_handler_mt))
 }

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -57,7 +57,9 @@ kamu-data-utils = { workspace = true }
 kamu-adapter-auth-oso = { workspace = true }
 kamu-adapter-flight-sql = { optional = true, workspace = true }
 kamu-adapter-graphql = { workspace = true }
-kamu-adapter-http = { workspace = true, features = ["e2e"], default-features = false }
+kamu-adapter-http = { workspace = true, features = [
+    "e2e",
+], default-features = false }
 kamu-adapter-oauth = { workspace = true }
 kamu-adapter-odata = { workspace = true }
 kamu-datafusion-cli = { workspace = true }
@@ -128,11 +130,18 @@ serde_json = "1"
 tonic = { version = "0.12", default-features = false }
 tower = "0.5"
 tower-http = { version = "0.5", features = ["trace", "cors"] }
+utoipa = { version = "5", default-features = true, features = ["macros"] }
+utoipa-swagger-ui = { version = "8", default-features = true, features = [
+    "axum",
+] }
+utoipa-axum = { version = "0.1", default-features = true, features = [] }
 
 # Web UI
 rust-embed = { optional = true, version = "8", features = [
     "interpolate-folder-path",
-    "compression",
+    # TODO: Re-enable compression when utoipa-swagger-ui supports it
+    # See: https://github.com/juhaku/utoipa/issues/1151
+    # "compression",
 ] }
 mime = "0.3"
 mime_guess = "2"

--- a/src/e2e/app/cli/inmem/tests/tests/mod.rs
+++ b/src/e2e/app/cli/inmem/tests/tests/mod.rs
@@ -10,6 +10,7 @@
 mod commands;
 mod test_auth;
 mod test_flow;
+mod test_openapi;
 mod test_rest_api;
 mod test_selftest;
 mod test_smart_transfer_protocol;

--- a/src/e2e/app/cli/inmem/tests/tests/test_openapi.rs
+++ b/src/e2e/app/cli/inmem/tests/tests/test_openapi.rs
@@ -1,0 +1,25 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use kamu_cli_e2e_common::prelude::*;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+kamu_cli_run_api_server_e2e_test!(
+    storage = inmem,
+    fixture = kamu_cli_e2e_repo_tests::test_openapi_st,
+);
+
+kamu_cli_run_api_server_e2e_test!(
+    storage = inmem,
+    fixture = kamu_cli_e2e_repo_tests::test_openapi_mt,
+    options = Options::default().with_multi_tenant()
+);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/e2e/app/cli/repo-tests/Cargo.toml
+++ b/src/e2e/app/cli/repo-tests/Cargo.toml
@@ -31,13 +31,16 @@ kamu = { workspace = true, features = ["testing"] }
 # We add a dependency to ensure kamu-cli is up to date before calling tests
 kamu-cli = { workspace = true }
 kamu-cli-e2e-common = { workspace = true }
-kamu-cli-puppet = { workspace = true, default-features = false, features = ["extensions"] }
+kamu-cli-puppet = { workspace = true, default-features = false, features = [
+    "extensions",
+] }
 opendatafabric = { workspace = true }
 
 chrono = { version = "0.4", default-features = false }
 indoc = "2"
 pretty_assertions = { version = "1" }
 reqwest = { version = "0.12", default-features = false, features = [] }
+serde_json = { version = "1", default-features = false }
 tokio = { version = "1", default-features = false, features = [] }
 tokio-retry = "0.3"
 

--- a/src/e2e/app/cli/repo-tests/src/lib.rs
+++ b/src/e2e/app/cli/repo-tests/src/lib.rs
@@ -12,6 +12,7 @@
 mod commands;
 mod test_auth;
 mod test_flow;
+mod test_openapi;
 mod test_rest_api;
 mod test_selftest;
 mod test_smart_transfer_protocol;
@@ -19,6 +20,7 @@ mod test_smart_transfer_protocol;
 pub use commands::*;
 pub use test_auth::*;
 pub use test_flow::*;
+pub use test_openapi::*;
 pub use test_rest_api::*;
 pub use test_selftest::*;
 pub use test_smart_transfer_protocol::*;

--- a/src/e2e/app/cli/repo-tests/src/test_openapi.rs
+++ b/src/e2e/app/cli/repo-tests/src/test_openapi.rs
@@ -1,0 +1,41 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+
+use kamu_cli_e2e_common::KamuApiServerClient;
+use reqwest::Method;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+async fn test_openapi(kamu_api_server_client: KamuApiServerClient, schema_path: PathBuf) {
+    let response = kamu_api_server_client
+        .rest_api_call(None, Method::GET, "/openapi.json", None)
+        .await
+        .error_for_status()
+        .unwrap();
+
+    let schema: serde_json::Value = response.json().await.unwrap();
+    let schema = serde_json::to_string_pretty(&schema).unwrap();
+    std::fs::write(&schema_path, &schema).unwrap();
+}
+
+pub async fn test_openapi_st(kamu_api_server_client: KamuApiServerClient) {
+    let mut schema_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    schema_path.push("../../../../../resources/openapi.json");
+    test_openapi(kamu_api_server_client, schema_path).await;
+}
+
+pub async fn test_openapi_mt(kamu_api_server_client: KamuApiServerClient) {
+    let mut schema_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    schema_path.push("../../../../../resources/openapi-mt.json");
+    test_openapi(kamu_api_server_client, schema_path).await;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/e2e/app/cli/repo-tests/src/test_rest_api.rs
+++ b/src/e2e/app/cli/repo-tests/src/test_rest_api.rs
@@ -67,7 +67,7 @@ pub async fn test_rest_api_request_dataset_tail(kamu_api_server_client: KamuApiS
         .rest_api_call_assert(
             None,
             Method::GET,
-            "player-scores/tail?includeSchema=false",
+            "player-scores/tail",
             None,
             StatusCode::OK,
             Some(ExpectedResponseBody::Json(
@@ -93,7 +93,8 @@ pub async fn test_rest_api_request_dataset_tail(kamu_api_server_client: KamuApiS
                           "score": 80,
                           "system_time": "<SYSTEM_TIME>"
                         }
-                      ]
+                      ],
+                      "dataFormat": "JsonAoS"
                     }
                     "#
                 )

--- a/src/utils/http-common/src/comma_separated.rs
+++ b/src/utils/http-common/src/comma_separated.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeSet;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CommaSeparatedSet<T>(BTreeSet<T>);
 
 impl<T> CommaSeparatedSet<T> {


### PR DESCRIPTION
## Description

Addresses: https://github.com/kamu-data/kamu-node/issues/140

This PR:
- Introduces OpenAPI spec generation using [utoipa-axum](https://crates.io/crates/utoipa-axum).
  - `/openapi.json` endpoint returns the generated spec (also saved into `resources/` alongside out GraphQL schema)
  - `/swagger` endpoint has an embedded Swagger UI for viewing the spec directly in the running server
- Drops old V1 `/query` endpoint
- Updates `/tail` endpoint to better match V2 `/query`

To preview the schema open https://petstore.swagger.io/ and paste this link:
```
https://raw.githubusercontent.com/kamu-data/kamu-cli/refs/heads/feature/openapi/resources/openapi-mt.json
```
![image](https://github.com/user-attachments/assets/c6f42383-e2f2-473a-8c79-840045f739ab)


## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ❌
    - Removed V1 version of `/query` API after a sufficient deprecation time
    - Updated `/tail` endpoint to match the structure of `/query`
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ❌
    - https://github.com/kamu-data/kamu-node/pull/151
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)