### PR TITLE
Fix crash on resolve dataset by invalid account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Fixed
+- Fix crash on resolving dataset by non existing account
+
 ## [0.217.2] - 2025-01-10
 ### Changed
 - Updated to latest `datafusion` and `alloy` dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6275,6 +6275,7 @@ dependencies = [
  "pretty_assertions",
  "secrecy",
  "test-log",
+ "thiserror 2.0.10",
  "time-source",
  "tokio",
  "tokio-stream",

--- a/src/domain/datasets/services/Cargo.toml
+++ b/src/domain/datasets/services/Cargo.toml
@@ -41,6 +41,7 @@ petgraph = { version = "0.6", default-features = false, features = [
     "stable_graph",
 ] }
 secrecy = "0.10"
+thiserror = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/src/domain/datasets/services/tests/tests/test_dataset_entry_service.rs
+++ b/src/domain/datasets/services/tests/tests/test_dataset_entry_service.rs
@@ -7,10 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::assert_matches::assert_matches;
 use std::sync::{Arc, RwLock};
 
 use chrono::{DateTime, TimeZone, Utc};
 use dill::{Catalog, CatalogBuilder, Component};
+use futures::TryStreamExt;
 use init_on_startup::InitOnStartup;
 use kamu::{DatasetRepositoryWriter, MockDatasetRepositoryWriter};
 use kamu_accounts::{Account, AccountRepository, CurrentAccountSubject};
@@ -18,8 +20,10 @@ use kamu_accounts_inmem::InMemoryAccountRepository;
 use kamu_core::testing::MockDatasetRepository;
 use kamu_core::{
     DatasetLifecycleMessage,
+    DatasetRegistry,
     DatasetRepository,
     DatasetVisibility,
+    GetDatasetError,
     TenancyConfig,
     MESSAGE_PRODUCER_KAMU_CORE_DATASET_SERVICE,
 };
@@ -194,11 +198,53 @@ async fn test_indexes_datasets_correctly() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_log::test(tokio::test)]
+async fn test_try_to_resolve_non_existing_dataset() {
+    let harness = DatasetEntryServiceHarness::new(
+        MockDatasetEntryRepository::new(),
+        MockDatasetRepository::new(),
+    );
+
+    let dataset_ref = DatasetAlias::new(
+        Some(AccountName::new_unchecked("foo")),
+        DatasetName::new_unchecked("bar"),
+    )
+    .as_local_ref();
+
+    let resolve_dataset_result = harness
+        .dataset_registry
+        .resolve_dataset_handle_by_ref(&dataset_ref)
+        .await;
+
+    assert_matches!(resolve_dataset_result, Err(GetDatasetError::NotFound(_)));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_try_to_resolve_all_datasets_for_non_existing_user() {
+    let harness = DatasetEntryServiceHarness::new(
+        MockDatasetEntryRepository::new(),
+        MockDatasetRepository::new(),
+    );
+
+    let resolve_dataset_result = harness
+        .dataset_registry
+        .all_dataset_handles_by_owner(&AccountName::new_unchecked("foo"));
+
+    let list_dataset: Vec<_> = resolve_dataset_result.try_collect().await.unwrap();
+
+    assert!(list_dataset.is_empty());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 struct DatasetEntryServiceHarness {
     _catalog: Catalog,
     outbox: Arc<dyn Outbox>,
     dataset_entry_indexer: Arc<DatasetEntryIndexer>,
     account_repo: Arc<dyn AccountRepository>,
+    dataset_registry: Arc<dyn DatasetRegistry>,
 }
 
 impl DatasetEntryServiceHarness {
@@ -252,6 +298,7 @@ impl DatasetEntryServiceHarness {
             outbox: catalog.get_one().unwrap(),
             dataset_entry_indexer: catalog.get_one().unwrap(),
             account_repo: catalog.get_one().unwrap(),
+            dataset_registry: catalog.get_one().unwrap(),
             _catalog: catalog,
         }
     }


### PR DESCRIPTION
## Description

Fix application crash when trying to get dataset for non existing account

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)