### PR TITLE
Move TLS configuration to top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Recommendation: for ease of reading, use the following order:
 - Upgraded to `datafusion v47.0.0` and latest `arrow`, `object-store`, and `flatbuffers` versions
 - Commands and APIs that query data are now more tolerant to the situation when dataset is empty and doesn't have a schema yet and will return results with empty rows and columns instead of returning errors
 ### Fixed
+- Crash on push/pull over TLS connection (#1231)
 - Patched `GQL DatasetFlowTriggers::all_paused` to use similar optimization as account flow views
 
 ## [0.235.0] - 2025-04-24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,9 @@ dependencies = [
  "read_input",
  "regex",
  "reqwest",
+ "rumqttc",
  "rust-embed",
+ "rustls 0.23.26",
  "secrecy",
  "serde",
  "serde_json",
@@ -6543,6 +6545,7 @@ dependencies = [
  "serde_yaml",
  "server-console",
  "shlex",
+ "sqlx",
  "strum 0.26.3",
  "tempfile",
  "test-group",
@@ -6551,6 +6554,7 @@ dependencies = [
  "time-source",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.26.2",
  "tokio-util",
  "tonic",
  "tower 0.5.2",
@@ -11617,11 +11621,11 @@ dependencies = [
  "futures-util",
  "log",
  "rustls 0.23.26",
- "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -69,7 +69,6 @@ headers = { version = "0.4", default-features = false }
 http = "1"
 indoc = "2"
 reqwest = { version = "0.12", default-features = false, features = [
-    "rustls-tls",
     "multipart",
     "json",
     "stream",
@@ -90,10 +89,7 @@ tokio-util = { version = "0.7", default-features = false, features = [
     "compat",
     "io",
 ] }
-tokio-tungstenite = { version = "0.26", features = [
-    "rustls-tls-native-roots",
-    "url",
-] }
+tokio-tungstenite = { version = "0.26", features = ["url"] }
 tower = "0.5"
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }

--- a/src/adapter/oauth/Cargo.toml
+++ b/src/adapter/oauth/Cargo.toml
@@ -30,10 +30,7 @@ kamu-accounts = { workspace = true }
 async-trait = "0.1"
 dill = { version = "0.13", default-features = false }
 http = "1"
-reqwest = { version = "0.12", default-features = false, features = [
-    "rustls-tls",
-    "json",
-] }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false }
 thiserror = { version = "2", default-features = false, features = ["std"] }

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -33,7 +33,7 @@ default = ["ingest-evm", "ingest-mqtt", "query-extensions-json"]
 
 ingest-evm = ["kamu/ingest-evm"]
 ingest-ftp = ["kamu/ingest-ftp"]
-ingest-mqtt = ["kamu/ingest-mqtt"]
+ingest-mqtt = ["kamu/ingest-mqtt", "dep:rumqttc"]
 query-extensions-json = ["kamu/query-extensions-json"]
 web-ui = ["rust-embed"]
 
@@ -105,6 +105,25 @@ kamu-search-services = { workspace = true }
 kamu-search-openai = { workspace = true }
 kamu-search-qdrant = { workspace = true }
 
+# Top-level TLS and runtime configurations
+# TODO: Include alloy, aws-smithy
+# TODO: Unify deps around either ring or aws-lc-rs
+# TODO: Unify deps around either using webpki or native certs
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls-webpki-roots",
+] }
+rustls = { version = "0.23", default-features = false, features = [
+    "aws-lc-rs",
+] }
+rumqttc = { optional = true, version = "0.24", default-features = false, features = [
+    "use-rustls",
+] }
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls-aws-lc-rs",
+] }
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+
 # CLI
 chrono-humanize = "0.2"                                           # Human readable durations
 clap = "4"
@@ -124,7 +143,6 @@ async-graphql = { version = "7", default-features = false }
 async-graphql-axum = "7"
 axum = { version = "0.8", features = ["ws"] }
 http = "1"
-reqwest = { version = "0.12", default-features = false }
 serde_json = "1"
 tonic = { version = "0.12", default-features = false }
 tower = "0.5"
@@ -165,7 +183,14 @@ tracing-bunyan-formatter = "0.3"
 async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1" # Conditional compilation
-datafusion = { version = "47", default-features = false, features = ["crypto_expressions", "encoding_expressions", "parquet", "regex_expressions", "unicode_expressions", "compression"] }
+datafusion = { version = "47", default-features = false, features = [
+    "crypto_expressions",
+    "encoding_expressions",
+    "parquet",
+    "regex_expressions",
+    "unicode_expressions",
+    "compression",
+] }
 dill = { version = "0.13", default-features = false }
 dirs = "6"
 fs_extra = "1.3"

