### PR TITLE
Remove flaky group from push trigger test

### DIFF
--- a/src/e2e/app/cli/mysql/tests/tests/test_smart_transfer_protocol.rs
+++ b/src/e2e/app/cli/mysql/tests/tests/test_smart_transfer_protocol.rs
@@ -423,6 +423,29 @@ kamu_cli_run_api_server_e2e_test!(
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+kamu_cli_run_api_server_e2e_test!(
+    storage = mysql,
+    fixture = kamu_cli_e2e_repo_tests::test_smart_push_trigger_dependent_dataset_update_mt,
+    options = Options::default()
+        .with_multi_tenant()
+        .with_kamu_config(indoc::indoc!(
+            r#"
+            kind: CLIConfig
+            version: 1
+            content:
+              flowSystem:
+                flowAgent:
+                  awaitingStepSecs: 1
+                  mandatoryThrottlingPeriodSecs: 5
+                taskAgent:
+                  taskCheckingIntervalSecs: 1
+            "#
+        )),
+    extra_test_groups = "containerized, engine, ingest, transform, datafusion"
+);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // test_smart_push_smart_pull_force_overwrite_seed_block
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/e2e/app/cli/mysql/tests/tests/test_smart_transfer_protocol.rs
+++ b/src/e2e/app/cli/mysql/tests/tests/test_smart_transfer_protocol.rs
@@ -419,7 +419,7 @@ kamu_cli_run_api_server_e2e_test!(
                   taskCheckingIntervalSecs: 1
             "#
         )),
-    extra_test_groups = "containerized, engine, ingest, transform, datafusion, flaky"
+    extra_test_groups = "containerized, engine, ingest, transform, datafusion"
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/e2e/app/cli/postgres/tests/tests/test_smart_transfer_protocol.rs
+++ b/src/e2e/app/cli/postgres/tests/tests/test_smart_transfer_protocol.rs
@@ -423,6 +423,29 @@ kamu_cli_run_api_server_e2e_test!(
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+kamu_cli_run_api_server_e2e_test!(
+    storage = postgres,
+    fixture = kamu_cli_e2e_repo_tests::test_smart_push_trigger_dependent_dataset_update_mt,
+    options = Options::default()
+        .with_multi_tenant()
+        .with_kamu_config(indoc::indoc!(
+            r#"
+            kind: CLIConfig
+            version: 1
+            content:
+              flowSystem:
+                flowAgent:
+                  awaitingStepSecs: 1
+                  mandatoryThrottlingPeriodSecs: 5
+                taskAgent:
+                  taskCheckingIntervalSecs: 1
+            "#
+        )),
+    extra_test_groups = "containerized, engine, ingest, transform, datafusion"
+);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // test_smart_push_smart_pull_force_overwrite_seed_block
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/e2e/app/cli/postgres/tests/tests/test_smart_transfer_protocol.rs
+++ b/src/e2e/app/cli/postgres/tests/tests/test_smart_transfer_protocol.rs
@@ -419,7 +419,7 @@ kamu_cli_run_api_server_e2e_test!(
                   taskCheckingIntervalSecs: 1
             "#
         )),
-    extra_test_groups = "containerized, engine, ingest, transform, datafusion, flaky"
+    extra_test_groups = "containerized, engine, ingest, transform, datafusion"
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/e2e/app/cli/sqlite/tests/tests/test_smart_transfer_protocol.rs
+++ b/src/e2e/app/cli/sqlite/tests/tests/test_smart_transfer_protocol.rs
@@ -423,6 +423,29 @@ kamu_cli_run_api_server_e2e_test!(
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+kamu_cli_run_api_server_e2e_test!(
+    storage = sqlite,
+    fixture = kamu_cli_e2e_repo_tests::test_smart_push_trigger_dependent_dataset_update_mt,
+    options = Options::default()
+        .with_multi_tenant()
+        .with_kamu_config(indoc::indoc!(
+            r#"
+            kind: CLIConfig
+            version: 1
+            content:
+              flowSystem:
+                flowAgent:
+                  awaitingStepSecs: 1
+                  mandatoryThrottlingPeriodSecs: 5
+                taskAgent:
+                  taskCheckingIntervalSecs: 1
+            "#
+        )),
+    extra_test_groups = "containerized, engine, ingest, transform, datafusion"
+);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // test_smart_push_smart_pull_force_overwrite_seed_block
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/e2e/app/cli/sqlite/tests/tests/test_smart_transfer_protocol.rs
+++ b/src/e2e/app/cli/sqlite/tests/tests/test_smart_transfer_protocol.rs
@@ -419,7 +419,7 @@ kamu_cli_run_api_server_e2e_test!(
                   taskCheckingIntervalSecs: 1
             "#
         )),
-    extra_test_groups = "containerized, engine, ingest, transform, datafusion, flaky"
+    extra_test_groups = "containerized, engine, ingest, transform, datafusion"
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In the scope of https://github.com/kamu-data/kamu-cli/pull/1237 we handled a floating race condition issue during simultaneous dataset creating and push ingest. 
PR with removing `flaky` testgroup from the test where it was reproducible.