### PR TITLE
Extended handling of webhook delivery errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Recommendation: for ease of reading, use the following order:
 -->
 
 ## [Unreleased]
+## Added
+- Extended support for webhook delivery errors, differentiating between:
+    - connection failure
+    - response timeout
+    - bad status code in response
 ## Changed
 - Moved versioned file logic from GQL level to `use_case`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6922,6 +6922,7 @@ dependencies = [
  "event-sourcing",
  "file-utils",
  "futures",
+ "http 1.3.1",
  "humansize",
  "indoc 2.0.6",
  "init-on-startup",
@@ -7151,6 +7152,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -3605,7 +3605,7 @@ type Task {
 	finishedAt: DateTime
 }
 
-union TaskFailureReason = TaskFailureReasonGeneral | TaskFailureReasonInputDatasetCompacted
+union TaskFailureReason = TaskFailureReasonGeneral | TaskFailureReasonInputDatasetCompacted | TaskFailureReasonWebhookDeliveryProblem
 
 type TaskFailureReasonGeneral {
 	message: String!
@@ -3613,6 +3613,11 @@ type TaskFailureReasonGeneral {
 
 type TaskFailureReasonInputDatasetCompacted {
 	inputDataset: Dataset!
+	message: String!
+}
+
+type TaskFailureReasonWebhookDeliveryProblem {
+	targetUrl: Url!
 	message: String!
 }
 

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -70,6 +70,7 @@ chrono = "0.4"
 datafusion = { version = "49", default-features = false, features = ["serde"] }
 dill = { version = "0.14", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
+http = { version = "1", default-features = false }
 humansize = { version = "2", default-features = false }
 indoc = "2"
 jsonschema = { version = "0.30", default-features = false }

--- a/src/adapter/task-webhook/Cargo.toml
+++ b/src/adapter/task-webhook/Cargo.toml
@@ -40,6 +40,7 @@ dill = { version = "0.14", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", default-features = false }
 tracing = "0.1"
+url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }
 
 

--- a/src/adapter/task-webhook/src/runners/deliver_webhook_task_runner.rs
+++ b/src/adapter/task-webhook/src/runners/deliver_webhook_task_runner.rs
@@ -47,6 +47,7 @@ impl DeliverWebhookTaskRunner {
         {
             Ok(_) => Ok(TaskOutcome::Success(TaskResult::empty())),
             Err(err) => {
+                // TODO: detalize delivery error (send, status, other)
                 tracing::error!(error = ?err, "Send webhook failed");
                 Ok(TaskOutcome::Failed(TaskError::empty()))
             }

--- a/src/adapter/task-webhook/src/runners/deliver_webhook_task_runner.rs
+++ b/src/adapter/task-webhook/src/runners/deliver_webhook_task_runner.rs
@@ -11,9 +11,14 @@ use std::sync::Arc;
 
 use internal_error::InternalError;
 use kamu_task_system::*;
-use kamu_webhooks::{WebhookDeliveryID, WebhookDeliveryWorker};
+use kamu_webhooks::{
+    WebhookDeliveryError,
+    WebhookDeliveryID,
+    WebhookDeliveryWorker,
+    WebhookSendError,
+};
 
-use crate::TaskDefinitionWebhookDeliver;
+use crate::{TaskDefinitionWebhookDeliver, TaskErrorWebhookDelivery};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -47,9 +52,31 @@ impl DeliverWebhookTaskRunner {
         {
             Ok(_) => Ok(TaskOutcome::Success(TaskResult::empty())),
             Err(err) => {
-                // TODO: detalize delivery error (send, status, other)
-                tracing::error!(error = ?err, "Send webhook failed");
-                Ok(TaskOutcome::Failed(TaskError::empty()))
+                tracing::error!(
+                    error = ?err,
+                    error_msg = %err,
+                    "Webhook delivery failed"
+                );
+
+                match err {
+                    WebhookDeliveryError::UnsuccessfulResponse(e) => Ok(TaskOutcome::Failed(
+                        TaskErrorWebhookDelivery::UnsuccessfulResponse(e).into_task_error(),
+                    )),
+                    WebhookDeliveryError::SendError(WebhookSendError::FailedToConnect(e)) => {
+                        Ok(TaskOutcome::Failed(
+                            TaskErrorWebhookDelivery::FailedToConnect(e).into_task_error(),
+                        ))
+                    }
+                    WebhookDeliveryError::SendError(WebhookSendError::ConnectionTimeout(e)) => {
+                        Ok(TaskOutcome::Failed(
+                            TaskErrorWebhookDelivery::ConnectionTimeout(e).into_task_error(),
+                        ))
+                    }
+                    WebhookDeliveryError::SendError(WebhookSendError::Internal(_))
+                    | WebhookDeliveryError::Internal(_) => {
+                        Ok(TaskOutcome::Failed(TaskError::empty()))
+                    }
+                }
             }
         }
     }

--- a/src/adapter/task-webhook/src/task_errors/mod.rs
+++ b/src/adapter/task-webhook/src/task_errors/mod.rs
@@ -7,20 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod dependencies;
-pub use dependencies::*;
+mod task_error_webhook_delivery;
 
-mod logical_plans;
-pub use logical_plans::*;
-
-mod task_definitions;
-pub use task_definitions::*;
-
-mod task_errors;
-pub use task_errors::*;
-
-mod planners;
-pub use planners::*;
-
-mod runners;
-pub use runners::*;
+pub use task_error_webhook_delivery::*;

--- a/src/adapter/task-webhook/src/task_errors/task_error_webhook_delivery.rs
+++ b/src/adapter/task-webhook/src/task_errors/task_error_webhook_delivery.rs
@@ -1,0 +1,27 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use kamu_webhooks::{
+    WebhookSendConnectionTimeoutError,
+    WebhookSendFailedToConnectError,
+    WebhookUnsuccessfulResponseError,
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+kamu_task_system::task_error_enum! {
+    pub enum TaskErrorWebhookDelivery {
+        FailedToConnect(WebhookSendFailedToConnectError),
+        ConnectionTimeout(WebhookSendConnectionTimeoutError),
+        UnsuccessfulResponse(WebhookUnsuccessfulResponseError),
+    }
+    => "WebhookDeliveryError"
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/task-webhook/src/task_errors/task_error_webhook_delivery.rs
+++ b/src/adapter/task-webhook/src/task_errors/task_error_webhook_delivery.rs
@@ -25,3 +25,15 @@ kamu_task_system::task_error_enum! {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl TaskErrorWebhookDelivery {
+    pub fn target_url(&self) -> &url::Url {
+        match self {
+            TaskErrorWebhookDelivery::FailedToConnect(e) => &e.target_url,
+            TaskErrorWebhookDelivery::ConnectionTimeout(e) => &e.target_url,
+            TaskErrorWebhookDelivery::UnsuccessfulResponse(e) => &e.target_url,
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/webhooks/domain/src/services/webhook_delivery_worker.rs
+++ b/src/domain/webhooks/domain/src/services/webhook_delivery_worker.rs
@@ -8,8 +8,9 @@
 // by the Apache License, Version 2.0.
 
 use internal_error::InternalError;
+use thiserror::Error;
 
-use crate::{WebhookDeliveryID, WebhookEventType, WebhookSubscriptionID};
+use crate::{WebhookDeliveryID, WebhookEventType, WebhookSendError, WebhookSubscriptionID};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -21,7 +22,30 @@ pub trait WebhookDeliveryWorker: Send + Sync {
         webhook_subscription_id: WebhookSubscriptionID,
         event_type: WebhookEventType,
         payload: serde_json::Value,
-    ) -> Result<(), InternalError>;
+    ) -> Result<(), WebhookDeliveryError>;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Error, Debug)]
+pub enum WebhookDeliveryError {
+    #[error(transparent)]
+    SendError(#[from] WebhookSendError),
+
+    #[error(transparent)]
+    UnsuccessfulResponse(#[from] WebhookUnsuccessfulResponseError),
+
+    #[error(transparent)]
+    Internal(#[from] InternalError),
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Error, Debug)]
+#[error("Webhook target URL '{target_url}' returned an unsuccessful response: {status_code}")]
+pub struct WebhookUnsuccessfulResponseError {
+    pub target_url: url::Url,
+    pub status_code: http::StatusCode,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/webhooks/domain/src/services/webhook_delivery_worker.rs
+++ b/src/domain/webhooks/domain/src/services/webhook_delivery_worker.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use internal_error::InternalError;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{WebhookDeliveryID, WebhookEventType, WebhookSendError, WebhookSubscriptionID};
@@ -41,11 +42,11 @@ pub enum WebhookDeliveryError {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[error("Webhook target URL '{target_url}' returned an unsuccessful response: {status_code}")]
 pub struct WebhookUnsuccessfulResponseError {
     pub target_url: url::Url,
-    pub status_code: http::StatusCode,
+    pub status_code: u16,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/webhooks/domain/src/services/webhook_sender.rs
+++ b/src/domain/webhooks/domain/src/services/webhook_sender.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use internal_error::InternalError;
+use thiserror::Error;
 
 use crate::WebhookResponse;
 
@@ -21,7 +22,38 @@ pub trait WebhookSender: Send + Sync {
         target_url: url::Url,
         payload_bytes: bytes::Bytes,
         headers: http::HeaderMap,
-    ) -> Result<WebhookResponse, InternalError>;
+    ) -> Result<WebhookResponse, WebhookSendError>;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Error, Debug)]
+pub enum WebhookSendError {
+    #[error(transparent)]
+    FailedToConnect(#[from] WebhookSendFailedToConnectError),
+
+    #[error(transparent)]
+    ConnectionTimeout(#[from] WebhookSendConnectionTimeoutError),
+
+    #[error(transparent)]
+    Internal(#[from] InternalError),
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Error, Debug)]
+#[error("Failed to connect to webhook target URL: '{target_url}'")]
+pub struct WebhookSendFailedToConnectError {
+    pub target_url: url::Url,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Error, Debug)]
+#[error("Webhook target URL '{target_url}' timed out after {timeout:?}")]
+pub struct WebhookSendConnectionTimeoutError {
+    pub target_url: url::Url,
+    pub timeout: std::time::Duration,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/webhooks/domain/src/services/webhook_sender.rs
+++ b/src/domain/webhooks/domain/src/services/webhook_sender.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use internal_error::InternalError;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::WebhookResponse;
@@ -41,7 +42,7 @@ pub enum WebhookSendError {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[error("Failed to connect to webhook target URL: '{target_url}'")]
 pub struct WebhookSendFailedToConnectError {
     pub target_url: url::Url,
@@ -49,7 +50,7 @@ pub struct WebhookSendFailedToConnectError {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[error("Webhook target URL '{target_url}' timed out after {timeout:?}")]
 pub struct WebhookSendConnectionTimeoutError {
     pub target_url: url::Url,

--- a/src/domain/webhooks/services/src/services/webhook_delivery_worker_impl.rs
+++ b/src/domain/webhooks/services/src/services/webhook_delivery_worker_impl.rs
@@ -211,7 +211,7 @@ impl WebhookDeliveryWorker for WebhookDeliveryWorkerImpl {
             Err(WebhookDeliveryError::UnsuccessfulResponse(
                 WebhookUnsuccessfulResponseError {
                     target_url: delivery_data.target_url,
-                    status_code: response_status,
+                    status_code: response_status.as_u16(),
                 },
             ))
         }

--- a/src/domain/webhooks/services/src/services/webhook_delivery_worker_impl.rs
+++ b/src/domain/webhooks/services/src/services/webhook_delivery_worker_impl.rs
@@ -178,7 +178,8 @@ impl WebhookDeliveryWorker for WebhookDeliveryWorkerImpl {
         webhook_subscription_id: WebhookSubscriptionID,
         event_type: WebhookEventType,
         payload: serde_json::Value,
-    ) -> Result<(), internal_error::InternalError> {
+    ) -> Result<(), WebhookDeliveryError> {
+        // Prepare delivery, headers
         let delivery_data = self
             .prepare_delivery(
                 webhook_delivery_id,
@@ -188,20 +189,32 @@ impl WebhookDeliveryWorker for WebhookDeliveryWorkerImpl {
             )
             .await?;
 
+        // Send the webhook
         let webhook_response = self
             .webhook_sender
             .send_webhook(
-                delivery_data.target_url,
+                delivery_data.target_url.clone(),
                 delivery_data.payload_bytes,
                 delivery_data.headers,
             )
-            .await
-            .int_err()?;
+            .await?;
 
+        // Write the response back to the database
+        let response_status = webhook_response.status_code;
         self.write_delivery_response(webhook_delivery_id, webhook_response)
             .await?;
 
-        Ok(())
+        // Fail delivery, unless the response is successful
+        if response_status.is_success() {
+            Ok(())
+        } else {
+            Err(WebhookDeliveryError::UnsuccessfulResponse(
+                WebhookUnsuccessfulResponseError {
+                    target_url: delivery_data.target_url,
+                    status_code: response_status,
+                },
+            ))
+        }
     }
 }
 

--- a/src/domain/webhooks/services/tests/tests/services/test_webhook_delivery_worker_impl.rs
+++ b/src/domain/webhooks/services/tests/tests/services/test_webhook_delivery_worker_impl.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::assert_matches::assert_matches;
 use std::sync::Arc;
 
 use chrono::Utc;
@@ -66,18 +67,26 @@ async fn test_deliver_webhook() {
         serde_json::json!({"key": "value"})
     );
 
+    assert_matches!(
+        delivery.response,
+        Some(WebhookResponse {
+            status_code: http::StatusCode::OK,
+            ..
+        })
+    );
+
     assert!(delivery.is_successful());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[test_log::test(tokio::test)]
-async fn test_deliver_webhook_failed() {
+async fn test_deliver_webhook_timeout_failure() {
     let subscription_id = WebhookSubscriptionID::new(uuid::Uuid::new_v4());
     let webhook_delivery_id = WebhookDeliveryID::new(uuid::Uuid::new_v4());
 
     let mut mock_webhook_sender = MockWebhookSender::new();
-    TestWebhookDeliveryWorkerHarness::add_failing_sender_expectation(
+    TestWebhookDeliveryWorkerHarness::add_timeout_sender_expectation(
         &mut mock_webhook_sender,
         url::Url::parse("https://example.com/webhook").unwrap(),
         webhook_delivery_id,
@@ -88,7 +97,7 @@ async fn test_deliver_webhook_failed() {
 
     harness.new_webhook_subscription(subscription_id).await;
 
-    harness
+    let res = harness
         .webhook_delivery_worker
         .deliver_webhook(
             webhook_delivery_id,
@@ -96,8 +105,16 @@ async fn test_deliver_webhook_failed() {
             WebhookEventTypeCatalog::dataset_ref_updated(),
             serde_json::json!({"key": "value"}),
         )
-        .await
-        .unwrap();
+        .await;
+    assert_matches!(
+        res,
+        Err(WebhookDeliveryError::SendError(
+            WebhookSendError::ConnectionTimeout(WebhookSendConnectionTimeoutError {
+                target_url,
+                timeout: _,
+            })
+        )) if target_url == Url::parse("https://example.com/webhook").unwrap()
+    );
 
     let delivery = harness
         .webhook_delivery_repo
@@ -115,6 +132,135 @@ async fn test_deliver_webhook_failed() {
     assert_eq!(
         delivery.event_type,
         WebhookEventTypeCatalog::dataset_ref_updated()
+    );
+
+    assert_eq!(delivery.response, None);
+
+    assert!(!delivery.is_successful());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_deliver_webhook_connection_failure() {
+    let subscription_id = WebhookSubscriptionID::new(uuid::Uuid::new_v4());
+    let webhook_delivery_id = WebhookDeliveryID::new(uuid::Uuid::new_v4());
+
+    let mut mock_webhook_sender = MockWebhookSender::new();
+    TestWebhookDeliveryWorkerHarness::add_connection_failure_sender_expectation(
+        &mut mock_webhook_sender,
+        url::Url::parse("https://example.com/webhook").unwrap(),
+        webhook_delivery_id,
+        subscription_id,
+    );
+
+    let harness = TestWebhookDeliveryWorkerHarness::new(mock_webhook_sender);
+
+    harness.new_webhook_subscription(subscription_id).await;
+
+    let res = harness
+        .webhook_delivery_worker
+        .deliver_webhook(
+            webhook_delivery_id,
+            subscription_id,
+            WebhookEventTypeCatalog::dataset_ref_updated(),
+            serde_json::json!({"key": "value"}),
+        )
+        .await;
+    assert_matches!(
+        res,
+        Err(WebhookDeliveryError::SendError(WebhookSendError::FailedToConnect(WebhookSendFailedToConnectError { target_url, .. })))
+            if target_url == Url::parse("https://example.com/webhook").unwrap()
+    );
+
+    let delivery = harness
+        .webhook_delivery_repo
+        .get_by_webhook_delivery_id(webhook_delivery_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(delivery.webhook_subscription_id, subscription_id);
+    assert_eq!(delivery.webhook_delivery_id, webhook_delivery_id);
+    assert_eq!(
+        delivery.request.payload,
+        serde_json::json!({"key": "value"})
+    );
+    assert_eq!(
+        delivery.event_type,
+        WebhookEventTypeCatalog::dataset_ref_updated()
+    );
+
+    assert_eq!(delivery.response, None);
+
+    assert!(!delivery.is_successful());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_deliver_webhook_bad_status_failure() {
+    let subscription_id = WebhookSubscriptionID::new(uuid::Uuid::new_v4());
+    let webhook_delivery_id = WebhookDeliveryID::new(uuid::Uuid::new_v4());
+
+    let mut mock_webhook_sender = MockWebhookSender::new();
+    let target_url = url::Url::parse("https://example.com/webhook").unwrap();
+    TestWebhookDeliveryWorkerHarness::add_bad_status_sender_expectation(
+        &mut mock_webhook_sender,
+        &target_url,
+        webhook_delivery_id,
+        subscription_id,
+        http::StatusCode::BAD_REQUEST,
+    );
+
+    let harness = TestWebhookDeliveryWorkerHarness::new(mock_webhook_sender);
+
+    harness.new_webhook_subscription(subscription_id).await;
+
+    let res = harness
+        .webhook_delivery_worker
+        .deliver_webhook(
+            webhook_delivery_id,
+            subscription_id,
+            WebhookEventTypeCatalog::dataset_ref_updated(),
+            serde_json::json!({"key": "value"}),
+        )
+        .await;
+    assert_matches!(
+        res,
+        Err(WebhookDeliveryError::UnsuccessfulResponse(
+            WebhookUnsuccessfulResponseError {
+                status_code,
+                target_url: a_target_url
+            }
+        )) if status_code == http::StatusCode::BAD_REQUEST &&
+            a_target_url == target_url
+    );
+
+    let delivery = harness
+        .webhook_delivery_repo
+        .get_by_webhook_delivery_id(webhook_delivery_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(delivery.webhook_subscription_id, subscription_id);
+    assert_eq!(delivery.webhook_delivery_id, webhook_delivery_id);
+    assert_eq!(
+        delivery.request.payload,
+        serde_json::json!({"key": "value"})
+    );
+    assert_eq!(
+        delivery.event_type,
+        WebhookEventTypeCatalog::dataset_ref_updated()
+    );
+
+    assert_matches!(
+        delivery.response,
+        Some(WebhookResponse {
+            status_code: http::StatusCode::BAD_REQUEST,
+            ..
+        })
     );
 
     assert!(!delivery.is_successful());
@@ -171,96 +317,134 @@ impl TestWebhookDeliveryWorkerHarness {
         delivery_id: WebhookDeliveryID,
         subscription_id: WebhookSubscriptionID,
     ) {
-        mock_webhook_sender
-            .expect_send_webhook()
-            .withf(move |url, _, headers| {
-                assert_eq!(target_url, *url);
-
-                assert_eq!(
-                    headers.get("Content-Type").map(|h| h.to_str().unwrap()),
-                    Some("application/json")
-                );
-
-                assert_eq!(
-                    headers
-                        .get(HEADER_WEBHOOK_DELIVERY_ID)
-                        .map(|h| h.to_str().unwrap()),
-                    Some(delivery_id.into_inner().to_string().as_str())
-                );
-                assert_eq!(
-                    headers
-                        .get(HEADER_WEBHOOK_SUBSCRIPTION_ID)
-                        .map(|h| h.to_str().unwrap()),
-                    Some(subscription_id.into_inner().to_string().as_str())
-                );
-                assert_eq!(
-                    headers
-                        .get(HEADER_WEBHOOK_EVENT_TYPE)
-                        .map(|h| h.to_str().unwrap()),
-                    Some(WebhookEventTypeCatalog::DATASET_REF_UPDATED)
-                );
-                assert_eq!(
-                    headers
-                        .get(HEADER_WEBHOOK_DELIVERY_ATTEMPT)
-                        .map(|h| h.to_str().unwrap()),
-                    Some("1")
-                );
-                assert!(headers.contains_key(HEADER_WEBHOOK_TIMESTAMP));
-                assert!(headers.contains_key(HEADER_CONTENT_DIGEST));
-                assert!(headers.contains_key(HEADER_SIGNATURE));
-                assert!(headers.contains_key(HEADER_SIGNATURE_INPUT));
-
-                true
-            })
-            .returning(|_, _, _| {
-                Ok(WebhookResponse::new(
-                    http::StatusCode::OK,
-                    http::HeaderMap::new(),
-                    "ok".to_string(),
-                    Utc::now(),
-                ))
-            });
+        Self::add_webhook_sender_expectation(
+            mock_webhook_sender,
+            target_url,
+            delivery_id,
+            subscription_id,
+            Ok(WebhookResponse::new(
+                http::StatusCode::OK,
+                http::HeaderMap::new(),
+                "OK".to_string(),
+                Utc::now(),
+            )),
+        );
     }
 
-    fn add_failing_sender_expectation(
+    fn add_connection_failure_sender_expectation(
         mock_webhook_sender: &mut MockWebhookSender,
         target_url: Url,
         delivery_id: WebhookDeliveryID,
         subscription_id: WebhookSubscriptionID,
     ) {
+        Self::add_webhook_sender_expectation(
+            mock_webhook_sender,
+            target_url.clone(),
+            delivery_id,
+            subscription_id,
+            Err(WebhookSendError::FailedToConnect(
+                WebhookSendFailedToConnectError { target_url },
+            )),
+        );
+    }
+
+    fn add_timeout_sender_expectation(
+        mock_webhook_sender: &mut MockWebhookSender,
+        target_url: Url,
+        delivery_id: WebhookDeliveryID,
+        subscription_id: WebhookSubscriptionID,
+    ) {
+        Self::add_webhook_sender_expectation(
+            mock_webhook_sender,
+            target_url.clone(),
+            delivery_id,
+            subscription_id,
+            Err(WebhookSendError::ConnectionTimeout(
+                WebhookSendConnectionTimeoutError {
+                    target_url,
+                    timeout: std::time::Duration::from_secs(10),
+                },
+            )),
+        );
+    }
+
+    fn add_bad_status_sender_expectation(
+        mock_webhook_sender: &mut MockWebhookSender,
+        target_url: &Url,
+        delivery_id: WebhookDeliveryID,
+        subscription_id: WebhookSubscriptionID,
+        status_code: http::StatusCode,
+    ) {
+        Self::add_webhook_sender_expectation(
+            mock_webhook_sender,
+            target_url.clone(),
+            delivery_id,
+            subscription_id,
+            Ok(WebhookResponse::new(
+                status_code,
+                http::HeaderMap::new(),
+                "Some Bad Response".to_string(),
+                Utc::now(),
+            )),
+        );
+    }
+
+    fn add_webhook_sender_expectation(
+        mock_webhook_sender: &mut MockWebhookSender,
+        target_url: Url,
+        delivery_id: WebhookDeliveryID,
+        subscription_id: WebhookSubscriptionID,
+        expected_result: Result<WebhookResponse, WebhookSendError>,
+    ) {
         mock_webhook_sender
             .expect_send_webhook()
+            .times(1)
             .withf(move |url, _, headers| {
                 assert_eq!(target_url, *url);
-
-                assert_eq!(
-                    headers.get("Content-Type").map(|h| h.to_str().unwrap()),
-                    Some("application/json")
-                );
-
-                assert_eq!(
-                    headers
-                        .get(HEADER_WEBHOOK_DELIVERY_ID)
-                        .map(|h| h.to_str().unwrap()),
-                    Some(delivery_id.into_inner().to_string().as_str())
-                );
-                assert_eq!(
-                    headers
-                        .get(HEADER_WEBHOOK_SUBSCRIPTION_ID)
-                        .map(|h| h.to_str().unwrap()),
-                    Some(subscription_id.into_inner().to_string().as_str())
-                );
-
+                Self::assert_webhook_sender_headers(headers, delivery_id, subscription_id);
                 true
             })
-            .returning(|_, _, _| {
-                Ok(WebhookResponse::new(
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
-                    http::HeaderMap::new(),
-                    "Internal error".to_string(),
-                    Utc::now(),
-                ))
-            });
+            .return_once(move |_, _, _| expected_result);
+    }
+
+    fn assert_webhook_sender_headers(
+        headers: &http::HeaderMap,
+        delivery_id: WebhookDeliveryID,
+        subscription_id: WebhookSubscriptionID,
+    ) {
+        assert_eq!(
+            headers.get("Content-Type").map(|h| h.to_str().unwrap()),
+            Some("application/json")
+        );
+
+        assert_eq!(
+            headers
+                .get(HEADER_WEBHOOK_DELIVERY_ID)
+                .map(|h| h.to_str().unwrap()),
+            Some(delivery_id.into_inner().to_string().as_str())
+        );
+        assert_eq!(
+            headers
+                .get(HEADER_WEBHOOK_SUBSCRIPTION_ID)
+                .map(|h| h.to_str().unwrap()),
+            Some(subscription_id.into_inner().to_string().as_str())
+        );
+        assert_eq!(
+            headers
+                .get(HEADER_WEBHOOK_EVENT_TYPE)
+                .map(|h| h.to_str().unwrap()),
+            Some(WebhookEventTypeCatalog::DATASET_REF_UPDATED)
+        );
+        assert_eq!(
+            headers
+                .get(HEADER_WEBHOOK_DELIVERY_ATTEMPT)
+                .map(|h| h.to_str().unwrap()),
+            Some("1")
+        );
+        assert!(headers.contains_key(HEADER_WEBHOOK_TIMESTAMP));
+        assert!(headers.contains_key(HEADER_CONTENT_DIGEST));
+        assert!(headers.contains_key(HEADER_SIGNATURE));
+        assert!(headers.contains_key(HEADER_SIGNATURE_INPUT));
     }
 }
 


### PR DESCRIPTION
## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: #1335

Extended support for webhook delivery errors, differentiating between:
   - connection failure
   - response timeout
   - bad status code in response

Handling at: domain level, task adapter level, GQL API level.

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [x] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [ ] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)