--- a/src/app/cli/src/main.rs
+++ b/src/app/cli/src/main.rs
@@ -10,6 +10,14 @@
 use clap::Parser as _;
 
 fn main() {
+    // TODO: Currently we are compiling `rustls` with both `ring` and `aws-cl-rs`
+    // backends and since v0.23 `rustls` requires to disambiguate between which
+    // one to use. Eventually we should unify all dependencies around the same
+    // backend, but a number of them don't yet expose the necessary feature flags.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("Could not install default TLS provider");
+
     let workspace_layout = kamu_cli::WorkspaceService::find_workspace();
     let args = kamu_cli::cli::Cli::parse();
 

--- a/src/infra/accounts/mysql/Cargo.toml
+++ b/src/infra/accounts/mysql/Cargo.toml
@@ -34,7 +34,6 @@ chrono = { version = "0.4", default-features = false }
 dill = { version = "0.13", default-features = false }
 futures = { version = "0.3", default-features = false }
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "mysql",
     "chrono",

--- a/src/infra/accounts/postgres/Cargo.toml
+++ b/src/infra/accounts/postgres/Cargo.toml
@@ -34,7 +34,6 @@ chrono = { version = "0.4", default-features = false }
 dill = { version = "0.13", default-features = false }
 futures = { version = "0.3", default-features = false }
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "postgres",
     "chrono",

--- a/src/infra/accounts/sqlite/Cargo.toml
+++ b/src/infra/accounts/sqlite/Cargo.toml
@@ -34,7 +34,6 @@ chrono = { version = "0.4", default-features = false }
 dill = { version = "0.13", default-features = false }
 futures = { version = "0.3", default-features = false }
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "sqlite",
     "chrono",

--- a/src/infra/auth-rebac/postgres/Cargo.toml
+++ b/src/infra/auth-rebac/postgres/Cargo.toml
@@ -29,7 +29,6 @@ kamu-auth-rebac = { workspace = true, features = ["sqlx"] }
 async-trait = "0.1"
 dill = { version = "0.13", default-features = false }
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "postgres",
     "chrono",

--- a/src/infra/auth-rebac/sqlite/Cargo.toml
+++ b/src/infra/auth-rebac/sqlite/Cargo.toml
@@ -29,7 +29,6 @@ kamu-auth-rebac = { workspace = true, features = ["sqlx"] }
 async-trait = "0.1"
 dill = { version = "0.13", default-features = false }
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "sqlite",
     "chrono",

--- a/src/infra/core/Cargo.toml
+++ b/src/infra/core/Cargo.toml
@@ -55,10 +55,7 @@ kamu-core = { workspace = true }
 kamu-datasets = { workspace = true }
 kamu-ingest-datafusion = { workspace = true }
 messaging-outbox = { workspace = true }
-odf = { workspace = true, default-features = false, features = [
-    "lfs",
-    "s3"
-] }
+odf = { workspace = true, default-features = false, features = ["lfs", "s3"] }
 random-names = { workspace = true }
 s3-utils = { workspace = true }
 time-source = { workspace = true }
@@ -75,7 +72,6 @@ serde_yaml = "0.9"
 flate2 = "1" # GZip decoder
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
-    "rustls-tls",
     "stream",
     "gzip",
     "brotli",
@@ -138,7 +134,8 @@ curl = { optional = true, version = "0.4", features = [
 curl-sys = { optional = true, version = "0.4" }
 datafusion-ethers = { optional = true, version = "47" }
 datafusion-functions-json = { optional = true, version = "0.47" }
-rumqttc = { optional = true, version = "0.24" }
+rumqttc = { optional = true, version = "0.24", default-features = false, features = [
+] }
 mockall = { optional = true, version = "0.13", default-features = false }
 oop = { optional = true, version = "0.0.2" }
 lazy_static = { version = "1" }
@@ -150,16 +147,24 @@ libc = "0.2" # For getting uid:gid
 
 [dev-dependencies]
 kamu = { workspace = true, default-features = false, features = ["testing"] }
-kamu-accounts = { workspace = true, default-features = false, features = ["testing"] }
-kamu-core = { workspace = true, default-features = false, features = ["testing"] }
+kamu-accounts = { workspace = true, default-features = false, features = [
+    "testing",
+] }
+kamu-core = { workspace = true, default-features = false, features = [
+    "testing",
+] }
 kamu-datasets-inmem = { workspace = true, default-features = false }
-kamu-datasets-services = { workspace = true, default-features = false, features = ["testing"] }
+kamu-datasets-services = { workspace = true, default-features = false, features = [
+    "testing",
+] }
 odf = { workspace = true, default-features = false, features = ["testing"] }
 test-utils = { workspace = true, default-features = false }
 
 bon = { version = "3", default-features = false }
 criterion = { version = "0.5", features = ["async_tokio"] }
-datafusion = { version = "47", default-features = false, features = ["parquet"] }
+datafusion = { version = "47", default-features = false, features = [
+    "parquet",
+] }
 filetime = "0.2"
 fs_extra = "1.3"
 indoc = "2"

--- a/src/infra/datasets/postgres/Cargo.toml
+++ b/src/infra/datasets/postgres/Cargo.toml
@@ -33,10 +33,9 @@ bytes = { version = "1", default-features = false }
 dill = { version = "0.13", default-features = false }
 futures = "0.3"
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "postgres",
-    "chrono"
+    "chrono",
 ] }
 tracing = "0.1"
 uuid = "1"

--- a/src/infra/datasets/sqlite/Cargo.toml
+++ b/src/infra/datasets/sqlite/Cargo.toml
@@ -34,7 +34,6 @@ chrono = { version = "0.4" }
 dill = { version = "0.13", default-features = false }
 futures = "0.3"
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "sqlite",
     "chrono",

--- a/src/infra/flow-system/postgres/Cargo.toml
+++ b/src/infra/flow-system/postgres/Cargo.toml
@@ -33,11 +33,10 @@ dill = { version = "0.13", default-features = false }
 futures = "0.3"
 serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "json",
     "macros",
     "postgres",
-    "chrono"
+    "chrono",
 ] }
 tracing = { version = "0.1", default-features = false }
 

