### PR TITLE
Private Datasets: GQL: make new parameters mandatory, after frontend update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ Recommendation: for ease of reading, use the following order:
 
 ## [Unreleased]
 ### Added
-- New `engine.datafusionEmbedded` config section allows to pass custom DataFusion settings when engine is used in igest, batch query, and compaction contexts.
+- New `engine.datafusionEmbedded` config section allows to pass custom DataFusion settings 
+    when engine is used in ingest, batch query, and compaction contexts.
+### Changed
+- GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: `dataset_visibility` is now mandatory
 ### Fixed
 - Multiple performance improvements in batch queries to avoid unnecessary metadata scanning.
 - New `PushIngestDataUseCase` and used it in Http `/ingest` handler and `ingest_command`

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -1039,11 +1039,11 @@ type DatasetsMut {
 	"""
 	Creates a new empty dataset
 	"""
-	createEmpty(datasetKind: DatasetKind!, datasetAlias: DatasetAlias!, datasetVisibility: DatasetVisibility): CreateDatasetResult!
+	createEmpty(datasetKind: DatasetKind!, datasetAlias: DatasetAlias!, datasetVisibility: DatasetVisibility!): CreateDatasetResult!
 	"""
 	Creates a new dataset from provided DatasetSnapshot manifest
 	"""
-	createFromSnapshot(snapshot: String!, snapshotFormat: MetadataManifestFormat!, datasetVisibility: DatasetVisibility): CreateDatasetFromSnapshotResult!
+	createFromSnapshot(snapshot: String!, snapshotFormat: MetadataManifestFormat!, datasetVisibility: DatasetVisibility!): CreateDatasetFromSnapshotResult!
 }
 
 """

--- a/src/adapter/graphql/src/mutations/datasets_mut.rs
+++ b/src/adapter/graphql/src/mutations/datasets_mut.rs
@@ -66,9 +66,7 @@ impl DatasetsMut {
         ctx: &Context<'_>,
         dataset_kind: DatasetKind,
         dataset_alias: DatasetAlias<'_>,
-        // TODO: Private Datasets: GQL: make new parameters mandatory, after frontend update
-        //       https://github.com/kamu-data/kamu-cli/issues/780
-        dataset_visibility: Option<DatasetVisibility>,
+        dataset_visibility: DatasetVisibility,
     ) -> Result<CreateDatasetResult> {
         match self
             .create_from_snapshot_impl(
@@ -78,7 +76,7 @@ impl DatasetsMut {
                     kind: dataset_kind.into(),
                     metadata: Vec::new(),
                 },
-                dataset_visibility.map(Into::into).unwrap_or_default(),
+                dataset_visibility.into(),
             )
             .await?
         {

--- a/src/adapter/graphql/src/mutations/datasets_mut.rs
+++ b/src/adapter/graphql/src/mutations/datasets_mut.rs
@@ -127,12 +127,8 @@ impl DatasetsMut {
             }
         };
 
-        self.create_from_snapshot_impl(
-            ctx,
-            snapshot,
-            dataset_visibility.map(Into::into).unwrap_or_default(),
-        )
-        .await
+        self.create_from_snapshot_impl(ctx, snapshot, dataset_visibility.into())
+            .await
     }
 
     // TODO: Multi-tenancy

--- a/src/adapter/graphql/src/mutations/datasets_mut.rs
+++ b/src/adapter/graphql/src/mutations/datasets_mut.rs
@@ -99,9 +99,7 @@ impl DatasetsMut {
         ctx: &Context<'_>,
         snapshot: String,
         snapshot_format: MetadataManifestFormat,
-        // TODO: Private Datasets: GQL: make new parameters mandatory, after frontend update
-        //       https://github.com/kamu-data/kamu-cli/issues/780
-        dataset_visibility: Option<DatasetVisibility>,
+        dataset_visibility: DatasetVisibility,
     ) -> Result<CreateDatasetFromSnapshotResult> {
         use odf::metadata::serde::DatasetSnapshotDeserializer;
 

--- a/src/app/cli/src/services/config/models.rs
+++ b/src/app/cli/src/services/config/models.rs
@@ -60,7 +60,7 @@ pub struct CLIConfig {
     #[merge(strategy = merge_recursive)]
     pub protocol: Option<ProtocolConfig>,
 
-    /// Seach configuration
+    /// Search configuration
     #[merge(strategy = merge_recursive)]
     pub search: Option<SearchConfig>,
 

--- a/src/e2e/app/cli/repo-tests/src/rest_api/test_gql_query.rs
+++ b/src/e2e/app/cli/repo-tests/src/rest_api/test_gql_query.rs
@@ -25,7 +25,7 @@ pub async fn test_gql_query_mut_create_empty_returns_correct_alias_mt(
                 r#"
                 mutation {
                   datasets {
-                    createEmpty(datasetKind: ROOT, datasetAlias: "empty-root-dataset") {
+                    createEmpty(datasetKind: ROOT, datasetAlias: "empty-root-dataset", datasetVisibility: PUBLIC) {
                       message
                       ... on CreateDatasetResultSuccess {
                         dataset {
@@ -74,7 +74,7 @@ pub async fn test_gql_query_mut_create_empty_returns_correct_alias_st(
                 r#"
                 mutation {
                   datasets {
-                    createEmpty(datasetKind: ROOT, datasetAlias: "empty-root-dataset") {
+                    createEmpty(datasetKind: ROOT, datasetAlias: "empty-root-dataset", datasetVisibility: PUBLIC) {
                       message
                       ... on CreateDatasetResultSuccess {
                         dataset {
@@ -134,7 +134,7 @@ pub async fn test_gql_query_mut_create_from_snapshot_returns_correct_alias_mt(
         r#"
         mutation {
           datasets {
-            createFromSnapshot (snapshot: "<content>", snapshotFormat: YAML) {
+            createFromSnapshot (snapshot: "<content>", snapshotFormat: YAML, datasetVisibility: PUBLIC) {
               ... on CreateDatasetResultSuccess {
                 dataset {
                   name
@@ -201,7 +201,7 @@ pub async fn test_gql_query_mut_create_from_snapshot_returns_correct_alias_st(
         r#"
         mutation {
           datasets {
-            createFromSnapshot (snapshot: "<content>", snapshotFormat: YAML) {
+            createFromSnapshot (snapshot: "<content>", snapshotFormat: YAML, datasetVisibility: PUBLIC) {
               ... on CreateDatasetResultSuccess {
                 dataset {
                   name

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -31,7 +31,6 @@ query-extensions-json = ["dep:datafusion-functions-json"]
 testing = [
     # Deps: kamu
     "dep:kamu-auth-rebac-services",
-    "dep:messaging-outbox",
     # Deps: 3-rd party
     "dep:bon",
     "dep:mockall",
@@ -55,6 +54,7 @@ kamu-auth-rebac = { workspace = true }
 kamu-core = { workspace = true }
 kamu-datasets = { workspace = true }
 kamu-ingest-datafusion = { workspace = true }
+messaging-outbox = { workspace = true }
 odf = { workspace = true, default-features = false, features = [
     "lfs",
     "s3"
@@ -120,7 +120,6 @@ tracing = "0.1"
 url = { version = "2", features = ["serde"] }
 
 # Optional dependencies
-messaging-outbox = { optional = true, workspace = true }
 kamu-auth-rebac-services = { optional = true, workspace = true }
 
 alloy = { optional = true, version = "0.9", default-features = false, features = [


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: #780 

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  - :warning: Not added but updated & deleted
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [x] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)