### PR TITLE
ODF: Hide datafusion under a feature flag

### DIFF
--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -69,7 +69,7 @@ kamu-adapter-http = { workspace = true, features = [
 kamu-adapter-oauth = { workspace = true }
 kamu-adapter-odata = { workspace = true }
 kamu-datafusion-cli = { workspace = true }
-odf = { workspace = true, features = ["http", "s3"] }
+odf = { workspace = true, features = ["datafusion", "http", "s3"] }
 random-strings = { workspace = true }
 
 kamu-flow-system = { workspace = true }
@@ -201,7 +201,14 @@ tracing-bunyan-formatter = "0.3"
 async-trait = "0.1"
 chrono = "0.4"
 cfg-if = "1" # Conditional compilation
-datafusion = { version = "49", default-features = false, features = ["crypto_expressions", "encoding_expressions", "parquet", "regex_expressions", "unicode_expressions", "compression"] }
+datafusion = { version = "49", default-features = false, features = [
+    "crypto_expressions",
+    "encoding_expressions",
+    "parquet",
+    "regex_expressions",
+    "unicode_expressions",
+    "compression",
+] }
 dill = { version = "0.14", default-features = false }
 dirs = "6"
 fs_extra = "1.3"

--- a/src/domain/core/Cargo.toml
+++ b/src/domain/core/Cargo.toml
@@ -34,7 +34,7 @@ container-runtime = { workspace = true }
 file-utils = { workspace = true }
 internal-error = { workspace = true }
 kamu-datasets = { workspace = true }
-odf = { workspace = true }
+odf = { workspace = true, features = ["datafusion"] }
 
 async-stream = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
@@ -52,7 +52,9 @@ tracing = "0.1"
 url = { version = "2", default-features = false, features = ["serde"] }
 
 # TODO: Avoid this dependency or depend on sub-crates
-datafusion = { version = "49", default-features = false, features = ["parquet"] }
+datafusion = { version = "49", default-features = false, features = [
+    "parquet",
+] }
 object_store = { version = "0.12", default-features = false }
 
 # TODO: Make serde optional
@@ -63,8 +65,7 @@ serde_with = { version = "3", default-features = false }
 # Optional
 mockall = { optional = true, version = "0.13", default-features = false }
 oso = { optional = true, version = "0.27", default-features = false }
-utoipa = { optional = true, version = "5", default-features = false, features = [
-] }
+utoipa = { optional = true, version = "5", default-features = false }
 
 
 [dev-dependencies]

--- a/src/odf/odf/Cargo.toml
+++ b/src/odf/odf/Cargo.toml
@@ -25,6 +25,7 @@ doctest = false
 default = ["lfs"]
 
 arrow = ["odf-metadata/arrow"]
+datafusion = ["arrow", "dep:odf-data-utils"]
 did-pkh = ["odf-metadata/did-pkh"]
 http = ["dep:odf-storage-http", "odf-dataset-impl/http"]
 lfs = ["dep:odf-storage-lfs", "odf-dataset/lfs", "odf-dataset-impl/lfs"]
@@ -37,7 +38,7 @@ testing = [
     "odf-dataset-impl/testing",
     "odf-metadata/testing",
     "odf-storage/testing",
-    "odf-data-utils/testing"
+    "odf-data-utils?/testing",
 ]
 utoipa = ["odf-metadata/utoipa"]
 
@@ -46,10 +47,10 @@ utoipa = ["odf-metadata/utoipa"]
 odf-dataset = { workspace = true }
 odf-metadata = { workspace = true }
 odf-storage = { workspace = true }
-odf-data-utils = { workspace = true }
 
 odf-dataset-impl = { workspace = true }
 
+odf-data-utils = { optional = true, workspace = true }
 odf-storage-http = { optional = true, workspace = true }
 odf-storage-inmem = { workspace = true }
 odf-storage-lfs = { optional = true, workspace = true }

--- a/src/odf/odf/src/lib.rs
+++ b/src/odf/odf/src/lib.rs
@@ -76,5 +76,6 @@ pub mod serde {
 }
 
 pub mod utils {
+    #[cfg(feature = "datafusion")]
     pub use odf_data_utils::*;
 }


### PR DESCRIPTION
It must be possible to use top-level `odf` library without `datafusion` as a dependency.