### PR TITLE
observability: make dill dependency optional

### DIFF
--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -45,7 +45,7 @@ kamu-flow-system-services = { workspace = true }
 kamu-search = { workspace = true }
 kamu-webhooks = { workspace = true }
 kamu-task-system = { workspace = true }
-observability = { workspace = true }
+observability = { workspace = true, features = ["dill"] }
 odf = { workspace = true, default-features = false, features = [
     "arrow",
     "http",

--- a/src/adapter/http/Cargo.toml
+++ b/src/adapter/http/Cargo.toml
@@ -114,7 +114,7 @@ kamu-auth-rebac-inmem = { workspace = true }
 kamu-datasets-services = { workspace = true }
 kamu-ingest-datafusion = { workspace = true }
 messaging-outbox = { workspace = true }
-observability = { workspace = true }
+observability = { workspace = true, features = ["dill"] }
 test-utils = { workspace = true }
 
 fs_extra = "1.3"                                               # Recursive folder copy

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -49,7 +49,7 @@ file-utils = { workspace = true }
 http-common = { workspace = true }
 init-on-startup = { workspace = true }
 internal-error = { workspace = true }
-observability = { workspace = true, features = ["prometheus"] }
+observability = { workspace = true, features = ["dill", "prometheus"] }
 time-source = { workspace = true }
 server-console = { workspace = true }
 
@@ -200,7 +200,14 @@ tracing-bunyan-formatter = "0.3"
 async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1" # Conditional compilation
-datafusion = { version = "48", default-features = false, features = ["crypto_expressions", "encoding_expressions", "parquet", "regex_expressions", "unicode_expressions", "compression"] }
+datafusion = { version = "48", default-features = false, features = [
+    "crypto_expressions",
+    "encoding_expressions",
+    "parquet",
+    "regex_expressions",
+    "unicode_expressions",
+    "compression",
+] }
 dill = { version = "0.14", default-features = false }
 dirs = "6"
 fs_extra = "1.3"

--- a/src/utils/observability/Cargo.toml
+++ b/src/utils/observability/Cargo.toml
@@ -24,6 +24,8 @@ doctest = false
 [features]
 default = []
 
+dill = ["dep:dill"]
+
 opentelemetry = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
@@ -37,8 +39,11 @@ prometheus = ["dep:prometheus"]
 
 [dependencies]
 async-trait = { version = "0.1" }
-axum = { version = "0.8", default-features = false, features = ["json", "matched-path", "query"] }
-dill = { version = "0.14", default-features = false }
+axum = { version = "0.8", default-features = false, features = [
+    "json",
+    "matched-path",
+    "query",
+] }
 http = { version = "1", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }
@@ -48,6 +53,7 @@ tracing-appender = { version = "0.2", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tower-http = { version = "0.6", default-features = false, features = ["trace"] }
 
+dill = { optional = true, version = "0.14", default-features = false }
 opentelemetry = { optional = true, version = "0.26", default-features = false }
 opentelemetry_sdk = { optional = true, version = "0.26", default-features = false, features = [
     "rt-tokio",

--- a/src/utils/observability/src/build_info.rs
+++ b/src/utils/observability/src/build_info.rs
@@ -33,6 +33,7 @@ pub struct BuildInfo {
 
 /// Axum handler for serving the build info. Depends on [`dill::Catalog`] and it
 /// having [`BuildInfo`] available.
+#[cfg(feature = "dill")]
 #[expect(clippy::unused_async)]
 pub async fn build_info_handler(
     axum::Extension(catalog): axum::Extension<dill::Catalog>,

--- a/src/utils/observability/src/health.rs
+++ b/src/utils/observability/src/health.rs
@@ -21,6 +21,7 @@ pub trait HealthCheck: Send + Sync {
 
 /// Axum handler for serving the health checks. Depends on [`dill::Catalog`] to
 /// instantiate the implementations of the [`HealthCheck`] trait.
+#[cfg(feature = "dill")]
 pub async fn health_handler(
     axum::Extension(catalog): axum::Extension<dill::Catalog>,
     axum::extract::Query(args): axum::extract::Query<CheckArgs>,


### PR DESCRIPTION
This allows using `observability` crate in other projects that may not want `dill` as a dependency, or may need to compile in stable rust that `dill` does not yet support.