### PR TITLE
Handle panic errors in kamu inspect command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Recommendation: for ease of reading, use the following order:
 - Upgraded to `datafusion v45` (#1063)
 ### Fixed
 - GQL metadata query now correctly returns dataset aliases for `SetTransform` event in multi-tenant mode
+- Handle panic errors in `kamu inspect lineage -- browse` command
 
 ## [0.222.0] - 2025-02-06
 ### Added

--- a/src/domain/core/src/services/provenance_service.rs
+++ b/src/domain/core/src/services/provenance_service.rs
@@ -32,7 +32,7 @@ pub trait LineageVisitor: Send {
     fn begin(&mut self);
     fn enter(&mut self, dataset: &NodeInfo<'_>) -> bool;
     fn exit(&mut self, dataset: &NodeInfo<'_>);
-    fn done(&mut self);
+    fn done(&mut self) -> Result<(), InternalError>;
 }
 
 #[derive(Debug, Clone)]

--- a/src/infra/core/src/services/provenance_service_impl.rs
+++ b/src/infra/core/src/services/provenance_service_impl.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use dill::*;
-use internal_error::ResultIntoInternal;
+use internal_error::{InternalError, ResultIntoInternal};
 use kamu_core::*;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -179,8 +179,8 @@ impl<W: Write + Send, S: DotStyle + Send> LineageVisitor for DotVisitor<W, S> {
 
     fn exit(&mut self, _dataset: &NodeInfo<'_>) {}
 
-    fn done(&mut self) {
-        writeln!(self.writer, "}}").unwrap();
+    fn done(&mut self) -> Result<(), InternalError> {
+        writeln!(self.writer, "}}").int_err()
     }
 }
 


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: https://github.com/kamu-data/kamu-cli/issues/1072

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [ ] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)