### PR TITLE
Release (minor): 0.240.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ on:
 env:
   PACKAGE_NAME: kamu-cli
   BINARY_NAME: kamu
-  KAMU_WEB_UI_VERSION: "0.47.0"
+  KAMU_WEB_UI_VERSION: "0.49.0"
 jobs:
   build:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
-## [Unreleased]
+## [0.240.0] - 2025-06-02
 ### Added
 - `kamu --show-error-stack-trace`: Added an argument to show stack trace in case of an error during command execution.
 - Implemented a new authorization provider for Web3 EVM-based wallets (`web3-wallet`):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "async-utils"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "common-macros"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2953,7 +2953,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-utils"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "database-common"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "email-utils"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -4619,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.239.0"
+version = "0.240.0"
 
 [[package]]
 name = "env_filter"
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4703,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4798,7 +4798,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "file-utils"
-version = "0.239.0"
+version = "0.240.0"
 
 [[package]]
 name = "filetime"
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "axum 0.8.3",
  "http 1.3.1",
@@ -5963,7 +5963,7 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "init-on-startup"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6003,7 +6003,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -6482,7 +6482,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -6514,7 +6514,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6535,7 +6535,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6581,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "argon2",
  "chrono",
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6636,7 +6636,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6691,7 +6691,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-web3"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -6752,7 +6752,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -6821,7 +6821,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -6912,7 +6912,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "axum 0.8.3",
@@ -6957,7 +6957,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -6972,7 +6972,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -6986,7 +6986,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7002,7 +7002,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "dill",
  "kamu-auth-rebac",
@@ -7011,7 +7011,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -7033,7 +7033,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7065,7 +7065,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7098,7 +7098,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "chrono",
  "dill",
@@ -7108,7 +7108,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-services"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7123,7 +7123,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -7315,7 +7315,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -7323,7 +7323,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "database-common",
  "indoc 2.0.6",
@@ -7336,7 +7336,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "database-common",
  "indoc 2.0.6",
@@ -7349,7 +7349,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -7379,7 +7379,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "indoc 2.0.6",
  "kamu-cli-e2e-common",
@@ -7391,7 +7391,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -7411,7 +7411,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7444,7 +7444,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -7464,7 +7464,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7489,7 +7489,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7510,7 +7510,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7533,7 +7533,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -7551,7 +7551,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7598,7 +7598,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7622,7 +7622,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7647,7 +7647,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7667,7 +7667,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -7702,7 +7702,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7739,7 +7739,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7761,7 +7761,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7827,7 +7827,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "chrono",
  "dill",
@@ -7840,7 +7840,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7859,7 +7859,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "chrono",
  "clap",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-openai"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -7903,7 +7903,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-qdrant"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "container-runtime",
