### PR TITLE
`database-common`: re-export `PgPoolOptions`

### DIFF
--- a/src/utils/database-common/src/lib.rs
+++ b/src/utils/database-common/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(iter_intersperse)]
 
 // Re-exports
+pub use sqlx::postgres::PgPoolOptions;
 pub use sqlx::sqlite::SqlitePoolOptions;
 
 mod db_connection_settings;


### PR DESCRIPTION
This change will remove the redundant dev dependency in `kamu-api-server`:
- https://github.com/kamu-data/kamu-node/blob/f2b8fd4fb875663794fab2f3990c76755a93269e/src/app/api-server/Cargo.toml#L154-L158