### PR TITLE
sqlx + nextest: stabilization

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,30 +2,10 @@
 fail-fast = false
 
 [test-groups]
-mysql = { max-threads = 1 } # Explanation below
 setup = { max-threads = 1 }  # Serialize the setup steps
 containerized = { max-threads = 8 }  # Don't use too much memory
 engine = { max-threads = 2 }  # Engine tests are very memory-hungry
 database = { max-threads = 8 }  # Don't use too much memory
-
-# NOTE: --> There is an incompatibility between nextest and sqlx:
-#           - nextest implies multiprocessing,
-#           - while sqlx has a lock on cleanup within the current process
-#             (https://github.com/launchbadge/sqlx/pull/2640#issuecomment-1659455042).
-
-# TODO: Delete this workaround when this PR is merged:
-#       - Fix: nextest cleanup race condition by bonega
-#         https://github.com/launchbadge/sqlx/pull/3334
-#
-[[profile.default.overrides]]
-filter = "test(::mysql::)"
-test-group = "mysql"
-retries = { count = 3, backoff = "exponential", delay = "3s" }
-
-[[profile.default.overrides]]
-filter = "test(::postgres::)"
-retries = { count = 3, backoff = "exponential", delay = "3s" }
-# NOTE: <-- There is an incompatibility between nextest and sqlx
 
 # NOTE: Periodic missing rows when the system is under load
 #       https://github.com/kamu-data/kamu-engine-risingwave/issues/7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Recommendation: for ease of reading, use the following order:
 
 ## [Unreleased]
 ### Changed
-- ObjectRepositoryS3`: can now support external address configuration
 - `kamu repo list`: supports all types of output
+- Tests: `sqlx + nextest` combination has been stabilized
 ### Fixed
 - `kamu push`: show correct error if server failed to store data
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9193,7 +9193,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -9278,8 +9278,7 @@ dependencies = [
 [[package]]
 name = "sqlx"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
+source = "git+https://github.com/kamu-data/sqlx?branch=nextest-race-condition#8379e21f8f2a57448140d786d7b2ceba7370dcf5"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -9291,30 +9290,25 @@ dependencies = [
 [[package]]
 name = "sqlx-core"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
+source = "git+https://github.com/kamu-data/sqlx?branch=nextest-race-condition#8379e21f8f2a57448140d786d7b2ceba7370dcf5"
 dependencies = [
- "atoi",
- "byteorder",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
  "hashbrown 0.14.5",
  "hashlink",
- "hex",
  "indexmap 2.6.0",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding",
  "rustls 0.23.14",
  "rustls-pemfile 2.2.0",
@@ -9335,8 +9329,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
+source = "git+https://github.com/kamu-data/sqlx?branch=nextest-race-condition#8379e21f8f2a57448140d786d7b2ceba7370dcf5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9348,8 +9341,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros-core"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
+source = "git+https://github.com/kamu-data/sqlx?branch=nextest-race-condition#8379e21f8f2a57448140d786d7b2ceba7370dcf5"
 dependencies = [
  "dotenvy",
  "either",
@@ -9374,8 +9366,7 @@ dependencies = [
 [[package]]
 name = "sqlx-mysql"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
+source = "git+https://github.com/kamu-data/sqlx?branch=nextest-race-condition#8379e21f8f2a57448140d786d7b2ceba7370dcf5"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -9395,6 +9386,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
+ "indoc 2.0.5",
  "itoa",
  "log",
  "md-5",
@@ -9418,8 +9410,7 @@ dependencies = [
 [[package]]
 name = "sqlx-postgres"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
+source = "git+https://github.com/kamu-data/sqlx?branch=nextest-race-condition#8379e21f8f2a57448140d786d7b2ceba7370dcf5"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -9431,7 +9422,6 @@ dependencies = [
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -9458,8 +9448,7 @@ dependencies = [
 [[package]]
 name = "sqlx-sqlite"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
+source = "git+https://github.com/kamu-data/sqlx?branch=nextest-race-condition#8379e21f8f2a57448140d786d7b2ceba7370dcf5"
 dependencies = [
  "atoi",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,3 +272,7 @@ debug = "line-tables-only"
 # datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", tag = "42.0.0" }
 # object_store = { git = 'https://github.com/s373r/arrow-rs', branch = 'add-debug-logs', package = "object_store" }
 assert_cmd = { git = 'https://github.com/kamu-data/assert_cmd', branch = "deactivate-output-truncation" }
+# TODO: Delete this workaround when this PR is merged:
+#       - Fix: nextest cleanup race condition by bonega
+#         https://github.com/launchbadge/sqlx/pull/3334
+sqlx = { git = 'https://github.com/kamu-data/sqlx', branch = 'nextest-race-condition' }


### PR DESCRIPTION
## Description

Using the patched version of `sqlx`:
- The bulk of the changes from https://github.com/launchbadge/sqlx/pull/3334
- And a little tweak on our part https://github.com/bonega/sqlx/pull/1

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

## Checklist before requesting a review

- [ ] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [ ] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)