### PR TITLE
images/demo: bump version

### DIFF
--- a/images/demo/Makefile
+++ b/images/demo/Makefile
@@ -3,7 +3,7 @@ IMAGE_REPO = ghcr.io/kamu-data
 KAMU_VERSION = $(shell cargo metadata --format-version 1 | jq -r '.packages[] | select( .name == "kamu") | .version')
 
 # Keep in sync with versions of Jupyter and Minio in docker-compose.yml
-DEMO_VERSION = 0.17.1
+DEMO_VERSION = 0.17.2
 
 #########################################################################################
 

--- a/images/demo/docker-compose.yml
+++ b/images/demo/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
 
 services:
   jupyter:
-    image: ghcr.io/kamu-data/kamu-cli-demo-jupyter:0.17.1
+    image: ghcr.io/kamu-data/kamu-cli-demo-jupyter:0.17.2
     # Unfortunately running podman within another container requires elevated permissions
     privileged: true
     command:


### PR DESCRIPTION
The images have already been built:
- https://github.com/kamu-data/kamu-cli/pkgs/container/kamu-cli-demo-minio/358089185?tag=0.17.2
- https://github.com/kamu-data/kamu-cli/pkgs/container/kamu-cli-demo-jupyter/358098699?tag=0.17.2