### PR TITLE
Added missing length validation for webhook subscription labels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## [Unreleased]
+### Fixed
+- Missing length validation for webhook subscription labels.
+
 ## [0.240.1] - 2025-06-04
 ### Changed
 - Updated `sqlx` crate to `0.8.6`, Vol. 2.

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -3921,13 +3921,15 @@ scalar WebhookSubscriptionID
 input WebhookSubscriptionInput {
 	targetUrl: URL!
 	eventTypes: [WebhookEventType!]!
-	label: WebhookSubscriptionlabel!
+	label: WebhookSubscriptionLabel!
 }
 
 type WebhookSubscriptionInvalidTargetUrl implements CreateWebhookSubscriptionResult & UpdateWebhookSubscriptionResult {
 	innerMessage: String!
 	message: String!
 }
+
+scalar WebhookSubscriptionLabel
 
 type WebhookSubscriptionMut {
 	update(input: WebhookSubscriptionInput!): UpdateWebhookSubscriptionResult!
@@ -3948,8 +3950,6 @@ enum WebhookSubscriptionStatus {
 	UNREACHABLE
 	REMOVED
 }
-
-scalar WebhookSubscriptionlabel
 
 type Webhooks {
 	"""

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -3921,7 +3921,7 @@ scalar WebhookSubscriptionID
 input WebhookSubscriptionInput {
 	targetUrl: URL!
 	eventTypes: [WebhookEventType!]!
-	label: String!
+	label: WebhookSubscriptionlabel!
 }
 
 type WebhookSubscriptionInvalidTargetUrl implements CreateWebhookSubscriptionResult & UpdateWebhookSubscriptionResult {
@@ -3948,6 +3948,8 @@ enum WebhookSubscriptionStatus {
 	UNREACHABLE
 	REMOVED
 }
+
+scalar WebhookSubscriptionlabel
 
 type Webhooks {
 	"""

--- a/src/adapter/graphql/src/mutations/webhooks_mut/dataset_webhooks_mut.rs
+++ b/src/adapter/graphql/src/mutations/webhooks_mut/dataset_webhooks_mut.rs
@@ -123,7 +123,7 @@ impl<'a> DatasetWebhooksMut<'a> {
 pub struct WebhookSubscriptionInput {
     pub target_url: GqlUrl,
     pub event_types: Vec<WebhookEventType>,
-    pub label: WebhookSubscriptionlabel,
+    pub label: WebhookSubscriptionLabel,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/mutations/webhooks_mut/dataset_webhooks_mut.rs
+++ b/src/adapter/graphql/src/mutations/webhooks_mut/dataset_webhooks_mut.rs
@@ -54,7 +54,7 @@ impl<'a> DatasetWebhooksMut<'a> {
                     .into_iter()
                     .map(|et| kamu_webhooks::WebhookEventType::try_new(et.0).unwrap())
                     .collect::<Vec<_>>(),
-                kamu_webhooks::WebhookSubscriptionLabel::new(&input.label),
+                input.label.0.clone(),
             )
             .await
         {
@@ -81,7 +81,9 @@ impl<'a> DatasetWebhooksMut<'a> {
 
             Err(kamu_webhooks::CreateWebhookSubscriptionError::DuplicateLabel(_)) => {
                 Ok(CreateWebhookSubscriptionResult::DuplicateLabel(
-                    WebhookSubscriptionDuplicateLabel { label: input.label },
+                    WebhookSubscriptionDuplicateLabel {
+                        label: input.label.0.to_string(),
+                    },
                 ))
             }
 
@@ -121,7 +123,7 @@ impl<'a> DatasetWebhooksMut<'a> {
 pub struct WebhookSubscriptionInput {
     pub target_url: GqlUrl,
     pub event_types: Vec<WebhookEventType>,
-    pub label: String,
+    pub label: WebhookSubscriptionlabel,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/mutations/webhooks_mut/webhook_subscription_mut.rs
+++ b/src/adapter/graphql/src/mutations/webhooks_mut/webhook_subscription_mut.rs
@@ -51,7 +51,7 @@ impl WebhookSubscriptionMut {
                     .into_iter()
                     .map(|et| kamu_webhooks::WebhookEventType::try_new(et.0).unwrap())
                     .collect::<Vec<_>>(),
-                kamu_webhooks::WebhookSubscriptionLabel::new(&input.label),
+                input.label.0.clone(),
             )
             .await
         {
@@ -83,7 +83,9 @@ impl WebhookSubscriptionMut {
 
             Err(kamu_webhooks::UpdateWebhookSubscriptionError::DuplicateLabel(_)) => {
                 Ok(UpdateWebhookSubscriptionResult::DuplicateLabel(
-                    WebhookSubscriptionDuplicateLabel { label: input.label },
+                    WebhookSubscriptionDuplicateLabel {
+                        label: input.label.0.to_string(),
+                    },
                 ))
             }
 

--- a/src/adapter/graphql/src/scalars/webhook_scalars.rs
+++ b/src/adapter/graphql/src/scalars/webhook_scalars.rs
@@ -70,23 +70,23 @@ impl ScalarType for WebhookEventType {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WebhookSubscriptionlabel(pub kamu_webhooks::WebhookSubscriptionLabel);
+pub struct WebhookSubscriptionLabel(pub kamu_webhooks::WebhookSubscriptionLabel);
 
-impl FromStr for WebhookSubscriptionlabel {
+impl FromStr for WebhookSubscriptionLabel {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         kamu_webhooks::WebhookSubscriptionLabel::try_new(s)
-            .map(WebhookSubscriptionlabel)
+            .map(WebhookSubscriptionLabel)
             .map_err(|e| e.to_string())
     }
 }
 
 #[Scalar()]
-impl ScalarType for WebhookSubscriptionlabel {
+impl ScalarType for WebhookSubscriptionLabel {
     fn parse(value: Value) -> InputValueResult<Self> {
         if let Value::String(s) = &value {
-            WebhookSubscriptionlabel::from_str(s).map_err(InputValueError::custom)
+            WebhookSubscriptionLabel::from_str(s).map_err(InputValueError::custom)
         } else {
             Err(InputValueError::expected_type(value))
         }

--- a/src/adapter/graphql/src/scalars/webhook_scalars.rs
+++ b/src/adapter/graphql/src/scalars/webhook_scalars.rs
@@ -68,3 +68,33 @@ impl ScalarType for WebhookEventType {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebhookSubscriptionlabel(pub kamu_webhooks::WebhookSubscriptionLabel);
+
+impl FromStr for WebhookSubscriptionlabel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        kamu_webhooks::WebhookSubscriptionLabel::try_new(s)
+            .map(WebhookSubscriptionlabel)
+            .map_err(|e| e.to_string())
+    }
+}
+
+#[Scalar()]
+impl ScalarType for WebhookSubscriptionlabel {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        if let Value::String(s) = &value {
+            WebhookSubscriptionlabel::from_str(s).map_err(InputValueError::custom)
+        } else {
+            Err(InputValueError::expected_type(value))
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.0.to_string())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/tests/tests/test_gql_webhook_subscriptions.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_webhook_subscriptions.rs
@@ -416,6 +416,111 @@ async fn test_duplicate_labels() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[test_log::test(tokio::test)]
+async fn test_empty_labels_arent_duplicates() {
+    let harness = WebhookSubscriptiuonsHarness::new().await;
+    let create_result = harness.create_root_dataset("foo").await;
+
+    let schema = kamu_adapter_graphql::schema_quiet();
+
+    let res = schema
+        .execute(
+            async_graphql::Request::new(
+                WebhookSubscriptiuonsHarness::create_subscription_mutation(),
+            )
+            .variables(async_graphql::Variables::from_json(json!({
+                "datasetId": create_result.dataset_handle.id.to_string(),
+                "targetUrl": "https://example.com/webhook/1",
+                "eventTypes": [kamu_webhooks::WebhookEventTypeCatalog::DATASET_REF_UPDATED],
+                "label": "",
+            })))
+            .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(res.is_ok(), "{res:?}");
+
+    let res = schema
+        .execute(
+            async_graphql::Request::new(
+                WebhookSubscriptiuonsHarness::create_subscription_mutation(),
+            )
+            .variables(async_graphql::Variables::from_json(json!({
+                "datasetId": create_result.dataset_handle.id.to_string(),
+                "targetUrl": "https://example.com/webhook/2",
+                "eventTypes": [kamu_webhooks::WebhookEventTypeCatalog::DATASET_REF_UPDATED],
+                "label": "",
+            })))
+            .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(res.is_ok());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_label_length_validation() {
+    let harness = WebhookSubscriptiuonsHarness::new().await;
+    let create_result = harness.create_root_dataset("foo").await;
+
+    let schema = kamu_adapter_graphql::schema_quiet();
+
+    let res = schema
+        .execute(
+            async_graphql::Request::new(
+                WebhookSubscriptiuonsHarness::create_subscription_mutation(),
+            )
+            .variables(async_graphql::Variables::from_json(json!({
+                "datasetId": create_result.dataset_handle.id.to_string(),
+                "targetUrl": "https://example.com/webhook",
+                "eventTypes": [kamu_webhooks::WebhookEventTypeCatalog::DATASET_REF_UPDATED],
+                "label": "My Very Very Very Very Very Very Very Long Webhook Subscription Label That Exceeds The Maximum Length",
+            })))
+            .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(res.is_err(), "{res:?}");
+
+    let errors = res.errors;
+    assert_eq!(errors.len(), 1);
+    assert!(errors[0].message.contains(
+        "WebhookSubscriptionLabel is too long. The value length must be less than 100 character(s)"
+    ),);
+
+    assert_eq!(
+        errors[0].path,
+        &[
+            PathSegment::Field("datasets".into()),
+            PathSegment::Field("byId".into()),
+            PathSegment::Field("webhooks".into()),
+            PathSegment::Field("createSubscription".into()),
+        ],
+    );
+
+    let res = schema
+        .execute(
+            async_graphql::Request::new(
+                WebhookSubscriptiuonsHarness::create_subscription_mutation(),
+            )
+            .variables(async_graphql::Variables::from_json(json!({
+                "datasetId": create_result.dataset_handle.id.to_string(),
+                "targetUrl": "https://example.com/webhook",
+                "eventTypes": [kamu_webhooks::WebhookEventTypeCatalog::DATASET_REF_UPDATED],
+                // Exactly 100 characters
+                "label": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            })))
+            .data(harness.catalog_authorized.clone()),
+        )
+        .await;
+
+    assert!(res.is_ok(), "{res:?}");
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
 async fn test_update_subscription() {
     let harness = WebhookSubscriptiuonsHarness::new().await;
     let create_result = harness.create_root_dataset("foo").await;

--- a/src/domain/webhooks/domain/src/entities/webhook_subscription/webhook_subscription_label.rs
+++ b/src/domain/webhooks/domain/src/entities/webhook_subscription/webhook_subscription_label.rs
@@ -14,6 +14,7 @@ use nutype::nutype;
 // Note: empty label is fine
 #[nutype(
     sanitize(trim),
+    validate(len_char_max = 100,),
     derive(Debug, Display, AsRef, Clone, Eq, PartialEq, Serialize, Deserialize)
 )]
 pub struct WebhookSubscriptionLabel(String);

--- a/src/domain/webhooks/services/tests/tests/services/test_webhook_dataset_removal_handler.rs
+++ b/src/domain/webhooks/services/tests/tests/services/test_webhook_dataset_removal_handler.rs
@@ -29,7 +29,7 @@ async fn test_subscriptions_removed_with_dataset() {
         let mut subscription_id_1_1 = WebhookSubscription::new(
             WebhookSubscriptionID::new(uuid::Uuid::new_v4()),
             url::Url::parse("https://example.com/webhook/1/1").unwrap(),
-            WebhookSubscriptionLabel::new(""),
+            WebhookSubscriptionLabel::try_new("").unwrap(),
             Some(dataset_id_1.clone()),
             vec![WebhookEventTypeCatalog::dataset_ref_updated()],
             WebhookSubscriptionSecret::try_new("secret_1_1").unwrap(),
@@ -44,7 +44,7 @@ async fn test_subscriptions_removed_with_dataset() {
         let mut subscription_id_1_2 = WebhookSubscription::new(
             WebhookSubscriptionID::new(uuid::Uuid::new_v4()),
             url::Url::parse("https://example.com/webhook/1/2").unwrap(),
-            WebhookSubscriptionLabel::new(""),
+            WebhookSubscriptionLabel::try_new("").unwrap(),
             Some(dataset_id_1.clone()),
             vec![WebhookEventTypeCatalog::dataset_ref_updated()],
             WebhookSubscriptionSecret::try_new("secret_1_2").unwrap(),
@@ -59,7 +59,7 @@ async fn test_subscriptions_removed_with_dataset() {
         let mut subscription_id_2 = WebhookSubscription::new(
             WebhookSubscriptionID::new(uuid::Uuid::new_v4()),
             url::Url::parse("https://example.com/webhook/2").unwrap(),
-            WebhookSubscriptionLabel::new(""),
+            WebhookSubscriptionLabel::try_new("").unwrap(),
             Some(dataset_id_2.clone()),
             vec![WebhookEventTypeCatalog::dataset_ref_updated()],
             WebhookSubscriptionSecret::try_new("secret_2").unwrap(),

--- a/src/domain/webhooks/services/tests/tests/services/test_webhook_delivery_scheduler.rs
+++ b/src/domain/webhooks/services/tests/tests/services/test_webhook_delivery_scheduler.rs
@@ -190,7 +190,7 @@ async fn test_subscription_non_matching_event_type() {
         let mut subscription = WebhookSubscription::new(
             subscription_id,
             url::Url::parse("https://example.com/webhook/").unwrap(),
-            WebhookSubscriptionLabel::new(""),
+            WebhookSubscriptionLabel::try_new("").unwrap(),
             Some(dataset_id.clone()),
             vec![WebhookEventTypeCatalog::test()],
             WebhookSubscriptionSecret::try_new("secret").unwrap(),
@@ -285,7 +285,7 @@ impl TestWebhookDeliverySchedulerHarness {
         let mut subscription = WebhookSubscription::new(
             subscription_id,
             url::Url::parse("https://example.com/webhook/").unwrap(),
-            WebhookSubscriptionLabel::new(""),
+            WebhookSubscriptionLabel::try_new("").unwrap(),
             Some(dataset_id.clone()),
             vec![WebhookEventTypeCatalog::dataset_ref_updated()],
             WebhookSubscriptionSecret::try_new("secret").unwrap(),

--- a/src/domain/webhooks/services/tests/tests/services/test_webhook_delivery_worker_impl.rs
+++ b/src/domain/webhooks/services/tests/tests/services/test_webhook_delivery_worker_impl.rs
@@ -161,7 +161,7 @@ impl TestWebhookDeliveryWorkerHarness {
         let mut subscription = WebhookSubscription::new(
             subscription_id,
             Url::parse("https://example.com/webhook").unwrap(),
-            WebhookSubscriptionLabel::new("test".to_string()),
+            WebhookSubscriptionLabel::try_new("test".to_string()).unwrap(),
             None,
             vec![WebhookEventTypeCatalog::test()],
             WebhookSubscriptionSecret::try_new("some-secret").unwrap(),

--- a/src/domain/webhooks/services/tests/tests/use_cases/test_create_webhook_subscription_use_case.rs
+++ b/src/domain/webhooks/services/tests/tests/use_cases/test_create_webhook_subscription_use_case.rs
@@ -34,7 +34,7 @@ async fn test_create_in_dataset_success() {
             Some(dataset_id),
             url::Url::parse("https://example.com").unwrap(),
             vec![WebhookEventTypeCatalog::test()],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
     assert!(res.is_ok(), "Failed to create subscription: {res:?}",);
@@ -63,7 +63,7 @@ async fn test_invalid_target_url_rejected() {
                 Some(dataset_id.clone()),
                 url::Url::parse(invalid_url).unwrap(),
                 vec![WebhookEventTypeCatalog::test()],
-                WebhookSubscriptionLabel::new("test_label"),
+                WebhookSubscriptionLabel::try_new("test_label").unwrap(),
             )
             .await;
         assert_matches!(
@@ -87,7 +87,7 @@ async fn test_no_event_types_rejected() {
             Some(dataset_id.clone()),
             url::Url::parse("https://example.com/webhook").unwrap(),
             vec![],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
     assert_matches!(
@@ -113,7 +113,7 @@ async fn test_event_types_deduplicated() {
                 WebhookEventTypeCatalog::test(),
                 WebhookEventTypeCatalog::test(),
             ],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
     assert!(res.is_ok(), "Failed to create subscription: {res:?}",);
@@ -148,7 +148,7 @@ async fn test_label_unique_in_dataset() {
             Some(dataset_id_1.clone()),
             url::Url::parse("https://example.com/webhook/1").unwrap(),
             vec![WebhookEventTypeCatalog::test()],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
     assert!(res.is_ok(), "Failed to create subscription: {res:?}",);
@@ -160,7 +160,7 @@ async fn test_label_unique_in_dataset() {
             Some(dataset_id_1),
             url::Url::parse("https://example.com/webhook/2").unwrap(),
             vec![WebhookEventTypeCatalog::test()],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
     assert_matches!(
@@ -176,7 +176,7 @@ async fn test_label_unique_in_dataset() {
             Some(dataset_id_2),
             url::Url::parse("https://example.com/webhook/3").unwrap(),
             vec![WebhookEventTypeCatalog::test()],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
     assert!(res.is_ok(), "Failed to create subscription: {res:?}",);

--- a/src/domain/webhooks/services/tests/tests/use_cases/test_update_webhook_subscription_use_case.rs
+++ b/src/domain/webhooks/services/tests/tests/use_cases/test_update_webhook_subscription_use_case.rs
@@ -33,7 +33,7 @@ async fn test_update_in_dataset_success() {
             &mut subscription,
             url::Url::parse("https://example.com/updated").unwrap(),
             vec![WebhookEventTypeCatalog::dataset_ref_updated()],
-            WebhookSubscriptionLabel::new("test_label_updated"),
+            WebhookSubscriptionLabel::try_new("test_label_updated").unwrap(),
         )
         .await;
     assert!(res.is_ok(), "Failed to update subscription: {res:?}",);
@@ -71,7 +71,7 @@ async fn test_invalid_target_url_rejected() {
                 &mut subscription,
                 url::Url::parse(invalid_url).unwrap(),
                 vec![WebhookEventTypeCatalog::test()],
-                WebhookSubscriptionLabel::new("test_label"),
+                WebhookSubscriptionLabel::try_new("test_label").unwrap(),
             )
             .await;
 
@@ -95,7 +95,7 @@ async fn test_no_event_types_rejected() {
             &mut subscription,
             url::Url::parse("https://example.com").unwrap(),
             vec![],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
 
@@ -121,7 +121,7 @@ async fn test_event_types_deduplicated() {
                 WebhookEventTypeCatalog::test(),
                 WebhookEventTypeCatalog::test(),
             ],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
     assert!(res.is_ok(), "Failed to update subscription: {res:?}",);
@@ -149,19 +149,19 @@ async fn test_label_unique_in_dataset() {
     let _subscription_1_1 = harness
         .create_subscription_in_dataset(
             dataset_id_1.clone(),
-            Some(WebhookSubscriptionLabel::new("test-label-1")),
+            Some(WebhookSubscriptionLabel::try_new("test-label-1").unwrap()),
         )
         .await;
     let mut subscription_1_2 = harness
         .create_subscription_in_dataset(
             dataset_id_1,
-            Some(WebhookSubscriptionLabel::new("test-label-2")),
+            Some(WebhookSubscriptionLabel::try_new("test-label-2").unwrap()),
         )
         .await;
     let _subscription_2 = harness
         .create_subscription_in_dataset(
             dataset_id_2,
-            Some(WebhookSubscriptionLabel::new("test-label-another")),
+            Some(WebhookSubscriptionLabel::try_new("test-label-another").unwrap()),
         )
         .await;
 
@@ -171,7 +171,7 @@ async fn test_label_unique_in_dataset() {
             &mut subscription_1_2,
             url::Url::parse("https://example.com/webhook/2").unwrap(),
             vec![WebhookEventTypeCatalog::test()],
-            WebhookSubscriptionLabel::new("test-label-1"),
+            WebhookSubscriptionLabel::try_new("test-label-1").unwrap(),
         )
         .await;
     assert_matches!(
@@ -186,7 +186,7 @@ async fn test_label_unique_in_dataset() {
             &mut subscription_1_2,
             url::Url::parse("https://example.com/webhook/2").unwrap(),
             vec![WebhookEventTypeCatalog::test()],
-            WebhookSubscriptionLabel::new("test-label-another"),
+            WebhookSubscriptionLabel::try_new("test-label-another").unwrap(),
         )
         .await;
     assert!(res.is_ok(), "Failed to update subscription: {res:?}",);
@@ -206,7 +206,7 @@ async fn test_update_unexpected() {
             &mut subscription,
             url::Url::parse("https://example.com").unwrap(),
             vec![WebhookEventTypeCatalog::test()],
-            WebhookSubscriptionLabel::new("test_label"),
+            WebhookSubscriptionLabel::try_new("test_label").unwrap(),
         )
         .await;
 

--- a/src/domain/webhooks/services/tests/tests/use_cases/webhook_subscription_use_case_harness.rs
+++ b/src/domain/webhooks/services/tests/tests/use_cases/webhook_subscription_use_case_harness.rs
@@ -54,7 +54,7 @@ impl WebhookSubscriptionUseCaseHarness {
         let mut subscription = WebhookSubscription::new(
             WebhookSubscriptionID::new(uuid::Uuid::new_v4()),
             url::Url::parse("https://example.com/webhook").unwrap(),
-            label.unwrap_or_else(|| WebhookSubscriptionLabel::new("test_label")),
+            label.unwrap_or_else(|| WebhookSubscriptionLabel::try_new("test_label").unwrap()),
             Some(dataset_id),
             vec![WebhookEventTypeCatalog::test()],
             WebhookSubscriptionSecret::try_new("secret").unwrap(),

--- a/src/infra/webhooks/repo-tests/src/helpers.rs
+++ b/src/infra/webhooks/repo-tests/src/helpers.rs
@@ -76,7 +76,7 @@ pub(crate) async fn new_webhook_subscription(catalog: &dill::Catalog) -> Webhook
     let mut webhook_subscription = WebhookSubscription::new(
         webhook_subscription_id,
         Url::parse("https://example.com").unwrap(),
-        WebhookSubscriptionLabel::new("test".to_string()),
+        WebhookSubscriptionLabel::try_new("test".to_string()).unwrap(),
         None,
         vec![WebhookEventTypeCatalog::test()],
         WebhookSubscriptionSecret::try_new("some-secret").unwrap(),

--- a/src/infra/webhooks/repo-tests/src/webhook_subscription_event_store_test_suite.rs
+++ b/src/infra/webhooks/repo-tests/src/webhook_subscription_event_store_test_suite.rs
@@ -46,7 +46,7 @@ pub async fn test_no_events_initially(catalog: &dill::Catalog) {
     let res = event_store
         .find_subscription_id_by_dataset_and_label(
             &dataset_id,
-            &WebhookSubscriptionLabel::new("test-label"),
+            &WebhookSubscriptionLabel::try_new("test-label").unwrap(),
         )
         .await;
     assert_matches!(res, Ok(id) if id.is_none());
@@ -74,7 +74,7 @@ pub async fn test_store_single_aggregate(catalog: &dill::Catalog) {
     let mut subscription = WebhookSubscription::new(
         subscription_id,
         Url::parse("https://example.com").unwrap(),
-        WebhookSubscriptionLabel::new("test-label"),
+        WebhookSubscriptionLabel::try_new("test-label").unwrap(),
         Some(dataset_id.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret").unwrap(),
@@ -121,7 +121,7 @@ pub async fn test_store_single_aggregate(catalog: &dill::Catalog) {
     let res = event_store
         .find_subscription_id_by_dataset_and_label(
             &dataset_id,
-            &WebhookSubscriptionLabel::new("test-label"),
+            &WebhookSubscriptionLabel::try_new("test-label").unwrap(),
         )
         .await;
     assert_matches!(res, Ok(id) if id.is_some() && id.unwrap() == subscription_id);
@@ -129,7 +129,7 @@ pub async fn test_store_single_aggregate(catalog: &dill::Catalog) {
     let res = event_store
         .find_subscription_id_by_dataset_and_label(
             &dataset_id,
-            &WebhookSubscriptionLabel::new("wrong-label"),
+            &WebhookSubscriptionLabel::try_new("wrong-label").unwrap(),
         )
         .await;
     assert_matches!(res, Ok(id) if id.is_none());
@@ -169,7 +169,7 @@ pub async fn test_store_multiple_aggregates(catalog: &dill::Catalog) {
     let mut subscription_1 = WebhookSubscription::new(
         subscription_id_1,
         Url::parse("https://example.com/1").unwrap(),
-        WebhookSubscriptionLabel::new("label-1"),
+        WebhookSubscriptionLabel::try_new("label-1").unwrap(),
         Some(dataset_id.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_1").unwrap(),
@@ -180,7 +180,7 @@ pub async fn test_store_multiple_aggregates(catalog: &dill::Catalog) {
     let mut subscription_2 = WebhookSubscription::new(
         subscription_id_2,
         target_url_2,
-        WebhookSubscriptionLabel::new("label-2"),
+        WebhookSubscriptionLabel::try_new("label-2").unwrap(),
         Some(dataset_id.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_2").unwrap(),
@@ -193,7 +193,7 @@ pub async fn test_store_multiple_aggregates(catalog: &dill::Catalog) {
     let mut subscription_3 = WebhookSubscription::new(
         subscription_id_3,
         Url::parse("https://example.com/3").unwrap(),
-        WebhookSubscriptionLabel::new("label-3"),
+        WebhookSubscriptionLabel::try_new("label-3").unwrap(),
         Some(dataset_id.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_3").unwrap(),
@@ -285,7 +285,7 @@ pub async fn test_store_multiple_aggregates(catalog: &dill::Catalog) {
     let res = event_store
         .find_subscription_id_by_dataset_and_label(
             &dataset_id,
-            &WebhookSubscriptionLabel::new("label-1"),
+            &WebhookSubscriptionLabel::try_new("label-1").unwrap(),
         )
         .await;
     assert_matches!(res, Ok(id) if id.is_some() && id.unwrap() == subscription_id_1);
@@ -293,7 +293,7 @@ pub async fn test_store_multiple_aggregates(catalog: &dill::Catalog) {
     let res = event_store
         .find_subscription_id_by_dataset_and_label(
             &dataset_id,
-            &WebhookSubscriptionLabel::new("label-2"),
+            &WebhookSubscriptionLabel::try_new("label-2").unwrap(),
         )
         .await;
     assert_matches!(res, Ok(id) if id.is_some() && id.unwrap() == subscription_id_2);
@@ -301,7 +301,7 @@ pub async fn test_store_multiple_aggregates(catalog: &dill::Catalog) {
     let res = event_store
         .find_subscription_id_by_dataset_and_label(
             &dataset_id,
-            &WebhookSubscriptionLabel::new("label-3"),
+            &WebhookSubscriptionLabel::try_new("label-3").unwrap(),
         )
         .await;
     assert_matches!(res, Ok(id) if id.is_some() && id.unwrap() == subscription_id_3);
@@ -309,7 +309,7 @@ pub async fn test_store_multiple_aggregates(catalog: &dill::Catalog) {
     let res = event_store
         .find_subscription_id_by_dataset_and_label(
             &dataset_id,
-            &WebhookSubscriptionLabel::new("wrong-label"),
+            &WebhookSubscriptionLabel::try_new("wrong-label").unwrap(),
         )
         .await;
     assert_matches!(res, Ok(id) if id.is_none());
@@ -345,7 +345,7 @@ pub async fn test_modifying_subscription(catalog: &dill::Catalog) {
     let mut subscription = WebhookSubscription::new(
         subscription_id,
         Url::parse("https://example.com").unwrap(),
-        WebhookSubscriptionLabel::new("test-label"),
+        WebhookSubscriptionLabel::try_new("test-label").unwrap(),
         Some(dataset_id.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret").unwrap(),
@@ -355,7 +355,7 @@ pub async fn test_modifying_subscription(catalog: &dill::Catalog) {
     subscription
         .modify(
             Url::parse("https://example.com/modified").unwrap(),
-            WebhookSubscriptionLabel::new("modified-label"),
+            WebhookSubscriptionLabel::try_new("modified-label").unwrap(),
             vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         )
         .unwrap();
@@ -391,7 +391,7 @@ pub async fn test_non_unique_labels(catalog: &dill::Catalog) {
     let mut subscription_1 = WebhookSubscription::new(
         subscription_id_1,
         Url::parse("https://example.com/1").unwrap(),
-        WebhookSubscriptionLabel::new("test-label"),
+        WebhookSubscriptionLabel::try_new("test-label").unwrap(),
         Some(dataset_id_1.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_1").unwrap(),
@@ -401,7 +401,8 @@ pub async fn test_non_unique_labels(catalog: &dill::Catalog) {
     let mut subscription_2_1 = WebhookSubscription::new(
         subscription_id_2_1,
         Url::parse("https://example.com/2/1").unwrap(),
-        WebhookSubscriptionLabel::new("test-label"), // same label, but different dataset
+        WebhookSubscriptionLabel::try_new("test-label").unwrap(), /* same label, but different
+                                                                   * dataset */
         Some(dataset_id_2.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_2_1").unwrap(),
@@ -411,7 +412,7 @@ pub async fn test_non_unique_labels(catalog: &dill::Catalog) {
     let mut subscription_2_2 = WebhookSubscription::new(
         subscription_id_2_2,
         Url::parse("https://example.com/2/2").unwrap(),
-        WebhookSubscriptionLabel::new("test-label"), // same label in the same dataset
+        WebhookSubscriptionLabel::try_new("test-label").unwrap(), // same label in the same dataset
         Some(dataset_id_2.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_2_2").unwrap(),
@@ -437,7 +438,7 @@ pub async fn test_non_unique_labels_on_modify(catalog: &dill::Catalog) {
     let mut subscription_1 = WebhookSubscription::new(
         subscription_id_1,
         Url::parse("https://example.com/1").unwrap(),
-        WebhookSubscriptionLabel::new("test-label"),
+        WebhookSubscriptionLabel::try_new("test-label").unwrap(),
         Some(dataset_id_1.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_1").unwrap(),
@@ -447,7 +448,8 @@ pub async fn test_non_unique_labels_on_modify(catalog: &dill::Catalog) {
     let mut subscription_2_1 = WebhookSubscription::new(
         subscription_id_2_1,
         Url::parse("https://example.com/2/1").unwrap(),
-        WebhookSubscriptionLabel::new("test-label"), // same label, but different dataset
+        WebhookSubscriptionLabel::try_new("test-label").unwrap(), /* same label, but different
+                                                                   * dataset */
         Some(dataset_id_2.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_2_1").unwrap(),
@@ -457,7 +459,7 @@ pub async fn test_non_unique_labels_on_modify(catalog: &dill::Catalog) {
     let mut subscription_2_2 = WebhookSubscription::new(
         subscription_id_2_2,
         Url::parse("https://example.com/2/2").unwrap(),
-        WebhookSubscriptionLabel::new("test-label-2"),
+        WebhookSubscriptionLabel::try_new("test-label-2").unwrap(),
         Some(dataset_id_2.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_2_2").unwrap(),
@@ -467,7 +469,8 @@ pub async fn test_non_unique_labels_on_modify(catalog: &dill::Catalog) {
     subscription_2_2
         .modify(
             subscription_2_2.target_url().clone(),
-            WebhookSubscriptionLabel::new("test-label"), // same label in the same dataset
+            WebhookSubscriptionLabel::try_new("test-label").unwrap(), /* same label in the same
+                                                                       * dataset */
             subscription_2_2.event_types().to_vec(),
         )
         .unwrap();
@@ -493,7 +496,7 @@ pub async fn test_same_dataset_different_event_types(catalog: &dill::Catalog) {
     let mut subscription_1_1 = WebhookSubscription::new(
         subscription_id_1_1,
         Url::parse("https://example.com/1/1").unwrap(),
-        WebhookSubscriptionLabel::new("test-label-1"),
+        WebhookSubscriptionLabel::try_new("test-label-1").unwrap(),
         Some(dataset_id_1.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_1_1").unwrap(),
@@ -504,7 +507,7 @@ pub async fn test_same_dataset_different_event_types(catalog: &dill::Catalog) {
     let mut subscription_1_2 = WebhookSubscription::new(
         subscription_id_1_2,
         Url::parse("https://example.com/1/2").unwrap(),
-        WebhookSubscriptionLabel::new("test-label-2"),
+        WebhookSubscriptionLabel::try_new("test-label-2").unwrap(),
         Some(dataset_id_1.clone()),
         vec![WebhookEventTypeCatalog::test()],
         WebhookSubscriptionSecret::try_new("secret_1_2").unwrap(),
@@ -515,7 +518,7 @@ pub async fn test_same_dataset_different_event_types(catalog: &dill::Catalog) {
     let mut subscription_2_1 = WebhookSubscription::new(
         subscription_id_2_1,
         Url::parse("https://example.com/2/1").unwrap(),
-        WebhookSubscriptionLabel::new("test-label-1"),
+        WebhookSubscriptionLabel::try_new("test-label-1").unwrap(),
         Some(dataset_id_2.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret_2_1").unwrap(),
@@ -526,7 +529,7 @@ pub async fn test_same_dataset_different_event_types(catalog: &dill::Catalog) {
     let mut subscription_2_2 = WebhookSubscription::new(
         subscription_id_2_2,
         Url::parse("https://example.com/2/2").unwrap(),
-        WebhookSubscriptionLabel::new("test-label-2"),
+        WebhookSubscriptionLabel::try_new("test-label-2").unwrap(),
         Some(dataset_id_2.clone()),
         vec![WebhookEventTypeCatalog::test()],
         WebhookSubscriptionSecret::try_new("secret_2_2").unwrap(),
@@ -580,7 +583,7 @@ pub async fn test_removed_subscription_filters_out(catalog: &dill::Catalog) {
     let mut subscription = WebhookSubscription::new(
         subscription_id,
         Url::parse("https://example.com").unwrap(),
-        WebhookSubscriptionLabel::new("test-label"),
+        WebhookSubscriptionLabel::try_new("test-label").unwrap(),
         Some(dataset_id.clone()),
         vec![WebhookEventTypeCatalog::dataset_ref_updated()],
         WebhookSubscriptionSecret::try_new("secret").unwrap(),
@@ -603,7 +606,7 @@ pub async fn test_removed_subscription_filters_out(catalog: &dill::Catalog) {
     let res = event_store
         .find_subscription_id_by_dataset_and_label(
             &dataset_id,
-            &WebhookSubscriptionLabel::new("test-label"),
+            &WebhookSubscriptionLabel::try_new("test-label").unwrap(),
         )
         .await;
     assert_matches!(res, Ok(id) if id.is_none());


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: #1259

Added explicit validation for webhook subscription label length constraints.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [ ] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [ ] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [ ] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [ ] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [ ] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)