### PR TITLE
SQLite: protection against database locking, in case of parallel execution of `kamu` commands. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Recommendation: for ease of reading, use the following order:
 ## Unreleased
 ### Changed
 - Simple Transfer Protocol & Smart Transfer Protocol use `AppendDatasetMetadataBatchUseCase`
+- SQLite: protection against database locking, in case of parallel execution of `kamu` commands.
+  - Based on `journal_mode=WAL`
 
 ## [0.226.3] - 2025-02-27
 ### Changed

--- a/src/utils/database-common/src/db_error.rs
+++ b/src/utils/database-common/src/db_error.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum DatabaseError {
     #[error(transparent)]
-    SqlxError(sqlx::Error),
+    SqlxError(#[from] sqlx::Error),
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->

Closes: #1111

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

### Changed
- SQLite: protection against database locking, in case of parallel execution of `kamu` commands.
  - Based on `journal_mode=WAL`

### Context

The error, was reproduced with the following commands:
```shell
cd images/demo/user-home/01\ -\ Kamu\ Basics\ \(COVID-19\ example\)

# The 1-st terminal tab
rm -rf .kamu && kamu init && kamu sql

# The 2-nd terminal tab
kamu repo add kamu-node "odf+https://node.demo.kamu.dev/" && kamu pull kamu-node/kamu/covid19.ontario.case-details

# Updated to cee69bcf (8 block(s)) (kamu-node/kamu/covid19.ontario.case-details > covid19.ontario.case-details)                       # 1 dataset(s) updated
# Error:
#   0: Internal error
#   1: error returned from database
#   2: (code: 5) database is locked

```

## Checklist before requesting a review

- [ ] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not includes new versions of any container images -->
  - [x] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [ ] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)