### PR TITLE
Release (minor): 0.249.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ on:
 env:
   PACKAGE_NAME: kamu-cli
   BINARY_NAME: kamu
-  KAMU_WEB_UI_VERSION: "0.56.0"
+  KAMU_WEB_UI_VERSION: "0.58.1"
 jobs:
   build:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
-## Unreleased
+## [0.249.0] - 2025-09-23
 ### Changed
 - (#1372): GQL: Performance improvement via query vectorization for APIs:
   - `Dataset::by_ids()`;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "async-utils"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "common-macros"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -2998,7 +2998,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-utils"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "database-common"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "email-utils"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "serde",
  "thiserror 2.0.16",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.248.1"
+version = "0.249.0"
 
 [[package]]
 name = "env_filter"
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -4927,7 +4927,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "file-utils"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "serde",
 ]
@@ -5676,7 +5676,7 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "axum 0.8.4",
  "http 1.3.1",
@@ -6100,7 +6100,7 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "init-on-startup"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "bon",
@@ -6142,7 +6142,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "thiserror 2.0.16",
 ]
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -6632,7 +6632,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -6665,7 +6665,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6709,7 +6709,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "argon2",
  "chrono",
@@ -6751,7 +6751,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "bon",
@@ -6789,7 +6789,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6812,7 +6812,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-web3"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6874,7 +6874,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -6907,7 +6907,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flow-dataset"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6940,7 +6940,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flow-webhook"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6976,7 +6976,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -7052,7 +7052,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -7145,7 +7145,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "axum 0.8.4",
@@ -7190,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-task-dataset"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "common-macros",
@@ -7209,7 +7209,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-task-webhook"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7229,7 +7229,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -7244,7 +7244,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -7258,7 +7258,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7274,7 +7274,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "dill",
  "kamu-auth-rebac",
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -7308,7 +7308,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7324,7 +7324,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7340,7 +7340,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7355,7 +7355,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7373,7 +7373,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "chrono",
  "dill",
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-services"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7398,7 +7398,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7416,7 +7416,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -7565,7 +7565,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -7595,7 +7595,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -7603,7 +7603,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "database-common",
  "indoc 2.0.6",
@@ -7616,7 +7616,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "database-common",
  "indoc 2.0.6",
@@ -7629,7 +7629,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -7659,7 +7659,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "indoc 2.0.6",
  "kamu-cli-e2e-common",
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -7691,7 +7691,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7725,7 +7725,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7775,7 +7775,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "cheap-clone",
@@ -7797,7 +7797,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7821,7 +7821,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -7839,7 +7839,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7890,7 +7890,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7915,7 +7915,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7964,7 +7964,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7986,7 +7986,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -8000,7 +8000,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8096,7 +8096,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -8112,7 +8112,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8130,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "chrono",
  "dill",
@@ -8143,7 +8143,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8162,7 +8162,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "chrono",
  "clap",
@@ -8180,7 +8180,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -8192,7 +8192,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-openai"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -8206,7 +8206,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-qdrant"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "container-runtime",
@@ -8222,7 +8222,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-services"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -8243,7 +8243,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -8281,7 +8281,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8301,7 +8301,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8346,7 +8346,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8367,7 +8367,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8391,7 +8391,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8411,7 +8411,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-postgres"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8435,7 +8435,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-repo-tests"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -8451,7 +8451,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-services"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8487,7 +8487,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-sqlite"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9045,7 +9045,7 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -9584,7 +9584,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "axum 0.8.4",
@@ -9671,7 +9671,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -9686,7 +9686,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-data-utils"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -9712,7 +9712,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9738,7 +9738,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset-impl"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "arrow",
  "async-stream",
