### PR TITLE
Fix escaping in ParquetJson schema formatter, add JSON_AOS format alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Changed
+- GraphQL: Removed deprecated `JSON_LD` in favor of `ND_JSON` in `DataBatchFormat`
+- GraphQL: In `DataBatchFormat` introduced `JSON_AOS` format to replace the now deprecated `JSON` in effort to harmonize format names with REST API
+### Fixed
+- GraphQL: Fixed invalid JSON encoding in `PARQUET_JSON` schema format when column names contain special characters (#746)
+
 ## [0.206.1] - 2024-10-24
 ### Changed
 - `kamu repo list`: supports all types of output

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -341,7 +341,12 @@ type DataBatch {
 }
 
 enum DataBatchFormat {
+	"""
+	Deprecated: Use `JSON_AOS` instead and expect it to become default in
+	future versions
+	"""
 	JSON
+	JSON_AOS
 	JSON_SOA
 	JSON_AOA
 	ND_JSON

--- a/src/adapter/graphql/src/scalars/data_batch.rs
+++ b/src/adapter/graphql/src/scalars/data_batch.rs
@@ -18,8 +18,11 @@ const MAX_SOA_BUFFER_SIZE: usize = 100_000_000;
 
 #[derive(Enum, Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DataBatchFormat {
+    /// Deprecated: Use `JSON_AOS` instead and expect it to become default in
+    /// future versions
     #[default]
     Json,
+    JsonAOS,
     JsonSOA,
     JsonAOA,
     NdJson,
@@ -45,7 +48,9 @@ impl DataBatch {
                 DataBatchFormat::Csv | DataBatchFormat::JsonLD | DataBatchFormat::NdJson => {
                     String::new()
                 }
-                DataBatchFormat::Json | DataBatchFormat::JsonAOA => String::from("[]"),
+                DataBatchFormat::Json | DataBatchFormat::JsonAOS | DataBatchFormat::JsonAOA => {
+                    String::from("[]")
+                }
                 DataBatchFormat::JsonSOA => String::from("{}"),
             },
             num_records: 0,
@@ -77,7 +82,9 @@ impl DataBatch {
                         ..Default::default()
                     },
                 )),
-                DataBatchFormat::Json => Box::new(JsonArrayOfStructsWriter::new(&mut buf)),
+                DataBatchFormat::Json | DataBatchFormat::JsonAOS => {
+                    Box::new(JsonArrayOfStructsWriter::new(&mut buf))
+                }
                 DataBatchFormat::JsonSOA => {
                     Box::new(JsonStructOfArraysWriter::new(&mut buf, MAX_SOA_BUFFER_SIZE))
                 }


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: #746

- Removed deprecated `JSON_LD` in favor of `ND_JSON` in `DataBatchFormat`
- In `DataBatchFormat` introduced `JSON_AOS` format to replace the now deprecated `JSON` in effort to harmonize format names with REST API
- Fixed invalid JSON encoding in `PARQUET_JSON` schema format when column names contain special characters

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)