### PR TITLE
`DependencyGraphImmediateListener:` fix a message processing race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,14 @@ Recommendation: for ease of reading, use the following order:
 ### Fixed
 - Crash when multiple unlabeled webhook subscriptions are defined within the same dataset
 - Restrict dataset creation with duplicate transform inputs.
-- (#1263) DependencyGraphImmediateListener: fix a message processing race condition.
+- (#1263) `DependencyGraphImmediateListener`: fixed a message processing race condition.
   - Parallel processing message of one type, in the case of handlers that were dependent on each other, 
     could lead to incorrect formation of the upstream/downstream dependency list 
     when pulling/pushing existing remote datasets. 
+- (#1263) `OsoDatasetAuthorizer::classify_dataset_ids_by_allowance()`.
+  - Fixed a bug that returned an empty `unresolved_resources` list 
+    when there were no dataset entries. This could happen when pulling a dataset 
+    that had upstream dependencies but no dependencies itself.
 
 ## [0.247.0] - 2025-08-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Recommendation: for ease of reading, use the following order:
 ### Fixed
 - Crash when multiple unlabeled webhook subscriptions are defined within the same dataset
 - Restrict dataset creation with duplicate transform inputs.
+- (#1263) DependencyGraphImmediateListener: fix a message processing race condition.
+  - Parallel processing message of one type, in the case of handlers that were dependent on each other, 
+    could lead to incorrect formation of the upstream/downstream dependency list 
+    when pulling/pushing existing remote datasets. 
 
 ## [0.247.0] - 2025-08-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Recommendation: for ease of reading, use the following order:
 - Flows: each input contribution to batching rule is reflected as an update of start condition,
    so that flow history may show how many accumulated records were present at the moment of each update
 - GQL: `Search::query()`: case insensitive search.
+- (#1263): `images/kamu-base-with-data-mt`: make datasets public by default.
 ### Fixed
 - Crash when multiple unlabeled webhook subscriptions are defined within the same dataset
 - Restrict dataset creation with duplicate transform inputs.

--- a/images/kamu-base-with-data-mt/init-workspace.py
+++ b/images/kamu-base-with-data-mt/init-workspace.py
@@ -51,7 +51,7 @@ for did in s3_listdir(S3_REPO_URL):
     account, name = alias.split('/', 1)
 
     subprocess.run(
-        f"kamu --account {account} pull --no-alias {url} --as {name}",
+        f"kamu --account {account} pull --no-alias {url} --as {name} --visibility public",
         shell=True,
         check=True,
     )

--- a/src/adapter/auth-oso-rebac/src/oso_dataset_authorizer.rs
+++ b/src/adapter/auth-oso-rebac/src/oso_dataset_authorizer.rs
@@ -153,8 +153,6 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
         action: DatasetAction,
     ) -> Result<ClassifyByAllowanceResponse, InternalError> {
         let user_actor = self.user_actor().await?;
-        let mut matched_dataset_handles = Vec::with_capacity(dataset_handles.len());
-        let mut unmatched_results = Vec::new();
 
         let dataset_ids = dataset_handles
             .iter()
@@ -165,6 +163,11 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
             .get_multiple_dataset_resources(&dataset_ids)
             .await
             .int_err()?;
+        let mut authorized_handles =
+            Vec::with_capacity(dataset_resources_resolution.resolved_resources.len());
+        let mut unauthorized_handles_with_errors =
+            Vec::with_capacity(dataset_resources_resolution.unresolved_resources.len());
+
         let dataset_handle_id_mapping =
             dataset_handles
                 .into_iter()
@@ -187,19 +190,38 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
                 .int_err()?;
 
             if is_allowed {
-                matched_dataset_handles.push(dataset_handle);
+                authorized_handles.push(dataset_handle);
             } else {
                 let dataset_ref = dataset_handle.as_local_ref();
-                unmatched_results.push((
+                unauthorized_handles_with_errors.push((
                     dataset_handle,
-                    DatasetActionUnauthorizedError::not_enough_permissions(dataset_ref, action),
+                    MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                        dataset_ref,
+                        action,
+                    ),
                 ));
             }
         }
 
+        for unresolved_dataset_id in dataset_resources_resolution.unresolved_resources {
+            let dataset_handle = dataset_handle_id_mapping
+                .get(&unresolved_dataset_id)
+                .ok_or_else(|| {
+                    format!("Unexpectedly, dataset_handle not was found: {unresolved_dataset_id}")
+                        .int_err()
+                })?
+                .clone();
+            let dataset_ref = dataset_handle.as_local_ref();
+
+            unauthorized_handles_with_errors.push((
+                dataset_handle,
+                odf::DatasetNotFoundError::new(dataset_ref).into(),
+            ));
+        }
+
         Ok(ClassifyByAllowanceResponse {
-            authorized_handles: matched_dataset_handles,
-            unauthorized_handles_with_errors: unmatched_results,
+            authorized_handles,
+            unauthorized_handles_with_errors,
         })
     }
 
@@ -210,14 +232,16 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
         action: DatasetAction,
     ) -> Result<ClassifyByAllowanceIdsResponse, InternalError> {
         let user_actor = self.user_actor().await?;
-        let mut authorized_ids = Vec::with_capacity(dataset_ids.len());
-        let mut unauthorized_ids_with_errors = Vec::new();
 
         let dataset_resources_resolution = self
             .oso_resource_service
             .get_multiple_dataset_resources(dataset_ids)
             .await
             .int_err()?;
+        let mut authorized_ids =
+            Vec::with_capacity(dataset_resources_resolution.resolved_resources.len());
+        let mut unauthorized_ids_with_errors =
+            Vec::with_capacity(dataset_resources_resolution.unresolved_resources.len());
 
         for (dataset_id, dataset_resource) in dataset_resources_resolution.resolved_resources {
             let is_allowed = self
@@ -231,7 +255,10 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
                 let dataset_ref = dataset_id.as_local_ref();
                 unauthorized_ids_with_errors.push((
                     dataset_id,
-                    DatasetActionUnauthorizedError::not_enough_permissions(dataset_ref, action),
+                    MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                        dataset_ref,
+                        action,
+                    ),
                 ));
             }
         }
@@ -240,7 +267,7 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
             let dataset_ref = unresolved_dataset_id.as_local_ref();
             unauthorized_ids_with_errors.push((
                 unresolved_dataset_id,
-                DatasetActionUnauthorizedError::unresolved(dataset_ref, action),
+                odf::DatasetNotFoundError::new(dataset_ref).into(),
             ));
         }
 

--- a/src/adapter/auth-oso-rebac/src/oso_dataset_authorizer.rs
+++ b/src/adapter/auth-oso-rebac/src/oso_dataset_authorizer.rs
@@ -236,6 +236,14 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
             }
         }
 
