### PR TITLE
Move verbose parameters from spans to log events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6984,6 +6984,7 @@ name = "kamu-adapter-task-dataset"
 version = "0.245.2"
 dependencies = [
  "async-trait",
+ "common-macros",
  "database-common",
  "database-common-macros",
  "dill",
@@ -7777,6 +7778,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
+ "common-macros",
  "cron",
  "database-common",
  "database-common-macros",

--- a/src/adapter/graphql/src/extensions.rs
+++ b/src/adapter/graphql/src/extensions.rs
@@ -33,7 +33,7 @@ pub struct TracingExtension;
 
 #[async_trait::async_trait]
 impl async_graphql::extensions::Extension for TracingExtension {
-    #[tracing::instrument(level = "info", name = "GQL: request", skip_all)]
+    #[tracing::instrument(level = "info", name = "Gql::request", skip_all)]
     async fn request(
         &self,
         ctx: &ExtensionContext<'_>,

--- a/src/adapter/graphql/src/mutations/account_access_token_mut.rs
+++ b/src/adapter/graphql/src/mutations/account_access_token_mut.rs
@@ -19,7 +19,7 @@ pub struct AccountAccessTokensMut<'a> {
     account: &'a Account,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> AccountAccessTokensMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/account_mut.rs
+++ b/src/adapter/graphql/src/mutations/account_mut.rs
@@ -21,7 +21,7 @@ pub struct AccountMut {
     account: Account,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl AccountMut {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/accounts_mut.rs
+++ b/src/adapter/graphql/src/mutations/accounts_mut.rs
@@ -25,7 +25,7 @@ use crate::queries;
 
 pub struct AccountsMut;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl AccountsMut {
     /// Returns a mutable account by its id

--- a/src/adapter/graphql/src/mutations/auth_mut/auth_mut.rs
+++ b/src/adapter/graphql/src/mutations/auth_mut/auth_mut.rs
@@ -15,7 +15,7 @@ use crate::queries::Account;
 
 pub(crate) struct AuthMut;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl AuthMut {
     /// Web3-related functionality group

--- a/src/adapter/graphql/src/mutations/auth_mut/auth_web3_mut.rs
+++ b/src/adapter/graphql/src/mutations/auth_mut/auth_web3_mut.rs
@@ -13,7 +13,7 @@ use crate::prelude::*;
 
 pub(crate) struct AuthWeb3Mut;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl AuthWeb3Mut {
     #[tracing::instrument(level = "info", name = AuthWeb3Mut_eip4361_auth_nonce, skip_all, fields(%account))]

--- a/src/adapter/graphql/src/mutations/collaboration_mut.rs
+++ b/src/adapter/graphql/src/mutations/collaboration_mut.rs
@@ -16,7 +16,7 @@ use crate::prelude::*;
 #[derive(Debug)]
 pub struct CollaborationMut;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl CollaborationMut {
     /// Batch application of relations between accounts and datasets

--- a/src/adapter/graphql/src/mutations/dataset_env_vars_mut.rs
+++ b/src/adapter/graphql/src/mutations/dataset_env_vars_mut.rs
@@ -25,7 +25,7 @@ pub struct DatasetEnvVarsMut<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetEnvVarsMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/dataset_metadata_mut.rs
+++ b/src/adapter/graphql/src/mutations/dataset_metadata_mut.rs
@@ -22,7 +22,7 @@ pub struct DatasetMetadataMut<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetMetadataMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/dataset_mut/adapters_mut/collection_mut.rs
+++ b/src/adapter/graphql/src/mutations/dataset_mut/adapters_mut/collection_mut.rs
@@ -216,7 +216,7 @@ impl<'a> CollectionMut<'a> {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl CollectionMut<'_> {
     /// Links new entry to this collection

--- a/src/adapter/graphql/src/mutations/dataset_mut/adapters_mut/versioned_file_mut.rs
+++ b/src/adapter/graphql/src/mutations/dataset_mut/adapters_mut/versioned_file_mut.rs
@@ -155,7 +155,7 @@ impl<'a> VersionedFileMut<'a> {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl VersionedFileMut<'_> {
     /// Uploads a new version of content in-band. Can be used for very small

--- a/src/adapter/graphql/src/mutations/dataset_mut/dataset_collaboration_mut.rs
+++ b/src/adapter/graphql/src/mutations/dataset_mut/dataset_collaboration_mut.rs
@@ -19,7 +19,7 @@ pub struct DatasetCollaborationMut<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetCollaborationMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/dataset_mut/dataset_mut.rs
+++ b/src/adapter/graphql/src/mutations/dataset_mut/dataset_mut.rs
@@ -24,7 +24,7 @@ pub struct DatasetMut {
     dataset_request_state: DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl DatasetMut {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/datasets_mut.rs
+++ b/src/adapter/graphql/src/mutations/datasets_mut.rs
@@ -63,7 +63,7 @@ impl DatasetsMut {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl DatasetsMut {
     /// Returns a mutable dataset by its ID

--- a/src/adapter/graphql/src/mutations/flows_mut/account_flow_triggers_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/account_flow_triggers_mut.rs
@@ -20,7 +20,7 @@ pub struct AccountFlowTriggersMut<'a> {
     account: &'a Account,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> AccountFlowTriggersMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_configs_mut.rs
@@ -21,7 +21,7 @@ pub struct DatasetFlowConfigsMut<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetFlowConfigsMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_runs_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_runs_mut.rs
@@ -29,7 +29,7 @@ pub struct DatasetFlowRunsMut<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetFlowRunsMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_triggers_mut.rs
+++ b/src/adapter/graphql/src/mutations/flows_mut/dataset_flow_triggers_mut.rs
@@ -27,7 +27,7 @@ pub struct DatasetFlowTriggersMut<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetFlowTriggersMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/metadata_chain_mut.rs
+++ b/src/adapter/graphql/src/mutations/metadata_chain_mut.rs
@@ -22,7 +22,7 @@ pub struct MetadataChainMut<'a> {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> MetadataChainMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/webhooks_mut/dataset_webhooks_mut.rs
+++ b/src/adapter/graphql/src/mutations/webhooks_mut/dataset_webhooks_mut.rs
@@ -22,7 +22,7 @@ pub struct DatasetWebhooksMut<'a> {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetWebhooksMut<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/mutations/webhooks_mut/webhook_subscription_mut.rs
+++ b/src/adapter/graphql/src/mutations/webhooks_mut/webhook_subscription_mut.rs
@@ -22,7 +22,7 @@ pub struct WebhookSubscriptionMut {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl WebhookSubscriptionMut {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/queries/access_tokens/access_token.rs
+++ b/src/adapter/graphql/src/queries/access_tokens/access_token.rs
@@ -18,7 +18,7 @@ pub struct AccountAccessTokens<'a> {
     account_id: &'a AccountID<'a>,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> AccountAccessTokens<'a> {
     const DEFAULT_PER_PAGE: usize = 15;

--- a/src/adapter/graphql/src/queries/accounts/account.rs
+++ b/src/adapter/graphql/src/queries/accounts/account.rs
@@ -38,7 +38,7 @@ pub enum AccountType {
     Organization,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Account {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/queries/accounts/account_flow_runs.rs
+++ b/src/adapter/graphql/src/queries/accounts/account_flow_runs.rs
@@ -28,7 +28,7 @@ pub struct AccountFlowRuns<'a> {
     account: &'a AccountEntity,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> AccountFlowRuns<'a> {
     const DEFAULT_PER_PAGE: usize = 15;

--- a/src/adapter/graphql/src/queries/accounts/account_flow_triggers.rs
+++ b/src/adapter/graphql/src/queries/accounts/account_flow_triggers.rs
@@ -19,7 +19,7 @@ pub struct AccountFlowTriggers<'a> {
     account: &'a AccountEntity,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> AccountFlowTriggers<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/queries/accounts/accounts.rs
+++ b/src/adapter/graphql/src/queries/accounts/accounts.rs
@@ -14,7 +14,7 @@ use crate::queries::Account;
 
 pub struct Accounts;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Accounts {
     /// Returns account by its ID

--- a/src/adapter/graphql/src/queries/auth.rs
+++ b/src/adapter/graphql/src/queries/auth.rs
@@ -13,7 +13,7 @@ use crate::prelude::*;
 
 pub struct Auth;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Auth {
     #[allow(clippy::unused_async)]

--- a/src/adapter/graphql/src/queries/data.rs
+++ b/src/adapter/graphql/src/queries/data.rs
@@ -16,7 +16,7 @@ use crate::prelude::*;
 
 pub struct DataQueries;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl DataQueries {
     const DEFAULT_QUERY_LIMIT: u64 = 100;

--- a/src/adapter/graphql/src/queries/datasets/adapters/collection.rs
+++ b/src/adapter/graphql/src/queries/datasets/adapters/collection.rs
@@ -60,7 +60,7 @@ impl Collection {
     }
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Collection {
     #[graphql(skip)]
@@ -96,7 +96,7 @@ impl CollectionProjection {
     }
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl CollectionProjection {
     const DEFAULT_ENTRIES_PER_PAGE: usize = 100;

--- a/src/adapter/graphql/src/queries/datasets/adapters/collection_entry.rs
+++ b/src/adapter/graphql/src/queries/datasets/adapters/collection_entry.rs
@@ -80,7 +80,7 @@ impl CollectionEntry {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[ComplexObject]
 impl CollectionEntry {
     /// Resolves the reference to linked dataset

--- a/src/adapter/graphql/src/queries/datasets/adapters/versioned_file.rs
+++ b/src/adapter/graphql/src/queries/datasets/adapters/versioned_file.rs
@@ -129,7 +129,7 @@ impl VersionedFile {
     }
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl VersionedFile {
     const DEFAULT_VERSIONS_PER_PAGE: usize = 100;

--- a/src/adapter/graphql/src/queries/datasets/adapters/versioned_file_entry.rs
+++ b/src/adapter/graphql/src/queries/datasets/adapters/versioned_file_entry.rs
@@ -111,7 +111,7 @@ impl VersionedFileEntry {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[ComplexObject]
 impl VersionedFileEntry {
     /// Returns encoded content in-band. Should be used for small files only and

--- a/src/adapter/graphql/src/queries/datasets/dataset.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset.rs
@@ -112,7 +112,7 @@ impl Dataset {
     }
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Dataset {
     /// Unique identifier of the dataset

--- a/src/adapter/graphql/src/queries/datasets/dataset_collaboration.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_collaboration.rs
@@ -19,7 +19,7 @@ pub struct DatasetCollaboration<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetCollaboration<'a> {
     const DEFAULT_RESULTS_PER_PAGE: usize = 15;

--- a/src/adapter/graphql/src/queries/datasets/dataset_data.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_data.rs
@@ -18,7 +18,7 @@ pub struct DatasetData<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetData<'a> {
     const DEFAULT_TAIL_LIMIT: u64 = 20;

--- a/src/adapter/graphql/src/queries/datasets/dataset_env_vars.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_env_vars.rs
@@ -21,7 +21,7 @@ pub struct DatasetEnvVars<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetEnvVars<'a> {
     const DEFAULT_PER_PAGE: usize = 15;

--- a/src/adapter/graphql/src/queries/datasets/dataset_flow_configs.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_flow_configs.rs
@@ -18,7 +18,7 @@ pub struct DatasetFlowConfigs<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetFlowConfigs<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/queries/datasets/dataset_flow_runs.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_flow_runs.rs
@@ -24,7 +24,7 @@ pub struct DatasetFlowRuns<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetFlowRuns<'a> {
     const DEFAULT_PER_PAGE: usize = 15;

--- a/src/adapter/graphql/src/queries/datasets/dataset_flow_triggers.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_flow_triggers.rs
@@ -18,7 +18,7 @@ pub struct DatasetFlowTriggers<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetFlowTriggers<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/queries/datasets/dataset_metadata.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_metadata.rs
@@ -25,7 +25,7 @@ pub struct DatasetMetadata<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> DatasetMetadata<'a> {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/queries/datasets/datasets.rs
+++ b/src/adapter/graphql/src/queries/datasets/datasets.rs
@@ -17,7 +17,7 @@ use crate::queries::*;
 
 pub struct Datasets;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Datasets {
     const DEFAULT_PER_PAGE: usize = 15;

--- a/src/adapter/graphql/src/queries/datasets/metadata_chain.rs
+++ b/src/adapter/graphql/src/queries/datasets/metadata_chain.rs
@@ -31,7 +31,7 @@ pub struct MetadataChain<'a> {
     dataset_request_state: &'a DatasetRequestState,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl<'a> MetadataChain<'a> {
     const DEFAULT_BLOCKS_PER_PAGE: usize = 20;

--- a/src/adapter/graphql/src/queries/flows/flow.rs
+++ b/src/adapter/graphql/src/queries/flows/flow.rs
@@ -24,7 +24,7 @@ pub struct Flow {
     description: FlowDescription,
 }
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Flow {
     #[graphql(skip)]

--- a/src/adapter/graphql/src/queries/search.rs
+++ b/src/adapter/graphql/src/queries/search.rs
@@ -23,7 +23,7 @@ use crate::utils::from_catalog_n;
 
 pub struct Search;
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Search {
     const DEFAULT_RESULTS_PER_PAGE: usize = 15;

--- a/src/adapter/graphql/src/queries/webhooks/webhook_subscription.rs
+++ b/src/adapter/graphql/src/queries/webhooks/webhook_subscription.rs
@@ -26,7 +26,7 @@ impl WebhookSubscription {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl WebhookSubscription {
     /// Unique identifier of the webhook subscription

--- a/src/adapter/graphql/src/queries/webhooks/webhooks.rs
+++ b/src/adapter/graphql/src/queries/webhooks/webhooks.rs
@@ -15,7 +15,7 @@ pub struct Webhooks;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[common_macros::method_names_consts(const_value_prefix = "GQL: ")]
+#[common_macros::method_names_consts(const_value_prefix = "Gql::")]
 #[Object]
 impl Webhooks {
     /// List of supported event types

--- a/src/adapter/task-dataset/Cargo.toml
+++ b/src/adapter/task-dataset/Cargo.toml
@@ -27,6 +27,7 @@ testing = []
 
 
 [dependencies]
+common-macros = { workspace = true }
 kamu-core = { workspace = true }
 kamu-datasets = { workspace = true }
 kamu-task-system = { workspace = true }

--- a/src/adapter/task-dataset/src/runners/hard_compact_dataset_task_runner.rs
+++ b/src/adapter/task-dataset/src/runners/hard_compact_dataset_task_runner.rs
@@ -28,12 +28,15 @@ pub struct HardCompactDatasetTaskRunner {
     compaction_executor: Arc<dyn CompactionExecutor>,
 }
 
+#[common_macros::method_names_consts]
 impl HardCompactDatasetTaskRunner {
-    #[tracing::instrument(level = "debug", skip_all, fields(?task_compact))]
+    #[tracing::instrument(name = HardCompactDatasetTaskRunner_run_hard_compact, level = "debug", skip_all)]
     async fn run_hard_compact(
         &self,
         task_compact: TaskDefinitionDatasetHardCompact,
     ) -> Result<TaskOutcome, InternalError> {
+        tracing::debug!(?task_compact, "Running hard compaction task");
+
         // Run compaction execution without transaction
         let compaction_result = self
             .compaction_executor
@@ -80,7 +83,7 @@ impl HardCompactDatasetTaskRunner {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(%dataset_handle, %new_head))]
+    #[tracing::instrument(name = HardCompactDatasetTaskRunner_update_dataset_head, level = "debug", skip_all, fields(%dataset_handle, %new_head))]
     #[transactional_method1(dataset_registry: Arc<dyn DatasetRegistry>)]
     async fn update_dataset_head(
         &self,

--- a/src/adapter/task-dataset/src/runners/update_dataset_task_runner.rs
+++ b/src/adapter/task-dataset/src/runners/update_dataset_task_runner.rs
@@ -36,12 +36,15 @@ pub struct UpdateDatasetTaskRunner {
     sync_service: Arc<dyn SyncService>,
 }
 
+#[common_macros::method_names_consts]
 impl UpdateDatasetTaskRunner {
-    #[tracing::instrument(level = "debug", skip_all, fields(?task_update))]
+    #[tracing::instrument(name = UpdateDatasetTaskRunner_run_update, level = "debug", skip_all)]
     async fn run_update(
         &self,
         task_update: TaskDefinitionDatasetUpdate,
     ) -> Result<TaskOutcome, InternalError> {
+        tracing::debug!(?task_update, "Running update task");
+
         match task_update.pull_job {
             PullPlanIterationJob::Ingest(ingest_item) => {
                 self.run_ingest_update(ingest_item, task_update.pull_options.ingest_options)
@@ -194,7 +197,7 @@ impl UpdateDatasetTaskRunner {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(%dataset_handle, %new_head))]
+    #[tracing::instrument(name = UpdateDatasetTaskRunner_update_dataset_head, level = "debug", skip_all, fields(%dataset_handle, %new_head))]
     #[transactional_method1(dataset_registry: Arc<dyn DatasetRegistry>)]
     async fn update_dataset_head(
         &self,

--- a/src/app/cli/src/services/confirm_delete_service.rs
+++ b/src/app/cli/src/services/confirm_delete_service.rs
@@ -30,11 +30,13 @@ impl ConfirmDeleteService {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(?dataset_handles))]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn confirm_delete(
         &self,
         dataset_handles: &[odf::DatasetHandle],
     ) -> Result<(), CLIError> {
+        tracing::debug!(?dataset_handles, "Asking to confirm deletion of datasets");
+
         for hdl in dataset_handles {
             let statuses = self.push_status_service.check_remotes_status(hdl).await?;
 

--- a/src/domain/datasets/services/src/use_cases/commit_dataset_event_use_case_impl.rs
+++ b/src/domain/datasets/services/src/use_cases/commit_dataset_event_use_case_impl.rs
@@ -67,13 +67,15 @@ impl CommitDatasetEventUseCase for CommitDatasetEventUseCaseImpl {
         level = "info",
         name = CommitDatasetEventUseCaseImpl_execute,
         skip_all,
-        fields(dataset_handle, ?event)
+        fields(dataset_handle),
     )]
     async fn execute(
         &self,
         dataset_handle: &odf::DatasetHandle,
         event: odf::MetadataEvent,
     ) -> Result<odf::dataset::CommitResult, CommitError> {
+        tracing::info!(?event, "Initiating event commit");
+
         let resolved_dataset = self
             .rebac_dataset_registry_facade
             .resolve_dataset_by_ref(&dataset_handle.as_local_ref(), auth::DatasetAction::Write)

--- a/src/domain/datasets/services/src/use_cases/create_dataset_from_snapshot_use_case_impl.rs
+++ b/src/domain/datasets/services/src/use_cases/create_dataset_from_snapshot_use_case_impl.rs
@@ -73,12 +73,18 @@ impl CreateDatasetFromSnapshotUseCaseImpl {
 #[common_macros::method_names_consts]
 #[async_trait::async_trait]
 impl CreateDatasetFromSnapshotUseCase for CreateDatasetFromSnapshotUseCaseImpl {
-    #[tracing::instrument(level = "info", name = CreateDatasetFromSnapshotUseCaseImpl_execute, skip_all, fields(?snapshot, ?options))]
+    #[tracing::instrument(level = "info", name = CreateDatasetFromSnapshotUseCaseImpl_execute, skip_all)]
     async fn execute(
         &self,
         mut snapshot: odf::DatasetSnapshot,
         options: CreateDatasetUseCaseOptions,
     ) -> Result<CreateDatasetResult, CreateDatasetFromSnapshotError> {
+        tracing::info!(
+            ?snapshot,
+            ?options,
+            "Initiating creation of dataset from snapshot"
+        );
+
         // There must be a logged-in user
         let subject = match self.current_account_subject.as_ref() {
             CurrentAccountSubject::Logged(subj) => subj,

--- a/src/domain/datasets/services/src/use_cases/create_dataset_use_case_impl.rs
+++ b/src/domain/datasets/services/src/use_cases/create_dataset_use_case_impl.rs
@@ -33,13 +33,19 @@ pub struct CreateDatasetUseCaseImpl {
 #[common_macros::method_names_consts]
 #[async_trait::async_trait]
 impl CreateDatasetUseCase for CreateDatasetUseCaseImpl {
-    #[tracing::instrument(level = "info", name = CreateDatasetUseCaseImpl_execute, skip_all, fields(dataset_alias, ?seed_block, ?options))]
+    #[tracing::instrument(level = "info", name = CreateDatasetUseCaseImpl_execute, skip_all, fields(dataset_alias))]
     async fn execute(
         &self,
         dataset_alias: &odf::DatasetAlias,
         seed_block: odf::MetadataBlockTyped<odf::metadata::Seed>,
         options: CreateDatasetUseCaseOptions,
     ) -> Result<CreateDatasetResult, CreateDatasetError> {
+        tracing::info!(
+            ?seed_block,
+            ?options,
+            "Initiating creation of dataset from seed block"
+        );
+
         // There must be a logged-in user
         let subject = match self.current_account_subject.as_ref() {
             CurrentAccountSubject::Logged(subj) => subj,

--- a/src/domain/flow-system/services/Cargo.toml
+++ b/src/domain/flow-system/services/Cargo.toml
@@ -22,6 +22,7 @@ doctest = false
 
 
 [dependencies]
+common-macros = { workspace = true }
 database-common = { workspace = true }
 database-common-macros = { workspace = true }
 init-on-startup = { workspace = true }
@@ -48,7 +49,7 @@ tracing = { version = "0.1", default-features = false }
 kamu-accounts = { workspace = true }
 kamu-adapter-flow-dataset = { workspace = true }
 kamu-adapter-task-dataset = { workspace = true }
-kamu-core ={ workspace = true }
+kamu-core = { workspace = true }
 kamu-datasets-inmem = { workspace = true }
 kamu-datasets-services = { workspace = true, features = ["testing"] }
 kamu-flow-system-inmem = { workspace = true }

--- a/src/domain/flow-system/services/src/flow_trigger/flow_trigger_service_impl.rs
+++ b/src/domain/flow-system/services/src/flow_trigger/flow_trigger_service_impl.rs
@@ -307,11 +307,13 @@ impl FlowTriggerService for FlowTriggerServiceImpl {
     }
 
     /// Find all triggers by datasets
-    #[tracing::instrument(level = "info", skip_all, fields(?dataset_ids))]
+    #[tracing::instrument(level = "info", skip_all)]
     async fn has_active_triggers_for_datasets(
         &self,
         dataset_ids: &[odf::DatasetID],
     ) -> Result<bool, InternalError> {
+        tracing::info!(?dataset_ids, "Checking for active triggers for datasets");
+
         self.event_store
             .has_active_triggers_for_datasets(dataset_ids)
             .await

--- a/src/domain/webhooks/services/src/use_cases/create_webhook_subscription_use_case_impl.rs
+++ b/src/domain/webhooks/services/src/use_cases/create_webhook_subscription_use_case_impl.rs
@@ -30,7 +30,7 @@ impl CreateWebhookSubscriptionUseCase for CreateWebhookSubscriptionUseCaseImpl {
         level = "info",
         name = CreateWebhookSubscriptionUseCaseImpl_execute,
         skip_all,
-        fields(?dataset_id, %target_url, ?event_types, %label)
+        fields(?dataset_id),
     )]
     async fn execute(
         &self,
@@ -40,6 +40,14 @@ impl CreateWebhookSubscriptionUseCase for CreateWebhookSubscriptionUseCaseImpl {
         label: WebhookSubscriptionLabel,
     ) -> Result<CreateWebhookSubscriptionResult, CreateWebhookSubscriptionError> {
         use super::helpers::*;
+
+        tracing::info!(
+            %target_url,
+            ?event_types,
+            %label,
+            "Initiating creation of webhook subscription",
+        );
+
         validate_webhook_target_url(&target_url)?;
         validate_webhook_event_types(&event_types)?;
         deduplicate_event_types(&mut event_types);

--- a/src/domain/webhooks/services/src/use_cases/update_webhook_subscription_use_case_impl.rs
+++ b/src/domain/webhooks/services/src/use_cases/update_webhook_subscription_use_case_impl.rs
@@ -29,7 +29,7 @@ impl UpdateWebhookSubscriptionUseCase for UpdateWebhookSubscriptionUseCaseImpl {
         level = "info",
         name = UpdateWebhookSubscriptionUseCaseImpl_execute,
         skip_all,
-        fields(subscription_id=%subscription.id(), %target_url, ?event_types, %label)
+        fields(subscription_id=%subscription.id()),
     )]
     async fn execute(
         &self,
@@ -39,6 +39,14 @@ impl UpdateWebhookSubscriptionUseCase for UpdateWebhookSubscriptionUseCaseImpl {
         label: WebhookSubscriptionLabel,
     ) -> Result<(), UpdateWebhookSubscriptionError> {
         use super::helpers::*;
+
+        tracing::info!(
+            %target_url,
+            ?event_types,
+            %label,
+            "Initiating update of webhook subscription",
+        );
+
         validate_webhook_target_url(&target_url)?;
         validate_webhook_event_types(&event_types)?;
         deduplicate_event_types(&mut event_types);

--- a/src/utils/common-macros/src/lib.rs
+++ b/src/utils/common-macros/src/lib.rs
@@ -57,10 +57,10 @@ use syn::{Ident, ImplItem, LitStr, Token, Type, parse_macro_input};
 ///
 /// ```compile_fail
 /// /* 3. Macro combination with options */
-/// #[method_names_consts(const_value_prefix = "GQL: ")]
+/// #[method_names_consts(const_value_prefix = "Gql::")]
 /// #[Object]
 /// impl Search {
-///     // Logged as: "GQL: Search::query"
+///     // Logged as: "Gql::Search::query"
 ///     #[tracing::instrument(level = "info", name = Search_query, skip_all)]
 ///     async fn query(/* ... */) -> Result<SearchResultConnection> {
 ///         /* ... */

--- a/src/utils/database-common/src/transactions/db_transaction_manager.rs
+++ b/src/utils/database-common/src/transactions/db_transaction_manager.rs
@@ -44,7 +44,11 @@ impl DatabaseTransactionRunner {
         Self { catalog }
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(
+        name = "DatabaseTransactionRunner::transactional",
+        level = "debug",
+        skip_all
+    )]
     pub async fn transactional<H, HFut, HFutResultT, HFutResultE>(
         &self,
         callback: H,
@@ -74,7 +78,9 @@ impl DatabaseTransactionRunner {
                 .build();
 
             callback(catalog_with_transaction)
-                .instrument(tracing::debug_span!("Transaction Body"))
+                .instrument(tracing::trace_span!(
+                    "DatabaseTransactionRunner::transactional::callback"
+                ))
                 .await
         };
 


### PR DESCRIPTION
A few of these span parameters are destroying our logs by being duplicated into every log message that appears under that span.

Also few renaming for consistency:
- Changed `GQL: Blah::blah` prefix to `Gql::Blah::blah` to unify it with `Http::request` and `Grpc::request` root spans
- Renamed `transactional` to `DatabaseTransactionRunner::transactional`
- Renamed `Transaction Body` to `DatabaseTransactionRunner::transactional::callback` and moved it under `trace` level as its rare that we need to differentiate the callback from the parent `transactional` span