@@ -7919,7 +7919,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-services"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -7940,7 +7940,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7978,7 +7978,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -8010,7 +8010,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8089,7 +8089,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-postgres"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8137,7 +8137,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-repo-tests"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -8154,7 +8154,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-services"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8191,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-sqlite"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8753,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8910,7 +8910,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -9275,7 +9275,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "axum 0.8.3",
@@ -9353,7 +9353,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -9368,7 +9368,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-data-utils"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -9393,7 +9393,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9418,7 +9418,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset-impl"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9457,7 +9457,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-metadata"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -9490,7 +9490,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9512,7 +9512,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-http"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9535,7 +9535,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-inmem"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9551,7 +9551,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-lfs"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9571,7 +9571,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-s3"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10737,7 +10737,7 @@ dependencies = [
 
 [[package]]
 name = "random-strings"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -11459,7 +11459,7 @@ checksum = "700de91d5fd6091442d00fdd9ee790af6d4f0f480562b0f5a1e8f59e90aafe73"
 
 [[package]]
 name = "s3-utils"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -11775,7 +11775,7 @@ dependencies = [
 
 [[package]]
 name = "server-console"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-graphql",
  "axum 0.8.3",
@@ -12748,7 +12748,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "axum 0.8.3",
  "container-runtime",
@@ -12883,7 +12883,7 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -13305,7 +13305,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.239.0"
+version = "0.240.0"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,132 +130,132 @@ resolver = "2"
 aws-sdk-s3 = "=1.68.0"
 
 # Apps
-kamu-cli = { version = "0.239.0", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.240.0", path = "src/app/cli", default-features = false }
 
 # Utils
-async-utils = { version = "0.239.0", path = "src/utils/async-utils", default-features = false }
-common-macros = { version = "0.239.0", path = "src/utils/common-macros", default-features = false }
-container-runtime = { version = "0.239.0", path = "src/utils/container-runtime", default-features = false }
-crypto-utils = { version = "0.239.0", path = "src/utils/crypto-utils", default-features = false }
-database-common = { version = "0.239.0", path = "src/utils/database-common", default-features = false }
-database-common-macros = { version = "0.239.0", path = "src/utils/database-common-macros", default-features = false }
-email-utils = { version = "0.239.0", path = "src/utils/email-utils", default-features = false }
-enum-variants = { version = "0.239.0", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.239.0", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.239.0", path = "src/utils/event-sourcing-macros", default-features = false }
-file-utils = { version = "0.239.0", path = "src/utils/file-utils", default-features = false }
-http-common = { version = "0.239.0", path = "src/utils/http-common", default-features = false }
-init-on-startup = { version = "0.239.0", path = "src/utils/init-on-startup", default-features = false }
-internal-error = { version = "0.239.0", path = "src/utils/internal-error", default-features = false }
-kamu-cli-puppet = { version = "0.239.0", path = "src/utils/kamu-cli-puppet", default-features = false }
-kamu-datafusion-cli = { version = "0.239.0", path = "src/utils/datafusion-cli", default-features = false }
-messaging-outbox = { version = "0.239.0", path = "src/utils/messaging-outbox", default-features = false }
-multiformats = { version = "0.239.0", path = "src/utils/multiformats", default-features = false }
-observability = { version = "0.239.0", path = "src/utils/observability", default-features = false }
-random-strings = { version = "0.239.0", path = "src/utils/random-strings", default-features = false }
-s3-utils = { version = "0.239.0", path = "src/utils/s3-utils", default-features = false }
-server-console = { version = "0.239.0", path = "src/utils/server-console", default-features = false }
-test-utils = { version = "0.239.0", path = "src/utils/test-utils", default-features = false }
-time-source = { version = "0.239.0", path = "src/utils/time-source", default-features = false }
-tracing-perfetto = { version = "0.239.0", path = "src/utils/tracing-perfetto", default-features = false }
+async-utils = { version = "0.240.0", path = "src/utils/async-utils", default-features = false }
+common-macros = { version = "0.240.0", path = "src/utils/common-macros", default-features = false }
+container-runtime = { version = "0.240.0", path = "src/utils/container-runtime", default-features = false }
+crypto-utils = { version = "0.240.0", path = "src/utils/crypto-utils", default-features = false }
+database-common = { version = "0.240.0", path = "src/utils/database-common", default-features = false }
+database-common-macros = { version = "0.240.0", path = "src/utils/database-common-macros", default-features = false }
+email-utils = { version = "0.240.0", path = "src/utils/email-utils", default-features = false }
+enum-variants = { version = "0.240.0", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.240.0", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.240.0", path = "src/utils/event-sourcing-macros", default-features = false }
+file-utils = { version = "0.240.0", path = "src/utils/file-utils", default-features = false }
+http-common = { version = "0.240.0", path = "src/utils/http-common", default-features = false }
+init-on-startup = { version = "0.240.0", path = "src/utils/init-on-startup", default-features = false }
+internal-error = { version = "0.240.0", path = "src/utils/internal-error", default-features = false }
+kamu-cli-puppet = { version = "0.240.0", path = "src/utils/kamu-cli-puppet", default-features = false }
+kamu-datafusion-cli = { version = "0.240.0", path = "src/utils/datafusion-cli", default-features = false }
+messaging-outbox = { version = "0.240.0", path = "src/utils/messaging-outbox", default-features = false }
+multiformats = { version = "0.240.0", path = "src/utils/multiformats", default-features = false }
+observability = { version = "0.240.0", path = "src/utils/observability", default-features = false }
+random-strings = { version = "0.240.0", path = "src/utils/random-strings", default-features = false }
+s3-utils = { version = "0.240.0", path = "src/utils/s3-utils", default-features = false }
+server-console = { version = "0.240.0", path = "src/utils/server-console", default-features = false }
+test-utils = { version = "0.240.0", path = "src/utils/test-utils", default-features = false }
+time-source = { version = "0.240.0", path = "src/utils/time-source", default-features = false }
+tracing-perfetto = { version = "0.240.0", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-kamu-accounts = { version = "0.239.0", path = "src/domain/accounts/domain", default-features = false }
-kamu-auth-rebac = { version = "0.239.0", path = "src/domain/auth-rebac/domain", default-features = false }
-kamu-auth-web3 = { version = "0.239.0", path = "src/domain/auth-web3/domain", default-features = false }
-kamu-core = { version = "0.239.0", path = "src/domain/core", default-features = false }
-kamu-datasets = { version = "0.239.0", path = "src/domain/datasets/domain", default-features = false }
-kamu-flow-system = { version = "0.239.0", path = "src/domain/flow-system/domain", default-features = false }
-kamu-search = { version = "0.239.0", path = "src/domain/search/domain", default-features = false }
-kamu-task-system = { version = "0.239.0", path = "src/domain/task-system/domain", default-features = false }
-kamu-webhooks = { version = "0.239.0", path = "src/domain/webhooks/domain", default-features = false }
+kamu-accounts = { version = "0.240.0", path = "src/domain/accounts/domain", default-features = false }
+kamu-auth-rebac = { version = "0.240.0", path = "src/domain/auth-rebac/domain", default-features = false }
+kamu-auth-web3 = { version = "0.240.0", path = "src/domain/auth-web3/domain", default-features = false }
+kamu-core = { version = "0.240.0", path = "src/domain/core", default-features = false }
+kamu-datasets = { version = "0.240.0", path = "src/domain/datasets/domain", default-features = false }
+kamu-flow-system = { version = "0.240.0", path = "src/domain/flow-system/domain", default-features = false }
+kamu-search = { version = "0.240.0", path = "src/domain/search/domain", default-features = false }
+kamu-task-system = { version = "0.240.0", path = "src/domain/task-system/domain", default-features = false }
+kamu-webhooks = { version = "0.240.0", path = "src/domain/webhooks/domain", default-features = false }
 
 ## Open Data Fabric
-odf = { version = "0.239.0", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
-odf-metadata = { version = "0.239.0", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
-odf-dataset = { version = "0.239.0", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
-odf-data-utils = { version = "0.239.0", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
-odf-dataset-impl = { version = "0.239.0", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
-odf-storage = { version = "0.239.0", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
-odf-storage-http = { version = "0.239.0", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
-odf-storage-inmem = { version = "0.239.0", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
-odf-storage-lfs = { version = "0.239.0", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
-odf-storage-s3 = { version = "0.239.0", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
+odf = { version = "0.240.0", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
+odf-metadata = { version = "0.240.0", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
+odf-dataset = { version = "0.240.0", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
+odf-data-utils = { version = "0.240.0", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
+odf-dataset-impl = { version = "0.240.0", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
+odf-storage = { version = "0.240.0", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
+odf-storage-http = { version = "0.240.0", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
+odf-storage-inmem = { version = "0.240.0", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
+odf-storage-lfs = { version = "0.240.0", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
+odf-storage-s3 = { version = "0.240.0", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.239.0", path = "src/domain/accounts/services", default-features = false }
-kamu-auth-rebac-services = { version = "0.239.0", path = "src/domain/auth-rebac/services", default-features = false }
-kamu-auth-web3-services = { version = "0.239.0", path = "src/domain/auth-web3/services", default-features = false }
-kamu-datasets-services = { version = "0.239.0", path = "src/domain/datasets/services", default-features = false, features = ["lfs", "s3"] }
-kamu-flow-system-services = { version = "0.239.0", path = "src/domain/flow-system/services", default-features = false }
-kamu-search-services = { version = "0.239.0", path = "src/domain/search/services", default-features = false }
-kamu-task-system-services = { version = "0.239.0", path = "src/domain/task-system/services", default-features = false }
-kamu-webhooks-services = { version = "0.239.0", path = "src/domain/webhooks/services", default-features = false }
+kamu-accounts-services = { version = "0.240.0", path = "src/domain/accounts/services", default-features = false }
+kamu-auth-rebac-services = { version = "0.240.0", path = "src/domain/auth-rebac/services", default-features = false }
+kamu-auth-web3-services = { version = "0.240.0", path = "src/domain/auth-web3/services", default-features = false }
+kamu-datasets-services = { version = "0.240.0", path = "src/domain/datasets/services", default-features = false, features = ["lfs", "s3"] }
+kamu-flow-system-services = { version = "0.240.0", path = "src/domain/flow-system/services", default-features = false }
+kamu-search-services = { version = "0.240.0", path = "src/domain/search/services", default-features = false }
+kamu-task-system-services = { version = "0.240.0", path = "src/domain/task-system/services", default-features = false }
+kamu-webhooks-services = { version = "0.240.0", path = "src/domain/webhooks/services", default-features = false }
 
 # Infra
-kamu = { version = "0.239.0", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.239.0", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.240.0", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.240.0", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.239.0", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.239.0", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.239.0", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.239.0", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.240.0", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.240.0", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.240.0", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.240.0", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.239.0", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.239.0", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.239.0", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.239.0", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.239.0", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.240.0", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.240.0", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.240.0", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.240.0", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.240.0", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Datasets
-kamu-datasets-inmem = { version = "0.239.0", path = "src/infra/datasets/inmem", default-features = false }
-kamu-datasets-postgres = { version = "0.239.0", path = "src/infra/datasets/postgres", default-features = false }
-kamu-datasets-sqlite = { version = "0.239.0", path = "src/infra/datasets/sqlite", default-features = false }
-kamu-datasets-repo-tests = { version = "0.239.0", path = "src/infra/datasets/repo-tests", default-features = false }
+kamu-datasets-inmem = { version = "0.240.0", path = "src/infra/datasets/inmem", default-features = false }
+kamu-datasets-postgres = { version = "0.240.0", path = "src/infra/datasets/postgres", default-features = false }
+kamu-datasets-sqlite = { version = "0.240.0", path = "src/infra/datasets/sqlite", default-features = false }
+kamu-datasets-repo-tests = { version = "0.240.0", path = "src/infra/datasets/repo-tests", default-features = false }
 ## Search
-kamu-search-openai = { version = "0.239.0", path = "src/infra/search/openai", default-features = false }
-kamu-search-qdrant = { version = "0.239.0", path = "src/infra/search/qdrant", default-features = false }
+kamu-search-openai = { version = "0.240.0", path = "src/infra/search/openai", default-features = false }
+kamu-search-qdrant = { version = "0.240.0", path = "src/infra/search/qdrant", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.239.0", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.239.0", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.239.0", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.239.0", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.240.0", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.240.0", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.240.0", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.240.0", path = "src/infra/task-system/repo-tests", default-features = false }
 ## ReBAC
-kamu-auth-rebac-inmem = { version = "0.239.0", path = "src/infra/auth-rebac/inmem", default-features = false }
-kamu-auth-rebac-repo-tests = { version = "0.239.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
-kamu-auth-rebac-postgres = { version = "0.239.0", path = "src/infra/auth-rebac/postgres", default-features = false }
-kamu-auth-rebac-sqlite = { version = "0.239.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
+kamu-auth-rebac-inmem = { version = "0.240.0", path = "src/infra/auth-rebac/inmem", default-features = false }
+kamu-auth-rebac-repo-tests = { version = "0.240.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
+kamu-auth-rebac-postgres = { version = "0.240.0", path = "src/infra/auth-rebac/postgres", default-features = false }
+kamu-auth-rebac-sqlite = { version = "0.240.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
 ## Outbox
-kamu-messaging-outbox-inmem = { version = "0.239.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
-kamu-messaging-outbox-postgres = { version = "0.239.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
-kamu-messaging-outbox-sqlite = { version = "0.239.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
-kamu-messaging-outbox-repo-tests = { version = "0.239.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
+kamu-messaging-outbox-inmem = { version = "0.240.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
+kamu-messaging-outbox-postgres = { version = "0.240.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
+kamu-messaging-outbox-sqlite = { version = "0.240.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
+kamu-messaging-outbox-repo-tests = { version = "0.240.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
 ## Webhooks
-kamu-webhooks-inmem = { version = "0.239.0", path = "src/infra/webhooks/inmem", default-features = false }
-kamu-webhooks-postgres = { version = "0.239.0", path = "src/infra/webhooks/postgres", default-features = false }
-kamu-webhooks-sqlite = { version = "0.239.0", path = "src/infra/webhooks/sqlite", default-features = false }
-kamu-webhooks-repo-tests = { version = "0.239.0", path = "src/infra/webhooks/repo-tests", default-features = false }
+kamu-webhooks-inmem = { version = "0.240.0", path = "src/infra/webhooks/inmem", default-features = false }
+kamu-webhooks-postgres = { version = "0.240.0", path = "src/infra/webhooks/postgres", default-features = false }
+kamu-webhooks-sqlite = { version = "0.240.0", path = "src/infra/webhooks/sqlite", default-features = false }
+kamu-webhooks-repo-tests = { version = "0.240.0", path = "src/infra/webhooks/repo-tests", default-features = false }
 ## Web3
-kamu-auth-web3-inmem = { version = "0.239.0", path = "src/infra/auth-web3/inmem", default-features = false }
-kamu-auth-web3-postgres = { version = "0.239.0", path = "src/infra/auth-web3/postgres", default-features = false }
-kamu-auth-web3-repo-tests = { version = "0.239.0", path = "src/infra/auth-web3/repo-tests", default-features = false }
-kamu-auth-web3-sqlite = { version = "0.239.0", path = "src/infra/auth-web3/sqlite", default-features = false }
+kamu-auth-web3-inmem = { version = "0.240.0", path = "src/infra/auth-web3/inmem", default-features = false }
+kamu-auth-web3-postgres = { version = "0.240.0", path = "src/infra/auth-web3/postgres", default-features = false }
+kamu-auth-web3-repo-tests = { version = "0.240.0", path = "src/infra/auth-web3/repo-tests", default-features = false }
+kamu-auth-web3-sqlite = { version = "0.240.0", path = "src/infra/auth-web3/sqlite", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso-rebac = { version = "0.239.0", path = "src/adapter/auth-oso-rebac", default-features = false }
-kamu-adapter-auth-web3 = { version = "0.239.0", path = "src/adapter/auth-web3", default-features = false }
-kamu-adapter-flight-sql = { version = "0.239.0", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-graphql = { version = "0.239.0", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.239.0", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.239.0", path = "src/adapter/odata", default-features = false }
-kamu-adapter-oauth = { version = "0.239.0", path = "src/adapter/oauth", default-features = false }
+kamu-adapter-auth-oso-rebac = { version = "0.240.0", path = "src/adapter/auth-oso-rebac", default-features = false }
+kamu-adapter-auth-web3 = { version = "0.240.0", path = "src/adapter/auth-web3", default-features = false }
+kamu-adapter-flight-sql = { version = "0.240.0", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-graphql = { version = "0.240.0", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.240.0", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.240.0", path = "src/adapter/odata", default-features = false }
+kamu-adapter-oauth = { version = "0.240.0", path = "src/adapter/oauth", default-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.239.0", path = "src/e2e/app/cli/common", default-features = false }
-kamu-cli-e2e-common-macros = { version = "0.239.0", path = "src/e2e/app/cli/common-macros", default-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.239.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
+kamu-cli-e2e-common = { version = "0.240.0", path = "src/e2e/app/cli/common", default-features = false }
+kamu-cli-e2e-common-macros = { version = "0.240.0", path = "src/e2e/app/cli/common-macros", default-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.240.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
 
 [workspace.package]
-version = "0.239.0"
+version = "0.240.0"
 edition = "2024"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.239.0
+Licensed Work:             Kamu CLI Version 0.240.0
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2029-05-26
+Change Date:               2029-06-02
 
 Change License:            Apache License, Version 2.0
 

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -971,7 +971,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.239.0"
+    "version": "0.240.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -971,7 +971,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.239.0"
+    "version": "0.240.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## [0.240.0] - 2025-06-02
### Added
- `kamu --show-error-stack-trace`: Added an argument to show stack trace in case of an error during command execution.
- Implemented a new authorization provider for Web3 EVM-based wallets (`web3-wallet`):
  - Flow authorization is based on the ERC-4361 (Sign-In with Ethereum) standard.
  - Any browser that supports EIP-1193 (Ethereum Provider JavaScript API) can be used for authentication.
  - Signature verification is based on ERC-191 (Signed Data Standard).
### Changed
- GQL: search also matches entries by account name.
- GQL: `Account::account_provider()` returns `AccountProvider` instead of string.
- GQL: `Auth::enabled_login_methods()` renamed to `Auth::enabled_providers()` returns `Vec<AccountProvider>`.
- GQL: `AuthMut::login()` takes `AccountProvider` as argument instead of string.