### PR TITLE
Datafusion error classification

### DIFF
--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -532,8 +532,6 @@ type DataQueryResultError {
 
 enum DataQueryResultErrorKind {
 	INVALID_SQL
-	UNAUTHORIZED
-	INTERNAL_ERROR
 }
 
 type DataQueryResultSuccess {

--- a/src/adapter/auth-oso-rebac/tests/tests/test_oso_dataset_authorizer.rs
+++ b/src/adapter/auth-oso-rebac/tests/tests/test_oso_dataset_authorizer.rs
@@ -156,7 +156,7 @@ async fn test_guest_can_read_but_not_write_public_dataset() {
             dataset_id = public_dataset_handle.id,
         expected:
             read_result = Ok(()),
-            write_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Forbidden(_))),
+            write_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Unauthorized(_))),
             allowed_actions_result = Ok(actual_actions)
                 if actual_actions == [DatasetAction::Read].into()
     );
@@ -179,8 +179,8 @@ async fn test_guest_can_not_read_and_write_private_dataset() {
             harness,
             dataset_id = private_dataset_handle.id,
         expected:
-            read_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Forbidden(_))),
-            write_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Forbidden(_))),
+            read_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Unauthorized(_))),
+            write_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Unauthorized(_))),
             allowed_actions_result = Ok(actual_actions)
                 if actual_actions.is_empty()
     );
@@ -206,7 +206,7 @@ async fn test_not_owner_can_read_but_not_write_public_dataset() {
             dataset_id = not_owned_public_dataset_handle.id,
         expected:
             read_result = Ok(()),
-            write_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Forbidden(_))),
+            write_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Unauthorized(_))),
             allowed_actions_result = Ok(actual_actions)
                 if actual_actions == [DatasetAction::Read].into()
     );
@@ -231,8 +231,8 @@ async fn test_not_owner_can_not_read_and_write_private_dataset() {
             harness,
             dataset_id = not_owned_private_dataset_handle.id,
         expected:
-            read_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Forbidden(_))),
-            write_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Forbidden(_))),
+            read_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Unauthorized(_))),
+            write_result = Err(DatasetActionUnauthorizedError::Access(odf::AccessError::Unauthorized(_))),
             allowed_actions_result = Ok(actual_actions)
                 if actual_actions.is_empty()
     );
