### PR TITLE
Using batch query to count datasets with flows belonging to an account (more listing speedup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Changed
+- Using batch query to count datasets with flows belonging to an account (more listing speedup)
+
+
 ## [0.234.0] - 2025-04-23
 ### Changed
 - Pin version for `aws-sdk-s3` crate version, that includes breaking changes

--- a/src/domain/flow-system/domain/src/repos/flow/flow_event_store.rs
+++ b/src/domain/flow-system/domain/src/repos/flow/flow_event_store.rs
@@ -67,11 +67,17 @@ pub trait FlowEventStore: EventStore<FlowState> {
 
     /// Returns number of flows associated with the specified datasets and
     /// matching filters, if specified
-    async fn get_count_flows_by_datasets(
+    async fn get_count_flows_by_multiple_datasets(
         &self,
         dataset_ids: &[&odf::DatasetID],
         filters: &DatasetFlowFilters,
     ) -> Result<usize, InternalError>;
+
+    /// Returns IDs of the datasets who have any flows associated with them
+    async fn filter_datasets_having_flows(
+        &self,
+        dataset_ids: &[&odf::DatasetID],
+    ) -> Result<Vec<odf::DatasetID>, InternalError>;
 
     /// Returns IDs of the flows associated with the specified
     /// dataset in reverse chronological order based on creation time.

--- a/src/domain/flow-system/domain/src/services/flow/flow_query_service.rs
+++ b/src/domain/flow-system/domain/src/services/flow/flow_query_service.rs
@@ -51,7 +51,7 @@ pub trait FlowQueryService: Sync + Send {
     async fn list_all_datasets_with_flow_by_account(
         &self,
         account_id: &odf::AccountID,
-    ) -> Result<FlowDatasetListing, ListFlowsByDatasetError>;
+    ) -> Result<Vec<odf::DatasetID>, ListFlowsByDatasetError>;
 
     /// Returns states of flows associated with a given account
     /// ordered by creation time from newest to oldest.
@@ -125,15 +125,6 @@ pub struct FlowInitiatorListing<'a> {
 
 pub type InitiatorsStream<'a> =
     std::pin::Pin<Box<dyn Stream<Item = Result<odf::AccountID, InternalError>> + Send + 'a>>;
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-pub struct FlowDatasetListing<'a> {
-    pub matched_stream: DatasetsStream<'a>,
-}
-
-pub type DatasetsStream<'a> =
-    std::pin::Pin<Box<dyn Stream<Item = Result<odf::DatasetID, InternalError>> + Send + 'a>>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/domain/flow-system/services/tests/tests/test_flow_agent_impl.rs
+++ b/src/domain/flow-system/services/tests/tests/test_flow_agent_impl.rs
@@ -5532,10 +5532,6 @@ async fn test_list_all_datasets_with_flow() {
         .flow_query_service
         .list_all_datasets_with_flow_by_account(&foo_account_id)
         .await
-        .unwrap()
-        .matched_stream
-        .try_collect()
-        .await
         .unwrap();
 
     pretty_assertions::assert_eq!([foo_id], *all_datasets_with_flow);
@@ -5543,10 +5539,6 @@ async fn test_list_all_datasets_with_flow() {
     let all_datasets_with_flow: Vec<_> = harness
         .flow_query_service
         .list_all_datasets_with_flow_by_account(&bar_account_id)
-        .await
-        .unwrap()
-        .matched_stream
-        .try_collect()
         .await
         .unwrap();
 

--- a/src/infra/flow-system/postgres/.sqlx/query-2e52fea61863e00be85877026c130c0045767c5bf30397406f428002fa00cca8.json
+++ b/src/infra/flow-system/postgres/.sqlx/query-2e52fea61863e00be85877026c130c0045767c5bf30397406f428002fa00cca8.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT DISTINCT(dataset_id) as dataset_id\n                FROM flows\n                WHERE dataset_id = ANY($1)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "dataset_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "2e52fea61863e00be85877026c130c0045767c5bf30397406f428002fa00cca8"
+}


### PR DESCRIPTION

## Description

Closes: #1215 


## Checklist before requesting a review

- [ ] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [ ] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [ ] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [ ] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [ ] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [ ] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)