### PR TITLE
Release (patch): `0.225.3`: fix `make sqlx-prepate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
-## Unreleased
+## [0.225.3] - 2025-02-24
 ### Fixed
-- E2E: `repo-tests` crete again contains the `kamu-cli` dependency, but as an optional one
+- E2E: `repo-tests` crate again contains the `kamu-cli` dependency, but as an optional one
   - This way we can correctly reuse the tests in the `kamu-node` repository without affecting the build time
+  - It also fixes `make sqlx-prepate` developer command
 
 ## [0.225.2] - 2025-02-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## Unreleased
+### Fixed
+- E2E: `repo-tests` crete again contains the `kamu-cli` dependency, but as an optional one
+  - This way we can correctly reuse the tests in the `kamu-node` repository without affecting the build time
+
 ## [0.225.2] - 2025-02-24
 ### Added
 - Added prometheus metrics for AWS SDK S3 calls
 ### Changed
-- Make `repo-tests` crate independent from `kamu-cli` crate
+- E2E: make `repo-tests` crate independent from `kamu-cli` crate
 
 ## [0.225.1] - 2025-02-23
 ### Fixed
@@ -24,8 +29,8 @@ Recommendation: for ease of reading, use the following order:
 ## [0.225.0] - 2025-02-20
 ### Added
 - Added [common-macros](src/utils/common-macros) crate containing macros of general use
-- `kamu list`: display dataset visibility in multi-tenant
-- `kamu pull`: added `--visibility private|public` argument to specify the created dataset visibility
+  - `kamu list`: display dataset visibility in multi-tenant
+  - `kamu pull`: added `--visibility private|public` argument to specify the created dataset visibility
 ### Changed
 - Improved/added trace for repositories & GQL to contain not only the method name but also the structure name
 ### Fixed
@@ -46,13 +51,13 @@ Recommendation: for ease of reading, use the following order:
 - Increased test coverage of the code responsible for access checks
 ### Changed
 - Restructured responsibilities between core and dataset domains upon key dataset CRUD use cases:
-   - 8 use cases moved from `core` to `kamu-datasets` domain
-   - no longer using outbox for "Renamed" and "DependenciesUpdated" events in datasets, 
-     these became internal aspect inside `kamu-datasets` domain
-   - simplified creation and commit result structures as they no longer transport new dependencies
-   - revised many integration tests:
-       - flow system no longer uses real datasets
-       - HTTP and GQL use real accounts and dataset entries
+  - 8 use cases moved from `core` to `kamu-datasets` domain
+  - no longer using outbox for "Renamed" and "DependenciesUpdated" events in datasets, 
+      these became internal aspect inside `kamu-datasets` domain
+  - simplified creation and commit result structures as they no longer transport new dependencies
+  - revised many integration tests:
+    - flow system no longer uses real datasets
+    - HTTP and GQL use real accounts and dataset entries
 - Moved several account-related routines from `AuthenticationService` to `AccountService`, 
   the authentication services has focus only on JWT token and login flows
 - Upgraded to `datafusion v45` (#1063)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6162,7 +6162,6 @@ name = "kamu-cli-e2e-inmem"
 version = "0.225.2"
 dependencies = [
  "indoc 2.0.5",
- "kamu-cli",
  "kamu-cli-e2e-common",
  "kamu-cli-e2e-repo-tests",
  "test-group",
@@ -6176,7 +6175,6 @@ version = "0.225.2"
 dependencies = [
  "database-common",
  "indoc 2.0.5",
- "kamu-cli",
  "kamu-cli-e2e-common",
  "kamu-cli-e2e-repo-tests",
  "sqlx",
@@ -6191,7 +6189,6 @@ version = "0.225.2"
 dependencies = [
  "database-common",
  "indoc 2.0.5",
- "kamu-cli",
  "kamu-cli-e2e-common",
  "kamu-cli-e2e-repo-tests",
  "sqlx",
@@ -6212,6 +6209,7 @@ dependencies = [
  "kamu",
  "kamu-accounts",
  "kamu-adapter-http",
+ "kamu-cli",
  "kamu-cli-e2e-common",
  "kamu-cli-puppet",
  "kamu-flow-system",
@@ -6232,7 +6230,6 @@ version = "0.225.2"
 dependencies = [
  "database-common",
  "indoc 2.0.5",
- "kamu-cli",
  "kamu-cli-e2e-common",
  "kamu-cli-e2e-repo-tests",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "async-utils"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "common-macros"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -2601,7 +2601,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3039,7 +3039,7 @@ checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "database-common"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "email-utils"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "serde",
  "thiserror 2.0.11",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.225.2"
+version = "0.225.3"
 
 [[package]]
 name = "env_filter"
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -4144,7 +4144,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "file-utils"
-version = "0.225.2"
+version = "0.225.3"
 
 [[package]]
 name = "filetime"
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "axum 0.8.1",
  "http 1.2.0",
@@ -5227,7 +5227,7 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "init-on-startup"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5258,7 +5258,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "thiserror 2.0.11",
 ]
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -5497,7 +5497,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "base32",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5569,7 +5569,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5592,7 +5592,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "argon2",
  "chrono",
@@ -5609,7 +5609,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5660,7 +5660,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "dill",
@@ -5864,7 +5864,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -5906,7 +5906,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5918,7 +5918,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-postgres"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5948,7 +5948,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-repo-tests"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "dill",
  "kamu-auth-rebac",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -6159,7 +6159,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-inmem"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "indoc 2.0.5",
  "kamu-cli-e2e-common",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "database-common",
  "indoc 2.0.5",
@@ -6185,7 +6185,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "database-common",
  "indoc 2.0.5",
@@ -6199,7 +6199,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "chrono",
  "database-common",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "database-common",
  "indoc 2.0.5",
@@ -6240,7 +6240,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6312,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6336,7 +6336,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6357,7 +6357,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6378,7 +6378,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-repo-tests"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "chrono",
  "database-common",
@@ -6395,7 +6395,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6436,7 +6436,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6457,7 +6457,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6504,7 +6504,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6526,7 +6526,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "chrono",
  "database-common",
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6599,7 +6599,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6665,7 +6665,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-repo-tests"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "chrono",
  "dill",
@@ -6678,7 +6678,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "chrono",
  "clap",
@@ -6715,7 +6715,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6734,7 +6734,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6751,7 +6751,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6771,7 +6771,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "chrono",
  "database-common",
@@ -6783,7 +6783,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6815,7 +6815,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7261,7 +7261,7 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7401,7 +7401,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -7807,7 +7807,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -7822,7 +7822,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-data-utils"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -7846,7 +7846,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7870,7 +7870,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset-impl"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-metadata"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7936,7 +7936,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7958,7 +7958,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-http"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7981,7 +7981,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-inmem"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7997,7 +7997,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-lfs"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -8017,7 +8017,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-s3"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9071,7 +9071,7 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "rand",
 ]
@@ -9661,7 +9661,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "s3-utils"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -10661,7 +10661,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "axum 0.8.1",
  "container-runtime",
@@ -10796,7 +10796,7 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.225.2"
+version = "0.225.3"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,110 +106,110 @@ resolver = "2"
 [workspace.dependencies]
 
 # Apps
-kamu-cli = { version = "0.225.2", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.225.3", path = "src/app/cli", default-features = false }
 
 # Utils
-async-utils = { version = "0.225.2", path = "src/utils/async-utils", default-features = false }
-common-macros = { version = "0.225.2", path = "src/utils/common-macros", default-features = false }
-container-runtime = { version = "0.225.2", path = "src/utils/container-runtime", default-features = false }
-database-common = { version = "0.225.2", path = "src/utils/database-common", default-features = false }
-database-common-macros = { version = "0.225.2", path = "src/utils/database-common-macros", default-features = false }
-email-utils = { version = "0.225.2", path = "src/utils/email-utils", default-features = false }
-enum-variants = { version = "0.225.2", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.225.2", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.225.2", path = "src/utils/event-sourcing-macros", default-features = false }
-file-utils = { version = "0.225.2", path = "src/utils/file-utils", default-features = false }
-http-common = { version = "0.225.2", path = "src/utils/http-common", default-features = false }
-init-on-startup = { version = "0.225.2", path = "src/utils/init-on-startup", default-features = false }
-internal-error = { version = "0.225.2", path = "src/utils/internal-error", default-features = false }
-kamu-cli-puppet = { version = "0.225.2", path = "src/utils/kamu-cli-puppet", default-features = false }
-kamu-datafusion-cli = { version = "0.225.2", path = "src/utils/datafusion-cli", default-features = false }
-messaging-outbox = { version = "0.225.2", path = "src/utils/messaging-outbox", default-features = false }
-multiformats = { version = "0.225.2", path = "src/utils/multiformats", default-features = false }
-observability = { version = "0.225.2", path = "src/utils/observability", default-features = false }
-random-names = { version = "0.225.2", path = "src/utils/random-names", default-features = false }
-s3-utils = { version = "0.225.2", path = "src/utils/s3-utils", default-features = false }
-test-utils = { version = "0.225.2", path = "src/utils/test-utils", default-features = false }
-time-source = { version = "0.225.2", path = "src/utils/time-source", default-features = false }
-tracing-perfetto = { version = "0.225.2", path = "src/utils/tracing-perfetto", default-features = false }
+async-utils = { version = "0.225.3", path = "src/utils/async-utils", default-features = false }
+common-macros = { version = "0.225.3", path = "src/utils/common-macros", default-features = false }
+container-runtime = { version = "0.225.3", path = "src/utils/container-runtime", default-features = false }
+database-common = { version = "0.225.3", path = "src/utils/database-common", default-features = false }
+database-common-macros = { version = "0.225.3", path = "src/utils/database-common-macros", default-features = false }
+email-utils = { version = "0.225.3", path = "src/utils/email-utils", default-features = false }
+enum-variants = { version = "0.225.3", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.225.3", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.225.3", path = "src/utils/event-sourcing-macros", default-features = false }
+file-utils = { version = "0.225.3", path = "src/utils/file-utils", default-features = false }
+http-common = { version = "0.225.3", path = "src/utils/http-common", default-features = false }
+init-on-startup = { version = "0.225.3", path = "src/utils/init-on-startup", default-features = false }
+internal-error = { version = "0.225.3", path = "src/utils/internal-error", default-features = false }
+kamu-cli-puppet = { version = "0.225.3", path = "src/utils/kamu-cli-puppet", default-features = false }
+kamu-datafusion-cli = { version = "0.225.3", path = "src/utils/datafusion-cli", default-features = false }
+messaging-outbox = { version = "0.225.3", path = "src/utils/messaging-outbox", default-features = false }
+multiformats = { version = "0.225.3", path = "src/utils/multiformats", default-features = false }
+observability = { version = "0.225.3", path = "src/utils/observability", default-features = false }
+random-names = { version = "0.225.3", path = "src/utils/random-names", default-features = false }
+s3-utils = { version = "0.225.3", path = "src/utils/s3-utils", default-features = false }
+test-utils = { version = "0.225.3", path = "src/utils/test-utils", default-features = false }
+time-source = { version = "0.225.3", path = "src/utils/time-source", default-features = false }
+tracing-perfetto = { version = "0.225.3", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-kamu-accounts = { version = "0.225.2", path = "src/domain/accounts/domain", default-features = false }
-kamu-auth-rebac = { version = "0.225.2", path = "src/domain/auth-rebac/domain", default-features = false }
-kamu-core = { version = "0.225.2", path = "src/domain/core", default-features = false }
-kamu-datasets = { version = "0.225.2", path = "src/domain/datasets/domain", default-features = false }
-kamu-flow-system = { version = "0.225.2", path = "src/domain/flow-system/domain", default-features = false }
-kamu-task-system = { version = "0.225.2", path = "src/domain/task-system/domain", default-features = false }
+kamu-accounts = { version = "0.225.3", path = "src/domain/accounts/domain", default-features = false }
+kamu-auth-rebac = { version = "0.225.3", path = "src/domain/auth-rebac/domain", default-features = false }
+kamu-core = { version = "0.225.3", path = "src/domain/core", default-features = false }
+kamu-datasets = { version = "0.225.3", path = "src/domain/datasets/domain", default-features = false }
+kamu-flow-system = { version = "0.225.3", path = "src/domain/flow-system/domain", default-features = false }
+kamu-task-system = { version = "0.225.3", path = "src/domain/task-system/domain", default-features = false }
 
 ## Open Data Fabric
-odf = { version = "0.225.2", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
-odf-metadata = { version = "0.225.2", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
-odf-dataset = { version = "0.225.2", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
-odf-data-utils = { version = "0.225.2", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
-odf-dataset-impl = { version = "0.225.2", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
-odf-storage = { version = "0.225.2", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
-odf-storage-http = { version = "0.225.2", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
-odf-storage-inmem = { version = "0.225.2", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
-odf-storage-lfs = { version = "0.225.2", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
-odf-storage-s3 = { version = "0.225.2", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
+odf = { version = "0.225.3", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
+odf-metadata = { version = "0.225.3", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
+odf-dataset = { version = "0.225.3", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
+odf-data-utils = { version = "0.225.3", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
+odf-dataset-impl = { version = "0.225.3", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
+odf-storage = { version = "0.225.3", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
+odf-storage-http = { version = "0.225.3", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
+odf-storage-inmem = { version = "0.225.3", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
+odf-storage-lfs = { version = "0.225.3", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
+odf-storage-s3 = { version = "0.225.3", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.225.2", path = "src/domain/accounts/services", default-features = false }
-kamu-auth-rebac-services = { version = "0.225.2", path = "src/domain/auth-rebac/services", default-features = false }
-kamu-datasets-services = { version = "0.225.2", path = "src/domain/datasets/services", default-features = false }
-kamu-flow-system-services = { version = "0.225.2", path = "src/domain/flow-system/services", default-features = false }
-kamu-task-system-services = { version = "0.225.2", path = "src/domain/task-system/services", default-features = false }
+kamu-accounts-services = { version = "0.225.3", path = "src/domain/accounts/services", default-features = false }
+kamu-auth-rebac-services = { version = "0.225.3", path = "src/domain/auth-rebac/services", default-features = false }
+kamu-datasets-services = { version = "0.225.3", path = "src/domain/datasets/services", default-features = false }
+kamu-flow-system-services = { version = "0.225.3", path = "src/domain/flow-system/services", default-features = false }
+kamu-task-system-services = { version = "0.225.3", path = "src/domain/task-system/services", default-features = false }
 
 # Infra
-kamu = { version = "0.225.2", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.225.2", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.225.3", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.225.3", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.225.2", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.225.2", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.225.2", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.225.2", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.225.3", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.225.3", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.225.3", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.225.3", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.225.2", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.225.2", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.225.2", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.225.2", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.225.2", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.225.3", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.225.3", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.225.3", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.225.3", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.225.3", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Datasets
-kamu-datasets-inmem = { version = "0.225.2", path = "src/infra/datasets/inmem", default-features = false }
-kamu-datasets-postgres = { version = "0.225.2", path = "src/infra/datasets/postgres", default-features = false }
-kamu-datasets-sqlite = { version = "0.225.2", path = "src/infra/datasets/sqlite", default-features = false }
-kamu-datasets-repo-tests = { version = "0.225.2", path = "src/infra/datasets/repo-tests", default-features = false }
+kamu-datasets-inmem = { version = "0.225.3", path = "src/infra/datasets/inmem", default-features = false }
+kamu-datasets-postgres = { version = "0.225.3", path = "src/infra/datasets/postgres", default-features = false }
+kamu-datasets-sqlite = { version = "0.225.3", path = "src/infra/datasets/sqlite", default-features = false }
+kamu-datasets-repo-tests = { version = "0.225.3", path = "src/infra/datasets/repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.225.2", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.225.2", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.225.2", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.225.2", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.225.3", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.225.3", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.225.3", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.225.3", path = "src/infra/task-system/repo-tests", default-features = false }
 ## ReBAC
-kamu-auth-rebac-inmem = { version = "0.225.2", path = "src/infra/auth-rebac/inmem", default-features = false }
-kamu-auth-rebac-repo-tests = { version = "0.225.2", path = "src/infra/auth-rebac/repo-tests", default-features = false }
-kamu-auth-rebac-postgres = { version = "0.225.2", path = "src/infra/auth-rebac/postgres", default-features = false }
-kamu-auth-rebac-sqlite = { version = "0.225.2", path = "src/infra/auth-rebac/sqlite", default-features = false }
+kamu-auth-rebac-inmem = { version = "0.225.3", path = "src/infra/auth-rebac/inmem", default-features = false }
+kamu-auth-rebac-repo-tests = { version = "0.225.3", path = "src/infra/auth-rebac/repo-tests", default-features = false }
+kamu-auth-rebac-postgres = { version = "0.225.3", path = "src/infra/auth-rebac/postgres", default-features = false }
+kamu-auth-rebac-sqlite = { version = "0.225.3", path = "src/infra/auth-rebac/sqlite", default-features = false }
 ## Outbox
-kamu-messaging-outbox-inmem = { version = "0.225.2", path = "src/infra/messaging-outbox/inmem", default-features = false }
-kamu-messaging-outbox-postgres = { version = "0.225.2", path = "src/infra/messaging-outbox/postgres", default-features = false }
-kamu-messaging-outbox-sqlite = { version = "0.225.2", path = "src/infra/messaging-outbox/sqlite", default-features = false }
-kamu-messaging-outbox-repo-tests = { version = "0.225.2", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
+kamu-messaging-outbox-inmem = { version = "0.225.3", path = "src/infra/messaging-outbox/inmem", default-features = false }
+kamu-messaging-outbox-postgres = { version = "0.225.3", path = "src/infra/messaging-outbox/postgres", default-features = false }
+kamu-messaging-outbox-sqlite = { version = "0.225.3", path = "src/infra/messaging-outbox/sqlite", default-features = false }
+kamu-messaging-outbox-repo-tests = { version = "0.225.3", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso-rebac = { version = "0.225.2", path = "src/adapter/auth-oso-rebac", default-features = false }
-kamu-adapter-flight-sql = { version = "0.225.2", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.225.2", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.225.2", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.225.2", path = "src/adapter/odata", default-features = false }
-kamu-adapter-oauth = { version = "0.225.2", path = "src/adapter/oauth", default-features = false }
+kamu-adapter-auth-oso-rebac = { version = "0.225.3", path = "src/adapter/auth-oso-rebac", default-features = false }
+kamu-adapter-flight-sql = { version = "0.225.3", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.225.3", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.225.3", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.225.3", path = "src/adapter/odata", default-features = false }
+kamu-adapter-oauth = { version = "0.225.3", path = "src/adapter/oauth", default-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.225.2", path = "src/e2e/app/cli/common", default-features = false }
-kamu-cli-e2e-common-macros = { version = "0.225.2", path = "src/e2e/app/cli/common-macros", default-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.225.2", path = "src/e2e/app/cli/repo-tests", default-features = false }
+kamu-cli-e2e-common = { version = "0.225.3", path = "src/e2e/app/cli/common", default-features = false }
+kamu-cli-e2e-common-macros = { version = "0.225.3", path = "src/e2e/app/cli/common-macros", default-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.225.3", path = "src/e2e/app/cli/repo-tests", default-features = false }
 
 [workspace.package]
-version = "0.225.2"
+version = "0.225.3"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.225.2
+Licensed Work:             Kamu CLI Version 0.225.3
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -818,7 +818,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.225.2"
+    "version": "0.225.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -818,7 +818,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.225.2"
+    "version": "0.225.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/src/e2e/app/cli/inmem/Cargo.toml
+++ b/src/e2e/app/cli/inmem/Cargo.toml
@@ -21,17 +21,13 @@ workspace = true
 doctest = false
 
 
-[package.metadata.cargo-udeps.ignore]
-normal = ["kamu-cli"]
-
-
 [dependencies]
-# We add a dependency to ensure kamu-cli is up to date before calling tests
-kamu-cli = { workspace = true }
+# We have only tests in this crate
+
 
 [dev-dependencies]
 kamu-cli-e2e-common = { workspace = true }
-kamu-cli-e2e-repo-tests = { workspace = true }
+kamu-cli-e2e-repo-tests = { workspace = true, default-features = false, features = ["build-kamu-cli"] }
 
 indoc = "2"
 test-group = { version = "1" }

--- a/src/e2e/app/cli/mysql/Cargo.toml
+++ b/src/e2e/app/cli/mysql/Cargo.toml
@@ -21,18 +21,14 @@ workspace = true
 doctest = false
 
 
-[package.metadata.cargo-udeps.ignore]
-normal = ["kamu-cli"]
-
-
 [dependencies]
-# We add a dependency to ensure kamu-cli is up to date before calling tests
-kamu-cli = { workspace = true }
+# We have only tests in this crate
+
 
 [dev-dependencies]
 database-common = { workspace = true, features = ["testing"] }
 kamu-cli-e2e-common = { workspace = true }
-kamu-cli-e2e-repo-tests = { workspace = true }
+kamu-cli-e2e-repo-tests = { workspace = true, default-features = false, features = ["build-kamu-cli"] }
 
 indoc = "2"
 sqlx = { version = "0.8", default-features = false, features = [

--- a/src/e2e/app/cli/postgres/Cargo.toml
+++ b/src/e2e/app/cli/postgres/Cargo.toml
@@ -21,18 +21,14 @@ workspace = true
 doctest = false
 
 
-[package.metadata.cargo-udeps.ignore]
-normal = ["kamu-cli"]
-
-
 [dependencies]
-# We add a dependency to ensure kamu-cli is up to date before calling tests
-kamu-cli = { workspace = true }
+# We have only tests in this crate
+
 
 [dev-dependencies]
 database-common = { workspace = true, features = ["testing"] }
 kamu-cli-e2e-common = { workspace = true }
-kamu-cli-e2e-repo-tests = { workspace = true }
+kamu-cli-e2e-repo-tests = { workspace = true, default-features = false, features = ["build-kamu-cli"] }
 
 indoc = "2"
 sqlx = { version = "0.8", default-features = false, features = [

--- a/src/e2e/app/cli/repo-tests/Cargo.toml
+++ b/src/e2e/app/cli/repo-tests/Cargo.toml
@@ -21,7 +21,20 @@ workspace = true
 doctest = false
 
 
+[features]
+default = []
+build-kamu-cli = [
+    # We add a dependency to ensure kamu-cli is up to date before calling tests
+    "dep:kamu-cli",
+]
+
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["kamu-cli"]
+
+
 [dependencies]
+# No features
 http-common = { workspace = true }
 database-common = { workspace = true, default-features = false }
 kamu = { workspace = true, features = ["testing"] }
@@ -36,6 +49,10 @@ odf = { workspace = true }
 regex = { version = "1", default-features = false }
 test-utils = { workspace = true }
 
+# Feature: extensions
+kamu-cli = { optional = true, workspace = true }
+
+
 chrono = { version = "0.4", default-features = false }
 indoc = "2"
 paste = { version = "1", default-features = false }
@@ -46,3 +63,5 @@ tempfile = { version = "3" }
 url = { version = "2", default-features = false }
 datafusion = { version = "45", default-features = false, features = [] }
 
+
+[dev-dependencies]

--- a/src/e2e/app/cli/sqlite/Cargo.toml
+++ b/src/e2e/app/cli/sqlite/Cargo.toml
@@ -21,19 +21,14 @@ workspace = true
 doctest = false
 
 
-[package.metadata.cargo-udeps.ignore]
-normal = ["kamu-cli"]
-
-
 [dependencies]
-# We add a dependency to ensure kamu-cli is up to date before calling tests
-kamu-cli = { workspace = true }
+# We have only tests in this crate
 
 
 [dev-dependencies]
-database-common = { workspace = true,  default-features = false, features = ["testing"] }
+database-common = { workspace = true, default-features = false, features = ["testing"] }
 kamu-cli-e2e-common = { workspace = true }
-kamu-cli-e2e-repo-tests = { workspace = true }
+kamu-cli-e2e-repo-tests = { workspace = true, default-features = false, features = ["build-kamu-cli"] }
 
 indoc = "2"
 sqlx = { version = "0.8", default-features = false, features = [


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->


<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

## [0.225.3] - 2025-02-24
### Fixed
- E2E: `repo-tests` crate again contains the `kamu-cli` dependency, but as an optional one
  - This way we can correctly reuse the tests in the `kamu-node` repository without affecting the build time
  - It also fixes `make sqlx-prepate` developer command

## Checklist before requesting a review

- [ ] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [ ] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [ ] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)