### PR TITLE
GQL, DatasetMetadata: be prepared for not accessed datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Recommendation: for ease of reading, use the following order:
   - E2E: Using the correct account in multi-tenant mode
     - And also the possibility of set it up
   - `DatasetOwnershipService`: moved to the `kamu-dataset` crate area & implemented via `DatasetEntryServiceImpl`
+  - GQL, `DatasetMetadata.currentUpstreamDependencies`: indication if datasets not found/not accessed
+  - GQL, `DatasetMetadata.currentDownstreamDependencies`: exclude datasets that cannot be accessed
 
 ## [0.213.1] - 2024-12-18
 ### Fixed

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -646,7 +646,7 @@ type DatasetMetadata {
 	"""
 	Current upstream dependencies of a dataset
 	"""
-	currentUpstreamDependencies: [Dataset!]!
+	currentUpstreamDependencies: [UpstreamDatasetResult!]!
 	"""
 	Current downstream dependencies of a dataset
 	"""
@@ -725,7 +725,7 @@ type DatasetMut {
 	"""
 	Set visibility for the dataset
 	"""
-	setVisibility(visibility: DatasetVisibilityInput!): SetDatasetPropertyResult!
+	setVisibility(visibility: DatasetVisibilityInput!): SetDatasetVisibilityResult!
 }
 
 scalar DatasetName
@@ -1758,11 +1758,11 @@ type SetDataSchema {
 	schema: DataSchema!
 }
 
-interface SetDatasetPropertyResult {
+interface SetDatasetVisibilityResult {
 	message: String!
 }
 
-type SetDatasetPropertyResultSuccess implements SetDatasetPropertyResult {
+type SetDatasetVisibilityResultSuccess implements SetDatasetVisibilityResult {
 	dummy: String
 	message: String!
 }
@@ -1993,6 +1993,21 @@ type TriggerFlowSuccess implements TriggerFlowResult {
 }
 
 interface UpdateReadmeResult {
+	message: String!
+}
+
+interface UpstreamDatasetResult {
+	message: String!
+}
+
+type UpstreamDatasetResultFound implements UpstreamDatasetResult {
+	dataset: Dataset!
+	message: String!
+}
+
+type UpstreamDatasetResultNotFound implements UpstreamDatasetResult {
+	datasetId: DatasetID!
+	datasetAlias: DatasetAlias!
 	message: String!
 }
 

--- a/src/adapter/graphql/src/mutations/dataset_mut/dataset_mut.rs
+++ b/src/adapter/graphql/src/mutations/dataset_mut/dataset_mut.rs
@@ -162,7 +162,7 @@ impl DatasetMut {
         &self,
         ctx: &Context<'_>,
         visibility: DatasetVisibilityInput,
-    ) -> Result<SetDatasetPropertyResult> {
+    ) -> Result<SetDatasetVisibilityResult> {
         ensure_account_owns_dataset(ctx, &self.dataset_handle).await?;
 
         let rebac_svc = from_catalog_n!(ctx, dyn kamu_auth_rebac::RebacService);
@@ -186,7 +186,7 @@ impl DatasetMut {
                 .int_err()?;
         }
 
-        Ok(SetDatasetPropertyResultSuccess::default().into())
+        Ok(SetDatasetVisibilityResultSuccess::default().into())
     }
 }
 
@@ -292,20 +292,20 @@ pub enum DatasetVisibilityInput {
 
 #[derive(Interface, Debug)]
 #[graphql(field(name = "message", ty = "String"))]
-pub enum SetDatasetPropertyResult {
-    Success(SetDatasetPropertyResultSuccess),
+pub enum SetDatasetVisibilityResult {
+    Success(SetDatasetVisibilityResultSuccess),
 }
 
 #[derive(SimpleObject, Debug, Default)]
 #[graphql(complex)]
-pub struct SetDatasetPropertyResultSuccess {
+pub struct SetDatasetVisibilityResultSuccess {
     _dummy: Option<String>,
 }
 
 #[ComplexObject]
-impl SetDatasetPropertyResultSuccess {
+impl SetDatasetVisibilityResultSuccess {
     async fn message(&self) -> String {
-        "Updated".to_string()
+        "Success".to_string()
     }
 }
 


### PR DESCRIPTION
### Changed
- Private Datasets:
  - GQL, `DatasetMetadata.currentUpstreamDependencies`: indication if datasets not found/not accessed
  - GQL, `DatasetMetadata.currentDownstreamDependencies`: exclude datasets that cannot be accessed