+        for unresolved_dataset_id in dataset_resources_resolution.unresolved_resources {
+            let dataset_ref = unresolved_dataset_id.as_local_ref();
+            unauthorized_ids_with_errors.push((
+                unresolved_dataset_id,
+                DatasetActionUnauthorizedError::unresolved(dataset_ref, action),
+            ));
+        }
+
         Ok(ClassifyByAllowanceIdsResponse {
             authorized_ids,
             unauthorized_ids_with_errors,

--- a/src/adapter/auth-oso-rebac/src/oso_dataset_authorizer.rs
+++ b/src/adapter/auth-oso-rebac/src/oso_dataset_authorizer.rs
@@ -195,7 +195,7 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
                 let dataset_ref = dataset_handle.as_local_ref();
                 unauthorized_handles_with_errors.push((
                     dataset_handle,
-                    MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                    ClassifyByAllowanceDatasetActionUnauthorizedError::not_enough_permissions(
                         dataset_ref,
                         action,
                     ),
@@ -255,7 +255,7 @@ impl DatasetActionAuthorizer for OsoDatasetAuthorizer {
                 let dataset_ref = dataset_id.as_local_ref();
                 unauthorized_ids_with_errors.push((
                     dataset_id,
-                    MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                    ClassifyByAllowanceDatasetActionUnauthorizedError::not_enough_permissions(
                         dataset_ref,
                         action,
                     ),

--- a/src/adapter/graphql/tests/utils/base_gql_dataset_harness.rs
+++ b/src/adapter/graphql/tests/utils/base_gql_dataset_harness.rs
@@ -105,6 +105,11 @@ impl BaseGQLDatasetHarness {
                 MESSAGE_PRODUCER_KAMU_DATASET_DEPENDENCY_GRAPH_SERVICE,
             );
 
+            register_message_dispatcher::<DatasetKeyBlocksMessage>(
+                &mut b,
+                MESSAGE_PRODUCER_KAMU_DATASET_KEY_BLOCK_UPDATE_HANDLER,
+            );
+
             b.build()
         };
 

--- a/src/app/cli/src/app.rs
+++ b/src/app/cli/src/app.rs
@@ -573,6 +573,11 @@ pub fn configure_base_catalog(
         kamu_datasets::MESSAGE_PRODUCER_KAMU_DATASET_DEPENDENCY_GRAPH_SERVICE,
     );
 
+    register_message_dispatcher::<kamu_datasets::DatasetKeyBlocksMessage>(
+        &mut b,
+        kamu_datasets::MESSAGE_PRODUCER_KAMU_DATASET_KEY_BLOCK_UPDATE_HANDLER,
+    );
+
     register_message_dispatcher::<kamu_datasets::DatasetExternallyChangedMessage>(
         &mut b,
         kamu_datasets::MESSAGE_PRODUCER_KAMU_HTTP_ADAPTER,

--- a/src/domain/auth-rebac/services/src/use_cases/apply_account_dataset_relations_use_case_impl.rs
+++ b/src/domain/auth-rebac/services/src/use_cases/apply_account_dataset_relations_use_case_impl.rs
@@ -54,7 +54,7 @@ impl ApplyAccountDatasetRelationsUseCaseImpl {
         let mut not_found_dataset_refs = Vec::with_capacity(unauthorized_ids_with_errors.len());
         let mut unauthorized_dataset_refs = Vec::with_capacity(unauthorized_ids_with_errors.len());
         for (dataset_id, e) in unauthorized_ids_with_errors {
-            use kamu_core::auth::MultipleDatasetActionUnauthorizedError as E;
+            use kamu_core::auth::ClassifyByAllowanceDatasetActionUnauthorizedError as E;
 
             match e {
                 E::NotFound(_) => {

--- a/src/domain/auth-rebac/services/src/use_cases/apply_account_dataset_relations_use_case_impl.rs
+++ b/src/domain/auth-rebac/services/src/use_cases/apply_account_dataset_relations_use_case_impl.rs
@@ -15,6 +15,7 @@ use internal_error::{ErrorIntoInternal, ResultIntoInternal};
 use kamu_auth_rebac::{
     AccountDatasetRelationOperation,
     ApplyAccountDatasetRelationsUseCase,
+    ApplyRelationMatrixBatchError,
     ApplyRelationMatrixError,
     DatasetRoleOperation,
     RebacService,
@@ -22,7 +23,7 @@ use kamu_auth_rebac::{
     UnsetAccountDatasetRelationsOperation,
 };
 use kamu_core::auth;
-use kamu_core::auth::{DatasetAction, DatasetActionUnauthorizedError};
+use kamu_core::auth::DatasetAction;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -50,22 +51,30 @@ impl ApplyAccountDatasetRelationsUseCaseImpl {
             return Ok(());
         }
 
+        let mut not_found_dataset_refs = Vec::with_capacity(unauthorized_ids_with_errors.len());
         let mut unauthorized_dataset_refs = Vec::with_capacity(unauthorized_ids_with_errors.len());
         for (dataset_id, e) in unauthorized_ids_with_errors {
+            use kamu_core::auth::MultipleDatasetActionUnauthorizedError as E;
+
             match e {
-                DatasetActionUnauthorizedError::Access(_) => {
+                E::NotFound(_) => {
+                    not_found_dataset_refs.push(dataset_id.as_local_ref());
+                }
+                E::Access(_) => {
                     unauthorized_dataset_refs.push(dataset_id.as_local_ref());
                 }
-                e @ DatasetActionUnauthorizedError::Internal(_) => {
+                e @ E::Internal(_) => {
                     return Err(ApplyRelationMatrixError::Internal(e.int_err()));
                 }
             }
         }
 
-        Err(ApplyRelationMatrixError::not_enough_permissions(
+        Err(ApplyRelationMatrixBatchError {
+            action: EXPECTED_ACCESS,
             unauthorized_dataset_refs,
-            EXPECTED_ACCESS,
-        ))
+            not_found_dataset_refs,
+        }
+        .into())
     }
 }
 

--- a/src/domain/core/src/auth/dataset_action_authorizer.rs
+++ b/src/domain/core/src/auth/dataset_action_authorizer.rs
@@ -269,6 +269,16 @@ impl DatasetActionUnauthorizedError {
             .into(),
         ))
     }
+
+    pub fn unresolved(dataset_ref: odf::DatasetRef, action: DatasetAction) -> Self {
+        Self::Access(odf::AccessError::Unauthorized(
+            DatasetActionUnresolvedError {
+                action,
+                dataset_ref,
+            }
+            .into(),
+        ))
+    }
 }
 
 #[derive(Debug, Error)]
@@ -296,6 +306,13 @@ impl std::fmt::Display for DatasetsActionNotEnoughPermissionsError {
         write!(f, "'")?;
         Ok(())
     }
+}
+
+#[derive(Debug, Error)]
+#[error("User attempts to get '{action}' permission for an unresolved dataset '{dataset_ref}'")]
+pub struct DatasetActionUnresolvedError {
+    pub action: DatasetAction,
+    pub dataset_ref: odf::DatasetRef,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/core/src/auth/dataset_action_authorizer.rs
+++ b/src/domain/core/src/auth/dataset_action_authorizer.rs
@@ -282,26 +282,6 @@ pub struct DatasetActionNotEnoughPermissionsError {
     pub dataset_ref: odf::DatasetRef,
 }
 
-#[derive(Debug, Error)]
-pub struct DatasetsActionNotEnoughPermissionsError {
-    pub action: DatasetAction,
-    pub dataset_refs: Vec<odf::DatasetRef>,
-}
-
-impl std::fmt::Display for DatasetsActionNotEnoughPermissionsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "User has no '{}' permission in datasets: '", self.action)?;
-        for (i, item) in self.dataset_refs.iter().enumerate() {
-            if i > 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "{item}")?;
-        }
-        write!(f, "'")?;
-        Ok(())
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Error)]

--- a/src/domain/core/src/auth/dataset_action_authorizer.rs
+++ b/src/domain/core/src/auth/dataset_action_authorizer.rs
@@ -285,7 +285,7 @@ pub struct DatasetActionNotEnoughPermissionsError {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Error)]
-pub enum MultipleDatasetActionUnauthorizedError {
+pub enum ClassifyByAllowanceDatasetActionUnauthorizedError {
     #[error(transparent)]
     NotFound(#[from] odf::DatasetNotFoundError),
 
@@ -300,7 +300,7 @@ pub enum MultipleDatasetActionUnauthorizedError {
     Internal(#[from] InternalError),
 }
 
-impl MultipleDatasetActionUnauthorizedError {
+impl ClassifyByAllowanceDatasetActionUnauthorizedError {
     pub fn not_enough_permissions(dataset_ref: odf::DatasetRef, action: DatasetAction) -> Self {
         Self::Access(odf::AccessError::Unauthorized(
             DatasetActionNotEnoughPermissionsError {
@@ -317,8 +317,10 @@ impl MultipleDatasetActionUnauthorizedError {
 #[derive(Debug)]
 pub struct ClassifyByAllowanceResponse {
     pub authorized_handles: Vec<odf::DatasetHandle>,
-    pub unauthorized_handles_with_errors:
-        Vec<(odf::DatasetHandle, MultipleDatasetActionUnauthorizedError)>,
+    pub unauthorized_handles_with_errors: Vec<(
+        odf::DatasetHandle,
+        ClassifyByAllowanceDatasetActionUnauthorizedError,
+    )>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -397,7 +399,10 @@ where
 #[derive(Debug)]
 pub struct ClassifyByAllowanceIdsResponse {
     pub authorized_ids: Vec<odf::DatasetID>,
-    pub unauthorized_ids_with_errors: Vec<(odf::DatasetID, MultipleDatasetActionUnauthorizedError)>,
+    pub unauthorized_ids_with_errors: Vec<(
+        odf::DatasetID,
+        ClassifyByAllowanceDatasetActionUnauthorizedError,
+    )>,
 }
 
 #[cfg(any(feature = "testing", test))]

--- a/src/domain/core/src/services/sync_service.rs
+++ b/src/domain/core/src/services/sync_service.rs
@@ -286,6 +286,7 @@ pub enum IpfsAddError {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// TODO: Remove this error in favor of `odf::DatasetNotFoundError`
 #[derive(Error, Clone, Eq, PartialEq, Debug)]
 #[error("Dataset {dataset_ref} not found")]
 pub struct DatasetAnyRefUnresolvedError {
@@ -296,6 +297,14 @@ impl DatasetAnyRefUnresolvedError {
     pub fn new(r: impl Into<odf::DatasetRefAny>) -> Self {
         Self {
             dataset_ref: r.into(),
+        }
+    }
+}
+
+impl From<odf::DatasetNotFoundError> for DatasetAnyRefUnresolvedError {
+    fn from(v: odf::DatasetNotFoundError) -> Self {
+        Self {
+            dataset_ref: v.dataset_ref.as_any_ref(),
         }
     }
 }

--- a/src/domain/core/src/testing/owner_by_alias_dataset_action_authorizer.rs
+++ b/src/domain/core/src/testing/owner_by_alias_dataset_action_authorizer.rs
@@ -15,12 +15,12 @@ use dill::*;
 use internal_error::{InternalError, ResultIntoInternal};
 
 use crate::auth::{
+    ClassifyByAllowanceDatasetActionUnauthorizedError,
     ClassifyByAllowanceIdsResponse,
     ClassifyByAllowanceResponse,
     DatasetAction,
     DatasetActionAuthorizer,
     DatasetActionUnauthorizedError,
-    MultipleDatasetActionUnauthorizedError,
 };
 use crate::{DatasetRegistry, DatasetRegistryExt};
 
@@ -112,7 +112,7 @@ impl DatasetActionAuthorizer for OwnerByAliasDatasetActionAuthorizer {
                     let dataset_ref = dataset_handle.as_local_ref();
                     (
                         dataset_handle,
-                        MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                        ClassifyByAllowanceDatasetActionUnauthorizedError::not_enough_permissions(
                             dataset_ref,
                             action,
                         ),
@@ -134,10 +134,11 @@ impl DatasetActionAuthorizer for OwnerByAliasDatasetActionAuthorizer {
             if self.owns_dataset_by_id(dataset_id).await? {
                 allowed.push(dataset_id.as_ref().clone());
             } else {
-                let error = MultipleDatasetActionUnauthorizedError::not_enough_permissions(
-                    dataset_id.as_local_ref(),
-                    action,
-                );
+                let error =
+                    ClassifyByAllowanceDatasetActionUnauthorizedError::not_enough_permissions(
+                        dataset_id.as_local_ref(),
+                        action,
+                    );
 
                 not_allowed.push((dataset_id.as_ref().clone(), error));
             }

--- a/src/domain/core/src/testing/owner_by_alias_dataset_action_authorizer.rs
+++ b/src/domain/core/src/testing/owner_by_alias_dataset_action_authorizer.rs
@@ -20,6 +20,7 @@ use crate::auth::{
     DatasetAction,
     DatasetActionAuthorizer,
     DatasetActionUnauthorizedError,
+    MultipleDatasetActionUnauthorizedError,
 };
 use crate::{DatasetRegistry, DatasetRegistryExt};
 
@@ -111,7 +112,10 @@ impl DatasetActionAuthorizer for OwnerByAliasDatasetActionAuthorizer {
                     let dataset_ref = dataset_handle.as_local_ref();
                     (
                         dataset_handle,
-                        DatasetActionUnauthorizedError::not_enough_permissions(dataset_ref, action),
+                        MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                            dataset_ref,
+                            action,
+                        ),
                     )
                 })
                 .collect(),
@@ -130,7 +134,7 @@ impl DatasetActionAuthorizer for OwnerByAliasDatasetActionAuthorizer {
             if self.owns_dataset_by_id(dataset_id).await? {
                 allowed.push(dataset_id.as_ref().clone());
             } else {
-                let error = DatasetActionUnauthorizedError::not_enough_permissions(
+                let error = MultipleDatasetActionUnauthorizedError::not_enough_permissions(
                     dataset_id.as_local_ref(),
                     action,
                 );

--- a/src/domain/datasets/domain/src/messages/dataset_key_blocks_message.rs
+++ b/src/domain/datasets/domain/src/messages/dataset_key_blocks_message.rs
@@ -16,30 +16,30 @@ const DATASET_REFERENCE_OUTBOX_VERSION: u32 = 1;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Represents messages related to dataset references.
+/// Represents messages related to dataset key blocks.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum DatasetReferenceMessage {
-    /// Message indicating that a dataset reference has been updated.
-    Updated(DatasetReferenceMessageUpdated),
+pub enum DatasetKeyBlocksMessage {
+    /// Message indicating that dataset key blocks have been introduced.
+    Introduced(DatasetKeyBlocksMessageIntroduced),
 }
 
-impl DatasetReferenceMessage {
-    pub fn updated(
+impl DatasetKeyBlocksMessage {
+    pub fn introduced(
         dataset_id: &odf::DatasetID,
         block_ref: &odf::BlockRef,
-        maybe_prev_block_hash: Option<&odf::Multihash>,
-        new_block_hash: &odf::Multihash,
+        tail_key_block_hash: &odf::Multihash,
+        head_key_block_hash: &odf::Multihash,
     ) -> Self {
-        Self::Updated(DatasetReferenceMessageUpdated {
+        Self::Introduced(DatasetKeyBlocksMessageIntroduced {
             dataset_id: dataset_id.clone(),
             block_ref: block_ref.clone(),
-            maybe_prev_block_hash: maybe_prev_block_hash.cloned(),
-            new_block_hash: new_block_hash.clone(),
+            tail_key_block_hash: tail_key_block_hash.clone(),
+            head_key_block_hash: head_key_block_hash.clone(),
         })
     }
 }
 
-impl Message for DatasetReferenceMessage {
+impl Message for DatasetKeyBlocksMessage {
     fn version() -> u32 {
         DATASET_REFERENCE_OUTBOX_VERSION
     }
@@ -47,21 +47,23 @@ impl Message for DatasetReferenceMessage {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Contains details about an updated dataset reference.
+/// Contains details about introduced dataset key blocks.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DatasetReferenceMessageUpdated {
+pub struct DatasetKeyBlocksMessageIntroduced {
     /// The unique identifier of the dataset.
     pub dataset_id: odf::DatasetID,
 
-    /// The reference being updated.
+    /// The reference for which key blocks were introduced.
     pub block_ref: odf::BlockRef,
 
-    /// The previous block hash: this value will only be None
-    /// for datasets that were just created.
-    pub maybe_prev_block_hash: Option<odf::Multihash>,
+    /// The tail interval key block hash (inclusive).
+    /// Note: Data blocks might be present within the interval (exclusive).
+    pub tail_key_block_hash: odf::Multihash,
 
-    /// The new block hash after the update.
-    pub new_block_hash: odf::Multihash,
+    /// The head interval key block hash (inclusive) where key blocks are
+    /// present.
+    /// Note: Data blocks might be present within the interval (exclusive).
+    pub head_key_block_hash: odf::Multihash,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/domain/src/messages/dataset_key_blocks_message.rs
+++ b/src/domain/datasets/domain/src/messages/dataset_key_blocks_message.rs
@@ -29,12 +29,16 @@ impl DatasetKeyBlocksMessage {
         block_ref: &odf::BlockRef,
         tail_key_block_hash: &odf::Multihash,
         head_key_block_hash: &odf::Multihash,
+        key_blocks_event_flags: odf::metadata::MetadataEventTypeFlags,
+        divergence_detected: bool,
     ) -> Self {
         Self::Introduced(DatasetKeyBlocksMessageIntroduced {
             dataset_id: dataset_id.clone(),
             block_ref: block_ref.clone(),
             tail_key_block_hash: tail_key_block_hash.clone(),
             head_key_block_hash: head_key_block_hash.clone(),
+            key_blocks_event_flags,
+            divergence_detected,
         })
     }
 }
@@ -64,6 +68,13 @@ pub struct DatasetKeyBlocksMessageIntroduced {
     /// present.
     /// Note: Data blocks might be present within the interval (exclusive).
     pub head_key_block_hash: odf::Multihash,
+
+    /// Key blocks event flags present within the interval.
+    pub key_blocks_event_flags: odf::metadata::MetadataEventTypeFlags,
+
+    /// A flag indicating that a chain of blocks has been rewritten.
+    /// This can happen as a result of a dataset reset or force push.
+    pub divergence_detected: bool,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/domain/src/messages/dataset_key_blocks_message.rs
+++ b/src/domain/datasets/domain/src/messages/dataset_key_blocks_message.rs
@@ -19,12 +19,12 @@ const DATASET_REFERENCE_OUTBOX_VERSION: u32 = 1;
 /// Represents messages related to dataset key blocks.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DatasetKeyBlocksMessage {
-    /// Message indicating that dataset key blocks have been introduced.
-    Introduced(DatasetKeyBlocksMessageIntroduced),
+    /// Message indicating that dataset key blocks have been appended.
+    Appended(DatasetKeyBlocksMessageAppended),
 }
 
 impl DatasetKeyBlocksMessage {
-    pub fn introduced(
+    pub fn appended(
         dataset_id: &odf::DatasetID,
         block_ref: &odf::BlockRef,
         tail_key_block_hash: &odf::Multihash,
@@ -32,7 +32,7 @@ impl DatasetKeyBlocksMessage {
         key_blocks_event_flags: odf::metadata::MetadataEventTypeFlags,
         divergence_detected: bool,
     ) -> Self {
-        Self::Introduced(DatasetKeyBlocksMessageIntroduced {
+        Self::Appended(DatasetKeyBlocksMessageAppended {
             dataset_id: dataset_id.clone(),
             block_ref: block_ref.clone(),
             tail_key_block_hash: tail_key_block_hash.clone(),
@@ -51,13 +51,13 @@ impl Message for DatasetKeyBlocksMessage {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Contains details about introduced dataset key blocks.
+/// Contains details about appended dataset key blocks.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DatasetKeyBlocksMessageIntroduced {
+pub struct DatasetKeyBlocksMessageAppended {
     /// The unique identifier of the dataset.
     pub dataset_id: odf::DatasetID,
 
-    /// The reference for which key blocks were introduced.
+    /// The reference for which key blocks were appended.
     pub block_ref: odf::BlockRef,
 
     /// The tail interval key block hash (inclusive).

--- a/src/domain/datasets/domain/src/messages/dataset_message_producers.rs
+++ b/src/domain/datasets/domain/src/messages/dataset_message_producers.rs
@@ -17,6 +17,9 @@ pub const MESSAGE_PRODUCER_KAMU_DATASET_REFERENCE_SERVICE: &str =
 pub const MESSAGE_PRODUCER_KAMU_DATASET_DEPENDENCY_GRAPH_SERVICE: &str =
     "dev.kamu.domain.datasets.DependencyGraphService";
 
+pub const MESSAGE_PRODUCER_KAMU_DATASET_KEY_BLOCK_UPDATE_HANDLER: &str =
+    "dev.kamu.domain.datasets.DatasetKeyBlockUpdateHandler";
+
 pub const MESSAGE_PRODUCER_KAMU_HTTP_ADAPTER: &str = "dev.kamu.adapter.http.HttpAdapter";
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/domain/src/messages/dataset_reference_message.rs
+++ b/src/domain/datasets/domain/src/messages/dataset_reference_message.rs
@@ -19,11 +19,28 @@ const DATASET_REFERENCE_OUTBOX_VERSION: u32 = 1;
 /// Represents messages related to dataset references.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DatasetReferenceMessage {
+    /// Message indicating that a dataset reference is currently updating.
+    Updating(DatasetReferenceMessageUpdating),
+
     /// Message indicating that a dataset reference has been updated.
     Updated(DatasetReferenceMessageUpdated),
 }
 
 impl DatasetReferenceMessage {
+    pub fn updating(
+        dataset_id: &odf::DatasetID,
+        block_ref: &odf::BlockRef,
+        maybe_prev_block_hash: Option<&odf::Multihash>,
+        new_block_hash: &odf::Multihash,
+    ) -> Self {
+        Self::Updating(DatasetReferenceMessageUpdating {
+            dataset_id: dataset_id.clone(),
+            block_ref: block_ref.clone(),
+            maybe_prev_block_hash: maybe_prev_block_hash.cloned(),
+            new_block_hash: new_block_hash.clone(),
+        })
+    }
+
     pub fn updated(
         dataset_id: &odf::DatasetID,
         block_ref: &odf::BlockRef,
@@ -47,6 +64,26 @@ impl Message for DatasetReferenceMessage {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Contains details about a reference that is currently updating.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetReferenceMessageUpdating {
+    /// The unique identifier of the dataset. +
+    pub dataset_id: odf::DatasetID,
+
+    /// The reference being updated.
+    pub block_ref: odf::BlockRef,
+
+    /// The previous block hash: this value will only be None
+    /// for datasets that were just created. +
+    pub maybe_prev_block_hash: Option<odf::Multihash>,
+
+    /// The new block hash after the update. +
+    pub new_block_hash: odf::Multihash,
+    // pub read_from_storage: bool,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 /// Contains details about an updated dataset reference.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DatasetReferenceMessageUpdated {
@@ -62,22 +99,6 @@ pub struct DatasetReferenceMessageUpdated {
 
     /// The new block hash after the update.
     pub new_block_hash: odf::Multihash,
-}
-
-impl DatasetReferenceMessageUpdated {
-    pub fn new(
-        dataset_id: odf::DatasetID,
-        block_ref: odf::BlockRef,
-        maybe_prev_block_hash: Option<odf::Multihash>,
-        new_block_hash: odf::Multihash,
-    ) -> Self {
-        Self {
-            dataset_id,
-            block_ref,
-            maybe_prev_block_hash,
-            new_block_hash,
-        }
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/domain/src/messages/dataset_reference_message.rs
+++ b/src/domain/datasets/domain/src/messages/dataset_reference_message.rs
@@ -67,19 +67,18 @@ impl Message for DatasetReferenceMessage {
 /// Contains details about a reference that is currently updating.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DatasetReferenceMessageUpdating {
-    /// The unique identifier of the dataset. +
+    /// The unique identifier of the dataset.
     pub dataset_id: odf::DatasetID,
 
     /// The reference being updated.
     pub block_ref: odf::BlockRef,
 
     /// The previous block hash: this value will only be None
-    /// for datasets that were just created. +
+    /// for datasets that were just created.
     pub maybe_prev_block_hash: Option<odf::Multihash>,
 
-    /// The new block hash after the update. +
+    /// The new block hash after the update.
     pub new_block_hash: odf::Multihash,
-    // pub read_from_storage: bool,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/domain/src/messages/mod.rs
+++ b/src/domain/datasets/domain/src/messages/mod.rs
@@ -9,6 +9,7 @@
 
 mod dataset_changed_message;
 mod dataset_dependencies_message;
+mod dataset_key_blocks_message;
 mod dataset_lifecycle_message;
 mod dataset_message_consumers;
 mod dataset_message_producers;
@@ -16,6 +17,7 @@ mod dataset_reference_message;
 
 pub use dataset_changed_message::*;
 pub use dataset_dependencies_message::*;
+pub use dataset_key_blocks_message::*;
 pub use dataset_lifecycle_message::*;
 pub use dataset_message_consumers::*;
 pub use dataset_message_producers::*;

--- a/src/domain/datasets/domain/src/use_cases/get_dataset_downstream_dependencies_use_case.rs
+++ b/src/domain/datasets/domain/src/use_cases/get_dataset_downstream_dependencies_use_case.rs
@@ -58,6 +58,10 @@ impl DatasetDependency {
             owner_name,
         })
     }
+
+    pub fn unresolved(dataset_id: odf::DatasetID) -> Self {
+        Self::Unresolved(dataset_id)
+    }
 }
 
 impl PartialOrd for DatasetDependency {

--- a/src/domain/datasets/services/src/services/graph/dependency_extraction_helper.rs
+++ b/src/domain/datasets/services/src/services/graph/dependency_extraction_helper.rs
@@ -10,7 +10,7 @@
 use std::collections::HashSet;
 
 use internal_error::{InternalError, ResultIntoInternal};
-use odf::dataset::AcceptByIntervalOptions;
+use odf::dataset::{AcceptByIntervalOptions, MetadataChainVisitor};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -23,20 +23,63 @@ pub(crate) enum DependencyChange {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+enum SeedPresence {
+    KnownByHint(bool), // yes/no (w/o iteration)
+    SearchRequired(odf::dataset::SearchSingleTypedBlockVisitor<odf::metadata::Seed>),
+}
+
+impl SeedPresence {
+    fn into_bool(self) -> bool {
+        match self {
+            SeedPresence::KnownByHint(present) => present,
+            SeedPresence::SearchRequired(seed_visitor) => seed_visitor.into_event().is_some(),
+        }
+    }
+}
+
 pub(crate) async fn extract_modified_dependencies_in_interval(
     metadata_chain: &dyn odf::MetadataChain,
     head: &odf::Multihash,
     maybe_tail: Option<&odf::Multihash>,
+    maybe_hint_flags: Option<odf::metadata::MetadataEventTypeFlags>,
 ) -> Result<DependencyChange, InternalError> {
+    use odf::metadata::MetadataEventTypeFlags as Flag;
+
+    // With hints available, we can immediately assess the necessity of iteration.
+    // If there are no necessary events in the interval, exit immediately.
+    if let Some(hint_flags) = maybe_hint_flags
+        && !hint_flags.contains(Flag::SEED | Flag::SET_TRANSFORM)
+    {
+        return Ok(DependencyChange::Unchanged);
+    }
+
     let mut new_upstream_ids: HashSet<odf::DatasetID> = HashSet::new();
 
+    // Prepare visitors:
+    // - We need to search for SetTransform in any case, as we need data from the
+    //   event itself,
+    // - For Seed we only need to know its presence: we search only if we don't
+    //   initially know if it exists.
     let mut set_transform_visitor = odf::dataset::SearchSetTransformVisitor::new();
-    let mut seed_visitor = odf::dataset::SearchSeedVisitor::new();
+    let mut seed_presence = match maybe_hint_flags {
+        Some(flags) => {
+            let present = flags.contains(Flag::SEED);
+            SeedPresence::KnownByHint(present)
+        }
+        None => SeedPresence::SearchRequired(odf::dataset::SearchSeedVisitor::new()),
+    };
+
+    let mut visitors = Vec::<&mut dyn MetadataChainVisitor<Error = _>>::with_capacity(2);
+    visitors.push(&mut set_transform_visitor);
+
+    if let SeedPresence::SearchRequired(seed_visitor) = &mut seed_presence {
+        visitors.push(seed_visitor);
+    }
 
     use odf::dataset::MetadataChainExt;
     metadata_chain
         .accept_by_interval_ext(
-            &mut [&mut set_transform_visitor, &mut seed_visitor],
+            &mut visitors,
             Some(head),
             maybe_tail,
             AcceptByIntervalOptions {
@@ -61,7 +104,7 @@ pub(crate) async fn extract_modified_dependencies_in_interval(
     //  - we don't see it and reach seed (dropped)
     if !new_upstream_ids.is_empty() {
         Ok(DependencyChange::Changed(new_upstream_ids))
-    } else if seed_visitor.into_event().is_some() {
+    } else if seed_presence.into_bool() {
         Ok(DependencyChange::Dropped)
     } else {
         Ok(DependencyChange::Unchanged)

--- a/src/domain/datasets/services/src/services/graph/dependency_extraction_helper.rs
+++ b/src/domain/datasets/services/src/services/graph/dependency_extraction_helper.rs
@@ -10,6 +10,7 @@
 use std::collections::HashSet;
 
 use internal_error::{InternalError, ResultIntoInternal};
+use odf::dataset::AcceptByIntervalOptions;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -34,10 +35,14 @@ pub(crate) async fn extract_modified_dependencies_in_interval(
 
     use odf::dataset::MetadataChainExt;
     metadata_chain
-        .accept_by_interval(
+        .accept_by_interval_ext(
             &mut [&mut set_transform_visitor, &mut seed_visitor],
             Some(head),
             maybe_tail,
+            AcceptByIntervalOptions {
+                inclusive_tail: true,
+                ignore_missing_tail: true,
+            },
         )
         .await
         .int_err()?;

--- a/src/domain/datasets/services/src/services/graph/dependency_graph_immediate_listener.rs
+++ b/src/domain/datasets/services/src/services/graph/dependency_graph_immediate_listener.rs
@@ -90,6 +90,7 @@ impl DependencyGraphImmediateListener {
             target.as_metadata_chain(),
             &message.head_key_block_hash,
             Some(&message.tail_key_block_hash),
+            Some(message.key_blocks_event_flags),
         )
         .await?;
 

--- a/src/domain/datasets/services/src/services/graph/dependency_graph_immediate_listener.rs
+++ b/src/domain/datasets/services/src/services/graph/dependency_graph_immediate_listener.rs
@@ -17,7 +17,7 @@ use kamu_datasets::{
     DatasetDependenciesMessage,
     DatasetDependencyRepository,
     DatasetKeyBlocksMessage,
-    DatasetKeyBlocksMessageIntroduced,
+    DatasetKeyBlocksMessageAppended,
     DependencyGraphService,
     MESSAGE_CONSUMER_KAMU_DATASET_DEPENDENCY_GRAPH_IMMEDIATE_LISTENER,
     MESSAGE_PRODUCER_KAMU_DATASET_DEPENDENCY_GRAPH_SERVICE,
@@ -52,9 +52,9 @@ pub struct DependencyGraphImmediateListener {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 impl DependencyGraphImmediateListener {
-    async fn handle_dataset_key_blocks_introduced_message(
+    async fn handle_dataset_key_blocks_appended_message(
         &self,
-        message: &DatasetKeyBlocksMessageIntroduced,
+        message: &DatasetKeyBlocksMessageAppended,
     ) -> Result<(), InternalError> {
         // For now, react only on Head updates
         if message.block_ref != odf::dataset::BlockRef::Head {
@@ -83,7 +83,7 @@ impl DependencyGraphImmediateListener {
     async fn handle_derived_dependency_updates(
         &self,
         target: ResolvedDataset,
-        message: &DatasetKeyBlocksMessageIntroduced,
+        message: &DatasetKeyBlocksMessageAppended,
     ) -> Result<(), InternalError> {
         // Compute if there are modified dependencies
         let dependency_change = extract_modified_dependencies_in_interval(
@@ -176,8 +176,8 @@ impl MessageConsumerT<DatasetKeyBlocksMessage> for DependencyGraphImmediateListe
         tracing::debug!(received_message = ?message, "Received dataset reference message");
 
         match message {
-            DatasetKeyBlocksMessage::Introduced(message) => {
-                self.handle_dataset_key_blocks_introduced_message(message)
+            DatasetKeyBlocksMessage::Appended(message) => {
+                self.handle_dataset_key_blocks_appended_message(message)
                     .await
             }
         }

--- a/src/domain/datasets/services/src/services/graph/dependency_graph_indexer.rs
+++ b/src/domain/datasets/services/src/services/graph/dependency_graph_indexer.rs
@@ -93,8 +93,13 @@ impl DependencyGraphIndexer {
 
             // Compute if there are some dependencies
             if let DependencyChange::Changed(upstream_ids) =
-                extract_modified_dependencies_in_interval(dataset.as_metadata_chain(), &head, None)
-                    .await?
+                extract_modified_dependencies_in_interval(
+                    dataset.as_metadata_chain(),
+                    &head,
+                    None,
+                    None,
+                )
+                .await?
             {
                 self.dataset_dependency_repo
                     .add_upstream_dependencies(

--- a/src/domain/datasets/services/src/services/graph/dependency_graph_service_impl.rs
+++ b/src/domain/datasets/services/src/services/graph/dependency_graph_service_impl.rs
@@ -98,14 +98,16 @@ impl DependencyGraphServiceImpl {
         tracing::debug!("Restoring dataset nodes in dependency graph");
 
         let mut datasets_stream = dataset_registry.all_dataset_handles();
-        while let Some(Ok(dataset_handle)) = datasets_stream.next().await {
+        while let Some(next_res) = datasets_stream.next().await {
+            let dataset_handle = next_res?;
             state.get_or_create_dataset_node(&dataset_handle.id);
         }
 
         tracing::debug!("Restoring dependency graph edges");
 
         let mut dependencies_stream = dependency_repository.list_all_dependencies();
-        while let Some(Ok(dataset_dependencies)) = dependencies_stream.next().await {
+        while let Some(next_res) = dependencies_stream.next().await {
+            let dataset_dependencies = next_res?;
             let DatasetDependencies {
                 downstream_dataset_id,
                 upstream_dataset_ids,

--- a/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_indexing_job.rs
+++ b/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_indexing_job.rs
@@ -166,6 +166,7 @@ pub(crate) async fn collect_dataset_key_blocks_in_range(
     // Resulting blocks
     let mut key_blocks = Vec::new();
 
+    // TODO: PERF: iterate only over key blocks
     // Iterate over blocks in the dataset in the specified range.
     // Note: don't ignore missing tail, we want to detect InvalidInterval error
     let mut blocks_stream = target

--- a/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_indexing_job.rs
+++ b/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_indexing_job.rs
@@ -166,7 +166,7 @@ pub(crate) async fn collect_dataset_key_blocks_in_range(
     // Resulting blocks
     let mut key_blocks = Vec::new();
 
-    // TODO: PERF: iterate only over key blocks
+    // TODO: PERF: iterate only over key blocks from (!) storage
     // Iterate over blocks in the dataset in the specified range.
     // Note: don't ignore missing tail, we want to detect InvalidInterval error
     let mut blocks_stream = target

--- a/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_indexing_job.rs
+++ b/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_indexing_job.rs
@@ -163,10 +163,13 @@ pub(crate) async fn collect_dataset_key_blocks_in_range(
     use futures::stream::TryStreamExt;
     use odf::dataset::MetadataChainExt;
 
-    // Resulting blocks
+    // Resulting blocks and event flags
     let mut key_blocks = Vec::new();
+    let mut key_event_flags = odf::metadata::MetadataEventTypeFlags::empty();
 
-    // TODO: PERF: iterate only over key blocks from (!) storage
+    // TODO: PERF: iterate only over key blocks (using visitors) from (!) storage
+    //             not all blocks.
+
     // Iterate over blocks in the dataset in the specified range.
     // Note: don't ignore missing tail, we want to detect InvalidInterval error
     let mut blocks_stream = target
@@ -183,6 +186,7 @@ pub(crate) async fn collect_dataset_key_blocks_in_range(
             Err(odf::dataset::IterBlocksError::InvalidInterval(_)) => {
                 return Ok(CollectKeyBlockResponse {
                     key_blocks,
+                    key_event_flags,
                     divergence_detected: true,
                 });
             }
@@ -202,11 +206,13 @@ pub(crate) async fn collect_dataset_key_blocks_in_range(
         if !event_flags.has_data_flags() {
             // Create a key block entity
             key_blocks.push(make_key_block(block_hash, &block));
+            key_event_flags |= event_flags;
         }
     }
 
     Ok(CollectKeyBlockResponse {
         key_blocks,
+        key_event_flags,
         divergence_detected: false,
     })
 }
@@ -237,6 +243,7 @@ pub(crate) fn make_key_block(
 #[derive(Debug)]
 pub(crate) struct CollectKeyBlockResponse {
     pub(crate) key_blocks: Vec<DatasetKeyBlock>,
+    pub(crate) key_event_flags: odf::metadata::MetadataEventTypeFlags,
     pub(crate) divergence_detected: bool,
 }
 

--- a/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_update_handler.rs
+++ b/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_update_handler.rs
@@ -81,7 +81,7 @@ impl DatasetKeyBlockUpdateHandler {
             self.outbox
                 .post_message(
                     MESSAGE_PRODUCER_KAMU_DATASET_KEY_BLOCK_UPDATE_HANDLER,
-                    DatasetKeyBlocksMessage::introduced(
+                    DatasetKeyBlocksMessage::appended(
                         &message.dataset_id,
                         &message.block_ref,
                         &tail_key_block.block_hash,

--- a/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_update_handler.rs
+++ b/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_update_handler.rs
@@ -15,7 +15,6 @@ use kamu_core::{DatasetRegistry, DatasetRegistryExt, ResolvedDataset};
 use kamu_datasets::{
     DatasetKeyBlockRepository,
     DatasetReferenceMessage,
-    DatasetReferenceMessageUpdated,
     DatasetReferenceMessageUpdating,
     MESSAGE_CONSUMER_KAMU_DATASET_KEY_BLOCK_UPDATE_HANDLER,
     MESSAGE_PRODUCER_KAMU_DATASET_REFERENCE_SERVICE,

--- a/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_update_handler.rs
+++ b/src/domain/datasets/services/src/services/key_blocks/dataset_key_block_update_handler.rs
@@ -70,7 +70,8 @@ impl DatasetKeyBlockUpdateHandler {
 
         let CollectKeyBlockResponse {
             key_blocks,
-            divergence_detected: _, // We don't care about divergence here
+            key_event_flags,
+            divergence_detected,
         } = self.update_dataset_key_blocks(target, message).await?;
 
         if !key_blocks.is_empty() {
@@ -85,6 +86,8 @@ impl DatasetKeyBlockUpdateHandler {
                         &message.block_ref,
                         &tail_key_block.block_hash,
                         &head_key_block.block_hash,
+                        key_event_flags,
+                        divergence_detected,
                     ),
                 )
                 .await?;

--- a/src/domain/datasets/services/src/services/odf/metadata_chain_db_backed_impl.rs
+++ b/src/domain/datasets/services/src/services/odf/metadata_chain_db_backed_impl.rs
@@ -260,8 +260,8 @@ where
                             &key_block.block_hash,
                             &key_block.block_payload,
                         )
-                        .int_err()
                         .map(|metadata_block| (key_block.block_hash, metadata_block))
+                        .int_err()
                     })
                     .collect::<Result<Vec<_>, InternalError>>()?;
 

--- a/src/domain/datasets/services/src/services/refs/dataset_reference_service_impl.rs
+++ b/src/domain/datasets/services/src/services/refs/dataset_reference_service_impl.rs
@@ -13,6 +13,7 @@ use dill::{Catalog, component, interface, meta};
 use internal_error::*;
 use kamu_datasets::{
     DatasetReferenceMessage,
+    DatasetReferenceMessageUpdated,
     DatasetReferenceRepository,
     DatasetReferenceService,
     GetDatasetReferenceError,
@@ -52,6 +53,34 @@ pub struct DatasetReferenceServiceImpl {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+impl DatasetReferenceServiceImpl {
+    async fn handle_dataset_reference_updated_message(
+        &self,
+        message: &DatasetReferenceMessageUpdated,
+    ) -> Result<(), InternalError> {
+        // Update reference at storage level
+        self.dataset_storage_unit_writer
+            .write_dataset_reference(
+                &message.dataset_id,
+                &message.block_ref,
+                &message.new_block_hash,
+            )
+            .await
+            .int_err()?;
+
+        tracing::debug!(
+            dataset_id = %message.dataset_id,
+            block_ref = %message.block_ref,
+            new_block_hash = %message.new_block_hash,
+            "Storage-level dataset references updated"
+        );
+
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 #[async_trait::async_trait]
 impl DatasetReferenceService for DatasetReferenceServiceImpl {
     async fn get_reference(
@@ -79,12 +108,25 @@ impl DatasetReferenceService for DatasetReferenceServiceImpl {
             "Setting dataset reference in persistent storage"
         );
 
-        // Try repository operation
+        // Signal the beginning of the reference update process
+        self.outbox
+            .post_message(
+                MESSAGE_PRODUCER_KAMU_DATASET_REFERENCE_SERVICE,
+                DatasetReferenceMessage::updating(
+                    dataset_id,
+                    block_ref,
+                    maybe_prev_block_hash,
+                    new_block_hash,
+                ),
+            )
+            .await?;
+
+        // Try to set the reference in the repository
         self.dataset_reference_repo
             .set_dataset_reference(dataset_id, block_ref, maybe_prev_block_hash, new_block_hash)
             .await?;
 
-        // Send outbox message
+        // Signal the completion of the reference update process
         self.outbox
             .post_message(
                 MESSAGE_PRODUCER_KAMU_DATASET_REFERENCE_SERVICE,
@@ -120,27 +162,14 @@ impl MessageConsumerT<DatasetReferenceMessage> for DatasetReferenceServiceImpl {
         tracing::debug!(received_message = ?message, "Received dataset reference message");
 
         match message {
-            DatasetReferenceMessage::Updated(updated_message) => {
-                // Update reference at storage level
-                self.dataset_storage_unit_writer
-                    .write_dataset_reference(
-                        &updated_message.dataset_id,
-                        &updated_message.block_ref,
-                        &updated_message.new_block_hash,
-                    )
-                    .await
-                    .int_err()?;
-
-                tracing::debug!(
-                    dataset_id = %updated_message.dataset_id,
-                    block_ref = %updated_message.block_ref,
-                    new_block_hash = %updated_message.new_block_hash,
-                    "Storage-level dataset references updated"
-                );
+            DatasetReferenceMessage::Updated(message) => {
+                self.handle_dataset_reference_updated_message(message).await
+            }
+            DatasetReferenceMessage::Updating(_) => {
+                // No action required
+                Ok(())
             }
         }
-
-        Ok(())
     }
 }
 

--- a/src/domain/datasets/services/src/services/statistics/dataset_statistics_update_handler.rs
+++ b/src/domain/datasets/services/src/services/statistics/dataset_statistics_update_handler.rs
@@ -145,10 +145,6 @@ impl MessageConsumerT<DatasetReferenceMessage> for DatasetStatisticsUpdateHandle
             DatasetReferenceMessage::Updated(message) => {
                 self.handle_dataset_reference_updated_message(message).await
             }
-            DatasetReferenceMessage::Updating(_) => {
-                // No action required
-                Ok(())
-            }
         }
     }
 }

--- a/src/domain/datasets/services/src/testing/test_dataset_outbox_listener.rs
+++ b/src/domain/datasets/services/src/testing/test_dataset_outbox_listener.rs
@@ -227,8 +227,8 @@ impl std::fmt::Display for TestDatasetOutboxListener {
 
             for msg in &guard.dataset_key_blocks_messages {
                 match msg {
-                    DatasetKeyBlocksMessage::Introduced(msg) => {
-                        writeln!(f, "  Key Blocks Introduced {{",)?;
+                    DatasetKeyBlocksMessage::Appended(msg) => {
+                        writeln!(f, "  Key Blocks Appended {{",)?;
                         writeln!(f, "    Dataset ID: {}", msg.dataset_id)?;
                         writeln!(f, "    Ref: {}", msg.block_ref)?;
                         writeln!(f, "    Key Block Tail: {}", msg.tail_key_block_hash)?;

--- a/src/domain/datasets/services/src/testing/test_dataset_outbox_listener.rs
+++ b/src/domain/datasets/services/src/testing/test_dataset_outbox_listener.rs
@@ -153,6 +153,14 @@ impl std::fmt::Display for TestDatasetOutboxListener {
 
             for msg in &guard.dataset_reference_messages {
                 match msg {
+                    DatasetReferenceMessage::Updating(msg) => {
+                        writeln!(f, "  Ref Updating {{",)?;
+                        writeln!(f, "    Dataset ID: {}", msg.dataset_id)?;
+                        writeln!(f, "    Ref: {}", msg.block_ref)?;
+                        writeln!(f, "    Prev Head: {:?}", msg.maybe_prev_block_hash)?;
+                        writeln!(f, "    New Head: {:?}", msg.new_block_hash)?;
+                        writeln!(f, "  }}")?;
+                    }
                     DatasetReferenceMessage::Updated(msg) => {
                         writeln!(f, "  Ref Updated {{",)?;
                         writeln!(f, "    Dataset ID: {}", msg.dataset_id)?;

--- a/src/domain/datasets/services/src/testing/test_dataset_outbox_listener.rs
+++ b/src/domain/datasets/services/src/testing/test_dataset_outbox_listener.rs
@@ -153,14 +153,6 @@ impl std::fmt::Display for TestDatasetOutboxListener {
 
             for msg in &guard.dataset_reference_messages {
                 match msg {
-                    DatasetReferenceMessage::Updating(msg) => {
-                        writeln!(f, "  Ref Updating {{",)?;
-                        writeln!(f, "    Dataset ID: {}", msg.dataset_id)?;
-                        writeln!(f, "    Ref: {}", msg.block_ref)?;
-                        writeln!(f, "    Prev Head: {:?}", msg.maybe_prev_block_hash)?;
-                        writeln!(f, "    New Head: {:?}", msg.new_block_hash)?;
-                        writeln!(f, "  }}")?;
-                    }
                     DatasetReferenceMessage::Updated(msg) => {
                         writeln!(f, "  Ref Updated {{",)?;
                         writeln!(f, "    Dataset ID: {}", msg.dataset_id)?;

--- a/src/domain/datasets/services/src/testing/test_dataset_outbox_listener.rs
+++ b/src/domain/datasets/services/src/testing/test_dataset_outbox_listener.rs
@@ -13,6 +13,7 @@ use dill::*;
 use internal_error::InternalError;
 use kamu_datasets::{
     DatasetDependenciesMessage,
+    DatasetKeyBlocksMessage,
     DatasetLifecycleMessage,
     DatasetReferenceMessage,
     MESSAGE_PRODUCER_KAMU_DATASET_DEPENDENCY_GRAPH_SERVICE,
@@ -34,6 +35,7 @@ struct State {
     dataset_lifecycle_messages: Vec<DatasetLifecycleMessage>,
     dataset_reference_messages: Vec<DatasetReferenceMessage>,
     dataset_dependency_messages: Vec<DatasetDependenciesMessage>,
+    dataset_key_blocks_messages: Vec<DatasetKeyBlocksMessage>,
 }
 
 #[component(pub)]
@@ -42,6 +44,7 @@ struct State {
 #[interface(dyn MessageConsumerT<DatasetLifecycleMessage>)]
 #[interface(dyn MessageConsumerT<DatasetReferenceMessage>)]
 #[interface(dyn MessageConsumerT<DatasetDependenciesMessage>)]
+#[interface(dyn MessageConsumerT<DatasetKeyBlocksMessage>)]
 #[meta(MessageConsumerMeta {
     consumer_name: "TestOutboxDispatcher",
     feeding_producers: &[
@@ -64,6 +67,7 @@ impl TestDatasetOutboxListener {
         guard.dataset_lifecycle_messages.clear();
         guard.dataset_reference_messages.clear();
         guard.dataset_dependency_messages.clear();
+        guard.dataset_key_blocks_messages.clear();
     }
 }
 
@@ -104,6 +108,19 @@ impl MessageConsumerT<DatasetDependenciesMessage> for TestDatasetOutboxListener 
     ) -> Result<(), InternalError> {
         let mut guard = self.state.lock().unwrap();
         guard.dataset_dependency_messages.push(message.clone());
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl MessageConsumerT<DatasetKeyBlocksMessage> for TestDatasetOutboxListener {
+    async fn consume_message(
+        &self,
+        _: &Catalog,
+        message: &DatasetKeyBlocksMessage,
+    ) -> Result<(), InternalError> {
+        let mut guard = self.state.lock().unwrap();
+        guard.dataset_key_blocks_messages.push(message.clone());
         Ok(())
     }
 }
@@ -195,6 +212,27 @@ impl std::fmt::Display for TestDatasetOutboxListener {
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         )?;
+                        writeln!(f, "  }}")?;
+                    }
+                }
+            }
+        }
+
+        if !guard.dataset_key_blocks_messages.is_empty() {
+            writeln!(
+                f,
+                "Dataset Key Block Messages: {}",
+                guard.dataset_key_blocks_messages.len()
+            )?;
+
+            for msg in &guard.dataset_key_blocks_messages {
+                match msg {
+                    DatasetKeyBlocksMessage::Introduced(msg) => {
+                        writeln!(f, "  Key Blocks Introduced {{",)?;
+                        writeln!(f, "    Dataset ID: {}", msg.dataset_id)?;
+                        writeln!(f, "    Ref: {}", msg.block_ref)?;
+                        writeln!(f, "    Key Block Tail: {}", msg.tail_key_block_hash)?;
+                        writeln!(f, "    Key Block Head: {}", msg.head_key_block_hash)?;
                         writeln!(f, "  }}")?;
                     }
                 }

--- a/src/domain/datasets/services/src/use_cases/get_dataset_upstream_dependencies_use_case_impl.rs
+++ b/src/domain/datasets/services/src/use_cases/get_dataset_upstream_dependencies_use_case_impl.rs
@@ -101,6 +101,10 @@ impl GetDatasetUpstreamDependenciesUseCase for GetDatasetUpstreamDependenciesUse
             ));
         }
 
+        for dataset_id in dataset_entries_resolution.unresolved_entries {
+            upstream_dependencies.push(DatasetDependency::unresolved(dataset_id));
+        }
+
         Ok(upstream_dependencies)
     }
 }

--- a/src/domain/datasets/services/tests/tests/services/test_dependency_graph_service_impl.rs
+++ b/src/domain/datasets/services/tests/tests/services/test_dependency_graph_service_impl.rs
@@ -29,6 +29,7 @@ use kamu_datasets_services::utils::CreateDatasetUseCaseHelper;
 use kamu_datasets_services::*;
 use messaging_outbox::{Outbox, OutboxImmediateImpl, register_message_dispatcher};
 use odf::metadata::testing::MetadataFactory;
+use pretty_assertions::assert_eq;
 use time_source::SystemTimeSourceDefault;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -664,7 +665,8 @@ impl DependencyGraphHarness {
         .add::<CreateDatasetUseCaseHelper>()
         .add::<DatasetReferenceServiceImpl>()
         .add::<InMemoryDatasetReferenceRepository>()
-        .add::<InMemoryDatasetKeyBlockRepository>();
+        .add::<InMemoryDatasetKeyBlockRepository>()
+        .add::<DatasetKeyBlockUpdateHandler>();
 
         register_message_dispatcher::<DatasetLifecycleMessage>(
             &mut b,
@@ -679,6 +681,11 @@ impl DependencyGraphHarness {
         register_message_dispatcher::<DatasetDependenciesMessage>(
             &mut b,
             MESSAGE_PRODUCER_KAMU_DATASET_DEPENDENCY_GRAPH_SERVICE,
+        );
+
+        register_message_dispatcher::<DatasetKeyBlocksMessage>(
+            &mut b,
+            MESSAGE_PRODUCER_KAMU_DATASET_KEY_BLOCK_UPDATE_HANDLER,
         );
 
         let catalog_without_subject = b.build();

--- a/src/domain/datasets/services/tests/tests/use_cases/dataset_base_use_case_harness.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/dataset_base_use_case_harness.rs
@@ -115,6 +115,11 @@ impl DatasetBaseUseCaseHarness {
                 MESSAGE_PRODUCER_KAMU_DATASET_DEPENDENCY_GRAPH_SERVICE,
             );
 
+            register_message_dispatcher::<DatasetKeyBlocksMessage>(
+                &mut b,
+                MESSAGE_PRODUCER_KAMU_DATASET_KEY_BLOCK_UPDATE_HANDLER,
+            );
+
             b.build()
         };
 

--- a/src/domain/datasets/services/tests/tests/use_cases/test_append_dataset_metadata_batch_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_append_dataset_metadata_batch_use_case.rs
@@ -83,7 +83,7 @@ async fn test_append_dataset_metadata_batch() {
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
             Dataset Key Block Messages: 1
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <foo_id>
                 Ref: head
                 Key Block Tail: <foo_key_tail>
@@ -174,7 +174,7 @@ async fn test_append_dataset_metadata_batch_with_same_dependencies() {
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
             Dataset Key Block Messages: 1
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <baz_id>
                 Ref: head
                 Key Block Tail: <foo_key_tail>
@@ -267,7 +267,7 @@ async fn test_append_dataset_metadata_batch_with_new_dependencies() {
                 Removed: [<foo_id>]
               }
             Dataset Key Block Messages: 1
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <bar_id>
                 Ref: head
                 Key Block Tail: <key_tail>

--- a/src/domain/datasets/services/tests/tests/use_cases/test_append_dataset_metadata_batch_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_append_dataset_metadata_batch_use_case.rs
@@ -58,7 +58,7 @@ async fn test_append_dataset_metadata_batch() {
     let hash_set_license_block = BaseRepoHarness::hash_from_block(&set_license_block);
 
     let new_blocks = VecDeque::from([
-        (hash_set_info_block, set_info_block),
+        (hash_set_info_block.clone(), set_info_block),
         (hash_set_license_block.clone(), set_license_block),
     ]);
 
@@ -75,24 +75,31 @@ async fn test_append_dataset_metadata_batch() {
     assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 2
-              Ref Updating {
-                Dataset ID: <foo_id>
-                Ref: head
-                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
-                New Head: Multihash<Sha3_256>(<new_head>)
-              }
+            Dataset Reference Messages: 1
               Ref Updated {
                 Dataset ID: <foo_id>
                 Ref: head
                 Prev Head: Some(Multihash<Sha3_256>(<old_head>))
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
+            Dataset Key Block Messages: 1
+              Key Blocks Introduced {
+                Dataset ID: <foo_id>
+                Ref: head
+                Key Block Tail: <foo_key_tail>
+                Key Block Head: <foo_key_head>
+              }
             "#
         )
         .replace("<foo_id>", predefined_foo_id.to_string().as_str())
         .replace("<old_head>", foo_old_head.to_string().as_str())
-        .replace("<new_head>", hash_set_license_block.to_string().as_str()),
+        .replace("<new_head>", hash_set_license_block.to_string().as_str())
+        .replace("<foo_id>", predefined_foo_id.to_string().as_str())
+        .replace("<foo_key_tail>", hash_set_info_block.to_string().as_str())
+        .replace(
+            "<foo_key_head>",
+            hash_set_license_block.to_string().as_str()
+        ),
         harness.collected_outbox_messages(),
     );
 }
@@ -159,24 +166,34 @@ async fn test_append_dataset_metadata_batch_with_same_dependencies() {
     assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 2
-              Ref Updating {
-                Dataset ID: <baz_id>
-                Ref: head
-                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
-                New Head: Multihash<Sha3_256>(<new_head>)
-              }
+            Dataset Reference Messages: 1
               Ref Updated {
                 Dataset ID: <baz_id>
                 Ref: head
                 Prev Head: Some(Multihash<Sha3_256>(<old_head>))
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
+            Dataset Key Block Messages: 1
+              Key Blocks Introduced {
+                Dataset ID: <baz_id>
+                Ref: head
+                Key Block Tail: <foo_key_tail>
+                Key Block Head: <foo_key_head>
+              }
             "#
         )
         .replace("<old_head>", baz_old_head.to_string().as_str())
         .replace("<new_head>", hash_set_transform_block.to_string().as_str())
-        .replace("<baz_id>", baz.dataset_handle.id.to_string().as_str()),
+        .replace("<baz_id>", baz.dataset_handle.id.to_string().as_str())
+        .replace("<baz_id>", baz.dataset_handle.id.to_string().as_str())
+        .replace(
+            "<foo_key_tail>",
+            hash_set_transform_block.to_string().as_str()
+        )
+        .replace(
+            "<foo_key_head>",
+            hash_set_transform_block.to_string().as_str()
+        ),
         harness.collected_outbox_messages(),
     );
 }
@@ -236,13 +253,7 @@ async fn test_append_dataset_metadata_batch_with_new_dependencies() {
     assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 2
-              Ref Updating {
-                Dataset ID: <bar_id>
-                Ref: head
-                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
-                New Head: Multihash<Sha3_256>(<new_head>)
-              }
+            Dataset Reference Messages: 1
               Ref Updated {
                 Dataset ID: <bar_id>
                 Ref: head
@@ -255,13 +266,23 @@ async fn test_append_dataset_metadata_batch_with_new_dependencies() {
                 Added: [<baz_id>]
                 Removed: [<foo_id>]
               }
+            Dataset Key Block Messages: 1
+              Key Blocks Introduced {
+                Dataset ID: <bar_id>
+                Ref: head
+                Key Block Tail: <key_tail>
+                Key Block Head: <key_head>
+              }
             "#
         )
         .replace("<old_head>", bar_old_head.to_string().as_str())
         .replace("<new_head>", hash_set_transform_block.to_string().as_str())
         .replace("<foo_id>", foo.dataset_handle.id.to_string().as_str())
         .replace("<bar_id>", bar.dataset_handle.id.to_string().as_str())
-        .replace("<baz_id>", baz.dataset_handle.id.to_string().as_str()),
+        .replace("<baz_id>", baz.dataset_handle.id.to_string().as_str())
+        .replace("<bar_id>", bar.dataset_handle.id.to_string().as_str())
+        .replace("<key_tail>", hash_set_transform_block.to_string().as_str())
+        .replace("<key_head>", hash_set_transform_block.to_string().as_str()),
         harness.collected_outbox_messages(),
     );
 }

--- a/src/domain/datasets/services/tests/tests/use_cases/test_append_dataset_metadata_batch_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_append_dataset_metadata_batch_use_case.rs
@@ -17,6 +17,7 @@ use kamu_core::MockDidGenerator;
 use kamu_datasets::AppendDatasetMetadataBatchUseCase;
 use kamu_datasets_services::AppendDatasetMetadataBatchUseCaseImpl;
 use odf::metadata::testing::MetadataFactory;
+use pretty_assertions::assert_eq;
 use time_source::SystemTimeSourceStub;
 
 use super::dataset_base_use_case_harness::{
@@ -71,10 +72,16 @@ async fn test_append_dataset_metadata_batch() {
         .await;
     assert_matches!(res, Ok(_));
 
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 1
+            Dataset Reference Messages: 2
+              Ref Updating {
+                Dataset ID: <foo_id>
+                Ref: head
+                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
+                New Head: Multihash<Sha3_256>(<new_head>)
+              }
               Ref Updated {
                 Dataset ID: <foo_id>
                 Ref: head
@@ -148,11 +155,17 @@ async fn test_append_dataset_metadata_batch_with_same_dependencies() {
         .await;
     assert_matches!(res, Ok(_));
 
-    // No dependency updates, as they havent' changed
-    pretty_assertions::assert_eq!(
+    // No dependency updates, as they haven't changed
+    assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 1
+            Dataset Reference Messages: 2
+              Ref Updating {
+                Dataset ID: <baz_id>
+                Ref: head
+                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
+                New Head: Multihash<Sha3_256>(<new_head>)
+              }
               Ref Updated {
                 Dataset ID: <baz_id>
                 Ref: head
@@ -220,10 +233,16 @@ async fn test_append_dataset_metadata_batch_with_new_dependencies() {
         .await;
     assert_matches!(res, Ok(_));
 
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 1
+            Dataset Reference Messages: 2
+              Ref Updating {
+                Dataset ID: <bar_id>
+                Ref: head
+                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
+                New Head: Multihash<Sha3_256>(<new_head>)
+              }
               Ref Updated {
                 Dataset ID: <bar_id>
                 Ref: head

--- a/src/domain/datasets/services/tests/tests/use_cases/test_commit_dataset_event_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_commit_dataset_event_use_case.rs
@@ -53,27 +53,32 @@ async fn test_commit_dataset_event() {
         .await;
     assert_matches!(res, Ok(_));
 
+    let foo_new_head = res.unwrap().new_head.to_string();
     assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 2
-              Ref Updating {
-                Dataset ID: <foo_id>
-                Ref: head
-                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
-                New Head: Multihash<Sha3_256>(<new_head>)
-              }
+            Dataset Reference Messages: 1
               Ref Updated {
                 Dataset ID: <foo_id>
                 Ref: head
                 Prev Head: Some(Multihash<Sha3_256>(<old_head>))
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
+            Dataset Key Block Messages: 1
+              Key Blocks Introduced {
+                Dataset ID: <foo_id>
+                Ref: head
+                Key Block Tail: <foo_key_tail>
+                Key Block Head: <foo_key_head>
+              }
             "#
         )
         .replace("<foo_id>", dataset_id_foo.to_string().as_str())
         .replace("<old_head>", foo_old_head.to_string().as_str())
-        .replace("<new_head>", res.unwrap().new_head.to_string().as_str()),
+        .replace("<new_head>", foo_new_head.as_str())
+        .replace("<foo_id>", dataset_id_foo.to_string().as_str())
+        .replace("<foo_key_tail>", foo_new_head.as_str())
+        .replace("<foo_key_head>", foo_new_head.as_str()),
         harness.collected_outbox_messages(),
     );
 }
@@ -152,27 +157,31 @@ async fn test_commit_event_with_same_dependencies() {
     assert_matches!(res, Ok(_));
 
     // No dependency updates happened
+    let bar_new_head = res.unwrap().new_head.to_string();
     assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 2
-              Ref Updating {
-                Dataset ID: <bar_id>
-                Ref: head
-                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
-                New Head: Multihash<Sha3_256>(<new_head>)
-              }
+            Dataset Reference Messages: 1
               Ref Updated {
                 Dataset ID: <bar_id>
                 Ref: head
                 Prev Head: Some(Multihash<Sha3_256>(<old_head>))
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
+            Dataset Key Block Messages: 1
+              Key Blocks Introduced {
+                Dataset ID: <bar_id>
+                Ref: head
+                Key Block Tail: <bar_key_tail>
+                Key Block Head: <bar_key_head>
+              }
             "#
         )
         .replace("<bar_id>", dataset_id_bar.to_string().as_str())
         .replace("<old_head>", bar_old_head.to_string().as_str())
-        .replace("<new_head>", res.unwrap().new_head.to_string().as_str()),
+        .replace("<new_head>", bar_new_head.as_str())
+        .replace("<bar_key_tail>", bar_new_head.as_str())
+        .replace("<bar_key_head>", bar_new_head.as_str()),
         harness.collected_outbox_messages(),
     );
 }
@@ -226,16 +235,11 @@ async fn test_commit_event_with_new_dependencies() {
     assert_matches!(res, Ok(_));
 
     // No dependency updates happened
+    let baz_new_head = res.unwrap().new_head.to_string();
     assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 2
-              Ref Updating {
-                Dataset ID: <baz_id>
-                Ref: head
-                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
-                New Head: Multihash<Sha3_256>(<new_head>)
-              }
+            Dataset Reference Messages: 1
               Ref Updated {
                 Dataset ID: <baz_id>
                 Ref: head
@@ -248,13 +252,23 @@ async fn test_commit_event_with_new_dependencies() {
                 Added: [<bar_id>]
                 Removed: [<foo_id>]
               }
+            Dataset Key Block Messages: 1
+              Key Blocks Introduced {
+                Dataset ID: <baz_id>
+                Ref: head
+                Key Block Tail: <baz_key_tail>
+                Key Block Head: <baz_key_head>
+              }
             "#
         )
         .replace("<foo_id>", dataset_id_foo.to_string().as_str())
         .replace("<bar_id>", dataset_id_bar.to_string().as_str())
         .replace("<baz_id>", dataset_id_baz.to_string().as_str())
         .replace("<old_head>", baz_old_head.to_string().as_str())
-        .replace("<new_head>", res.unwrap().new_head.to_string().as_str()),
+        .replace("<new_head>", baz_new_head.as_str())
+        .replace("<baz_id>", dataset_id_baz.to_string().as_str())
+        .replace("<baz_key_tail>", baz_new_head.as_str())
+        .replace("<baz_key_head>", baz_new_head.as_str()),
         harness.collected_outbox_messages(),
     );
 }

--- a/src/domain/datasets/services/tests/tests/use_cases/test_commit_dataset_event_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_commit_dataset_event_use_case.rs
@@ -16,6 +16,7 @@ use kamu_core::MockDidGenerator;
 use kamu_datasets::CommitDatasetEventUseCase;
 use kamu_datasets_services::CommitDatasetEventUseCaseImpl;
 use odf::metadata::testing::MetadataFactory;
+use pretty_assertions::assert_eq;
 use time_source::SystemTimeSourceStub;
 
 use super::dataset_base_use_case_harness::{
@@ -52,10 +53,16 @@ async fn test_commit_dataset_event() {
         .await;
     assert_matches!(res, Ok(_));
 
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 1
+            Dataset Reference Messages: 2
+              Ref Updating {
+                Dataset ID: <foo_id>
+                Ref: head
+                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
+                New Head: Multihash<Sha3_256>(<new_head>)
+              }
               Ref Updated {
                 Dataset ID: <foo_id>
                 Ref: head
@@ -98,7 +105,7 @@ async fn test_commit_event_unauthorized() {
         .await;
     assert_matches!(res, Err(odf::dataset::CommitError::Access(_)));
 
-    pretty_assertions::assert_eq!("", harness.collected_outbox_messages(),);
+    assert_eq!("", harness.collected_outbox_messages(),);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -145,10 +152,16 @@ async fn test_commit_event_with_same_dependencies() {
     assert_matches!(res, Ok(_));
 
     // No dependency updates happened
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 1
+            Dataset Reference Messages: 2
+              Ref Updating {
+                Dataset ID: <bar_id>
+                Ref: head
+                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
+                New Head: Multihash<Sha3_256>(<new_head>)
+              }
               Ref Updated {
                 Dataset ID: <bar_id>
                 Ref: head
@@ -213,10 +226,16 @@ async fn test_commit_event_with_new_dependencies() {
     assert_matches!(res, Ok(_));
 
     // No dependency updates happened
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         indoc::indoc!(
             r#"
-            Dataset Reference Messages: 1
+            Dataset Reference Messages: 2
+              Ref Updating {
+                Dataset ID: <baz_id>
+                Ref: head
+                Prev Head: Some(Multihash<Sha3_256>(<old_head>))
+                New Head: Multihash<Sha3_256>(<new_head>)
+              }
               Ref Updated {
                 Dataset ID: <baz_id>
                 Ref: head

--- a/src/domain/datasets/services/tests/tests/use_cases/test_commit_dataset_event_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_commit_dataset_event_use_case.rs
@@ -65,7 +65,7 @@ async fn test_commit_dataset_event() {
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
             Dataset Key Block Messages: 1
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <foo_id>
                 Ref: head
                 Key Block Tail: <foo_key_tail>
@@ -169,7 +169,7 @@ async fn test_commit_event_with_same_dependencies() {
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
             Dataset Key Block Messages: 1
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <bar_id>
                 Ref: head
                 Key Block Tail: <bar_key_tail>
@@ -253,7 +253,7 @@ async fn test_commit_event_with_new_dependencies() {
                 Removed: [<foo_id>]
               }
             Dataset Key Block Messages: 1
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <baz_id>
                 Ref: head
                 Key Block Tail: <baz_key_tail>

--- a/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_from_snapshot_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_from_snapshot_use_case.rs
@@ -17,6 +17,7 @@ use kamu_datasets::{CreateDatasetFromSnapshotUseCase, DatasetReferenceRepository
 use kamu_datasets_services::CreateDatasetFromSnapshotUseCaseImpl;
 use kamu_datasets_services::utils::CreateDatasetUseCaseHelper;
 use odf::metadata::testing::MetadataFactory;
+use pretty_assertions::assert_eq;
 use time_source::SystemTimeSourceStub;
 
 use super::dataset_base_use_case_harness::{
@@ -48,7 +49,7 @@ async fn test_create_root_dataset_from_snapshot() {
         .unwrap();
 
     assert_matches!(harness.check_dataset_exists(&alias_foo).await, Ok(_));
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         harness
             .get_dataset_reference(&foo_created.dataset_handle.id, &odf::BlockRef::Head)
             .await,
@@ -57,7 +58,7 @@ async fn test_create_root_dataset_from_snapshot() {
 
     // Note: the stability of these identifiers is ensured via
     //  predefined dataset ID and stubbed system time
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         indoc::indoc!(
             r#"
             Dataset Lifecycle Messages: 1
@@ -67,7 +68,13 @@ async fn test_create_root_dataset_from_snapshot() {
                 Owner: did:odf:fed016b61ed2ab1b63a006b61ed2ab1b63a00b016d65607000000e0821aafbf163e6f
                 Visibility: private
               }
-            Dataset Reference Messages: 1
+            Dataset Reference Messages: 2
+              Ref Updating {
+                Dataset ID: <foo_id>
+                Ref: head
+                Prev Head: None
+                New Head: Multihash<Sha3_256>(<foo_head>)
+              }
               Ref Updated {
                 Dataset ID: <foo_id>
                 Ref: head
@@ -129,13 +136,13 @@ async fn test_create_derived_dataset_from_snapshot() {
     assert_matches!(harness.check_dataset_exists(&alias_foo).await, Ok(_));
     assert_matches!(harness.check_dataset_exists(&alias_bar).await, Ok(_));
 
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         harness
             .get_dataset_reference(&foo_created.dataset_handle.id, &odf::BlockRef::Head)
             .await,
         foo_created.head,
     );
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         harness
             .get_dataset_reference(&bar_created.dataset_handle.id, &odf::BlockRef::Head)
             .await,
@@ -144,7 +151,7 @@ async fn test_create_derived_dataset_from_snapshot() {
 
     // Note: the stability of these identifiers is ensured via
     //  predefined dataset ID and stubbed system time
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         indoc::indoc!(
             r#"
             Dataset Lifecycle Messages: 2
@@ -160,12 +167,24 @@ async fn test_create_derived_dataset_from_snapshot() {
                 Owner: did:odf:fed016b61ed2ab1b63a006b61ed2ab1b63a00b016d65607000000e0821aafbf163e6f
                 Visibility: private
               }
-            Dataset Reference Messages: 2
+            Dataset Reference Messages: 4
+              Ref Updating {
+                Dataset ID: <foo_id>
+                Ref: head
+                Prev Head: None
+                New Head: Multihash<Sha3_256>(<foo_head>)
+              }
               Ref Updated {
                 Dataset ID: <foo_id>
                 Ref: head
                 Prev Head: None
                 New Head: Multihash<Sha3_256>(<foo_head>)
+              }
+              Ref Updating {
+                Dataset ID: <bar_id>
+                Ref: head
+                Prev Head: None
+                New Head: Multihash<Sha3_256>(<bar_head>)
               }
               Ref Updated {
                 Dataset ID: <bar_id>
@@ -210,7 +229,7 @@ async fn test_create_dataset_from_snapshot_creates_did_secret_key() {
         .unwrap();
 
     assert_matches!(harness.check_dataset_exists(&alias_foo).await, Ok(_));
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         harness
             .get_dataset_reference(&foo_created.dataset_handle.id, &odf::BlockRef::Head)
             .await,
@@ -236,7 +255,7 @@ async fn test_create_dataset_from_snapshot_creates_did_secret_key() {
 
     // Compare original account_id from db and id generated from a stored private
     // key
-    pretty_assertions::assert_eq!(foo_created.dataset_handle.id.as_did(), &did_odf);
+    assert_eq!(foo_created.dataset_handle.id.as_did(), &did_odf);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_from_snapshot_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_from_snapshot_use_case.rs
@@ -87,7 +87,7 @@ async fn test_create_root_dataset_from_snapshot() {
                 New Head: Multihash<Sha3_256>(<foo_head>)
               }
             Dataset Key Block Messages: 1
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <foo_id>
                 Ref: head
                 Key Block Tail: <foo_key_tail>
@@ -222,13 +222,13 @@ async fn test_create_derived_dataset_from_snapshot() {
                 Removed: []
               }
             Dataset Key Block Messages: 2
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <foo_id>
                 Ref: head
                 Key Block Tail: <foo_key_tail>
                 Key Block Head: <foo_key_head>
               }
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <bar_id>
                 Ref: head
                 Key Block Tail: <bar_key_tail>

--- a/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_use_case.rs
@@ -16,6 +16,7 @@ use kamu_datasets::{CreateDatasetUseCase, DatasetReferenceRepository};
 use kamu_datasets_services::CreateDatasetUseCaseImpl;
 use kamu_datasets_services::utils::CreateDatasetUseCaseHelper;
 use odf::metadata::testing::MetadataFactory;
+use pretty_assertions::assert_eq;
 use time_source::SystemTimeSourceStub;
 
 use super::dataset_base_use_case_harness::{
@@ -59,7 +60,7 @@ async fn test_create_root_dataset() {
 
     // Note: the stability of these identifiers is ensured via
     //  predefined dataset ID and stubbed system time
-    pretty_assertions::assert_eq!(
+    assert_eq!(
         indoc::indoc!(
             r#"
             Dataset Lifecycle Messages: 1
@@ -69,7 +70,13 @@ async fn test_create_root_dataset() {
                 Owner: did:odf:fed016b61ed2ab1b63a006b61ed2ab1b63a00b016d65607000000e0821aafbf163e6f
                 Visibility: private
               }
-            Dataset Reference Messages: 1
+            Dataset Reference Messages: 2
+              Ref Updating {
+                Dataset ID: <foo_id>
+                Ref: head
+                Prev Head: None
+                New Head: Multihash<Sha3_256>(<new_head>)
+              }
               Ref Updated {
                 Dataset ID: <foo_id>
                 Ref: head

--- a/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_use_case.rs
@@ -78,7 +78,7 @@ async fn test_create_root_dataset() {
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
             Dataset Key Block Messages: 1
-              Key Blocks Introduced {
+              Key Blocks Appended {
                 Dataset ID: <foo_id>
                 Ref: head
                 Key Block Tail: <key_head>

--- a/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_use_case.rs
+++ b/src/domain/datasets/services/tests/tests/use_cases/test_create_dataset_use_case.rs
@@ -70,23 +70,27 @@ async fn test_create_root_dataset() {
                 Owner: did:odf:fed016b61ed2ab1b63a006b61ed2ab1b63a00b016d65607000000e0821aafbf163e6f
                 Visibility: private
               }
-            Dataset Reference Messages: 2
-              Ref Updating {
-                Dataset ID: <foo_id>
-                Ref: head
-                Prev Head: None
-                New Head: Multihash<Sha3_256>(<new_head>)
-              }
+            Dataset Reference Messages: 1
               Ref Updated {
                 Dataset ID: <foo_id>
                 Ref: head
                 Prev Head: None
                 New Head: Multihash<Sha3_256>(<new_head>)
               }
+            Dataset Key Block Messages: 1
+              Key Blocks Introduced {
+                Dataset ID: <foo_id>
+                Ref: head
+                Key Block Tail: <key_head>
+                Key Block Head: <new_head>
+              }
             "#
         )
         .replace("<foo_id>", predefined_foo_id.to_string().as_str())
-        .replace("<new_head>", foo_created.head.to_string().as_str()),
+        .replace("<new_head>", foo_created.head.to_string().as_str())
+        .replace("<foo_id>", predefined_foo_id.to_string().as_str())
+        .replace("<key_tail>", foo_created.head.to_string().as_str())
+        .replace("<key_head>", foo_created.head.to_string().as_str()),
         harness.collected_outbox_messages()
     );
 }

--- a/src/e2e/app/cli/postgres/tests/tests/commands/test_login_command.rs
+++ b/src/e2e/app/cli/postgres/tests/tests/commands/test_login_command.rs
@@ -101,7 +101,8 @@ kamu_cli_run_api_server_e2e_test!(
 kamu_cli_run_api_server_e2e_test!(
     storage = postgres,
     fixture = kamu_cli_e2e_repo_tests::commands::test_login_interactive_successful_st,
-    options = Options::default().with_multi_tenant()
+    options = Options::default().with_multi_tenant(),
+    extra_test_groups = "flaky"
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -109,7 +110,8 @@ kamu_cli_run_api_server_e2e_test!(
 kamu_cli_run_api_server_e2e_test!(
     storage = postgres,
     fixture = kamu_cli_e2e_repo_tests::commands::test_login_interactive_successful_mt,
-    options = Options::default().with_multi_tenant()
+    options = Options::default().with_multi_tenant(),
+    extra_test_groups = "flaky"
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/e2e/app/cli/sqlite/tests/tests/commands/test_login_command.rs
+++ b/src/e2e/app/cli/sqlite/tests/tests/commands/test_login_command.rs
@@ -101,7 +101,8 @@ kamu_cli_run_api_server_e2e_test!(
 kamu_cli_run_api_server_e2e_test!(
     storage = sqlite,
     fixture = kamu_cli_e2e_repo_tests::commands::test_login_interactive_successful_st,
-    options = Options::default().with_multi_tenant()
+    options = Options::default().with_multi_tenant(),
+    extra_test_groups = "flaky"
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -109,7 +110,8 @@ kamu_cli_run_api_server_e2e_test!(
 kamu_cli_run_api_server_e2e_test!(
     storage = sqlite,
     fixture = kamu_cli_e2e_repo_tests::commands::test_login_interactive_successful_mt,
-    options = Options::default().with_multi_tenant()
+    options = Options::default().with_multi_tenant(),
+    extra_test_groups = "flaky"
 );
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/core/src/testing/mock_dataset_action_authorizer.rs
+++ b/src/infra/core/src/testing/mock_dataset_action_authorizer.rs
@@ -12,12 +12,12 @@ use std::collections::HashSet;
 
 use internal_error::InternalError;
 use kamu_core::auth::{
+    ClassifyByAllowanceDatasetActionUnauthorizedError,
     ClassifyByAllowanceIdsResponse,
     ClassifyByAllowanceResponse,
     DatasetAction,
     DatasetActionAuthorizer,
     DatasetActionUnauthorizedError,
-    MultipleDatasetActionUnauthorizedError,
 };
 use mockall::Predicate;
 use mockall::predicate::{always, eq, function};
@@ -92,7 +92,7 @@ impl MockDatasetActionAuthorizer {
                             } else {
                                 (
                                     id.as_ref().clone(),
-                                    MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                                    ClassifyByAllowanceDatasetActionUnauthorizedError::not_enough_permissions(
                                         id.as_local_ref(),
                                         action,
                                     ),
@@ -118,7 +118,7 @@ impl MockDatasetActionAuthorizer {
                             } else {
                                 (
                                     hdl.clone(),
-                                    MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                                    ClassifyByAllowanceDatasetActionUnauthorizedError::not_enough_permissions(
                                         hdl.id.as_local_ref(),
                                         action,
                                     ),
@@ -273,7 +273,7 @@ impl MockDatasetActionAuthorizer {
                     if authorized.contains(&handle.alias) {
                         good.push(handle);
                     } else {
-                        let error = MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                        let error = ClassifyByAllowanceDatasetActionUnauthorizedError::not_enough_permissions(
                             handle.as_local_ref(),
                             action,
                         );
@@ -310,7 +310,7 @@ impl MockDatasetActionAuthorizer {
                             acc.authorized_ids.push(dataset_id.as_ref().clone());
                         } else {
                             let error =
-                                MultipleDatasetActionUnauthorizedError::not_enough_permissions(
+                                ClassifyByAllowanceDatasetActionUnauthorizedError::not_enough_permissions(
                                     dataset_id.as_local_ref(),
                                     action,
                                 );

--- a/src/infra/core/src/use_cases/pull_dataset_use_case_impl.rs
+++ b/src/infra/core/src/use_cases/pull_dataset_use_case_impl.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use dill::*;
 use internal_error::{InternalError, ResultIntoInternal};
 use kamu_core::auth::{
+    ClassifyByAllowanceDatasetActionUnauthorizedError,
     ClassifyByAllowanceResponse,
     DatasetAction,
     DatasetActionAuthorizer,
-    MultipleDatasetActionUnauthorizedError,
 };
 use kamu_core::*;
 
@@ -194,7 +194,7 @@ impl PullDatasetUseCaseImpl {
                     maybe_remote_ref: None,
                     maybe_original_request: job.into_original_pull_request(),
                     result: Err({
-                        use MultipleDatasetActionUnauthorizedError as E;
+                        use ClassifyByAllowanceDatasetActionUnauthorizedError as E;
 
                         match auth_error {
                             E::NotFound(e) => PullError::NotFound(e),
@@ -267,7 +267,7 @@ impl PullDatasetUseCaseImpl {
 
         let mut unauthorized_handles_to_errors: HashMap<
             odf::DatasetHandle,
-            MultipleDatasetActionUnauthorizedError,
+            ClassifyByAllowanceDatasetActionUnauthorizedError,
         > = unauthorized_handles_with_errors.into_iter().collect();
 
         let mut unauthorized_responses = Vec::new();
@@ -281,7 +281,7 @@ impl PullDatasetUseCaseImpl {
             for read_hdl in read_handles {
                 if let Some(auth_error) = unauthorized_handles_to_errors.remove(read_hdl) {
                     maybe_error = Some({
-                        use MultipleDatasetActionUnauthorizedError as E;
+                        use ClassifyByAllowanceDatasetActionUnauthorizedError as E;
 
                         match auth_error {
                             E::NotFound(e) => PullError::NotFound(e),

--- a/src/infra/core/src/use_cases/pull_dataset_use_case_impl.rs
+++ b/src/infra/core/src/use_cases/pull_dataset_use_case_impl.rs
@@ -16,7 +16,7 @@ use kamu_core::auth::{
     ClassifyByAllowanceResponse,
     DatasetAction,
     DatasetActionAuthorizer,
-    DatasetActionUnauthorizedError,
+    MultipleDatasetActionUnauthorizedError,
 };
 use kamu_core::*;
 
@@ -193,9 +193,14 @@ impl PullDatasetUseCaseImpl {
                     maybe_local_ref: Some(hdl.as_local_ref()),
                     maybe_remote_ref: None,
                     maybe_original_request: job.into_original_pull_request(),
-                    result: Err(match auth_error {
-                        DatasetActionUnauthorizedError::Access(e) => PullError::Access(e),
-                        DatasetActionUnauthorizedError::Internal(e) => PullError::Internal(e),
+                    result: Err({
+                        use MultipleDatasetActionUnauthorizedError as E;
+
+                        match auth_error {
+                            E::NotFound(e) => PullError::NotFound(e),
+                            E::Access(e) => PullError::Access(e),
+                            E::Internal(e) => PullError::Internal(e),
+                        }
                     }),
                 }
             })
@@ -262,7 +267,7 @@ impl PullDatasetUseCaseImpl {
 
         let mut unauthorized_handles_to_errors: HashMap<
             odf::DatasetHandle,
-            DatasetActionUnauthorizedError,
+            MultipleDatasetActionUnauthorizedError,
         > = unauthorized_handles_with_errors.into_iter().collect();
 
         let mut unauthorized_responses = Vec::new();
@@ -275,9 +280,14 @@ impl PullDatasetUseCaseImpl {
             let mut maybe_error = None;
             for read_hdl in read_handles {
                 if let Some(auth_error) = unauthorized_handles_to_errors.remove(read_hdl) {
-                    maybe_error = Some(match auth_error {
-                        DatasetActionUnauthorizedError::Access(e) => PullError::Access(e),
-                        DatasetActionUnauthorizedError::Internal(e) => PullError::Internal(e),
+                    maybe_error = Some({
+                        use MultipleDatasetActionUnauthorizedError as E;
+
+                        match auth_error {
+                            E::NotFound(e) => PullError::NotFound(e),
+                            E::Access(e) => PullError::Access(e),
+                            E::Internal(e) => PullError::Internal(e),
+                        }
                     });
                     break;
                 }

--- a/src/infra/core/src/use_cases/push_dataset_use_case_impl.rs
+++ b/src/infra/core/src/use_cases/push_dataset_use_case_impl.rs
@@ -11,12 +11,7 @@ use std::sync::Arc;
 
 use dill::{component, interface};
 use internal_error::InternalError;
-use kamu_core::auth::{
-    ClassifyByAllowanceResponse,
-    DatasetAction,
-    DatasetActionAuthorizer,
-    DatasetActionUnauthorizedError,
-};
+use kamu_core::auth::{ClassifyByAllowanceResponse, DatasetAction, DatasetActionAuthorizer};
 use kamu_core::{
     PushDatasetUseCase,
     PushError,
@@ -67,9 +62,14 @@ impl PushDatasetUseCaseImpl {
             .map(|(hdl, error)| PushResponse {
                 local_handle: Some(hdl),
                 target: push_target.cloned(),
-                result: Err(PushError::SyncError(match error {
-                    DatasetActionUnauthorizedError::Access(e) => SyncError::Access(e),
-                    DatasetActionUnauthorizedError::Internal(e) => SyncError::Internal(e),
+                result: Err(PushError::SyncError({
+                    use kamu_core::auth::MultipleDatasetActionUnauthorizedError as E;
+
+                    match error {
+                        E::NotFound(e) => SyncError::DatasetNotFound(e.into()),
+                        E::Access(e) => SyncError::Access(e),
+                        E::Internal(e) => SyncError::Internal(e),
+                    }
                 })),
             })
             .collect();

--- a/src/infra/core/src/use_cases/push_dataset_use_case_impl.rs
+++ b/src/infra/core/src/use_cases/push_dataset_use_case_impl.rs
@@ -63,7 +63,7 @@ impl PushDatasetUseCaseImpl {
                 local_handle: Some(hdl),
                 target: push_target.cloned(),
                 result: Err(PushError::SyncError({
-                    use kamu_core::auth::MultipleDatasetActionUnauthorizedError as E;
+                    use kamu_core::auth::ClassifyByAllowanceDatasetActionUnauthorizedError as E;
 
                     match error {
                         E::NotFound(e) => SyncError::DatasetNotFound(e.into()),

--- a/src/odf/metadata/Cargo.toml
+++ b/src/odf/metadata/Cargo.toml
@@ -44,7 +44,7 @@ multiformats = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
 digest = "0.10"
 thiserror = { version = "2", default-features = false, features = ["std"] }
-bitflags = { version = "2", default-features = false }
+bitflags = { version = "2", default-features = false, features = ["serde"] }
 
 like = { version = "0.3", default-features = false }
 sha3 = "0.10"

--- a/src/odf/metadata/src/dtos/dtos_extra.rs
+++ b/src/odf/metadata/src/dtos/dtos_extra.rs
@@ -412,8 +412,11 @@ impl MetadataEventTypeFlags {
     pub const DATA_BLOCK: Self =
         Self::from_bits_retain(Self::ADD_DATA.bits() | Self::EXECUTE_TRANSFORM.bits());
 
+    pub const KEY_BLOCK: Self =
+        Self::from_bits_retain(Self::all().difference(Self::DATA_BLOCK).bits());
+
     pub fn has_data_flags(&self) -> bool {
-        self.bits() & Self::DATA_BLOCK.bits() != 0
+        !(*self & Self::DATA_BLOCK).is_empty()
     }
 }
 

--- a/src/odf/metadata/src/dtos/dtos_generated.rs
+++ b/src/odf/metadata/src/dtos/dtos_generated.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use bitflags::bitflags;
 use chrono::{DateTime, Utc};
 use enum_variants::*;
+use serde::{Deserialize, Serialize};
 
 use crate::formats::Multihash;
 use crate::identity::*;
@@ -997,7 +998,7 @@ impl_enum_variant!(MetadataEvent::DisablePushSource(DisablePushSource));
 impl_enum_variant!(MetadataEvent::DisablePollingSource(DisablePollingSource));
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     pub struct MetadataEventTypeFlags: u32 {
         const ADD_DATA = 1 << 0;
         const EXECUTE_TRANSFORM = 1 << 1;

--- a/src/odf/metadata/tests/tests/mod.rs
+++ b/src/odf/metadata/tests/tests/mod.rs
@@ -11,6 +11,7 @@ mod test_account_id;
 mod test_dataset_id;
 mod test_dataset_identity;
 mod test_dataset_refs;
+mod test_dto_extra;
 mod test_grammar;
 mod test_serde_buffer;
 mod test_serde_flatbuffers;

--- a/src/odf/metadata/tests/tests/test_dto_extra.rs
+++ b/src/odf/metadata/tests/tests/test_dto_extra.rs
@@ -1,0 +1,22 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use pretty_assertions::assert_eq;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test]
+fn test_metadata_event_type_flags_consts() {
+    use opendatafabric_metadata::MetadataEventTypeFlags;
+
+    assert_eq!(0, MetadataEventTypeFlags::DATA_BLOCK.bits());
+    assert_eq!(0, MetadataEventTypeFlags::KEY_BLOCK.bits());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/odf/metadata/tests/tests/test_dto_extra.rs
+++ b/src/odf/metadata/tests/tests/test_dto_extra.rs
@@ -15,8 +15,8 @@ use pretty_assertions::assert_eq;
 fn test_metadata_event_type_flags_consts() {
     use opendatafabric_metadata::MetadataEventTypeFlags;
 
-    assert_eq!(0, MetadataEventTypeFlags::DATA_BLOCK.bits());
-    assert_eq!(0, MetadataEventTypeFlags::KEY_BLOCK.bits());
+    assert_eq!(3, MetadataEventTypeFlags::DATA_BLOCK.bits());
+    assert_eq!(8188, MetadataEventTypeFlags::KEY_BLOCK.bits());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Notes:
- `DatasetKeyBlockUpdateHandler` is guaranteed to be called before `DependencyGraphImmediateListener`.
  - `DependencyGraphImmediateListener` depends on the results of `DatasetKeyBlockUpdateHandler`, as it relies on key blocks cached in the database.
- `DatasetKeyBlockUpdateHandler` started working earlier, but due to its asynchronous nature, it finished its work later than `DependencyGraphImmediateListener`.

<!-- Link issues that will be closed automatically when this PR is merged -->
Closes: #1263

<!-- Describe your changes in detail for the reviewers (e.g. include your changelog entries) -->

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [ ] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [x] Container images: ✅
- [ ] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [ ] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [ ] Alerts: ✅
- [ ] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [ ] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [ ] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [ ] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [ ] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)