### PR TITLE
GraphiQL playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Changed
+- Replaced default GraphQL playground with better maintained `graphiql` (old playground is still available)
+- Improved API server web console looks
+
 ## [0.227.1] - 2025-03-14
 ### Fixed
 - Trigger activation during flow throttling correctly save next activation time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,12 +1183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii_utils"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.16"
 source = "git+https://github.com/kamu-data/assert_cmd?branch=deactivate-output-truncation#c83b0859dcbce6f9bb941ea07b615cc90aebd003"
@@ -1235,7 +1229,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "fast_chemail",
  "fnv",
  "futures-timer",
  "futures-util",
@@ -1251,7 +1244,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "static_assertions_next",
- "tempfile",
  "thiserror 1.0.69",
  "url",
 ]
@@ -4173,15 +4165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast_chemail"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
-dependencies = [
- "ascii_utils",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6199,6 +6182,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "server-console",
  "shlex",
  "strum",
  "tempfile",
@@ -10154,6 +10138,14 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "server-console"
+version = "0.227.1"
+dependencies = [
+ "async-graphql",
+ "axum 0.8.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "src/utils/random-names",
     "src/utils/repo-tools",
     "src/utils/s3-utils",
+    "src/utils/server-console",
     "src/utils/test-utils",
     "src/utils/time-source",
     "src/utils/tracing-perfetto",
@@ -134,6 +135,7 @@ multiformats = { version = "0.227.1", path = "src/utils/multiformats", default-f
 observability = { version = "0.227.1", path = "src/utils/observability", default-features = false }
 random-names = { version = "0.227.1", path = "src/utils/random-names", default-features = false }
 s3-utils = { version = "0.227.1", path = "src/utils/s3-utils", default-features = false }
+server-console = { version = "0.227.1", path = "src/utils/server-console", default-features = false }
 test-utils = { version = "0.227.1", path = "src/utils/test-utils", default-features = false }
 time-source = { version = "0.227.1", path = "src/utils/time-source", default-features = false }
 tracing-perfetto = { version = "0.227.1", path = "src/utils/tracing-perfetto", default-features = false }

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -44,7 +44,7 @@ kamu-flow-system-services = { workspace = true }
 kamu-task-system = { workspace = true }
 kamu-search = { workspace = true }
 
-async-graphql = { version = "7", features = [
+async-graphql = { version = "7", default-features = false, features = [
     "chrono",
     "url",
     "apollo_tracing",
@@ -52,9 +52,7 @@ async-graphql = { version = "7", features = [
 async-trait = { version = "0.1", default-features = false }
 chrono = "0.4"
 # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
-datafusion = { version = "45", default-features = false, features = [
-    "serde",
-] }
+datafusion = { version = "45", default-features = false, features = ["serde"] }
 dill = "0.11"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 secrecy = "0.10"

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -50,6 +50,7 @@ init-on-startup = { workspace = true }
 internal-error = { workspace = true }
 observability = { workspace = true, features = ["prometheus"] }
 time-source = { workspace = true }
+server-console = { workspace = true }
 
 kamu = { workspace = true }
 
@@ -120,11 +121,7 @@ webbrowser = "1"                                                  # For opening 
 
 # APIs
 arrow-flight = { version = "54", features = ["flight-sql-experimental"] }
-async-graphql = { version = "7", features = [
-    "chrono",
-    "url",
-    "apollo_tracing",
-] }
+async-graphql = { version = "7", default-features = false }
 async-graphql-axum = "7"
 axum = { version = "0.8", features = ["ws"] }
 http = "1"

--- a/src/app/cli/src/explore/web_ui_server.rs
+++ b/src/app/cli/src/explore/web_ui_server.rs
@@ -155,10 +155,7 @@ impl WebUIServer {
             axum::routing::get(runtime_configuration_handler),
         )
         .route("/ui-config", axum::routing::get(ui_configuration_handler))
-        .route(
-            "/graphql",
-            axum::routing::get(graphql_playground_handler).post(graphql_handler),
-        )
+        .route("/graphql", axum::routing::post(graphql_handler))
         .merge(kamu_adapter_http::data::root_router())
         .routes(routes!(
             kamu_adapter_http::platform_file_upload_prepare_post_handler
@@ -311,14 +308,6 @@ async fn graphql_handler(
     let graphql_response = schema.execute(graphql_request).await.into();
 
     Ok(graphql_response)
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-async fn graphql_playground_handler() -> impl IntoResponse {
-    axum::response::Html(async_graphql::http::playground_source(
-        async_graphql::http::GraphQLPlaygroundConfig::new("/graphql"),
-    ))
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/server-console/Cargo.toml
+++ b/src/utils/server-console/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "server-console"
+description = "Web console for kamu server components"
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+
+
+[lints]
+workspace = true
+
+
+[lib]
+doctest = false
+
+
+[dependencies]
+axum = { version = "0.8", default-features = false }
+async-graphql = { version = "7", default-features = false, features = [
+    "graphiql",
+    "playground",
+] }

--- a/src/utils/server-console/assets/index.template.html
+++ b/src/utils/server-console/assets/index.template.html
@@ -1,0 +1,83 @@
+<html lang="en">
+<head>
+    <title>{{title}}</title>
+    <style>
+        body {
+            background-color: #0d012f;
+            color: #ddd;
+            font-family: poppins, sans-serif;
+        }
+
+        a {
+            text-decoration: none;
+            color: #ddd;
+            transition: color 0.3s ease-in-out;
+        }
+
+        a:hover {
+            color: #ec6e2a;
+        }
+
+        li {
+            font-size: large;
+            padding: 0 0 5px 0;
+        }
+
+        .title {
+            display: flex;
+            align-items: center;
+        }
+
+        .icon {
+            padding: 0 10px;
+        }
+
+        .title-version {
+            font-size: small;
+            vertical-align: top;
+        }
+    </style>
+</head>
+<body>
+<div class="title">
+    <path class="icon">
+        <svg width="51" height="44" viewBox="0 0 51 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M21.4536 0L39.2361 30.8345H33.3086L21.4534 10.2781L3.67079 41.1127L0.707031 35.9736L21.4536 0Z"
+                  fill="#F99B81"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4536 0L3.67079 41.1127L0.707031 35.9736L21.4536 0Z"
+                  fill="#F8CA51"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4527 0L21.4526 10.2781L3.66992 41.1127L21.4527 0Z"
+                  fill="#F9AF54"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4531 0L39.2356 30.8345H33.3081L21.4531 0Z"
+                  fill="#FA7789"/>
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M50.4559 37.2178L14.8906 37.2177L17.8544 32.0786L41.5646 32.0787L23.7818 1.24414L29.7094 1.24418L50.4559 37.2178Z"
+                  fill="#1993C6"/>
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M50.4534 37.2178L23.7793 1.24414L29.7069 1.24418L50.4534 37.2178Z" fill="#35D5D5"/>
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M50.4534 37.2178L41.5621 32.0787L23.7793 1.24414L50.4534 37.2178Z" fill="#2CBED7"/>
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M50.4559 37.2173L14.8906 37.2172L17.8544 32.0781L50.4559 37.2173Z" fill="#106FB0"/>
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M3.85547 43.9984L21.6382 13.1641L24.602 18.3031L12.7468 38.8594L48.3123 38.8593L45.3485 43.9984L3.85547 43.9984Z"
+                  fill="#565BD8"/>
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M3.85547 43.9984L48.3123 38.8594L45.3485 43.9985L3.85547 43.9984Z" fill="#DA76CB"/>
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M3.85547 43.9984L12.7468 38.8595L48.3123 38.8594L3.85547 43.9984Z" fill="#A26BD2"/>
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M3.85547 43.9984L21.6382 13.1641L24.602 18.3031L3.85547 43.9984Z" fill="#2C45AB"/>
+        </svg>
+    </path>
+    <h1>Kamu API Server <span class="title-version">{{version}}</span></h1>
+</div>
+<ul>
+    <li><a href="/openapi">OpenAPI Playground</a></li>
+    <li><a href="/graphql">GraphQL Playground</a></li>
+    <ul>
+        <li><a href="/graphql-legacy">Legacy version</a></li>
+    </ul>
+</ul>
+</body>

--- a/src/utils/server-console/src/lib.rs
+++ b/src/utils/server-console/src/lib.rs
@@ -26,9 +26,10 @@ pub fn router(title: String, version: String) -> axum::Router {
 
 #[allow(clippy::unused_async)]
 async fn index_handler(title: &str, version: &str) -> impl axum::response::IntoResponse {
+    let html = include_str!("../assets/index.template.html");
+
     axum::response::Html(
-        INDEX_HTML
-            .replace("{{title}}", title)
+        html.replace("{{title}}", title)
             .replace("{{version}}", version),
     )
 }
@@ -52,73 +53,3 @@ async fn graphql_playground_handler() -> impl axum::response::IntoResponse {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-const INDEX_HTML: &str = r###"
-<html lang="en">
-<head>
-    <title>{{title}}</title>
-    <style>
-        body {
-            background-color: #0d012f;
-            color: #ddd;
-            font-family: poppins,sans-serif;
-        }
-
-        a {
-            text-decoration: none;
-            color: #ddd;
-            transition: color 0.3s ease-in-out;
-        }
-        a:hover {
-            color: #ec6e2a;
-        }
-
-        li {
-            font-size: large;
-            padding: 0 0 5px 0;
-        }
-
-        .title {
-            display: flex;
-            align-items: center;
-        }
-
-        .icon {
-            padding: 0 10px;
-        }
-
-        .title-version {
-            font-size: small;
-            vertical-align: top;
-        }
-    </style>
-</head>
-<body>
-    <div class="title">
-    <path class="icon">
-        <svg width="51" height="44" viewBox="0 0 51 44" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4536 0L39.2361 30.8345H33.3086L21.4534 10.2781L3.67079 41.1127L0.707031 35.9736L21.4536 0Z" fill="#F99B81"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4536 0L3.67079 41.1127L0.707031 35.9736L21.4536 0Z" fill="#F8CA51"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4527 0L21.4526 10.2781L3.66992 41.1127L21.4527 0Z" fill="#F9AF54"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4531 0L39.2356 30.8345H33.3081L21.4531 0Z" fill="#FA7789"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M50.4559 37.2178L14.8906 37.2177L17.8544 32.0786L41.5646 32.0787L23.7818 1.24414L29.7094 1.24418L50.4559 37.2178Z" fill="#1993C6"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M50.4534 37.2178L23.7793 1.24414L29.7069 1.24418L50.4534 37.2178Z" fill="#35D5D5"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M50.4534 37.2178L41.5621 32.0787L23.7793 1.24414L50.4534 37.2178Z" fill="#2CBED7"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M50.4559 37.2173L14.8906 37.2172L17.8544 32.0781L50.4559 37.2173Z" fill="#106FB0"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.85547 43.9984L21.6382 13.1641L24.602 18.3031L12.7468 38.8594L48.3123 38.8593L45.3485 43.9984L3.85547 43.9984Z" fill="#565BD8"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.85547 43.9984L48.3123 38.8594L45.3485 43.9985L3.85547 43.9984Z" fill="#DA76CB"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.85547 43.9984L12.7468 38.8595L48.3123 38.8594L3.85547 43.9984Z" fill="#A26BD2"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.85547 43.9984L21.6382 13.1641L24.602 18.3031L3.85547 43.9984Z" fill="#2C45AB"/>
-        </svg>
-    </path>
-    <h1>Kamu API Server <span class="title-version">{{version}}</span></h1>
-    </div>
-    <ul>
-        <li><a href="/openapi">OpenAPI Playground</a></li>
-        <li><a href="/graphql">GraphQL Playground</a></li>
-        <ul>
-            <li><a href="/graphql-legacy">Legacy version</a></li>
-        </ul>
-    </ul>
-</body>
-"###;

--- a/src/utils/server-console/src/lib.rs
+++ b/src/utils/server-console/src/lib.rs
@@ -1,0 +1,124 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub fn router(title: String, version: String) -> axum::Router {
+    axum::Router::new()
+        .route(
+            "/",
+            axum::routing::get(async move || index_handler(&title, &version).await),
+        )
+        .route("/graphql", axum::routing::get(graphiql_handler))
+        .route(
+            "/graphql-legacy",
+            axum::routing::get(graphql_playground_handler),
+        )
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::unused_async)]
+async fn index_handler(title: &str, version: &str) -> impl axum::response::IntoResponse {
+    axum::response::Html(
+        INDEX_HTML
+            .replace("{{title}}", title)
+            .replace("{{version}}", version),
+    )
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+async fn graphiql_handler() -> impl axum::response::IntoResponse {
+    axum::response::Html(
+        async_graphql::http::GraphiQLSource::build()
+            .endpoint("/graphql")
+            .finish(),
+    )
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+async fn graphql_playground_handler() -> impl axum::response::IntoResponse {
+    axum::response::Html(async_graphql::http::playground_source(
+        async_graphql::http::GraphQLPlaygroundConfig::new("/graphql"),
+    ))
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const INDEX_HTML: &str = r###"
+<html lang="en">
+<head>
+    <title>{{title}}</title>
+    <style>
+        body {
+            background-color: #0d012f;
+            color: #ddd;
+            font-family: poppins,sans-serif;
+        }
+
+        a {
+            text-decoration: none;
+            color: #ddd;
+            transition: color 0.3s ease-in-out;
+        }
+        a:hover {
+            color: #ec6e2a;
+        }
+
+        li {
+            font-size: large;
+            padding: 0 0 5px 0;
+        }
+
+        .title {
+            display: flex;
+            align-items: center;
+        }
+
+        .icon {
+            padding: 0 10px;
+        }
+
+        .title-version {
+            font-size: small;
+            vertical-align: top;
+        }
+    </style>
+</head>
+<body>
+    <div class="title">
+    <path class="icon">
+        <svg width="51" height="44" viewBox="0 0 51 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4536 0L39.2361 30.8345H33.3086L21.4534 10.2781L3.67079 41.1127L0.707031 35.9736L21.4536 0Z" fill="#F99B81"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4536 0L3.67079 41.1127L0.707031 35.9736L21.4536 0Z" fill="#F8CA51"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4527 0L21.4526 10.2781L3.66992 41.1127L21.4527 0Z" fill="#F9AF54"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4531 0L39.2356 30.8345H33.3081L21.4531 0Z" fill="#FA7789"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M50.4559 37.2178L14.8906 37.2177L17.8544 32.0786L41.5646 32.0787L23.7818 1.24414L29.7094 1.24418L50.4559 37.2178Z" fill="#1993C6"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M50.4534 37.2178L23.7793 1.24414L29.7069 1.24418L50.4534 37.2178Z" fill="#35D5D5"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M50.4534 37.2178L41.5621 32.0787L23.7793 1.24414L50.4534 37.2178Z" fill="#2CBED7"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M50.4559 37.2173L14.8906 37.2172L17.8544 32.0781L50.4559 37.2173Z" fill="#106FB0"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.85547 43.9984L21.6382 13.1641L24.602 18.3031L12.7468 38.8594L48.3123 38.8593L45.3485 43.9984L3.85547 43.9984Z" fill="#565BD8"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.85547 43.9984L48.3123 38.8594L45.3485 43.9985L3.85547 43.9984Z" fill="#DA76CB"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.85547 43.9984L12.7468 38.8595L48.3123 38.8594L3.85547 43.9984Z" fill="#A26BD2"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M3.85547 43.9984L21.6382 13.1641L24.602 18.3031L3.85547 43.9984Z" fill="#2C45AB"/>
+        </svg>
+    </path>
+    <h1>Kamu API Server <span class="title-version">{{version}}</span></h1>
+    </div>
+    <ul>
+        <li><a href="/openapi">OpenAPI Playground</a></li>
+        <li><a href="/graphql">GraphQL Playground</a></li>
+        <ul>
+            <li><a href="/graphql-legacy">Legacy version</a></li>
+        </ul>
+    </ul>
+</body>
+"###;


### PR DESCRIPTION
## Description

Addresses: #1141 

This PR
- Adds `graphiql`-based playground which is a better maintained project
  - In comparison to old `graphql-playground` the only missing feature I see is the visualisation of Apollo traces. I found them quite useful, so not to lose them I preserved the old version too
    ![image](https://github.com/user-attachments/assets/387d9e09-5943-46fa-acc7-c58af081af2e)
- To reduce the duplication I extracted a new crate `server-console` which could become our modular foundation for building web UIs for individual service instances, currently it looks like this:
  ![image](https://github.com/user-attachments/assets/acd0a7f5-9ad8-480c-9268-c3cebc786fcf)
  - In future I expect us to evolve it to allow neat things like:
    - Viewing the current configuration
    - Modifying logging an metrics configuration in real time for debugging
    - Viewing recent request traces etc.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    https://github.com/kamu-data/kamu-node/pull/206
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)