--- a/src/infra/flow-system/sqlite/Cargo.toml
+++ b/src/infra/flow-system/sqlite/Cargo.toml
@@ -33,11 +33,10 @@ dill = { version = "0.13", default-features = false }
 futures = "0.3"
 serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "json",
     "macros",
     "sqlite",
-    "chrono"
+    "chrono",
 ] }
 tracing = { version = "0.1", default-features = false }
 

--- a/src/infra/messaging-outbox/postgres/Cargo.toml
+++ b/src/infra/messaging-outbox/postgres/Cargo.toml
@@ -31,7 +31,6 @@ async-trait = { version = "0.1", default-features = false }
 dill = { version = "0.13", default-features = false }
 futures = "0.3"
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "postgres",
     "chrono",

--- a/src/infra/messaging-outbox/sqlite/Cargo.toml
+++ b/src/infra/messaging-outbox/sqlite/Cargo.toml
@@ -32,7 +32,6 @@ dill = { version = "0.13", default-features = false }
 futures = "0.3"
 indoc = "2"
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "macros",
     "sqlite",
     "chrono",

--- a/src/infra/task-system/postgres/Cargo.toml
+++ b/src/infra/task-system/postgres/Cargo.toml
@@ -32,11 +32,10 @@ dill = { version = "0.13", default-features = false }
 futures = "0.3"
 serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "json",
     "macros",
     "postgres",
-    "chrono"
+    "chrono",
 ] }
 
 

--- a/src/infra/task-system/sqlite/Cargo.toml
+++ b/src/infra/task-system/sqlite/Cargo.toml
@@ -33,11 +33,10 @@ dill = { version = "0.13", default-features = false }
 futures = "0.3"
 serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio-rustls",
     "json",
     "macros",
     "sqlite",
-    "chrono"
+    "chrono",
 ] }
 
 

--- a/src/odf/metadata/Cargo.toml
+++ b/src/odf/metadata/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = { version = "2", default-features = false, features = ["std"] }
 bitflags = { version = "2", default-features = false }
 
 datafusion = { optional = true, version = "47", default-features = false }
-rand = { optional = true, version = "0.8", default-features =  false }
+rand = { optional = true, version = "0.8", default-features = false }
 
 like = { version = "0.3", default-features = false }
 sha3 = "0.10"
@@ -65,11 +65,13 @@ serde_with = "3"
 serde_yaml = "0.9"
 
 # gRPC
-prost = "0.13"
-tonic = "0.12"
+prost = { version = "0.13", default-features = false }
+tonic = { version = "0.12", default-features = false }
 
 # Optional
-arrow = { optional = true, version = "55", default-features = false, features = ["ipc"] }
+arrow = { optional = true, version = "55", default-features = false, features = [
+    "ipc",
+] }
 sqlx = { optional = true, version = "0.8", default-features = false }
 utoipa = { optional = true, version = "5", default-features = false, features = [
 ] }

--- a/src/utils/database-common/Cargo.toml
+++ b/src/utils/database-common/Cargo.toml
@@ -49,7 +49,6 @@ tracing = "0.1"
 version = "0.8"
 default-features = false
 features = [
-    "runtime-tokio-rustls",
     "macros",
     "mysql",
     "postgres",

--- a/src/utils/repo-tools/Cargo.toml
+++ b/src/utils/repo-tools/Cargo.toml
@@ -29,7 +29,7 @@ regex = { version = "1", default-features = false, features = [
     "unicode",
 ] }
 reqwest = { version = "0.12", default-features = false, features = [
-    "rustls-tls",
+    "rustls-tls-webpki-roots",
     "blocking",
     "json",
 ] }


### PR DESCRIPTION
Closes: #1231

Moves TLS configuration out of libraries and into top-level binaries.

Same change will need to be done in `kamu-node`.