### PR TITLE
Upgrade to datafusion 43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8ebf106e84a1c37f86244df7da0c7587e697b71a0d565cce079449b85ac6f8"
+checksum = "b5b524b8c28a7145d1fe4950f84360b5de3e307601679ff0558ddc20ea229399"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.47"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c5c520273946ecf715c0010b4e3503d7eba9893cd9ce6b7fff5654c4a3c470"
+checksum = "a0161082e0edd9013d23083465cc04b20e44b7a15646d36ba7b0cdb7cd6fe18f"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed961a48297c732a5d97ee321aa8bb5009ecadbcb077d8bec90cb54e651629"
+checksum = "ae09ffd7c29062431dd86061deefe4e3c6f07fa0d674930095f8dcedb0baf02c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460ab80ce4bda1c80bcf96fe7460520476f2c7b734581c6567fac2708e2a60ef"
+checksum = "66430a72d5bf5edead101c8c2f0a24bada5ec9f3cf9909b3e08b6d6899b4803e"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ffc577390ce50234e02d841214b3dc0bea6aaaae8e04bbf3cb82e9a45da9eb"
+checksum = "4c986539255fb839d1533c128e190e557e52ff652c9ef62939e233a81dd93f7e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69e06cf9c37be824b9d26d6d101114fdde6af0c87de2828b414c05c4b3daa71"
+checksum = "5b6aa3961694b30ba53d41006131a2fca3bdab22e4c344e46db2c639e7c2dfdd"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde15e14944a88bd6a57d325e9a49b75558746fe16aaccc79713ae50a6a9574c"
+checksum = "e53f7877ded3921d18a0a9556d55bedf84535567198c9edab2aa23106da91855"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5979e0d5a7bf9c7eb79749121e8256e59021af611322aee56e77e20776b4b3"
+checksum = "3694b7e480728c0b3e228384f223937f14c10caef5a4c766021190fc8f283d35"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "204237129086ce5dc17a58025e93739b01b45313841f98fa339eb1d780511e57"
+checksum = "ea94b8ceb5c75d7df0a93ba0acc53b55a22b47b532b600a800a87ef04eb5b0b4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -308,14 +308,16 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514f70ee2a953db21631cd817b13a1571474ec77ddc03d47616d5e8203489fde"
+checksum = "df9f3e281005943944d15ee8491534a1c7b3cbf7a7de26f8c433b842b93eb5f9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -354,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4814d141ede360bb6cd1b4b064f1aab9de391e7c4d0d4d50ac89ea4bc1e25fbd"
+checksum = "40c1f9eede27bf4c13c099e8e64d54efd7ce80ef6ea47478aa75d5d74e2dba3b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -390,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba46eb69ddf7a9925b81f15229cb74658e6eebe5dd30a5b74e2cd040380573"
+checksum = "90f1f34232f77341076541c405482e4ae12f0ee7153d8f9969fc1691201b2247"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -431,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc2bd1e7403463a5f2c61e955bcc9d3072b63aa177442b0f9aa6a6d22a941e3"
+checksum = "374dbe0dc3abdc2c964f36b3d3edf9cdb3db29d16bda34aa123f03d810bec1dd"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -455,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea9bf1abdd506f985a53533f5ac01296bcd6102c5e139bbc5d40bc468d2c916"
+checksum = "c74832aa474b670309c20fffc2a869fa141edab7c79ff7963fad0a08de60bae1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -467,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b034779a4850b4b03f5be5ea674a1cf7d746b2da762b34d1860ab45e48ca27"
+checksum = "a8a477281940d82d29315846c7216db45b15e90bcd52309da9f54bcf7ad94a11"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -486,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028e72eaa9703e4882344983cfe7636ce06d8cce104a78ea62fd19b46659efc4"
+checksum = "4dfa4a7ccf15b2492bb68088692481fd6b2604ccbee1d0d6c44c21427ae4df83"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -497,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592c185d7100258c041afac51877660c7bf6213447999787197db4842f0e938e"
+checksum = "2e10aec39d60dc27edcac447302c7803d2371946fb737245320a05b78eb2fafd"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -584,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77579633ebbc1266ae6fd7694f75c408beb1aeb6865d0b18f22893c265a061"
+checksum = "f99acddb34000d104961897dbb0240298e8b775a7efffb9fda2a1a3efedd65b3"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -604,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd1a5d0827939847983b46f2f79510361f901dc82f8e3c38ac7397af142c6e"
+checksum = "5dc013132e34eeadaa0add7e74164c1503988bfba8bae885b32e0918ba85a8a6"
 dependencies = [
  "alloy-transport",
  "url",
@@ -614,14 +616,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f27837bb4a1d6c83a28231c94493e814882f0e9058648a97e908a5f3fc9fcf"
+checksum = "abd170e600801116d5efe64f74a4fc073dbbb35c807013a7d0a388742aeebba0"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.1.0",
+ "http 1.2.0",
  "rustls 0.23.19",
  "serde_json",
  "tokio",
@@ -702,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "approx"
@@ -1198,7 +1200,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "handlebars",
- "http 1.1.0",
+ "http 1.2.0",
  "indexmap 2.7.0",
  "mime",
  "multer",
@@ -1381,7 +1383,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1412,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+checksum = "b5ac934720fbb46206292d2c75b57e67acfc56fe7dfd34fb9a02334af08409ea"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1438,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.64.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fe5e7f71b1cc6274e905d3bcc7daf94099ac2d4cba83447ffb959b5b27b3c1"
+checksum = "d3ba2c5c0f2618937ce3d4a5ad574b86775576fa24006bcb3128c6e2cbf3c34e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1449,7 +1451,7 @@ dependencies = [
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1472,15 +1474,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.53.0"
+version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3370af2d5d01f9ddf1705d9896cf8c406f444c9dc33abe1d2166d4d50f0b3b"
+checksum = "450b2e8cb5f0ee102e4a04c5f8e923aff8187ae9323058707c6cec238cf51699"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1495,15 +1497,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
+checksum = "05ca43a4ef210894f93096039ef1d6fa4ad3edfabb3be92b80908b9f2e4b4eab"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1517,15 +1519,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
+checksum = "abaf490c2e48eed0bb8e2da2fb08405647bd7f253996e0f93b981958ea0f73b0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1539,15 +1541,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ada54e5f26ac246dc79727def52f7f8ed38915cb47781e2a72213957dc3a7d5"
+checksum = "b68fde0d69c8bfdc1060ea7da21df3e39f6014da316783336deff0a9ec28f4bf"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.1",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1562,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.5"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
+checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -1577,7 +1579,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "once_cell",
  "p256",
  "percent-encoding",
@@ -1663,6 +1665,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-json"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
 name = "aws-smithy-query"
 version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+checksum = "9f20685047ca9d6f17b994a07f629c813f08b5bce65523e47124879e60103d45"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1709,7 +1720,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1727,7 +1738,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1776,7 +1787,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.1",
@@ -1812,7 +1823,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -1836,7 +1847,7 @@ dependencies = [
  "fastrand",
  "futures-util",
  "headers",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -2327,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2337,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2492,7 +2503,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2934,7 +2945,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
  "uuid",
@@ -2950,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae5f2abc725737d6e87b6d348a5aa2d0a77e4cf873045f004546da946e6e619"
+checksum = "cbba0799cf6913b456ed07a94f0f3b6e12c62a5d88b10809e2284a0f2b915c05"
 dependencies = [
  "ahash",
  "arrow",
@@ -3007,9 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998761705551f11ffa4ee692cc285b44eb1def6e0d28c4eaf5041b9e2810dc1e"
+checksum = "7493c5c2d40eec435b13d92e5703554f4efc7059451fcb8d3a79580ff0e45560"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -3022,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11986f191e88d950f10a5cc512a598afba27d92e04a0201215ad60785005115a"
+checksum = "24953049ebbd6f8964f91f60aa3514e121b5e81e068e33b60e77815ab369b25c"
 dependencies = [
  "ahash",
  "arrow",
@@ -3034,6 +3045,7 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown 0.14.5",
+ "indexmap 2.7.0",
  "instant",
  "libc",
  "num_cpus",
@@ -3046,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694c9d7ea1b82f95768215c4cb5c2d5c613690624e832a7ee64be563139d582f"
+checksum = "f06df4ef76872e11c924d3c814fd2a8dd09905ed2e2195f71c857d78abd19685"
 dependencies = [
  "log",
  "tokio",
@@ -3056,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ethers"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab3507a26e64835d679ad3dec8c39331c843406313ebce3d92ce844042d6b9"
+checksum = "1f33281d97d262dc10a864a696b6c04bd456e3dd4a2e0998775f32875cc9c38a"
 dependencies = [
  "alloy",
  "async-stream",
@@ -3066,16 +3078,16 @@ dependencies = [
  "datafusion",
  "futures",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "datafusion-execution"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b4cedcd98151e0a297f34021b6b232ff0ebc0f2f18ea5e7446b5ebda99b1a1"
+checksum = "6bbdcb628d690f3ce5fea7de81642b514486d58ff9779a51f180a69a4eadb361"
 dependencies = [
  "arrow",
  "chrono",
@@ -3094,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8dd114dc0296cacaee98ad3165724529fcca9a65b2875abcd447b9cc02b2b74"
+checksum = "8036495980e3131f706b7d33ab00b4492d73dc714e3cb74d11b50f9602a73246"
 dependencies = [
  "ahash",
  "arrow",
@@ -3106,7 +3118,9 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
+ "indexmap 2.7.0",
  "paste",
  "serde_json",
  "sqlparser",
@@ -3116,20 +3130,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1ba2bb018218d9260bbd7de6a46a20f61b93d4911dba8aa07735625004c4fb"
+checksum = "4da0f3cb4669f9523b403d6b5a0ec85023e0ab3bf0183afd1517475b3e64fdd2"
 dependencies = [
  "arrow",
  "datafusion-common",
+ "itertools 0.13.0",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547cb780a4ac51fd8e52c0fb9188bc16cea4e35aebf6c454bda0b82a7a417304"
+checksum = "f52c4012648b34853e40a2c6bcaa8772f837831019b68aca384fb38436dba162"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3154,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68cf5aa7ebcac08bd04bb709a9a6d4963eafd227da62b628133bc509c40f5a0"
+checksum = "e5b8bb624597ba28ed7446df4a9bd7c7a7bde7c578b6b527da3f47371d5f6741"
 dependencies = [
  "ahash",
  "arrow",
@@ -3168,16 +3183,16 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "half",
+ "indexmap 2.7.0",
  "log",
  "paste",
- "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2285d080dfecdfb8605b0ab2f1a41e2473208dc8e9bd6f5d1dbcfe97f517e6f"
+checksum = "6fb06208fc470bc8cf1ce2d9a1159d42db591f2c7264a8c1776b53ad8f675143"
 dependencies = [
  "ahash",
  "arrow",
@@ -3189,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-json"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532feb5c208fd1708f4d93b1984fb7a7ed678a9f0e6f799af97118d7c4e863a1"
+checksum = "744cf7ae121977c453586f3f098239e50da6b0cfcf2de3ccb9338a4896f97dc0"
 dependencies = [
  "datafusion",
  "jiter",
@@ -3201,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6ffbbb7cf7bf0c0e05eb6207023fef341cac83a593a5365a6fc83803c572a9"
+checksum = "fca25bbb87323716d05e54114666e942172ccca23c5a507e9c7851db6e965317"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3224,41 +3239,54 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e78d30ebd6e9f74d4aeddec32744f5a18b5f9584591bc586fb5259c4848bac5"
+checksum = "5ae23356c634e54c59f7c51acb7a5b9f6240ffb2cf997049a1a24a8a88598dbe"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b3d6ff7794acea026de36007077a06b18b89e4f9c3fea7f2215f9f7dd9059b"
+dependencies = [
+ "datafusion-common",
+ "datafusion-physical-expr-common",
 ]
 
 [[package]]
 name = "datafusion-odata"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab54b5cb73aebdea15ab97319c08ab2ed8b126e99f88169e9eb7f98533d96d"
+checksum = "b2aec0659fb8f95aa9e6e97fb1233216cdd8508e04dd35db70e7f96755eb0f56"
 dependencies = [
  "async-trait",
  "axum",
  "chrono",
  "datafusion",
- "http 1.1.0",
+ "http 1.2.0",
  "hyper 1.5.1",
  "odata-params",
- "quick-xml",
+ "quick-xml 0.37.1",
  "regex",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tracing",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be172c44bf344df707e0c041fa3f41e6dc5fb0976f539c68bc442bca150ee58c"
+checksum = "bec6241eb80c595fa0e1a8a6b69686b5cf3bd5fdacb8319582a0943b0bd788aa"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3276,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b86b7fa0b8161c49b0f005b0df193fc6d9b65ceec675f155422cda5d1583ca"
+checksum = "3370357b8fc75ec38577700644e5d1b0bc78f38babab99c0b8bd26bafb3e4335"
 dependencies = [
  "ahash",
  "arrow",
@@ -3287,30 +3315,26 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-string",
- "base64 0.22.1",
  "chrono",
  "datafusion-common",
- "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
- "hex",
  "indexmap 2.7.0",
  "itertools 0.13.0",
  "log",
  "paste",
  "petgraph",
- "regex",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242ba8a26351d9ca16295814c46743b0d1b00ec372174bdfbba991d0953dd596"
+checksum = "b8b7734d94bf2fa6f6e570935b0ddddd8421179ce200065be97874e13d46a47b"
 dependencies = [
  "ahash",
  "arrow",
@@ -3322,13 +3346,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca088eb904bf1cfc9c5e5653110c70a6eaba43164085a9d180b35b77ce3b8b"
+checksum = "7eee8c479522df21d7b395640dff88c5ed05361852dce6544d7c98e9dbcebffe"
 dependencies = [
+ "arrow",
  "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
+ "datafusion-expr-common",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "itertools 0.13.0",
@@ -3336,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4989a53b824abc759685eb643f4d604c2fc2fea4e2c309ac3473bea263ecbbeb"
+checksum = "17e1fc2e2c239d14e8556f2622b19a726bf6bc6962cc00c71fc52626274bee24"
 dependencies = [
  "ahash",
  "arrow",
@@ -3352,8 +3378,8 @@ dependencies = [
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
@@ -3371,15 +3397,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "42.2.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b9b75b9da10ed656073ac0553708f17eb8fa5a7b065ef9848914c93150ab9e"
+checksum = "63e3a4ed41dbee20a5d947a59ca035c225d67dc9cbe869c10f66dcdf25e7ce51"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
+ "indexmap 2.7.0",
  "log",
  "regex",
  "sqlparser",
@@ -3863,7 +3890,7 @@ dependencies = [
  "futures",
  "internal-error",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4321,7 +4348,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http 1.2.0",
  "indexmap 2.7.0",
  "slab",
  "tokio",
@@ -4406,7 +4433,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 1.1.0",
+ "http 1.2.0",
  "httpdate",
  "mime",
  "sha1",
@@ -4418,7 +4445,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -4511,9 +4538,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -4538,7 +4565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -4549,7 +4576,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -4559,13 +4586,13 @@ name = "http-common"
 version = "0.211.0"
 dependencies = [
  "axum",
- "http 1.1.0",
+ "http 1.2.0",
  "internal-error",
  "kamu-core",
  "serde",
  "serde_json",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tracing",
  "utoipa",
 ]
@@ -4637,7 +4664,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -4671,14 +4698,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "hyper 1.5.1",
  "hyper-util",
  "rustls 0.23.19",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tower-service",
  "webpki-roots",
 ]
@@ -4705,7 +4732,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "hyper 1.5.1",
  "pin-project-lite",
@@ -4994,7 +5021,7 @@ dependencies = [
  "paste",
  "petgraph",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
 ]
@@ -5030,7 +5057,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 name = "internal-error"
 version = "0.211.0"
 dependencies = [
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
 ]
 
 [[package]]
@@ -5210,7 +5237,7 @@ dependencies = [
  "futures",
  "glob",
  "hex",
- "http 1.1.0",
+ "http 1.2.0",
  "hyper 1.5.1",
  "indoc 2.0.5",
  "init-on-startup",
@@ -5253,7 +5280,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -5289,7 +5316,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sqlx",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tracing",
  "uuid",
 ]
@@ -5309,7 +5336,7 @@ dependencies = [
  "opendatafabric",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
  "uuid",
@@ -5331,7 +5358,7 @@ dependencies = [
  "sqlx",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tracing",
  "uuid",
 ]
@@ -5352,7 +5379,7 @@ dependencies = [
  "sqlx",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tracing",
  "uuid",
 ]
@@ -5393,7 +5420,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "time-source",
  "tokio",
  "tracing",
@@ -5416,7 +5443,7 @@ dependencies = [
  "sqlx",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tracing",
  "uuid",
 ]
@@ -5508,7 +5535,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -5540,7 +5567,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "headers",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body-util",
  "http-common",
  "hyper 1.5.1",
@@ -5572,7 +5599,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -5595,14 +5622,14 @@ dependencies = [
  "async-trait",
  "chrono",
  "dill",
- "http 1.1.0",
+ "http 1.2.0",
  "internal-error",
  "kamu-accounts",
  "opendatafabric",
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
 ]
@@ -5619,7 +5646,7 @@ dependencies = [
  "datafusion-odata",
  "dill",
  "futures",
- "http 1.1.0",
+ "http 1.2.0",
  "http-common",
  "hyper 1.5.1",
  "indoc 2.0.5",
@@ -5630,7 +5657,7 @@ dependencies = [
  "messaging-outbox",
  "opendatafabric",
  "pretty_assertions",
- "quick-xml",
+ "quick-xml 0.37.1",
  "reqwest",
  "serde",
  "tempfile",
@@ -5654,7 +5681,7 @@ dependencies = [
  "opendatafabric",
  "sqlx",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
 ]
 
 [[package]]
@@ -5762,7 +5789,7 @@ dependencies = [
  "futures",
  "glob",
  "hex",
- "http 1.1.0",
+ "http 1.2.0",
  "http-common",
  "humansize",
  "hyper 1.5.1",
@@ -5834,7 +5861,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -6006,7 +6033,7 @@ dependencies = [
  "datafusion",
  "dill",
  "futures",
- "http 1.1.0",
+ "http 1.2.0",
  "internal-error",
  "kamu-accounts",
  "kamu-datasets",
@@ -6018,7 +6045,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6044,7 +6071,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -6115,7 +6142,7 @@ dependencies = [
  "secrecy",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6142,7 +6169,7 @@ dependencies = [
  "sqlx",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tracing",
  "uuid",
 ]
@@ -6192,7 +6219,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -6220,7 +6247,7 @@ dependencies = [
  "sqlx",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tracing",
  "uuid",
 ]
@@ -6248,7 +6275,7 @@ dependencies = [
  "serde_with",
  "sqlx",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio-stream",
  "tracing",
  "url",
@@ -6276,7 +6303,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6359,7 +6386,7 @@ dependencies = [
  "serde_with",
  "tempfile",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -6420,7 +6447,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -6442,7 +6469,7 @@ dependencies = [
  "messaging-outbox",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6465,7 +6492,7 @@ dependencies = [
  "sqlx",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
  "uuid",
@@ -6503,7 +6530,7 @@ dependencies = [
  "sqlx",
  "test-group",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
 ]
@@ -6538,7 +6565,7 @@ dependencies = [
  "opendatafabric",
  "serde",
  "sqlx",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio-stream",
 ]
 
@@ -7083,7 +7110,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -7194,7 +7221,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "memchr",
  "mime",
@@ -7215,7 +7242,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "unsigned-varint",
  "utoipa",
 ]
@@ -7515,7 +7542,7 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.36.2",
  "rand",
  "reqwest",
  "ring",
@@ -7536,7 +7563,7 @@ dependencies = [
  "async-trait",
  "axum",
  "dill",
- "http 1.1.0",
+ "http 1.2.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -7544,7 +7571,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -7633,7 +7660,7 @@ dependencies = [
  "serde_yaml",
  "sha3",
  "sqlx",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tonic",
  "url",
  "utoipa",
@@ -7689,7 +7716,7 @@ checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 1.1.0",
+ "http 1.2.0",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -7815,14 +7842,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.0"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8781a75c6205af67215f382092b6e0a4ff3734798523e69073d4bcd294ec767b"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8457,6 +8484,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f22f29bdff3987b4d8632ef95fd6424ec7e4e0a57e2f4fc63e489e75357f6a03"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8469,7 +8506,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.19",
  "socket2",
- "thiserror 2.0.3",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
 ]
@@ -8488,7 +8525,7 @@ dependencies = [
  "rustls 0.23.19",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.4",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8688,7 +8725,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.1",
@@ -8712,7 +8749,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -9640,9 +9677,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e5b515a2bd5168426033e9efbfd05500114833916f1d5c268f938b4ee130ac"
+checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -10104,11 +10141,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.4",
 ]
 
 [[package]]
@@ -10124,9 +10161,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10165,9 +10202,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -10188,9 +10225,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -10253,9 +10290,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10314,12 +10351,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls 0.23.19",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -10347,16 +10383,16 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tungstenite",
  "webpki-roots",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -10412,7 +10448,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.1",
@@ -10475,7 +10511,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
@@ -10708,7 +10744,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "log",
  "rand",
@@ -11100,9 +11136,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtimer"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
+checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
 dependencies = [
  "futures",
  "js-sys",
@@ -11681,7 +11717,7 @@ dependencies = [
  "pbkdf2",
  "rand",
  "sha1",
- "thiserror 2.0.3",
+ "thiserror 2.0.4",
  "time",
  "zeroize",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,7 @@ debug = "line-tables-only"
 # Use this section to test or apply emergency overrides to dependencies
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 [patch.crates-io]
-# datafusion = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
+# datafusion = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
 # datafusion-common = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
 # datafusion-execution = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
 # datafusion-expr = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }

--- a/src/adapter/flight-sql/Cargo.toml
+++ b/src/adapter/flight-sql/Cargo.toml
@@ -26,7 +26,7 @@ arrow-flight = { version = "53", features = ["flight-sql-experimental"] }
 async-trait = { version = "0.1", default-features = false }
 base64 = { version = "0.22", default-features = false }
 dashmap = { version = "6", default-features = false }
-datafusion = { version = "42", default-features = false }
+datafusion = { version = "43", default-features = false }
 futures = "0.3"
 like = { version = "0.3", default-features = false }
 prost = { version = "0.13", default-features = false }

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -44,7 +44,7 @@ async-graphql = { version = "7", features = [
 async-trait = { version = "0.1", default-features = false }
 cron = { version = "0.12", default-features = false }
 chrono = "0.4"
-datafusion = { version = "42", default-features = false, features = [
+datafusion = { version = "43", default-features = false, features = [
     "serde",
 ] } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.9"
@@ -55,7 +55,7 @@ serde_json = "1"
 tokio = { version = "1", default-features = false, features = [] }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = "0.1"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }
 

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -49,7 +49,7 @@ base64 = { version = "0.22", default-features = false }
 bytes = "1"
 canonical_json = { version = "0.5.0", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
-datafusion = { version = "42", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
+datafusion = { version = "43", default-features = false } # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 dill = "0.9"
 ed25519-dalek = { version = "2", default-features = false, features = [
     "std",
@@ -76,7 +76,7 @@ serde_json = "1"
 serde_with = { version = "3", default-features = false }
 strum = { version = "0.26", features = ["derive"] }
 tar = "0.4"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = [] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", default-features = false, features = [

--- a/src/adapter/http/tests/tests/test_data_query.rs
+++ b/src/adapter/http/tests/tests/test_data_query.rs
@@ -149,7 +149,7 @@ impl Harness {
                     source_event_time: system_time,
                     new_watermark: None,
                     new_source_state: None,
-                    data_staging_path: run_info_dir.path().join(".temp-data"),
+                    data_staging_path: run_info_dir.path().join(".temp-data.parquet"),
                 },
             )
             .await
@@ -467,14 +467,14 @@ async fn test_data_query_handler() {
                 },
                 "subQueries": [],
                 "commitment": {
-                    "inputHash": "f16206ab5788a997a0d05c236c207ea66434f2d4ae933ad62556583979f47d2f522ed",
+                    "inputHash": "f1620c01c8a5746b5c70f76a42cae96b97639737f597f87a74fa3f6e4c4799a130891",
                     "outputHash": "f16208d66e08ce876ba35ce00ea56f02faf83dbc086f877c443e3d493427ccad133f1",
                     "subQueriesHash": "f1620ca4510738395af1429224dd785675309c344b2b549632e20275c69b15ed1d210",
                 },
                 "proof": {
                     "type": "Ed25519Signature2020",
                     "verificationMethod": "did:key:z6Mko2nqhQ9wYSTS5Giab2j1aHzGnxHimqwmFeEVY8aNsVnN",
-                    "proofValue": "uadIt9gTyeqRUwCIHiq4ILzK79h0jnZwOSVX86NeSJrmoMAV1keK9CJl7yyH9wiJCw1AjAb84nxeqB7kPzHyaDQ",
+                    "proofValue": "ulm5TqOk7Qkut08caRv0_vxzA8zTpScKPHvZKM0e9rO1irRylf1K_9FykhB1oWqgm51eppwFxwm5mrrv7J8BiDQ",
                 }
             }),
             response
@@ -621,14 +621,14 @@ async fn test_data_verify_handler() {
                 },
                 "subQueries": [],
                 "commitment": {
-                    "inputHash": "f16205ad9518f5dd9fe6bbc082afc92841dff1cb2ebe85f82d12fbb3567399aa879c1",
+                    "inputHash": "f162043b05d93c527d8573645d2529dd6678e6375f308cdfa21028c34593e1455edf4",
                     "outputHash": "f1620ff7f5beaf16900218a3ac4aae82cdccf764816986c7c739c716cf7dc03112a2c",
                     "subQueriesHash": "f1620ca4510738395af1429224dd785675309c344b2b549632e20275c69b15ed1d210",
                 },
                 "proof": {
                     "type": "Ed25519Signature2020",
                     "verificationMethod": "did:key:z6Mko2nqhQ9wYSTS5Giab2j1aHzGnxHimqwmFeEVY8aNsVnN",
-                    "proofValue": "uox4Jm0WJgSV-5K7Lp2jLvvRXnVTqu_N-DdGBt4NETRVN-cvZQINUDCcmBFrtmORsJV4PrjDtCNumvsEYeSLZAQ",
+                    "proofValue": "uyK1zM9v3MlkC2-2TyCuwN5hfbsUV15GSegzGuwgaWYKsTtQj1xxUrPsTbPZs0aBSmR569ozZ8ZtAUYVAjoy3Bg",
                 }
             }),
             response

--- a/src/adapter/oauth/Cargo.toml
+++ b/src/adapter/oauth/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 ] }
 serde = "1"
 serde_json = "1"
-thiserror = "1"
+thiserror = { version = "2", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = [] }

--- a/src/adapter/odata/Cargo.toml
+++ b/src/adapter/odata/Cargo.toml
@@ -32,12 +32,12 @@ opendatafabric = { workspace = true }
 
 axum = { version = "0.7", default-features = false, features = [] }
 chrono = { version = "0.4", default-features = false }
-datafusion = { version = "42", default-features = false }
-datafusion-odata = { version = "42", default-features = false }
+datafusion = { version = "43", default-features = false }
+datafusion-odata = { version = "43", default-features = false }
 dill = { version = "0.9" }
 futures = { version = "0.3", default-features = false }
 http = "1"
-quick-xml = { version = "0.36", features = ["serialize"] }
+quick-xml = { version = "0.37", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 utoipa = { version = "5", default-features = false, features = [] }

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -166,7 +166,7 @@ tracing-bunyan-formatter = "0.3"
 async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1" # Conditional compilation
-datafusion = { version = "42", default-features = false, features = [
+datafusion = { version = "43", default-features = false, features = [
     "crypto_expressions",
     "encoding_expressions",
     "parquet",
@@ -188,7 +188,7 @@ secrecy = "0.10"
 shlex = "1" # Parsing partial input for custom completions
 signal-hook = "0.3" # Signal handling
 tempfile = "3"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = ["io-util"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tokio-util = { version = "0.7", default-features = false, features = ["io"] }

--- a/src/domain/accounts/domain/Cargo.toml
+++ b/src/domain/accounts/domain/Cargo.toml
@@ -45,7 +45,7 @@ rand = "0.8"
 reusable = "0.1"
 serde = "1"
 serde_with = { version = "3", default-features = false }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v4"] }
 

--- a/src/domain/accounts/services/Cargo.toml
+++ b/src/domain/accounts/services/Cargo.toml
@@ -35,7 +35,7 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 jsonwebtoken = "9"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 password-hash = { version = "0.5", default-features = false }
 serde = "1"
 serde_json = "1"

--- a/src/domain/auth-rebac/domain/Cargo.toml
+++ b/src/domain/auth-rebac/domain/Cargo.toml
@@ -31,7 +31,7 @@ opendatafabric = { workspace = true }
 
 async-trait = "0.1"
 strum = { version = "0.26", features = ["derive"] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 
 # Optional
 sqlx = { optional = true, version = "0.8", default-features = false, features = [

--- a/src/domain/core/Cargo.toml
+++ b/src/domain/core/Cargo.toml
@@ -45,14 +45,14 @@ futures = { version = "0.3", default-features = false }
 http = { version = "1" }
 pathdiff = { version = "0.2", default-features = false }
 pin-project = { version = "1", default-features = false }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }
 url = { version = "2", default-features = false, features = ["serde"] }
 
 # TODO: Avoid this dependency or depend on sub-crates
-datafusion = { version = "42", default-features = false, features = [
+datafusion = { version = "43", default-features = false, features = [
     "parquet",
 ] }
 object_store = { version = "0.11", default-features = false }

--- a/src/domain/datasets/services/Cargo.toml
+++ b/src/domain/datasets/services/Cargo.toml
@@ -43,7 +43,7 @@ petgraph = { version = "0.6", default-features = false, features = [
 secrecy = "0.10"
 serde = "1"
 serde_json = "1"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/src/domain/flow-system/domain/Cargo.toml
+++ b/src/domain/flow-system/domain/Cargo.toml
@@ -39,7 +39,7 @@ dill = { version = "0.9" }
 lazy_static = { version = "1" }
 sqlx = { version = "0.8", default-features = false, features = ["macros"] }
 strum = { version = "0.26", features = ["derive"] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }
 url = { version = "2", default-features = false }
@@ -51,4 +51,4 @@ serde_with = { version = "3", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-datafusion = { version = "42", default-features = false }
+datafusion = { version = "43", default-features = false }

--- a/src/domain/flow-system/services/Cargo.toml
+++ b/src/domain/flow-system/services/Cargo.toml
@@ -40,7 +40,7 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = [] }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/src/domain/opendatafabric/Cargo.toml
+++ b/src/domain/opendatafabric/Cargo.toml
@@ -39,7 +39,7 @@ multiformats = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 digest = "0.10"
 futures-core = "0.3"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 bitflags = { version = "2", default-features = false }
 
 

--- a/src/domain/task-system/domain/Cargo.toml
+++ b/src/domain/task-system/domain/Cargo.toml
@@ -35,5 +35,5 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 sqlx = { version = "0.8", default-features = false, features = ["macros"] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio-stream = { version = "0.1", default-features = false }

--- a/src/infra/accounts/inmem/Cargo.toml
+++ b/src/infra/accounts/inmem/Cargo.toml
@@ -30,7 +30,7 @@ internal-error = { workspace = true }
 async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 uuid = "1"
 

--- a/src/infra/accounts/mysql/Cargo.toml
+++ b/src/infra/accounts/mysql/Cargo.toml
@@ -36,7 +36,7 @@ sqlx = { version = "0.8", default-features = false, features = [
     "mysql",
     "chrono",
 ] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 uuid = "1"
 

--- a/src/infra/accounts/postgres/Cargo.toml
+++ b/src/infra/accounts/postgres/Cargo.toml
@@ -36,7 +36,7 @@ sqlx = { version = "0.8", default-features = false, features = [
     "postgres",
     "chrono",
 ] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 uuid = "1"
 

--- a/src/infra/accounts/sqlite/Cargo.toml
+++ b/src/infra/accounts/sqlite/Cargo.toml
@@ -36,7 +36,7 @@ sqlx = { version = "0.8", default-features = false, features = [
     "sqlite",
     "chrono",
 ] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 uuid = "1"
 

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -70,7 +70,7 @@ secrecy = "0.10"
 zip = "2"
 
 # Data
-datafusion = { version = "42", default-features = false }
+datafusion = { version = "43", default-features = false }
 digest = "0.10"
 object_store = { version = "0.11", features = ["aws"] }
 parking_lot = { version = "0.12" }
@@ -104,7 +104,7 @@ pin-project = "1"
 rand = "0.8"
 regex = "1"
 tempfile = "3"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = [
     "fs",
     "process",
@@ -125,7 +125,7 @@ tower-http = { version = "0.6", features = ["fs", "trace"] }
 axum = "0.7"
 
 # Optional dependencies
-alloy = { optional = true, version = "0.5", default-features = false, features = [
+alloy = { optional = true, version = "0.6", default-features = false, features = [
     "std",
     "provider-http",
     "provider-ws",
@@ -138,8 +138,8 @@ curl = { optional = true, version = "0.4", features = [
     "static-ssl",
 ] }
 curl-sys = { optional = true, version = "0.4" }
-datafusion-ethers = { optional = true, version = "42" }
-datafusion-functions-json = { optional = true, version = "0.42" }
+datafusion-ethers = { optional = true, version = "43" }
+datafusion-functions-json = { optional = true, version = "0.43" }
 rumqttc = { optional = true, version = "0.24" }
 mockall = { optional = true, version = "0.13", default-features = false }
 lazy_static = { version = "1" }
@@ -159,7 +159,7 @@ kamu-datasets-services = { workspace = true }
 kamu-datasets-inmem = { workspace = true }
 
 criterion = { version = "0.5", features = ["async_tokio"] }
-datafusion = { version = "42", default-features = false, features = [
+datafusion = { version = "43", default-features = false, features = [
     "parquet",
 ] }
 filetime = "0.2"

--- a/src/infra/core/src/compaction_service_impl.rs
+++ b/src/infra/core/src/compaction_service_impl.rs
@@ -279,8 +279,11 @@ impl CompactionServiceImpl {
                     .sort(vec![col(Column::from_name(offset_column)).sort(true, false)])
                     .int_err()?;
 
+                // FIXME: The .parquet extension is currently necessary for DataFusion to
+                // respect the single-file output
+                // See: https://github.com/apache/datafusion/issues/13323
                 let new_file_path =
-                    compaction_dir_path.join(format!("merge-slice-{index}").as_str());
+                    compaction_dir_path.join(format!("merge-slice-{index}.parquet").as_str());
 
                 data_frame
                     .write_parquet(

--- a/src/infra/core/src/engine/engine_datafusion_inproc.rs
+++ b/src/infra/core/src/engine/engine_datafusion_inproc.rs
@@ -61,6 +61,7 @@ impl EngineDatafusionInproc {
             input: Arc::new(logical_plan),
             or_replace: false,
             definition: Some(query.to_string()),
+            temporary: false,
         }));
 
         ctx.execute_logical_plan(create_view).await.int_err()?;

--- a/src/infra/core/src/engine/engine_odf.rs
+++ b/src/infra/core/src/engine/engine_odf.rs
@@ -255,14 +255,17 @@ impl Engine for ODFEngine {
         let _ = std::fs::create_dir_all(&host_in_dir);
         let _ = std::fs::create_dir_all(&host_out_dir);
 
-        let host_input_data_path = host_in_dir.join("input");
-        let host_output_data_path = host_out_dir.join("output");
+        // FIXME: The .parquet extension is currently necessary for DataFusion to
+        // respect the single-file output
+        // See: https://github.com/apache/datafusion/issues/13323
+        let host_input_data_path = host_in_dir.join("input.parquet");
+        let host_output_data_path = host_out_dir.join("output.parquet");
 
         // Note: not using `PathBuf::join()` below to ensure linux style paths
         let container_in_dir = PathBuf::from("/opt/engine/in");
         let container_out_dir = PathBuf::from("/opt/engine/out");
-        let container_input_data_path = PathBuf::from("/opt/engine/in/input");
-        let container_output_data_path = PathBuf::from("/opt/engine/out/output");
+        let container_input_data_path = PathBuf::from("/opt/engine/in/input.parquet");
+        let container_output_data_path = PathBuf::from("/opt/engine/out/output.parquet");
 
         let volumes = vec![
             VolumeSpec {

--- a/src/infra/core/src/ingest/fetch_service/evm.rs
+++ b/src/infra/core/src/ingest/fetch_service/evm.rs
@@ -123,6 +123,11 @@ impl FetchService {
         // options in transform DTOs)
         cfg.options_mut().sql_parser.enable_ident_normalization = false;
 
+        // TODO: Disabling Utf8View types due to unresolved issues
+        // See: https://github.com/apache/datafusion/issues/13510
+        // See: https://github.com/apache/datafusion/issues/13504
+        cfg.options_mut().execution.parquet.schema_force_view_types = false;
+
         let mut ctx = SessionContext::new_with_config(cfg);
         datafusion_ethers::udf::register_all(&mut ctx).unwrap();
         ctx.register_catalog(

--- a/src/infra/core/src/ingest/ingest_common.rs
+++ b/src/infra/core/src/ingest/ingest_common.rs
@@ -178,6 +178,9 @@ pub fn new_session_context(object_store_registry: Arc<dyn ObjectStoreRegistry>) 
     use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
     use datafusion::prelude::*;
 
+    // TODO: Disabling Utf8View types due to unresolved issues
+    // See: https://github.com/apache/datafusion/issues/13510
+    // See: https://github.com/apache/datafusion/issues/13504
     let mut config = SessionConfig::new().with_default_catalog_and_schema("kamu", "kamu");
 
     // Forcing cese-sensitive identifiers in case-insensitive language seems to
@@ -189,12 +192,21 @@ pub fn new_session_context(object_store_registry: Arc<dyn ObjectStoreRegistry>) 
     // options in transform DTOs)
     config.options_mut().sql_parser.enable_ident_normalization = false;
 
+    // TODO: Disabling Utf8View types due to unresolved issues
+    // See: https://github.com/apache/datafusion/issues/13510
+    // See: https://github.com/apache/datafusion/issues/13504
+    config
+        .options_mut()
+        .execution
+        .parquet
+        .schema_force_view_types = false;
+
     let runtime_config = RuntimeConfig {
         object_store_registry: object_store_registry.as_datafusion_registry(),
         ..RuntimeConfig::default()
     };
 
-    let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
+    let runtime = Arc::new(RuntimeEnv::try_new(runtime_config).unwrap());
 
     #[allow(unused_mut)]
     let mut ctx = SessionContext::new_with_config_rt(config, runtime);

--- a/src/infra/core/src/ingest/polling_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/polling_ingest_service_impl.rs
@@ -268,7 +268,7 @@ impl PollingIngestServiceImpl {
         let new_source_state = savepoint.source_state.map(|ss| ss.to_source_state());
 
         let out_dir = args.operation_dir.join("out");
-        let data_staging_path = out_dir.join("data");
+        let data_staging_path = out_dir.join("data.parquet");
         std::fs::create_dir(&out_dir).int_err()?;
 
         let stage_result = args
@@ -284,6 +284,8 @@ impl PollingIngestServiceImpl {
                 },
             )
             .await;
+
+        tracing::info!(?stage_result, "Stage result");
 
         // Clean up intermediate files
         // Note that we are leaving the fetch data and savepoint intact

--- a/src/infra/core/src/ingest/push_ingest_service_impl.rs
+++ b/src/infra/core/src/ingest/push_ingest_service_impl.rs
@@ -237,7 +237,7 @@ impl PushIngestServiceImpl {
         };
 
         let out_dir = args.operation_dir.join("out");
-        let data_staging_path = out_dir.join("data");
+        let data_staging_path = out_dir.join("data.parquet");
         std::fs::create_dir(&out_dir).int_err()?;
 
         let stage_result = args

--- a/src/infra/core/src/query/mod.rs
+++ b/src/infra/core/src/query/mod.rs
@@ -67,6 +67,14 @@ impl CatalogProvider for KamuCatalog {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl std::fmt::Debug for KamuCatalog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KamuCatalog").finish_non_exhaustive()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Schema
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -229,6 +237,14 @@ impl SchemaProvider for KamuSchema {
         } else {
             Ok(None)
         }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl std::fmt::Debug for KamuSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KamuSchema").finish_non_exhaustive()
     }
 }
 
@@ -483,6 +499,16 @@ impl TableProvider for KamuTable {
 
     fn statistics(&self) -> Option<Statistics> {
         None
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl std::fmt::Debug for KamuTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KamuTable")
+            .field("resolved_dataset", &self.resolved_dataset)
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/infra/core/src/query_service_impl.rs
+++ b/src/infra/core/src/query_service_impl.rs
@@ -68,11 +68,16 @@ impl QueryServiceImpl {
         // options in transform DTOs)
         cfg.options_mut().sql_parser.enable_ident_normalization = false;
 
+        // TODO: Disabling Utf8View types due to unresolved issues
+        // See: https://github.com/apache/datafusion/issues/13510
+        // See: https://github.com/apache/datafusion/issues/13504
+        cfg.options_mut().execution.parquet.schema_force_view_types = false;
+
         let runtime_config = RuntimeConfig {
             object_store_registry: self.object_store_registry.clone().as_datafusion_registry(),
             ..RuntimeConfig::default()
         };
-        let runtime = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
+        let runtime = Arc::new(RuntimeEnv::try_new(runtime_config).unwrap());
         let session_context = SessionContext::new_with_config_rt(cfg, runtime);
 
         let schema = KamuSchema::prepare(

--- a/src/infra/core/tests/tests/test_query_service_impl.rs
+++ b/src/infra/core/tests/tests/test_query_service_impl.rs
@@ -737,7 +737,7 @@ async fn test_sql_statement_with_state_simple() {
                 source_event_time: Utc::now(),
                 new_watermark: None,
                 new_source_state: None,
-                data_staging_path: tempdir.path().join(".temp-data"),
+                data_staging_path: tempdir.path().join(".temp-data.parquet"),
             },
         )
         .await
@@ -816,7 +816,7 @@ async fn test_sql_statement_with_state_simple() {
                 source_event_time: Utc::now(),
                 new_watermark: None,
                 new_source_state: None,
-                data_staging_path: tempdir.path().join(".temp-data"),
+                data_staging_path: tempdir.path().join(".temp-data.parquet"),
             },
         )
         .await
@@ -965,7 +965,7 @@ async fn test_sql_statement_with_state_cte() {
                 source_event_time: Utc::now(),
                 new_watermark: None,
                 new_source_state: None,
-                data_staging_path: tempdir.path().join(".temp-data"),
+                data_staging_path: tempdir.path().join(".temp-data.parquet"),
             },
         )
         .await
@@ -1015,7 +1015,7 @@ async fn test_sql_statement_with_state_cte() {
                 source_event_time: Utc::now(),
                 new_watermark: None,
                 new_source_state: None,
-                data_staging_path: tempdir.path().join(".temp-data"),
+                data_staging_path: tempdir.path().join(".temp-data.parquet"),
             },
         )
         .await
@@ -1113,7 +1113,7 @@ async fn test_sql_statement_with_state_cte() {
                 source_event_time: Utc::now(),
                 new_watermark: None,
                 new_source_state: None,
-                data_staging_path: tempdir.path().join(".temp-data"),
+                data_staging_path: tempdir.path().join(".temp-data.parquet"),
             },
         )
         .await
@@ -1142,7 +1142,7 @@ async fn test_sql_statement_with_state_cte() {
                 source_event_time: Utc::now(),
                 new_watermark: None,
                 new_source_state: None,
-                data_staging_path: tempdir.path().join(".temp-data"),
+                data_staging_path: tempdir.path().join(".temp-data.parquet"),
             },
         )
         .await

--- a/src/infra/datasets/inmem/Cargo.toml
+++ b/src/infra/datasets/inmem/Cargo.toml
@@ -33,7 +33,7 @@ chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
 secrecy = "0.10"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 tokio-stream = "0.1"
 tracing = { version = "0.1", default-features = false }

--- a/src/infra/datasets/postgres/Cargo.toml
+++ b/src/infra/datasets/postgres/Cargo.toml
@@ -39,7 +39,7 @@ sqlx = { version = "0.8", default-features = false, features = [
     "postgres",
     "chrono",
 ] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 uuid = "1"
 

--- a/src/infra/datasets/sqlite/Cargo.toml
+++ b/src/infra/datasets/sqlite/Cargo.toml
@@ -39,7 +39,7 @@ sqlx = { version = "0.8", default-features = false, features = [
     "sqlite",
     "chrono",
 ] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 uuid = "1"
 

--- a/src/infra/flow-system/inmem/Cargo.toml
+++ b/src/infra/flow-system/inmem/Cargo.toml
@@ -33,7 +33,7 @@ async-trait = { version = "0.1", default-features = false }
 chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 futures = "0.3"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = [] }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/src/infra/ingest-datafusion/Cargo.toml
+++ b/src/infra/ingest-datafusion/Cargo.toml
@@ -27,7 +27,7 @@ opendatafabric = { workspace = true, features = ["arrow"] }
 kamu-core = { workspace = true }
 kamu-data-utils = { workspace = true }
 
-datafusion = { version = "42", default-features = false }
+datafusion = { version = "43", default-features = false }
 digest = "0.10"
 geo-types = { version = "0.7", default-features = false, features = [] }
 geojson = { version = "0.24", default-features = false, features = [
@@ -49,7 +49,7 @@ zip = { version = "2", default-features = false, features = [
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-thiserror = "1"
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = [
     "fs",
     "process",

--- a/src/infra/messaging-outbox/inmem/Cargo.toml
+++ b/src/infra/messaging-outbox/inmem/Cargo.toml
@@ -30,7 +30,7 @@ chrono = { version = "0.4", default-features = false }
 dill = "0.9"
 tokio = { version = "1", default-features = false }
 tokio-stream = "0.1"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 
 

--- a/src/infra/messaging-outbox/postgres/Cargo.toml
+++ b/src/infra/messaging-outbox/postgres/Cargo.toml
@@ -36,9 +36,9 @@ sqlx = { version = "0.8", default-features = false, features = [
     "macros",
     "postgres",
     "chrono",
-    "json"
+    "json",
 ] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 uuid = "1"
 

--- a/src/infra/messaging-outbox/sqlite/Cargo.toml
+++ b/src/infra/messaging-outbox/sqlite/Cargo.toml
@@ -37,9 +37,9 @@ sqlx = { version = "0.8", default-features = false, features = [
     "macros",
     "sqlite",
     "chrono",
-    "json"
+    "json",
 ] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 
 

--- a/src/utils/container-runtime/Cargo.toml
+++ b/src/utils/container-runtime/Cargo.toml
@@ -30,8 +30,13 @@ dill = "0.9"
 libc = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-thiserror = { version = "1", default-features = false }
-tokio = { version = "1", default-features = false, features = ["time", "sync", "process", "parking_lot"] }
+thiserror = { version = "2", default-features = false, features = ["std"] }
+tokio = { version = "1", default-features = false, features = [
+    "time",
+    "sync",
+    "process",
+    "parking_lot",
+] }
 tracing = "0.1"
 url = "2"
 

--- a/src/utils/data-utils/Cargo.toml
+++ b/src/utils/data-utils/Cargo.toml
@@ -33,7 +33,7 @@ async-trait = "0.1"
 arrow = { version = "53", default-features = false }
 arrow-json = { version = "53", default-features = false }
 arrow-digest = { version = "53", default-features = false }
-datafusion = { version = "42", default-features = false, features = [
+datafusion = { version = "43", default-features = false, features = [
     "parquet",
     "serde",
 ] }
@@ -41,7 +41,7 @@ digest = "0.10"
 hex = "0.4"
 sha3 = "0.10"
 tracing = { version = "0.1", default-features = false }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 url = "2"
 serde = { version = "1", default-features = false }
 serde_json = { version = "1" }

--- a/src/utils/data-utils/src/data/hash.rs
+++ b/src/utils/data-utils/src/data/hash.rs
@@ -45,6 +45,7 @@ pub fn get_parquet_logical_hash(
     use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
     let file = std::fs::File::open(data_path)?;
+
     let parquet_reader = ParquetRecordBatchReaderBuilder::try_new(file)?
         .with_batch_size(LOGICAL_HASH_BATCH_SIZE)
         .build()?;

--- a/src/utils/data-utils/src/testing/mod.rs
+++ b/src/utils/data-utils/src/testing/mod.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use arrow::datatypes::Schema;
 use datafusion::common::DFSchema;
 use datafusion::prelude::*;
 use pretty_assertions::assert_eq;
@@ -17,6 +18,12 @@ pub fn assert_schema_eq(schema: &DFSchema, expected: &str) {
     let parquet_schema = crate::schema::convert::dataframe_schema_to_parquet_schema(schema);
     let actual = crate::schema::format::format_schema_parquet(&parquet_schema);
     assert_eq!(expected.trim(), actual.trim());
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn assert_arrow_schema_eq(schema: &Schema, expected: serde_json::Value) {
+    let actual = serde_json::to_value(schema).unwrap();
+    assert_eq!(expected, actual);
 }
 
 pub async fn assert_data_eq(df: DataFrame, expected: &str) {

--- a/src/utils/database-common/Cargo.toml
+++ b/src/utils/database-common/Cargo.toml
@@ -33,7 +33,7 @@ hmac = "0.12"
 internal-error = { workspace = true }
 secrecy = "0.10"
 serde_json = "1"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 tracing = "0.1"
 serde = "1"

--- a/src/utils/datafusion-cli/Cargo.toml
+++ b/src/utils/datafusion-cli/Cargo.toml
@@ -38,7 +38,7 @@ aws-sdk-ssooidc = "1"
 aws-sdk-sts = "1"
 aws-credential-types = "1"
 clap = { version = "4", features = ["derive"] }
-datafusion = { version = "42", features = [
+datafusion = { version = "43", features = [
     "crypto_expressions",
     "datetime_expressions",
     "encoding_expressions",

--- a/src/utils/datafusion-cli/README.md
+++ b/src/utils/datafusion-cli/README.md
@@ -1,9 +1,9 @@
 # datafusion-cli
 
-This crate is heavily based on `datafusion-cli` in the https://github.com/apache/arrow-datafusion/ repository and therefore is licensed under the same `Apache 2.0` license.
+This crate is heavily based on `datafusion-cli` in the https://github.com/apache/datafusion/ repository and therefore is licensed under the same `Apache 2.0` license.
 
 We decided to copy the code instead of using the existing `datafusion-cli` crate because:
-- It was hard to align the dependency versions between our and `arrow-datafusion` repo
+- It was hard to align the dependency versions between our and `datafusion` repo
 - The crate comes with more dependencies than we actually need / want
 - Maintaining optional features in the upstream repo would introduce too much overhead
 - Maintaining a fork was problematic due to `datafusion-cli` sharing the repo with all other `datafusion` crates, not only due to slow clone speed, but also due to `cargo` also switching to use `datafusion` crates from that repo instead of using published artifacts from `crates.io`.

--- a/src/utils/datafusion-cli/src/catalog.rs
+++ b/src/utils/datafusion-cli/src/catalog.rs
@@ -33,6 +33,7 @@ use crate::object_storage::{get_object_store, AwsOptions, GcpOptions};
 
 /// Wraps another catalog, automatically register require object stores for the
 /// file locations
+#[derive(Debug)]
 pub struct DynamicObjectStoreCatalog {
     inner: Arc<dyn CatalogProviderList>,
     state: Weak<RwLock<SessionState>>,
@@ -70,6 +71,7 @@ impl CatalogProviderList for DynamicObjectStoreCatalog {
 }
 
 /// Wraps another catalog provider
+#[derive(Debug)]
 struct DynamicObjectStoreCatalogProvider {
     inner: Arc<dyn CatalogProvider>,
     state: Weak<RwLock<SessionState>>,
@@ -109,6 +111,7 @@ impl CatalogProvider for DynamicObjectStoreCatalogProvider {
 /// Wraps another schema provider. [DynamicObjectStoreSchemaProvider] is
 /// responsible for registering the required object stores for the file
 /// locations.
+#[derive(Debug)]
 struct DynamicObjectStoreSchemaProvider {
     inner: Arc<dyn SchemaProvider>,
     state: Weak<RwLock<SessionState>>,

--- a/src/utils/datafusion-cli/src/exec.rs
+++ b/src/utils/datafusion-cli/src/exec.rs
@@ -373,7 +373,7 @@ pub(crate) async fn register_object_store_and_config_extensions(
     ctx.register_table_options_extension_from_scheme(scheme);
 
     // Clone and modify the default table options based on the provided options
-    let mut table_options = ctx.session_state().default_table_options().clone();
+    let mut table_options = ctx.session_state().default_table_options();
     if let Some(format) = format {
         table_options.set_config_format(format);
     }

--- a/src/utils/datafusion-cli/src/functions.rs
+++ b/src/utils/datafusion-cli/src/functions.rs
@@ -214,6 +214,7 @@ pub fn display_all_functions() -> Result<()> {
 }
 
 /// PARQUET_META table function
+#[derive(Debug)]
 struct ParquetMetadataTable {
     schema: SchemaRef,
     batch: RecordBatch,
@@ -314,6 +315,7 @@ fn fixed_len_byte_array_to_string(val: Option<&FixedLenByteArray>) -> Option<Str
     })
 }
 
+#[derive(Debug)]
 pub struct ParquetMetadataFunc {}
 
 impl TableFunctionImpl for ParquetMetadataFunc {

--- a/src/utils/datafusion-cli/src/object_storage.rs
+++ b/src/utils/datafusion-cli/src/object_storage.rs
@@ -469,7 +469,7 @@ mod tests {
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
-            let mut table_options = ctx.state().default_table_options().clone();
+            let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
             let builder = get_s3_object_store_builder(table_url.as_ref(), aws_options).await?;
@@ -511,7 +511,7 @@ mod tests {
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
-            let mut table_options = ctx.state().default_table_options().clone();
+            let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
             let err = get_s3_object_store_builder(table_url.as_ref(), aws_options)
@@ -538,7 +538,7 @@ mod tests {
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
-            let mut table_options = ctx.state().default_table_options().clone();
+            let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
             // ensure this isn't an error
@@ -570,7 +570,7 @@ mod tests {
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
-            let mut table_options = ctx.state().default_table_options().clone();
+            let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let aws_options = table_options.extensions.get::<AwsOptions>().unwrap();
             let builder = get_oss_object_store_builder(table_url.as_ref(), aws_options)?;
@@ -612,7 +612,7 @@ mod tests {
 
         if let LogicalPlan::Ddl(DdlStatement::CreateExternalTable(cmd)) = &mut plan {
             ctx.register_table_options_extension_from_scheme(scheme);
-            let mut table_options = ctx.state().default_table_options().clone();
+            let mut table_options = ctx.state().default_table_options();
             table_options.alter_with_string_hash_map(&cmd.options)?;
             let gcp_options = table_options.extensions.get::<GcpOptions>().unwrap();
             let builder = get_gcs_object_store_builder(table_url.as_ref(), gcp_options)?;

--- a/src/utils/event-sourcing/Cargo.toml
+++ b/src/utils/event-sourcing/Cargo.toml
@@ -28,9 +28,11 @@ internal-error = { workspace = true }
 async-stream = "0.3"
 async-trait = { version = "0.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio-stream = { version = "0.1", default-features = false }
-tracing = { version = "0.1", default-features = false, features = ["attributes"] }
+tracing = { version = "0.1", default-features = false, features = [
+    "attributes",
+] }
 
 
 [dev-dependencies]

--- a/src/utils/http-common/Cargo.toml
+++ b/src/utils/http-common/Cargo.toml
@@ -28,7 +28,7 @@ kamu-core = { workspace = true }
 axum = { version = "0.7", default-features = false }
 http = { version = "1", default-features = false }
 serde = { version = "1", default-features = false }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false }
 utoipa = { version = "5", default-features = false, features = [] }
 

--- a/src/utils/init-on-startup/Cargo.toml
+++ b/src/utils/init-on-startup/Cargo.toml
@@ -27,8 +27,10 @@ internal-error = { workspace = true }
 
 async-trait = "0.1"
 dill = "0.9"
-petgraph = { version = "0.6", default-features = false, features = ["stable_graph"]}
-thiserror = "1"
+petgraph = { version = "0.6", default-features = false, features = [
+    "stable_graph",
+] }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/src/utils/internal-error/Cargo.toml
+++ b/src/utils/internal-error/Cargo.toml
@@ -22,4 +22,4 @@ doctest = false
 
 
 [dependencies]
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }

--- a/src/utils/kamu-cli-puppet/Cargo.toml
+++ b/src/utils/kamu-cli-puppet/Cargo.toml
@@ -48,7 +48,7 @@ kamu-data-utils = { optional = true, workspace = true, features = ["testing"] }
 opendatafabric = { optional = true, workspace = true }
 
 async-trait = { optional = true, version = "0.1" }
-datafusion = { optional = true, version = "42", default-features = false }
+datafusion = { optional = true, version = "43", default-features = false }
 indoc = { optional = true, version = "2" }
 pretty_assertions = { optional = true, version = "1" }
 serde = { optional = true, version = "1", default-features = false, features = [

--- a/src/utils/messaging-outbox/Cargo.toml
+++ b/src/utils/messaging-outbox/Cargo.toml
@@ -38,7 +38,7 @@ mockall = "0.13"
 prometheus = { version = "0.13", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = "0.1"

--- a/src/utils/multiformats/Cargo.toml
+++ b/src/utils/multiformats/Cargo.toml
@@ -42,7 +42,7 @@ rand = { version = "0.8", default-features = false, features = [
 ] }
 sha3 = { version = "0.10", default-features = false, features = [] }
 serde = { version = "1", default-features = false, features = [] }
-thiserror = { version = "1", default-features = false, features = [] }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 unsigned-varint = { version = "0.8", default-features = false, features = [
     "std",
 ] }

--- a/src/utils/observability/Cargo.toml
+++ b/src/utils/observability/Cargo.toml
@@ -46,7 +46,7 @@ dill = { version = "0.9", default-features = false }
 http = { version = "1", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false, features = ["std"] }
 tracing = { version = "0.1", default-features = false }
 tracing-appender = { version = "0.2", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }


### PR DESCRIPTION
Blocking issues:
- https://github.com/apache/datafusion/issues/13323
  - A workaround was implemented to add `.parquet` extension to all output files, forcing single-file output with the new heuristic. This is not ideal, but better than lagging behind
- https://github.com/apache/datafusion/issues/13510
  - A workaround was implemented by setting `datafusion.execution.parquet.schema_force_view_types = false` config. Will keep it on until https://github.com/apache/datafusion/issues/13504 is completed and then can re-assess