### PR TITLE
Extend parse error with reserved keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Fixed
+- Improved error message for SQL parsing method for queries which includes invalid or reserved keywords
+
 ## [0.223.0] - 2025-02-13
 ### Added
 - Increased test coverage of the code responsible for access checks

--- a/src/infra/ingest-datafusion/src/readers/mod.rs
+++ b/src/infra/ingest-datafusion/src/readers/mod.rs
@@ -27,17 +27,13 @@ pub(crate) async fn from_ddl_schema(
     ctx: &datafusion::prelude::SessionContext,
     ddl_schema: Option<&Vec<String>>,
 ) -> Result<Option<datafusion::arrow::datatypes::Schema>, kamu_core::ingest::ReadError> {
-    use internal_error::*;
-
     let Some(ddl_schema) = ddl_schema else {
         return Ok(None);
     };
 
     let ddl = ddl_schema.join(", ");
 
-    let schema = odf::utils::schema::parse::parse_ddl_to_arrow_schema(ctx, &ddl, true)
-        .await
-        .int_err()?;
+    let schema = odf::utils::schema::parse::parse_ddl_to_arrow_schema(ctx, &ddl, true).await?;
 
     Ok(Some(schema))
 }

--- a/src/odf/data-utils/src/lib.rs
+++ b/src/odf/data-utils/src/lib.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 #![feature(assert_matches)]
+#![feature(let_chains)]
 
 pub mod data;
 pub mod schema;

--- a/src/odf/data-utils/src/schema/parse.rs
+++ b/src/odf/data-utils/src/schema/parse.rs
@@ -39,9 +39,12 @@ pub async fn parse_ddl_to_datafusion_schema(
         if let Some(err_index) = extract_column_index(&err)
             && let Some(invalid_field) = extract_problematic_field(&sql, err_index)
         {
-            return Err(DataFusionError::Plan(format!(
-                "Argument {invalid_field} is invalid or a reserved keyword"
-            )));
+            return Err(DataFusionError::SQL(
+                ParserError::ParserError(format!(
+                    "Argument '{invalid_field}' is invalid or a reserved keyword"
+                )),
+                None,
+            ));
         }
     }
 

--- a/src/odf/data-utils/src/schema/parse.rs
+++ b/src/odf/data-utils/src/schema/parse.rs
@@ -180,13 +180,10 @@ fn extract_problematic_field(sql: &str, error_index: usize) -> Option<String> {
     let truncated = &sql[..error_index - 1];
 
     // Step 2: Find the last ',' or '(' before the error index
-    let last_separator = truncated.rfind(|c| c == ',' || c == '(')?;
+    let last_separator = truncated.rfind([',', '('])?;
 
     // Step 3: Extract the column definition
-    let column_part = truncated[(last_separator + 1)..].trim();
+    let column_definition = truncated[(last_separator + 1)..].trim();
 
-    // Step 4: Get only the column name (first word before space)
-    let column_name = column_part.split_whitespace().next()?;
-
-    Some(column_name.to_string())
+    Some(column_definition.to_string())
 }

--- a/src/odf/data-utils/tests/tests/test_schema.rs
+++ b/src/odf/data-utils/tests/tests/test_schema.rs
@@ -10,6 +10,7 @@
 use std::assert_matches::assert_matches;
 
 use datafusion::error::DataFusionError;
+use datafusion::sql::sqlparser::parser::ParserError;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -67,5 +68,5 @@ async fn test_parse_ddl_with_reserved_keyword() {
     )
     .await;
 
-    assert_matches!(result, Err(DataFusionError::Plan(err)) if err ==  *"Argument key TEXT is invalid or a reserved keyword");
+    assert_matches!(result, Err(DataFusionError::SQL(ParserError::ParserError(err), _)) if err ==  *"Argument 'key TEXT' is invalid or a reserved keyword");
 }

--- a/src/odf/data-utils/tests/tests/test_schema.rs
+++ b/src/odf/data-utils/tests/tests/test_schema.rs
@@ -67,5 +67,5 @@ async fn test_parse_ddl_with_reserved_keyword() {
     )
     .await;
 
-    assert_matches!(result, Err(DataFusionError::Plan(err)) if err ==  "Argument key is invalid or a reserved keyword".to_string());
+    assert_matches!(result, Err(DataFusionError::Plan(err)) if err ==  *"Argument key TEXT is invalid or a reserved keyword");
 }

--- a/src/odf/data-utils/tests/tests/test_schema.rs
+++ b/src/odf/data-utils/tests/tests/test_schema.rs
@@ -7,6 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::assert_matches::assert_matches;
+
+use datafusion::error::DataFusionError;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 #[test_log::test(tokio::test)]
 async fn test_parse_ddl() {
     let ctx = datafusion::prelude::SessionContext::new();
@@ -27,6 +33,8 @@ message arrow_schema {
     );
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 #[test_log::test(tokio::test)]
 async fn test_parse_ddl_with_force_utc() {
     let ctx = datafusion::prelude::SessionContext::new();
@@ -45,4 +53,19 @@ message arrow_schema {
 }
         "#,
     );
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_parse_ddl_with_reserved_keyword() {
+    let ctx = datafusion::prelude::SessionContext::new();
+    let result = opendatafabric_data_utils::schema::parse::parse_ddl_to_datafusion_schema(
+        &ctx,
+        "foo TEXT, key TEXT, bar TEXT",
+        false,
+    )
+    .await;
+
+    assert_matches!(result, Err(DataFusionError::Plan(err)) if err ==  "Argument key is invalid or a reserved keyword".to_string());
 }


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: https://github.com/kamu-data/kamu-cli/issues/1077

The result error looks next:
![image](https://github.com/user-attachments/assets/f8b7cccd-fc78-4c56-8359-9f1afaa869ed)


<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)