### PR TITLE
Added endpoint to read a recently uploaded file 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Recommendation: for ease of reading, use the following order:
   - `kamu push` command
   - `kamu pull` command
 - E2E: HTTP middleware is implemented, which improves stability of E2E tests
+- Added endpoint to read a recently uploaded file (`GET /platform/file/upload/{upload_token}`)
 ### Fixed
 - `kamu add`: fixed behavior when using `--stdin` and `--name` arguments
 

--- a/src/adapter/http/src/data/ingest_handler.rs
+++ b/src/adapter/http/src/data/ingest_handler.rs
@@ -73,6 +73,7 @@ pub async fn dataset_ingest_handler(
             .await
             .map_err(|e| match e {
                 UploadTokenIntoStreamError::ContentLengthMismatch(e) => ApiError::bad_request(e),
+                UploadTokenIntoStreamError::ContentNotFound(e) => ApiError::not_found(e),
                 UploadTokenIntoStreamError::Internal(e) => e.api_err(),
             })?;
 

--- a/src/adapter/http/tests/harness/test_api_server.rs
+++ b/src/adapter/http/tests/harness/test_api_server.rs
@@ -35,7 +35,8 @@ impl TestAPIServer {
             )
             .route(
                 "/platform/file/upload/:upload_token",
-                axum::routing::post(kamu_adapter_http::platform_file_upload_post_handler),
+                axum::routing::post(kamu_adapter_http::platform_file_upload_post_handler)
+                    .get(kamu_adapter_http::platform_file_upload_get_handler),
             )
             .nest("/", kamu_adapter_http::data::root_router())
             .nest("/", kamu_adapter_http::general::root_router())

--- a/src/app/cli/src/explore/api_server.rs
+++ b/src/app/cli/src/explore/api_server.rs
@@ -113,7 +113,8 @@ impl APIServer {
             )
             .route(
                 "/platform/file/upload/:upload_token",
-                axum::routing::post(kamu_adapter_http::platform_file_upload_post_handler),
+                axum::routing::post(kamu_adapter_http::platform_file_upload_post_handler)
+                    .get(kamu_adapter_http::platform_file_upload_get_handler),
             )
             .nest("/", kamu_adapter_http::data::root_router())
             .nest("/", kamu_adapter_http::general::root_router())

--- a/src/app/cli/src/explore/web_ui_server.rs
+++ b/src/app/cli/src/explore/web_ui_server.rs
@@ -165,7 +165,8 @@ impl WebUIServer {
             )
             .route(
                 "/platform/file/upload/:upload_token",
-                axum::routing::post(kamu_adapter_http::platform_file_upload_post_handler),
+                axum::routing::post(kamu_adapter_http::platform_file_upload_post_handler)
+                    .get(kamu_adapter_http::platform_file_upload_get_handler),
             )
             .nest(
                 "/odata",


### PR DESCRIPTION
## Description

Closes  #913

Added `GET /platform/file/upload/{upload_token}` endpoint.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)