### PR TITLE
GQL: Search::query(): case insensitive search (backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ Recommendation: for ease of reading, use the following order:
 ### Added
 - GQL: `Auth::relations()` for getting ReBAC triplets for debugging purposes.
 ### Changed
-- dep: `ringbug` updated from `0.3` to `0.4`.
+- dep: `ringbuf` updated from `0.3` to `0.4`.
 - Flows: each input contribution to batching rule is reflected as an update of start condition,
    so that flow history may show how many accumulated records were present at the moment of each update
+- GQL: `Search::query()`: case insensitive search.
 ### Fixed
 - Crash when multiple unlabeled webhook subscriptions are defined within the same dataset
 - Restrict dataset creation with duplicate transform inputs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9197,6 +9197,7 @@ dependencies = [
  "digest 0.10.7",
  "ed25519-dalek",
  "hex",
+ "pretty_assertions",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/src/utils/multiformats/Cargo.toml
+++ b/src/utils/multiformats/Cargo.toml
@@ -51,3 +51,7 @@ unsigned-varint = { version = "0.8", default-features = false, features = [
 utoipa = { optional = true, version = "5", default-features = false, features = [
 ] }
 serde_json = { optional = true, version = "1", default-features = false }
+
+
+[dev-dependencies]
+pretty_assertions = { version = "1", default-features = false, features = ["std", "unstable"] }

--- a/src/utils/multiformats/src/stack_string.rs
+++ b/src/utils/multiformats/src/stack_string.rs
@@ -24,6 +24,11 @@ impl<const S: usize> StackString<S> {
     pub fn as_str(&self) -> &str {
         std::str::from_utf8(&self.buf[..self.len]).unwrap()
     }
+
+    pub fn make_ascii_lowercase(&mut self) {
+        let buf = &mut self.buf[..self.len];
+        buf.make_ascii_lowercase();
+    }
 }
 
 impl<const S: usize> std::ops::Deref for StackString<S> {

--- a/src/utils/multiformats/tests/tests/mod.rs
+++ b/src/utils/multiformats/tests/tests/mod.rs
@@ -9,3 +9,4 @@
 
 mod test_did_key;
 mod test_multihash;
+mod test_stack_string;

--- a/src/utils/multiformats/tests/tests/test_stack_string.rs
+++ b/src/utils/multiformats/tests/tests/test_stack_string.rs
@@ -1,0 +1,44 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use multiformats::stack_string::StackString;
+use pretty_assertions::assert_eq;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test]
+fn test_as_str() {
+    let s = StackString::new(*b"hello", 5);
+    assert_eq!("hello", s.as_str());
+
+    let s = StackString::new(*b"hello", 3);
+    assert_eq!("hel", s.as_str());
+
+    let s = StackString::new(*b"hello", 0);
+    assert_eq!("", s.as_str());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test]
+fn test_make_ascii_lowercase() {
+    let mut s = StackString::new(*b"hello", 5);
+    s.make_ascii_lowercase();
+    assert_eq!("hello", s.as_str());
+
+    let mut s = StackString::new(*b"wOrLd", 5);
+    s.make_ascii_lowercase();
+    assert_eq!("world", s.as_str());
+
+    let mut s = StackString::new(*b"\xCE\xBB 42 teST", 10);
+    s.make_ascii_lowercase();
+    assert_eq!("λ 42 test", s.as_str());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- [x] Backported from:
  - https://github.com/kamu-data/kamu-cli/pull/1357

---

## Description

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: #1285

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [x] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)