@@ -359,8 +359,8 @@ async fn test_multi_datasets_matrix() {
                     - bob/public-dataset-4
 
                     unauthorized_with_errors:
-                    - bob/private-dataset-3: Forbidden
-                    - alice/private-dataset-1: Forbidden
+                    - bob/private-dataset-3: Unauthorized
+                    - alice/private-dataset-1: Unauthorized
                     "#
                 ),
                 write_classify_dataset_handles_by_allowance_result: indoc::indoc!(
@@ -368,10 +368,10 @@ async fn test_multi_datasets_matrix() {
                     authorized:
 
                     unauthorized_with_errors:
-                    - alice/public-dataset-2: Forbidden
-                    - bob/public-dataset-4: Forbidden
-                    - bob/private-dataset-3: Forbidden
-                    - alice/private-dataset-1: Forbidden
+                    - alice/public-dataset-2: Unauthorized
+                    - bob/public-dataset-4: Unauthorized
+                    - bob/private-dataset-3: Unauthorized
+                    - alice/private-dataset-1: Unauthorized
                     "#
                 ),
                 read_classify_dataset_ids_by_allowance_result: indoc::indoc!(
@@ -381,8 +381,8 @@ async fn test_multi_datasets_matrix() {
                     - bob/public-dataset-4
 
                     unauthorized_with_errors:
-                    - bob/private-dataset-3: Forbidden
-                    - alice/private-dataset-1: Forbidden
+                    - bob/private-dataset-3: Unauthorized
+                    - alice/private-dataset-1: Unauthorized
                     "#
                 ),
                 write_classify_dataset_ids_by_allowance_result: indoc::indoc!(
@@ -390,10 +390,10 @@ async fn test_multi_datasets_matrix() {
                     authorized:
 
                     unauthorized_with_errors:
-                    - alice/public-dataset-2: Forbidden
-                    - bob/public-dataset-4: Forbidden
-                    - bob/private-dataset-3: Forbidden
-                    - alice/private-dataset-1: Forbidden
+                    - alice/public-dataset-2: Unauthorized
+                    - bob/public-dataset-4: Unauthorized
+                    - bob/private-dataset-3: Unauthorized
+                    - alice/private-dataset-1: Unauthorized
                     "#
                 ),
             },
@@ -421,7 +421,7 @@ async fn test_multi_datasets_matrix() {
                     - alice/private-dataset-1
 
                     unauthorized_with_errors:
-                    - bob/private-dataset-3: Forbidden
+                    - bob/private-dataset-3: Unauthorized
                     "#
                 ),
                 write_classify_dataset_handles_by_allowance_result: indoc::indoc!(
@@ -431,8 +431,8 @@ async fn test_multi_datasets_matrix() {
                     - alice/private-dataset-1
 
                     unauthorized_with_errors:
-                    - bob/public-dataset-4: Forbidden
-                    - bob/private-dataset-3: Forbidden
+                    - bob/public-dataset-4: Unauthorized
+                    - bob/private-dataset-3: Unauthorized
                     "#
                 ),
                 read_classify_dataset_ids_by_allowance_result: indoc::indoc!(
@@ -443,7 +443,7 @@ async fn test_multi_datasets_matrix() {
                     - alice/private-dataset-1
 
                     unauthorized_with_errors:
-                    - bob/private-dataset-3: Forbidden
+                    - bob/private-dataset-3: Unauthorized
                     "#
                 ),
                 write_classify_dataset_ids_by_allowance_result: indoc::indoc!(
@@ -453,8 +453,8 @@ async fn test_multi_datasets_matrix() {
                     - alice/private-dataset-1
 
                     unauthorized_with_errors:
-                    - bob/public-dataset-4: Forbidden
-                    - bob/private-dataset-3: Forbidden
+                    - bob/public-dataset-4: Unauthorized
+                    - bob/private-dataset-3: Unauthorized
                     "#
                 ),
             },

--- a/src/adapter/graphql/src/extensions.rs
+++ b/src/adapter/graphql/src/extensions.rs
@@ -43,10 +43,19 @@ impl async_graphql::extensions::Extension for TracingExtension {
         for err in &response.errors {
             if let Some(source) = err.source::<InternalError>() {
                 tracing::error!(
+                    error = ?source,
                     error_msg = %ErrorMessageFormatter(source),
                     error_backtrace = %ErrorBacktraceFormatter(source),
                     gql_path = ?err.path,
                     "Unhandled error",
+                );
+            } else if let Some(source) = err.source::<odf::AccessError>() {
+                tracing::error!(
+                    error = ?source,
+                    error_msg = %ErrorMessageFormatter(source),
+                    error_backtrace = %ErrorBacktraceFormatter(source),
+                    gql_path = ?err.path,
+                    "Access error",
                 );
             } else {
                 tracing::error!(

--- a/src/adapter/graphql/src/utils.rs
+++ b/src/adapter/graphql/src/utils.rs
@@ -240,12 +240,19 @@ pub(crate) fn logged_account(ctx: &Context<'_>) -> bool {
 #[derive(Debug)]
 pub enum GqlError {
     Internal(InternalError),
+    Access(odf::AccessError),
     Gql(async_graphql::Error),
 }
 
 impl From<InternalError> for GqlError {
     fn from(value: InternalError) -> Self {
         Self::Internal(value)
+    }
+}
+
+impl From<odf::AccessError> for GqlError {
+    fn from(value: odf::AccessError) -> Self {
+        Self::Access(value)
     }
 }
 
@@ -259,6 +266,14 @@ impl From<GqlError> for async_graphql::Error {
     fn from(val: GqlError) -> Self {
         match val {
             GqlError::Internal(err) => async_graphql::Error::new_with_source(err),
+            GqlError::Access(err) => {
+                let code = match &err {
+                    odf::AccessError::ReadOnly(_) => "READ_ONLY",
+                    odf::AccessError::Unauthorized(_) => "UNAUTHORIZED",
+                    odf::AccessError::Forbidden(_) => "FORBIDDEN",
+                };
+                async_graphql::Error::new_with_source(err).extend_with(|_, ex| ex.set("code", code))
+            }
             GqlError::Gql(err) => err,
         }
     }

--- a/src/adapter/graphql/src/utils.rs
+++ b/src/adapter/graphql/src/utils.rs
@@ -269,8 +269,8 @@ impl From<GqlError> for async_graphql::Error {
             GqlError::Access(err) => {
                 let code = match &err {
                     odf::AccessError::ReadOnly(_) => "READ_ONLY",
+                    odf::AccessError::Unauthenticated(_) => "UNAUTHENTICATED",
                     odf::AccessError::Unauthorized(_) => "UNAUTHORIZED",
-                    odf::AccessError::Forbidden(_) => "FORBIDDEN",
                 };
                 async_graphql::Error::new_with_source(err).extend_with(|_, ex| ex.set("code", code))
             }

--- a/src/adapter/http/src/smart_protocol/ws_tungstenite_client.rs
+++ b/src/adapter/http/src/smart_protocol/ws_tungstenite_client.rs
@@ -954,10 +954,10 @@ fn map_tungstenite_error(error: TungsteniteError, dataset_endpoint: &Url) -> Syn
     if let TungsteniteError::Http(response) = &error {
         match response.status() {
             StatusCode::FORBIDDEN => {
-                return SyncError::Access(odf::AccessError::Forbidden(Box::new(error)));
+                return SyncError::Access(odf::AccessError::Unauthorized(Box::new(error)));
             }
             StatusCode::UNAUTHORIZED => {
-                return SyncError::Access(odf::AccessError::Unauthorized(Box::new(error)))
+                return SyncError::Access(odf::AccessError::Unauthenticated(Box::new(error)))
             }
             StatusCode::NOT_FOUND => {
                 return DatasetAnyRefUnresolvedError::new(dataset_endpoint).into();

--- a/src/adapter/http/tests/tests/test_account_info.rs
+++ b/src/adapter/http/tests/tests/test_account_info.rs
@@ -30,7 +30,7 @@ async fn test_get_account_info_with_wrong_token() {
         pretty_assertions::assert_eq!(401, res.status());
         pretty_assertions::assert_eq!(
             json!({
-                "message": "Unauthorized"
+                "message": "Unauthenticated"
             }),
             res.json::<serde_json::Value>().await.unwrap()
         );

--- a/src/adapter/http/tests/tests/tests_push/test_smart_push_special.rs
+++ b/src/adapter/http/tests/tests/tests_push/test_smart_push_special.rs
@@ -61,7 +61,7 @@ async fn test_smart_push_new_dataset_unauthenticated() {
             Ok(_) => panic!(),
             Err(e) => assert_matches!(
                 e,
-                PushError::SyncError(SyncError::Access(odf::AccessError::Unauthorized(_))),
+                PushError::SyncError(SyncError::Access(odf::AccessError::Unauthenticated(_))),
             ),
         }
     };
@@ -113,7 +113,7 @@ async fn test_smart_push_new_dataset_wrong_user() {
             Ok(_) => panic!(),
             Err(e) => assert_matches!(
                 e,
-                PushError::SyncError(SyncError::Access(odf::AccessError::Forbidden(_)))
+                PushError::SyncError(SyncError::Access(odf::AccessError::Unauthorized(_)))
             ),
         }
     };

--- a/src/app/cli/src/commands/pull_command.rs
+++ b/src/app/cli/src/commands/pull_command.rs
@@ -963,7 +963,7 @@ impl SyncListener for PrettySyncProgress {
 
 fn sanitize_pull_error(original_pull_error: PullError) -> PullError {
     // Tricky way...
-    if let PullError::Access(odf::AccessError::Forbidden(forbidden_error)) = &original_pull_error
+    if let PullError::Access(odf::AccessError::Unauthorized(forbidden_error)) = &original_pull_error
         && let Some(permissions_error) =
             forbidden_error.downcast_ref::<DatasetActionNotEnoughPermissionsError>()
     {

--- a/src/domain/core/src/auth/dataset_action_authorizer.rs
+++ b/src/domain/core/src/auth/dataset_action_authorizer.rs
@@ -260,7 +260,7 @@ pub enum DatasetActionUnauthorizedError {
 
 impl DatasetActionUnauthorizedError {
     pub fn not_enough_permissions(dataset_ref: odf::DatasetRef, action: DatasetAction) -> Self {
-        Self::Access(odf::AccessError::Forbidden(
+        Self::Access(odf::AccessError::Unauthorized(
             DatasetActionNotEnoughPermissionsError {
                 action,
                 dataset_ref,

--- a/src/domain/core/src/services/query_service.rs
+++ b/src/domain/core/src/services/query_service.rs
@@ -9,6 +9,7 @@
 
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use datafusion::arrow;
 use datafusion::parquet::schema::types::Type;
@@ -234,6 +235,73 @@ pub enum QueryError {
     ),
 }
 
+impl QueryError {
+    // WARNING: Datafusion error handling is cursed
+    fn classify_shared_error(
+        top_level: &Arc<datafusion::error::DataFusionError>,
+        inner: &datafusion::error::DataFusionError,
+    ) -> Self {
+        use datafusion::error::DataFusionError as DFError;
+
+        match inner {
+            DFError::Context(_, inner) | DFError::Diagnostic(_, inner) => {
+                Self::classify_shared_error(top_level, inner.as_ref())
+            }
+            DFError::SchemaError(_, _) | DFError::SQL(_, _) | DFError::Plan(_) => Self::BadQuery(
+                BadQueryError::new(BadQueryErrorSource::Shared(top_level.clone())),
+            ),
+            DFError::Shared(inner) => Self::classify_shared_error(top_level, inner.as_ref()),
+            // TODO: Handle Shared and Collection errors
+            DFError::ArrowError(_, _)
+            | DFError::ParquetError(_)
+            | DFError::ObjectStore(_)
+            | DFError::IoError(_)
+            | DFError::NotImplemented(_)
+            | DFError::Internal(_)
+            | DFError::Configuration(_)
+            | DFError::Execution(_)
+            | DFError::ExecutionJoin(_)
+            | DFError::ResourcesExhausted(_)
+            | DFError::External(_)
+            | DFError::Substrait(_)
+            | DFError::Collection(_) => Self::Internal(top_level.clone().int_err()),
+        }
+    }
+}
+
+// WARNING: Datafusion error handling is cursed
+impl From<datafusion::error::DataFusionError> for QueryError {
+    fn from(value: datafusion::error::DataFusionError) -> Self {
+        use datafusion::error::DataFusionError as DFError;
+
+        match value {
+            DFError::Context(_, inner) | DFError::Diagnostic(_, inner) => Self::from(*inner),
+            DFError::SchemaError(_, _) | DFError::SQL(_, _) | DFError::Plan(_) => {
+                Self::BadQuery(BadQueryError::new(BadQueryErrorSource::Single(value)))
+            }
+            DFError::Shared(inner) => Self::classify_shared_error(&inner, inner.as_ref()),
+            DFError::Collection(errors) => {
+                // NOTE: Assuming that collection errors would only be returned for user input
+                // errors
+                Self::BadQuery(BadQueryError::new(BadQueryErrorSource::Collection(errors)))
+            }
+            // TODO: Handle Shared and Collection errors
+            DFError::ArrowError(_, _)
+            | DFError::ParquetError(_)
+            | DFError::ObjectStore(_)
+            | DFError::IoError(_)
+            | DFError::NotImplemented(_)
+            | DFError::Internal(_)
+            | DFError::Configuration(_)
+            | DFError::Execution(_)
+            | DFError::ExecutionJoin(_)
+            | DFError::ResourcesExhausted(_)
+            | DFError::External(_)
+            | DFError::Substrait(_) => Self::Internal(value.int_err()),
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// This error returned only when the caller provides an explicit block hash to
@@ -256,48 +324,46 @@ impl DatasetBlockNotFoundError {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub struct BadQueryError {
-    // Using Arc because DF errors are not Clone, and we need to handle shared error type
-    pub source: datafusion::error::DataFusionError,
+    pub source: BadQueryErrorSource,
     pub backtrace: Backtrace,
 }
 
 impl BadQueryError {
-    pub fn new(source: datafusion::error::DataFusionError) -> Self {
+    pub fn new(source: BadQueryErrorSource) -> Self {
         Self {
             source,
             backtrace: Backtrace::capture(),
         }
     }
-}
 
-impl From<datafusion::error::DataFusionError> for QueryError {
-    fn from(value: datafusion::error::DataFusionError) -> Self {
-        // TODO: Datafusion error handling is cursed
-        match value {
-            datafusion::error::DataFusionError::Context(_, inner)
-            | datafusion::error::DataFusionError::Diagnostic(_, inner) => Self::from(*inner),
-            datafusion::error::DataFusionError::SchemaError(_, _)
-            | datafusion::error::DataFusionError::SQL(_, _)
-            | datafusion::error::DataFusionError::Plan(_) => {
-                Self::BadQuery(BadQueryError::new(value))
-            }
-            // TODO: Handle Shared and Collection errors
-            datafusion::error::DataFusionError::ArrowError(_, _)
-            | datafusion::error::DataFusionError::ParquetError(_)
-            | datafusion::error::DataFusionError::ObjectStore(_)
-            | datafusion::error::DataFusionError::IoError(_)
-            | datafusion::error::DataFusionError::NotImplemented(_)
-            | datafusion::error::DataFusionError::Internal(_)
-            | datafusion::error::DataFusionError::Configuration(_)
-            | datafusion::error::DataFusionError::Execution(_)
-            | datafusion::error::DataFusionError::ExecutionJoin(_)
-            | datafusion::error::DataFusionError::ResourcesExhausted(_)
-            | datafusion::error::DataFusionError::External(_)
-            | datafusion::error::DataFusionError::Shared(_)
-            | datafusion::error::DataFusionError::Substrait(_)
-            | datafusion::error::DataFusionError::Collection(_) => Self::Internal(value.int_err()),
+    fn fmt_df_error(
+        f: &mut std::fmt::Formatter<'_>,
+        e: &datafusion::error::DataFusionError,
+    ) -> std::fmt::Result {
+        use datafusion::error::DataFusionError as DFError;
+
+        match e {
+            DFError::SchemaError(e, _) => write!(f, "{e}"),
+            DFError::SQL(e, _) => write!(f, "{e}"),
+            DFError::Plan(msg) => write!(f, "{msg}"),
+            DFError::ArrowError(_, _)
+            | DFError::ParquetError(_)
+            | DFError::ObjectStore(_)
+            | DFError::IoError(_)
+            | DFError::NotImplemented(_)
+            | DFError::Internal(_)
+            | DFError::Configuration(_)
+            | DFError::Execution(_)
+            | DFError::ExecutionJoin(_)
+            | DFError::ResourcesExhausted(_)
+            | DFError::External(_)
+            | DFError::Context(_, _)
+            | DFError::Substrait(_)
+            | DFError::Diagnostic(_, _)
+            | DFError::Collection(_)
+            | DFError::Shared(_) => write!(f, "{e}"),
         }
     }
 }
@@ -305,27 +371,39 @@ impl From<datafusion::error::DataFusionError> for QueryError {
 impl std::fmt::Display for BadQueryError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.source {
-            datafusion::error::DataFusionError::SchemaError(e, _) => write!(f, "{e}"),
-            datafusion::error::DataFusionError::SQL(e, _) => write!(f, "{e}"),
-            datafusion::error::DataFusionError::Plan(msg) => write!(f, "{msg}"),
-            datafusion::error::DataFusionError::ArrowError(_, _)
-            | datafusion::error::DataFusionError::ParquetError(_)
-            | datafusion::error::DataFusionError::ObjectStore(_)
-            | datafusion::error::DataFusionError::IoError(_)
-            | datafusion::error::DataFusionError::NotImplemented(_)
-            | datafusion::error::DataFusionError::Internal(_)
-            | datafusion::error::DataFusionError::Configuration(_)
-            | datafusion::error::DataFusionError::Execution(_)
-            | datafusion::error::DataFusionError::ExecutionJoin(_)
-            | datafusion::error::DataFusionError::ResourcesExhausted(_)
-            | datafusion::error::DataFusionError::External(_)
-            | datafusion::error::DataFusionError::Context(_, _)
-            | datafusion::error::DataFusionError::Substrait(_)
-            | datafusion::error::DataFusionError::Diagnostic(_, _)
-            | datafusion::error::DataFusionError::Collection(_)
-            | datafusion::error::DataFusionError::Shared(_) => write!(f, "{}", self.source),
+            BadQueryErrorSource::Single(e) => Self::fmt_df_error(f, e)?,
+            BadQueryErrorSource::Shared(e) => Self::fmt_df_error(f, e.as_ref())?,
+            BadQueryErrorSource::Collection(errors) => {
+                for (i, e) in errors.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, "\n\n")?;
+                    }
+                    Self::fmt_df_error(f, e)?;
+                }
+            }
+        };
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for BadQueryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.source {
+            BadQueryErrorSource::Single(e) => Some(e),
+            BadQueryErrorSource::Shared(e) => Some(e.as_ref()),
+            BadQueryErrorSource::Collection(errors) => {
+                errors.first().map(|e| e as &dyn std::error::Error)
+            }
         }
     }
+}
+
+#[derive(Debug)]
+pub enum BadQueryErrorSource {
+    Single(datafusion::error::DataFusionError),
+    Shared(Arc<datafusion::error::DataFusionError>),
+    Collection(Vec<datafusion::error::DataFusionError>),
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/odf/metadata/src/errors/access_error.rs
+++ b/src/odf/metadata/src/errors/access_error.rs
@@ -16,10 +16,10 @@ use thiserror::Error;
 pub enum AccessError {
     #[error("Resource is read-only")]
     ReadOnly(#[source] Option<BoxedError>),
+    #[error("Unauthenticated")]
+    Unauthenticated(#[source] BoxedError),
     #[error("Unauthorized")]
     Unauthorized(#[source] BoxedError),
-    #[error("Forbidden")]
-    Forbidden(#[source] BoxedError),
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/odf/storage-http/src/repos/object_repository_http.rs
+++ b/src/odf/storage-http/src/repos/object_repository_http.rs
@@ -73,10 +73,10 @@ impl ObjectRepository for ObjectRepositoryHttp {
             Ok(_) => Ok(true),
             Err(e) if e.status() == Some(http::StatusCode::NOT_FOUND) => Ok(false),
             Err(e) if e.status() == Some(http::StatusCode::UNAUTHORIZED) => {
-                Err(AccessError::Unauthorized(e.into()).into())
+                Err(AccessError::Unauthenticated(e.into()).into())
             }
             Err(e) if e.status() == Some(http::StatusCode::FORBIDDEN) => {
-                Err(AccessError::Forbidden(e.into()).into())
+                Err(AccessError::Unauthorized(e.into()).into())
             }
             Err(e) => Err(e.int_err().into()),
         }
@@ -111,10 +111,10 @@ impl ObjectRepository for ObjectRepositoryHttp {
                 }))
             }
             Err(e) if e.status() == Some(http::StatusCode::UNAUTHORIZED) => {
-                Err(AccessError::Unauthorized(e.into()).into())
+                Err(AccessError::Unauthenticated(e.into()).into())
             }
             Err(e) if e.status() == Some(http::StatusCode::FORBIDDEN) => {
-                Err(AccessError::Forbidden(e.into()).into())
+                Err(AccessError::Unauthorized(e.into()).into())
             }
             Err(e) => Err(e.int_err().into()),
         }?;
@@ -149,10 +149,10 @@ impl ObjectRepository for ObjectRepositoryHttp {
                 }))
             }
             Err(e) if e.status() == Some(http::StatusCode::UNAUTHORIZED) => {
-                Err(AccessError::Unauthorized(e.into()).into())
+                Err(AccessError::Unauthenticated(e.into()).into())
             }
             Err(e) if e.status() == Some(http::StatusCode::FORBIDDEN) => {
-                Err(AccessError::Forbidden(e.into()).into())
+                Err(AccessError::Unauthorized(e.into()).into())
             }
             Err(e) => Err(e.int_err().into()),
         }?;

--- a/src/odf/storage-s3/tests/repos/test_object_repository_s3.rs
+++ b/src/odf/storage-s3/tests/repos/test_object_repository_s3.rs
@@ -43,7 +43,7 @@ async fn test_unauthorized() {
 
     assert_matches!(
         repo.insert_bytes(b"foo", InsertOpts::default()).await,
-        Err(InsertError::Access(AccessError::Unauthorized(_)))
+        Err(InsertError::Access(AccessError::Unauthenticated(_)))
     );
 }
 

--- a/src/utils/http-common/src/api_error.rs
+++ b/src/utils/http-common/src/api_error.rs
@@ -81,7 +81,7 @@ impl ApiError {
     }
 
     pub fn new_unauthorized() -> Self {
-        odf::AccessError::Unauthorized("Unauthorized access".into()).api_err()
+        odf::AccessError::Unauthenticated("Unauthorized access".into()).api_err()
     }
 
     pub fn new_unauthorized_from(source: impl std::error::Error + Send + Sync + 'static) -> Self {
@@ -89,7 +89,7 @@ impl ApiError {
     }
 
     pub fn new_forbidden() -> Self {
-        odf::AccessError::Forbidden("Forbidden access".into()).api_err()
+        odf::AccessError::Unauthorized("Forbidden access".into()).api_err()
     }
 
     pub fn bad_request(source: impl std::error::Error + Send + Sync + 'static) -> Self {
@@ -220,11 +220,11 @@ where
 {
     fn api_err(self) -> ApiError {
         match self.categorize() {
-            ApiErrorCategory::Access(odf::AccessError::Unauthorized(_)) => {
+            ApiErrorCategory::Access(odf::AccessError::Unauthenticated(_)) => {
                 ApiError::new(self, http::StatusCode::UNAUTHORIZED)
             }
             ApiErrorCategory::Access(
-                odf::AccessError::Forbidden(_) | odf::AccessError::ReadOnly(_),
+                odf::AccessError::Unauthorized(_) | odf::AccessError::ReadOnly(_),
             ) => ApiError::new(self, http::StatusCode::FORBIDDEN),
             ApiErrorCategory::Internal(_e) => {
                 ApiError::new(self, http::StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Closes: kamu-data/kamu-node#214

1) The core of the problem was the introduction of multiple nested error types in `DataFusionError` like:
- `DataFusionError::Shared(Arc<DataFusionError>)` - requires recursively classifying the inner error
- `DataFusionError::Diagnostics(Diag, Box<DataFusionError>)`  - also recursive
- `DataFusionError::Collection(Vec<DataFusionError>)` - need to classify at least by first error

This makes handing these error a nightmare, and some were incorrectly classified as `InternalError` instead of `BadQuery`. This PR improves the classification.

2) Additionally, our `DataQueryResult` was wrapping internal and access errors, preventing internal errors from reaching the top-level handler and not being logged. This PR removes these wrappers and surfaces internal and access errors to the top level handler.

3) Our `AccessError::Unauthorized` and `AccessError::Forbidden` were inspired by HTTP statuses which get widespread criticism of being misleading, so I renamed them to `Unauthenticated` and `Unauthorized` respectively.

4) Access levels in `GqlError` were not previously differentiated, but I feel like we need to handle them on the top level. Using GQL extension mechanism represent them as e.g.:
 ```
{
  "errors": [
    {
      "message": "Unauthorized",
      "extensions": { "code": "UNAUTHORIZED" }
    }
  ]
}
```