### PR TITLE
GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: alias name validation in multi-tenant mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Recommendation: for ease of reading, use the following order:
 ### Added
 - New `engine.datafusionEmbedded` config section allows to pass custom DataFusion settings 
     when engine is used in ingest, batch query, and compaction contexts.
+- GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: alias name validation in multi-tenant mode
 ### Changed
 - GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: `dataset_visibility` is now mandatory
 ### Fixed

--- a/src/adapter/graphql/src/mutations/datasets_mut.rs
+++ b/src/adapter/graphql/src/mutations/datasets_mut.rs
@@ -84,13 +84,6 @@ impl DatasetsMut {
             CreateDatasetFromSnapshotResult::NameCollision(e) => {
                 Ok(CreateDatasetResult::NameCollision(e))
             }
-            CreateDatasetFromSnapshotResult::IncorrectAliasAccountName(e) => {
-                Ok(CreateDatasetResult::IncorrectAliasAccountName(
-                    CreateDatasetResultIncorrectAliasAccountName {
-                        account_name: e.account_name,
-                    },
-                ))
-            }
             CreateDatasetFromSnapshotResult::InvalidSnapshot(_)
             | CreateDatasetFromSnapshotResult::Malformed(_)
             | CreateDatasetFromSnapshotResult::UnsupportedVersion(_)
@@ -208,7 +201,6 @@ impl DatasetsMut {
 pub enum CreateDatasetResult<'a> {
     Success(CreateDatasetResultSuccess),
     NameCollision(CreateDatasetResultNameCollision<'a>),
-    IncorrectAliasAccountName(CreateDatasetResultIncorrectAliasAccountName<'a>),
 }
 
 #[derive(Interface, Debug)]
@@ -216,7 +208,6 @@ pub enum CreateDatasetResult<'a> {
 pub enum CreateDatasetFromSnapshotResult<'a> {
     Success(CreateDatasetResultSuccess),
     NameCollision(CreateDatasetResultNameCollision<'a>),
-    IncorrectAliasAccountName(CreateDatasetResultIncorrectAliasAccountName<'a>),
     Malformed(MetadataManifestMalformed),
     UnsupportedVersion(MetadataManifestUnsupportedVersion),
     InvalidSnapshot(CreateDatasetResultInvalidSnapshot),
@@ -253,24 +244,6 @@ pub struct CreateDatasetResultNameCollision<'a> {
 impl CreateDatasetResultNameCollision<'_> {
     async fn message(&self) -> String {
         format!("Dataset with name '{}' already exists", self.dataset_name)
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#[derive(SimpleObject, Debug)]
-#[graphql(complex)]
-pub struct CreateDatasetResultIncorrectAliasAccountName<'a> {
-    pub account_name: AccountName<'a>,
-}
-
-#[ComplexObject]
-impl CreateDatasetResultIncorrectAliasAccountName<'_> {
-    async fn message(&self) -> String {
-        format!(
-            "Alias account name does not match the user's account name: {}",
-            self.account_name
-        )
     }
 }
 

--- a/src/adapter/graphql/src/mutations/datasets_mut.rs
+++ b/src/adapter/graphql/src/mutations/datasets_mut.rs
@@ -131,9 +131,6 @@ impl DatasetsMut {
             .await
     }
 
-    // TODO: Multi-tenancy
-    //       https://github.com/kamu-data/kamu-cli/issues/891
-
     // TODO: Multi-tenant resolution for derivative dataset inputs (should it only
     //       work by ID?)
     #[graphql(skip)]

--- a/src/adapter/graphql/tests/tests/test_gql_datasets.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_datasets.rs
@@ -373,6 +373,65 @@ async fn test_dataset_create_from_snapshot_malformed() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[test_log::test(tokio::test)]
+async fn test_dataset_create_from_snapshot_incorrect_alias_account_name() {
+    let harness = GraphQLDatasetsHarness::builder()
+        .tenancy_config(TenancyConfig::MultiTenant)
+        .build()
+        .await;
+
+    let snapshot_yaml = {
+        let snapshot = MetadataFactory::dataset_snapshot()
+            .name("another-user/foo")
+            .kind(odf::DatasetKind::Root)
+            .push_event(MetadataFactory::set_polling_source().build())
+            .build();
+
+        use odf::metadata::serde::yaml::YamlDatasetSnapshotSerializer;
+        use odf::metadata::serde::DatasetSnapshotSerializer;
+
+        String::from_utf8_lossy(
+            &YamlDatasetSnapshotSerializer
+                .write_manifest(&snapshot)
+                .unwrap(),
+        )
+        .to_string()
+    };
+
+    let request_code = indoc!(
+        r#"
+        mutation {
+            datasets {
+                createFromSnapshot (snapshot: "<content>", snapshotFormat: YAML, datasetVisibility: PUBLIC) {
+                    ... on CreateDatasetResultInvalidSnapshot {
+                        __typename
+                        message
+                    }
+                }
+            }
+        }
+        "#
+    )
+    .replace("<content>", &snapshot_yaml.escape_default().to_string());
+
+    let res = harness.execute_authorized_query(request_code).await;
+
+    assert!(res.is_ok(), "{res:?}");
+    pretty_assertions::assert_eq!(
+        async_graphql::value!({
+            "datasets": {
+                "createFromSnapshot": {
+                    "__typename": "CreateDatasetResultInvalidSnapshot",
+                    "message": "Alias account name does not match the user's account name: another-user",
+                }
+            }
+        }),
+        res.data,
+    );
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
 async fn test_dataset_rename_success() {
     let harness = GraphQLDatasetsHarness::builder()
         .tenancy_config(TenancyConfig::SingleTenant)

--- a/src/domain/accounts/domain/Cargo.toml
+++ b/src/domain/accounts/domain/Cargo.toml
@@ -24,7 +24,7 @@ doctest = false
 [features]
 default = []
 sqlx = ["dep:sqlx"]
-testing = ["dep:mockall"]
+testing = ["dep:mockall", "odf/testing"]
 
 
 [dependencies]

--- a/src/domain/accounts/domain/src/entities/current_account_subject.rs
+++ b/src/domain/accounts/domain/src/entities/current_account_subject.rs
@@ -61,6 +61,17 @@ impl CurrentAccountSubject {
         )
     }
 
+    #[cfg(any(feature = "testing", test))]
+    pub fn new_test_with(account_name: &odf::AccountName) -> Self {
+        let is_admin = false;
+
+        Self::logged(
+            odf::metadata::testing::account_id(account_name),
+            account_name.clone(),
+            is_admin,
+        )
+    }
+
     pub fn account_id(&self) -> &odf::AccountID {
         match self {
             CurrentAccountSubject::Anonymous(_) => {

--- a/src/domain/datasets/domain/src/use_cases/create_dataset_from_snapshot_use_case.rs
+++ b/src/domain/datasets/domain/src/use_cases/create_dataset_from_snapshot_use_case.rs
@@ -72,9 +72,6 @@ impl From<CreateDatasetError> for CreateDatasetFromSnapshotError {
     fn from(v: CreateDatasetError) -> Self {
         match v {
             CreateDatasetError::EmptyDataset => unreachable!(),
-            CreateDatasetError::IncorrectAliasAccountName(e) => {
-                Self::invalid_snapshot(e.to_string())
-            }
             CreateDatasetError::NameCollision(e) => Self::NameCollision(e),
             CreateDatasetError::RefCollision(e) => Self::RefCollision(e),
             CreateDatasetError::CASFailed(e) => Self::CASFailed(e),

--- a/src/domain/datasets/domain/src/use_cases/create_dataset_from_snapshot_use_case.rs
+++ b/src/domain/datasets/domain/src/use_cases/create_dataset_from_snapshot_use_case.rs
@@ -56,12 +56,21 @@ pub enum CreateDatasetFromSnapshotError {
     ),
 }
 
+impl CreateDatasetFromSnapshotError {
+    pub fn invalid_snapshot(reason: impl Into<String>) -> Self {
+        Self::InvalidSnapshot(odf::dataset::InvalidSnapshotError::new(reason))
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 impl From<CreateDatasetError> for CreateDatasetFromSnapshotError {
     fn from(v: CreateDatasetError) -> Self {
         match v {
             CreateDatasetError::EmptyDataset => unreachable!(),
+            CreateDatasetError::IncorrectAliasAccountName(e) => {
+                Self::invalid_snapshot(e.to_string())
+            }
             CreateDatasetError::NameCollision(e) => Self::NameCollision(e),
             CreateDatasetError::RefCollision(e) => Self::RefCollision(e),
             CreateDatasetError::CASFailed(e) => Self::CASFailed(e),

--- a/src/domain/datasets/domain/src/use_cases/create_dataset_from_snapshot_use_case.rs
+++ b/src/domain/datasets/domain/src/use_cases/create_dataset_from_snapshot_use_case.rs
@@ -15,6 +15,7 @@ use crate::{
     CreateDatasetResult,
     CreateDatasetUseCaseOptions,
     DatasetReferenceCASError,
+    IncorrectAliasAccountNameError,
     NameCollisionError,
 };
 
@@ -33,6 +34,9 @@ pub trait CreateDatasetFromSnapshotUseCase: Send + Sync {
 
 #[derive(Error, Debug)]
 pub enum CreateDatasetFromSnapshotError {
+    #[error(transparent)]
+    IncorrectAliasAccountName(#[from] IncorrectAliasAccountNameError),
+
     #[error(transparent)]
     InvalidSnapshot(#[from] odf::dataset::InvalidSnapshotError),
 

--- a/src/domain/datasets/domain/src/use_cases/create_dataset_use_case.rs
+++ b/src/domain/datasets/domain/src/use_cases/create_dataset_use_case.rs
@@ -82,6 +82,9 @@ pub enum CreateDatasetError {
     EmptyDataset,
 
     #[error(transparent)]
+    IncorrectAliasAccountName(#[from] IncorrectAliasAccountNameError),
+
+    #[error(transparent)]
     NameCollision(#[from] NameCollisionError),
 
     #[error(transparent)]
@@ -96,6 +99,14 @@ pub enum CreateDatasetError {
         #[backtrace]
         InternalError,
     ),
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Error)]
+#[error("The account name in the alias does not match the user's account name: {account_name}")]
+pub struct IncorrectAliasAccountNameError {
+    pub account_name: odf::AccountName,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/domain/src/use_cases/create_dataset_use_case.rs
+++ b/src/domain/datasets/domain/src/use_cases/create_dataset_use_case.rs
@@ -104,7 +104,7 @@ pub enum CreateDatasetError {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Error)]
-#[error("The account name in the alias does not match the user's account name: {account_name}")]
+#[error("Alias account name does not match the user's account name: {account_name}")]
 pub struct IncorrectAliasAccountNameError {
     pub account_name: odf::AccountName,
 }

--- a/src/domain/datasets/domain/src/use_cases/create_dataset_use_case.rs
+++ b/src/domain/datasets/domain/src/use_cases/create_dataset_use_case.rs
@@ -82,9 +82,6 @@ pub enum CreateDatasetError {
     EmptyDataset,
 
     #[error(transparent)]
-    IncorrectAliasAccountName(#[from] IncorrectAliasAccountNameError),
-
-    #[error(transparent)]
     NameCollision(#[from] NameCollisionError),
 
     #[error(transparent)]

--- a/src/domain/datasets/services/src/use_cases/create_dataset_from_snapshot_use_case_impl.rs
+++ b/src/domain/datasets/services/src/use_cases/create_dataset_from_snapshot_use_case_impl.rs
@@ -35,9 +35,10 @@ pub struct CreateDatasetFromSnapshotUseCaseImpl {
     create_helper: Arc<CreateDatasetUseCaseHelper>,
 }
 
+#[common_macros::method_names_consts]
 #[async_trait::async_trait]
 impl CreateDatasetFromSnapshotUseCase for CreateDatasetFromSnapshotUseCaseImpl {
-    #[tracing::instrument(level = "info", skip_all, fields(?snapshot, ?options))]
+    #[tracing::instrument(level = "info", name = CreateDatasetFromSnapshotUseCaseImpl_execute, skip_all, fields(?snapshot, ?options))]
     async fn execute(
         &self,
         mut snapshot: odf::DatasetSnapshot,

--- a/src/domain/datasets/services/src/use_cases/create_dataset_use_case_impl.rs
+++ b/src/domain/datasets/services/src/use_cases/create_dataset_use_case_impl.rs
@@ -30,9 +30,10 @@ pub struct CreateDatasetUseCaseImpl {
     create_helper: Arc<CreateDatasetUseCaseHelper>,
 }
 
+#[common_macros::method_names_consts]
 #[async_trait::async_trait]
 impl CreateDatasetUseCase for CreateDatasetUseCaseImpl {
-    #[tracing::instrument(level = "info", skip_all, fields(dataset_alias, ?seed_block, ?options))]
+    #[tracing::instrument(level = "info", name = CreateDatasetUseCaseImpl_execute, skip_all, fields(dataset_alias, ?seed_block, ?options))]
     async fn execute(
         &self,
         dataset_alias: &odf::DatasetAlias,

--- a/src/domain/datasets/services/src/utils/create_dataset_use_case_helper.rs
+++ b/src/domain/datasets/services/src/utils/create_dataset_use_case_helper.rs
@@ -199,12 +199,8 @@ impl From<CanonicalDatasetAliasError> for CreateDatasetFromSnapshotError {
 }
 
 impl From<CanonicalDatasetAliasError> for CreateDatasetError {
-    fn from(v: CanonicalDatasetAliasError) -> CreateDatasetError {
-        match v {
-            CanonicalDatasetAliasError::IncorrectAliasAccountName(e) => {
-                CreateDatasetError::IncorrectAliasAccountName(e)
-            }
-        }
+    fn from(_: CanonicalDatasetAliasError) -> CreateDatasetError {
+        unreachable!()
     }
 }
 


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: #1019 

- The task being closed required that the account name not be returned in the alias (single-tenant)
- After double-checking, it turns out this is already happening
- But the possibility of a minor collision was found in the case of the multi-tenant mode

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

### Added
- GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: alias name validation in multi-tenant mode

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [x] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [ ] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)