@@ -9780,7 +9780,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-metadata"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -9812,7 +9812,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9834,7 +9834,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-http"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9857,7 +9857,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-inmem"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9873,7 +9873,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-lfs"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9893,7 +9893,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-s3"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -11091,7 +11091,7 @@ dependencies = [
 
 [[package]]
 name = "random-strings"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -11781,7 +11781,7 @@ checksum = "700de91d5fd6091442d00fdd9ee790af6d4f0f480562b0f5a1e8f59e90aafe73"
 
 [[package]]
 name = "s3-utils"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -12142,7 +12142,7 @@ dependencies = [
 
 [[package]]
 name = "server-console"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-graphql",
  "axum 0.8.4",
@@ -13121,7 +13121,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "axum 0.8.4",
  "container-runtime",
@@ -13255,7 +13255,7 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -13758,7 +13758,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.248.1"
+version = "0.249.0"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,137 +134,137 @@ resolver = "2"
 aws-sdk-s3 = "=1.68.0"
 
 # Apps
-kamu-cli = { version = "0.248.1", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.249.0", path = "src/app/cli", default-features = false }
 
 # Utils
-async-utils = { version = "0.248.1", path = "src/utils/async-utils", default-features = false }
-common-macros = { version = "0.248.1", path = "src/utils/common-macros", default-features = false }
-container-runtime = { version = "0.248.1", path = "src/utils/container-runtime", default-features = false }
-crypto-utils = { version = "0.248.1", path = "src/utils/crypto-utils", default-features = false }
-database-common = { version = "0.248.1", path = "src/utils/database-common", default-features = false }
-database-common-macros = { version = "0.248.1", path = "src/utils/database-common-macros", default-features = false }
-email-utils = { version = "0.248.1", path = "src/utils/email-utils", default-features = false }
-enum-variants = { version = "0.248.1", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.248.1", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.248.1", path = "src/utils/event-sourcing-macros", default-features = false }
-file-utils = { version = "0.248.1", path = "src/utils/file-utils", default-features = false }
-http-common = { version = "0.248.1", path = "src/utils/http-common", default-features = false }
-init-on-startup = { version = "0.248.1", path = "src/utils/init-on-startup", default-features = false }
-internal-error = { version = "0.248.1", path = "src/utils/internal-error", default-features = false }
-kamu-cli-puppet = { version = "0.248.1", path = "src/utils/kamu-cli-puppet", default-features = false }
-kamu-datafusion-cli = { version = "0.248.1", path = "src/utils/datafusion-cli", default-features = false }
-messaging-outbox = { version = "0.248.1", path = "src/utils/messaging-outbox", default-features = false }
-multiformats = { version = "0.248.1", path = "src/utils/multiformats", default-features = false }
-observability = { version = "0.248.1", path = "src/utils/observability", default-features = false }
-random-strings = { version = "0.248.1", path = "src/utils/random-strings", default-features = false }
-s3-utils = { version = "0.248.1", path = "src/utils/s3-utils", default-features = false }
-server-console = { version = "0.248.1", path = "src/utils/server-console", default-features = false }
-test-utils = { version = "0.248.1", path = "src/utils/test-utils", default-features = false }
-time-source = { version = "0.248.1", path = "src/utils/time-source", default-features = false }
-tracing-perfetto = { version = "0.248.1", path = "src/utils/tracing-perfetto", default-features = false }
+async-utils = { version = "0.249.0", path = "src/utils/async-utils", default-features = false }
+common-macros = { version = "0.249.0", path = "src/utils/common-macros", default-features = false }
+container-runtime = { version = "0.249.0", path = "src/utils/container-runtime", default-features = false }
+crypto-utils = { version = "0.249.0", path = "src/utils/crypto-utils", default-features = false }
+database-common = { version = "0.249.0", path = "src/utils/database-common", default-features = false }
+database-common-macros = { version = "0.249.0", path = "src/utils/database-common-macros", default-features = false }
+email-utils = { version = "0.249.0", path = "src/utils/email-utils", default-features = false }
+enum-variants = { version = "0.249.0", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.249.0", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.249.0", path = "src/utils/event-sourcing-macros", default-features = false }
+file-utils = { version = "0.249.0", path = "src/utils/file-utils", default-features = false }
+http-common = { version = "0.249.0", path = "src/utils/http-common", default-features = false }
+init-on-startup = { version = "0.249.0", path = "src/utils/init-on-startup", default-features = false }
+internal-error = { version = "0.249.0", path = "src/utils/internal-error", default-features = false }
+kamu-cli-puppet = { version = "0.249.0", path = "src/utils/kamu-cli-puppet", default-features = false }
+kamu-datafusion-cli = { version = "0.249.0", path = "src/utils/datafusion-cli", default-features = false }
+messaging-outbox = { version = "0.249.0", path = "src/utils/messaging-outbox", default-features = false }
+multiformats = { version = "0.249.0", path = "src/utils/multiformats", default-features = false }
+observability = { version = "0.249.0", path = "src/utils/observability", default-features = false }
+random-strings = { version = "0.249.0", path = "src/utils/random-strings", default-features = false }
+s3-utils = { version = "0.249.0", path = "src/utils/s3-utils", default-features = false }
+server-console = { version = "0.249.0", path = "src/utils/server-console", default-features = false }
+test-utils = { version = "0.249.0", path = "src/utils/test-utils", default-features = false }
+time-source = { version = "0.249.0", path = "src/utils/time-source", default-features = false }
+tracing-perfetto = { version = "0.249.0", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-kamu-accounts = { version = "0.248.1", path = "src/domain/accounts/domain", default-features = false }
-kamu-auth-rebac = { version = "0.248.1", path = "src/domain/auth-rebac/domain", default-features = false }
-kamu-auth-web3 = { version = "0.248.1", path = "src/domain/auth-web3/domain", default-features = false }
-kamu-core = { version = "0.248.1", path = "src/domain/core", default-features = false }
-kamu-datasets = { version = "0.248.1", path = "src/domain/datasets/domain", default-features = false }
-kamu-flow-system = { version = "0.248.1", path = "src/domain/flow-system/domain", default-features = false }
-kamu-search = { version = "0.248.1", path = "src/domain/search/domain", default-features = false }
-kamu-task-system = { version = "0.248.1", path = "src/domain/task-system/domain", default-features = false }
-kamu-webhooks = { version = "0.248.1", path = "src/domain/webhooks/domain", default-features = false }
+kamu-accounts = { version = "0.249.0", path = "src/domain/accounts/domain", default-features = false }
+kamu-auth-rebac = { version = "0.249.0", path = "src/domain/auth-rebac/domain", default-features = false }
+kamu-auth-web3 = { version = "0.249.0", path = "src/domain/auth-web3/domain", default-features = false }
+kamu-core = { version = "0.249.0", path = "src/domain/core", default-features = false }
+kamu-datasets = { version = "0.249.0", path = "src/domain/datasets/domain", default-features = false }
+kamu-flow-system = { version = "0.249.0", path = "src/domain/flow-system/domain", default-features = false }
+kamu-search = { version = "0.249.0", path = "src/domain/search/domain", default-features = false }
+kamu-task-system = { version = "0.249.0", path = "src/domain/task-system/domain", default-features = false }
+kamu-webhooks = { version = "0.249.0", path = "src/domain/webhooks/domain", default-features = false }
 
 ## Open Data Fabric
-odf = { version = "0.248.1", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
-odf-metadata = { version = "0.248.1", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
-odf-dataset = { version = "0.248.1", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
-odf-data-utils = { version = "0.248.1", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
-odf-dataset-impl = { version = "0.248.1", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
-odf-storage = { version = "0.248.1", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
-odf-storage-http = { version = "0.248.1", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
-odf-storage-inmem = { version = "0.248.1", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
-odf-storage-lfs = { version = "0.248.1", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
-odf-storage-s3 = { version = "0.248.1", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
+odf = { version = "0.249.0", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
+odf-metadata = { version = "0.249.0", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
+odf-dataset = { version = "0.249.0", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
+odf-data-utils = { version = "0.249.0", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
+odf-dataset-impl = { version = "0.249.0", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
+odf-storage = { version = "0.249.0", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
+odf-storage-http = { version = "0.249.0", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
+odf-storage-inmem = { version = "0.249.0", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
+odf-storage-lfs = { version = "0.249.0", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
+odf-storage-s3 = { version = "0.249.0", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.248.1", path = "src/domain/accounts/services", default-features = false }
-kamu-auth-rebac-services = { version = "0.248.1", path = "src/domain/auth-rebac/services", default-features = false }
-kamu-auth-web3-services = { version = "0.248.1", path = "src/domain/auth-web3/services", default-features = false }
-kamu-datasets-services = { version = "0.248.1", path = "src/domain/datasets/services", default-features = false, features = ["lfs", "s3"] }
-kamu-flow-system-services = { version = "0.248.1", path = "src/domain/flow-system/services", default-features = false }
-kamu-search-services = { version = "0.248.1", path = "src/domain/search/services", default-features = false }
-kamu-task-system-services = { version = "0.248.1", path = "src/domain/task-system/services", default-features = false }
-kamu-webhooks-services = { version = "0.248.1", path = "src/domain/webhooks/services", default-features = false }
+kamu-accounts-services = { version = "0.249.0", path = "src/domain/accounts/services", default-features = false }
+kamu-auth-rebac-services = { version = "0.249.0", path = "src/domain/auth-rebac/services", default-features = false }
+kamu-auth-web3-services = { version = "0.249.0", path = "src/domain/auth-web3/services", default-features = false }
+kamu-datasets-services = { version = "0.249.0", path = "src/domain/datasets/services", default-features = false, features = ["lfs", "s3"] }
+kamu-flow-system-services = { version = "0.249.0", path = "src/domain/flow-system/services", default-features = false }
+kamu-search-services = { version = "0.249.0", path = "src/domain/search/services", default-features = false }
+kamu-task-system-services = { version = "0.249.0", path = "src/domain/task-system/services", default-features = false }
+kamu-webhooks-services = { version = "0.249.0", path = "src/domain/webhooks/services", default-features = false }
 
 # Infra
-kamu = { version = "0.248.1", path = "src/infra/core", default-features = false }
-kamu-ingest-datafusion = { version = "0.248.1", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.249.0", path = "src/infra/core", default-features = false }
+kamu-ingest-datafusion = { version = "0.249.0", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.248.1", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.248.1", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.248.1", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.248.1", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.249.0", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.249.0", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.249.0", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.249.0", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.248.1", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.248.1", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.248.1", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.248.1", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.248.1", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.249.0", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.249.0", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.249.0", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.249.0", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.249.0", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Datasets
-kamu-datasets-inmem = { version = "0.248.1", path = "src/infra/datasets/inmem", default-features = false }
-kamu-datasets-postgres = { version = "0.248.1", path = "src/infra/datasets/postgres", default-features = false }
-kamu-datasets-sqlite = { version = "0.248.1", path = "src/infra/datasets/sqlite", default-features = false }
-kamu-datasets-repo-tests = { version = "0.248.1", path = "src/infra/datasets/repo-tests", default-features = false }
+kamu-datasets-inmem = { version = "0.249.0", path = "src/infra/datasets/inmem", default-features = false }
+kamu-datasets-postgres = { version = "0.249.0", path = "src/infra/datasets/postgres", default-features = false }
+kamu-datasets-sqlite = { version = "0.249.0", path = "src/infra/datasets/sqlite", default-features = false }
+kamu-datasets-repo-tests = { version = "0.249.0", path = "src/infra/datasets/repo-tests", default-features = false }
 ## Search
-kamu-search-openai = { version = "0.248.1", path = "src/infra/search/openai", default-features = false }
-kamu-search-qdrant = { version = "0.248.1", path = "src/infra/search/qdrant", default-features = false }
+kamu-search-openai = { version = "0.249.0", path = "src/infra/search/openai", default-features = false }
+kamu-search-qdrant = { version = "0.249.0", path = "src/infra/search/qdrant", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.248.1", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.248.1", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.248.1", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.248.1", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.249.0", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.249.0", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.249.0", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.249.0", path = "src/infra/task-system/repo-tests", default-features = false }
 ## ReBAC
-kamu-auth-rebac-inmem = { version = "0.248.1", path = "src/infra/auth-rebac/inmem", default-features = false }
-kamu-auth-rebac-repo-tests = { version = "0.248.1", path = "src/infra/auth-rebac/repo-tests", default-features = false }
-kamu-auth-rebac-postgres = { version = "0.248.1", path = "src/infra/auth-rebac/postgres", default-features = false }
-kamu-auth-rebac-sqlite = { version = "0.248.1", path = "src/infra/auth-rebac/sqlite", default-features = false }
+kamu-auth-rebac-inmem = { version = "0.249.0", path = "src/infra/auth-rebac/inmem", default-features = false }
+kamu-auth-rebac-repo-tests = { version = "0.249.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
+kamu-auth-rebac-postgres = { version = "0.249.0", path = "src/infra/auth-rebac/postgres", default-features = false }
+kamu-auth-rebac-sqlite = { version = "0.249.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
 ## Outbox
-kamu-messaging-outbox-inmem = { version = "0.248.1", path = "src/infra/messaging-outbox/inmem", default-features = false }
-kamu-messaging-outbox-postgres = { version = "0.248.1", path = "src/infra/messaging-outbox/postgres", default-features = false }
-kamu-messaging-outbox-sqlite = { version = "0.248.1", path = "src/infra/messaging-outbox/sqlite", default-features = false }
-kamu-messaging-outbox-repo-tests = { version = "0.248.1", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
+kamu-messaging-outbox-inmem = { version = "0.249.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
+kamu-messaging-outbox-postgres = { version = "0.249.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
+kamu-messaging-outbox-sqlite = { version = "0.249.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
+kamu-messaging-outbox-repo-tests = { version = "0.249.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
 ## Webhooks
-kamu-webhooks-inmem = { version = "0.248.1", path = "src/infra/webhooks/inmem", default-features = false }
-kamu-webhooks-postgres = { version = "0.248.1", path = "src/infra/webhooks/postgres", default-features = false }
-kamu-webhooks-sqlite = { version = "0.248.1", path = "src/infra/webhooks/sqlite", default-features = false }
-kamu-webhooks-repo-tests = { version = "0.248.1", path = "src/infra/webhooks/repo-tests", default-features = false }
+kamu-webhooks-inmem = { version = "0.249.0", path = "src/infra/webhooks/inmem", default-features = false }
+kamu-webhooks-postgres = { version = "0.249.0", path = "src/infra/webhooks/postgres", default-features = false }
+kamu-webhooks-sqlite = { version = "0.249.0", path = "src/infra/webhooks/sqlite", default-features = false }
+kamu-webhooks-repo-tests = { version = "0.249.0", path = "src/infra/webhooks/repo-tests", default-features = false }
 ## Web3
-kamu-auth-web3-inmem = { version = "0.248.1", path = "src/infra/auth-web3/inmem", default-features = false }
-kamu-auth-web3-postgres = { version = "0.248.1", path = "src/infra/auth-web3/postgres", default-features = false }
-kamu-auth-web3-repo-tests = { version = "0.248.1", path = "src/infra/auth-web3/repo-tests", default-features = false }
-kamu-auth-web3-sqlite = { version = "0.248.1", path = "src/infra/auth-web3/sqlite", default-features = false }
+kamu-auth-web3-inmem = { version = "0.249.0", path = "src/infra/auth-web3/inmem", default-features = false }
+kamu-auth-web3-postgres = { version = "0.249.0", path = "src/infra/auth-web3/postgres", default-features = false }
+kamu-auth-web3-repo-tests = { version = "0.249.0", path = "src/infra/auth-web3/repo-tests", default-features = false }
+kamu-auth-web3-sqlite = { version = "0.249.0", path = "src/infra/auth-web3/sqlite", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso-rebac = { version = "0.248.1", path = "src/adapter/auth-oso-rebac", default-features = false }
-kamu-adapter-auth-web3 = { version = "0.248.1", path = "src/adapter/auth-web3", default-features = false }
-kamu-adapter-flight-sql = { version = "0.248.1", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-flow-dataset = { version = "0.248.1", path = "src/adapter/flow-dataset", default-features = false }
-kamu-adapter-flow-webhook = { version = "0.248.1", path = "src/adapter/flow-webhook", default-features = false }
-kamu-adapter-task-dataset = { version = "0.248.1", path = "src/adapter/task-dataset", default-features = false }
-kamu-adapter-task-webhook = { version = "0.248.1", path = "src/adapter/task-webhook", default-features = false }
+kamu-adapter-auth-oso-rebac = { version = "0.249.0", path = "src/adapter/auth-oso-rebac", default-features = false }
+kamu-adapter-auth-web3 = { version = "0.249.0", path = "src/adapter/auth-web3", default-features = false }
+kamu-adapter-flight-sql = { version = "0.249.0", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-flow-dataset = { version = "0.249.0", path = "src/adapter/flow-dataset", default-features = false }
+kamu-adapter-flow-webhook = { version = "0.249.0", path = "src/adapter/flow-webhook", default-features = false }
+kamu-adapter-task-dataset = { version = "0.249.0", path = "src/adapter/task-dataset", default-features = false }
+kamu-adapter-task-webhook = { version = "0.249.0", path = "src/adapter/task-webhook", default-features = false }
 kamu-adapter-flow-task = { version = "0.242.1", path = "src/adapter/flow-task", default-features = false }
-kamu-adapter-graphql = { version = "0.248.1", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.248.1", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.248.1", path = "src/adapter/odata", default-features = false }
-kamu-adapter-oauth = { version = "0.248.1", path = "src/adapter/oauth", default-features = false }
+kamu-adapter-graphql = { version = "0.249.0", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.249.0", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.249.0", path = "src/adapter/odata", default-features = false }
+kamu-adapter-oauth = { version = "0.249.0", path = "src/adapter/oauth", default-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.248.1", path = "src/e2e/app/cli/common", default-features = false }
-kamu-cli-e2e-common-macros = { version = "0.248.1", path = "src/e2e/app/cli/common-macros", default-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.248.1", path = "src/e2e/app/cli/repo-tests", default-features = false }
+kamu-cli-e2e-common = { version = "0.249.0", path = "src/e2e/app/cli/common", default-features = false }
+kamu-cli-e2e-common-macros = { version = "0.249.0", path = "src/e2e/app/cli/common-macros", default-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.249.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
 
 [workspace.package]
-version = "0.248.1"
+version = "0.249.0"
 edition = "2024"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.248.1
+Licensed Work:             Kamu CLI Version 0.249.0
                            The Licensed Work is © 2025 Kamu Data, Inc.
 
 Additional Use Grant:      You may not use the Licensed Work for a Data Service,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may not use the Licensed Work for a Data Service,
                            Further, you may not distribute the Licensed Work
                            under a different name or a brand.
 
-Change Date:               2029-09-09
+Change Date:               2029-09-23
 
 Change License:            Apache License, Version 2.0
 

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -973,7 +973,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.248.1"
+    "version": "0.249.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -973,7 +973,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.248.1"
+    "version": "0.249.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## [0.249.0] - 2025-09-23
### Changed
- (#1372): GQL: Performance improvement via query vectorization for APIs:
  - `Dataset::by_ids()`;
  - `DatasetMut::by_ids()`;
  - `Account::by_ids()`;
  - `AccountMut::by_ids()`.
- Improved compatibility with EVM-based sources
- Upgraded to `datafusion v50`
- (#1384) `kamu inspect`: speed-up of iteration through the metadata chain.
- (#1384) `GQL: Dataset::metadata().current_push_sources`: significant speed-up through iteration 
  over key blocks stored in the database 
- (#1384) General iteration optimizations based on the dataset type (root, derived). 
  Ability to disable hints during iteration.
- (#1384) `SearchActivePushSourcesVisitor`, `SearchActivePollingSourceVisitor`: accounting for the evolution of data 
  sources.
- (#1366): Experiment: beginning of `cheap_clone()` integration.

## [0.248.1] - 2025-09-11
### Fixed
- Crash on writing datasets with `List` field type