### PR TITLE
Molecule: global announcements feed

### DIFF
--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -2875,6 +2875,11 @@ type Molecule {
 	List the registered projects
 	"""
 	projects(page: Int, perPage: Int): MoleculeProjectConnection!
+	"""
+	Latest activity events across all projects in reverse chronological
+	order
+	"""
+	activity(page: Int, perPage: Int): MoleculeProjectEventConnection!
 }
 
 type MoleculeMut {
@@ -2949,10 +2954,15 @@ type MoleculeProjectEdge {
 }
 
 interface MoleculeProjectEvent {
+	project: MoleculeProject!
 	systemTime: DateTime!
 }
 
 type MoleculeProjectEventAnnouncement implements MoleculeProjectEvent {
+	"""
+	Associated project
+	"""
+	project: MoleculeProject!
 	"""
 	Announcement record
 	"""
@@ -2974,6 +2984,10 @@ type MoleculeProjectEventConnection {
 
 type MoleculeProjectEventDataRoomEntryAdded implements MoleculeProjectEvent {
 	"""
+	Associated project
+	"""
+	project: MoleculeProject!
+	"""
 	Collection entry
 	"""
 	entry: CollectionEntry!
@@ -2982,6 +2996,10 @@ type MoleculeProjectEventDataRoomEntryAdded implements MoleculeProjectEvent {
 
 type MoleculeProjectEventDataRoomEntryRemoved implements MoleculeProjectEvent {
 	"""
+	Associated project
+	"""
+	project: MoleculeProject!
+	"""
 	Collection entry
 	"""
 	entry: CollectionEntry!
@@ -2989,6 +3007,10 @@ type MoleculeProjectEventDataRoomEntryRemoved implements MoleculeProjectEvent {
 }
 
 type MoleculeProjectEventDataRoomEntryUpdated implements MoleculeProjectEvent {
+	"""
+	Associated project
+	"""
+	project: MoleculeProject!
 	"""
 	Collection entry
 	"""
@@ -3001,6 +3023,10 @@ type MoleculeProjectEventEdge {
 }
 
 type MoleculeProjectEventFileUpdated implements MoleculeProjectEvent {
+	"""
+	Associated project
+	"""
+	project: MoleculeProject!
 	"""
 	Versioned file dataset
 	"""

--- a/src/domain/core/src/services/dataset_registry.rs
+++ b/src/domain/core/src/services/dataset_registry.rs
@@ -35,6 +35,8 @@ pub trait DatasetRegistry: odf::dataset::DatasetHandleResolver {
         dataset_ids: &[Cow<odf::DatasetID>],
     ) -> Result<DatasetHandlesResolution, GetMultipleDatasetsError>;
 
+    // TODO: This likely should be a sync function to signify that handles are
+    // transformed to resolved datasets with no overhead
     async fn get_dataset_by_handle(&self, dataset_handle: &odf::DatasetHandle) -> ResolvedDataset;
 }
 

--- a/src/domain/core/src/services/query_service.rs
+++ b/src/domain/core/src/services/query_service.rs
@@ -49,7 +49,7 @@ pub trait QueryService: Send + Sync {
     ) -> Result<GetDataResponse, QueryError>;
 
     /// Prepares an execution plan for the SQL statement and returns a
-    /// [DataFrame] that can be used to get schema and data, and the state
+    /// [`DataFrameExt`] that can be used to get schema and data, and the state
     /// information that can be used for reproducibility.
     async fn sql_statement(
         &self,
@@ -83,12 +83,23 @@ pub trait QueryService: Send + Sync {
     // TODO: Introduce additional options that could be used to narrow down the
     // number of files we collect to construct the dataframe.
     //
-    /// Returns a [DataFrame] representing the contents of an entire dataset
+    /// Returns a [`DataFrameExt`] representing the contents of an entire
+    /// dataset
     async fn get_data(
         &self,
         dataset_ref: &odf::DatasetRef,
         options: GetDataOptions,
     ) -> Result<GetDataResponse, QueryError>;
+
+    // TODO: Consider replacing this function with a more sophisticated session
+    // context builder that can be reused for multiple queries
+    /// Returns [`DataFrameExt`]s representing the contents of multiple datasets
+    /// in a batch
+    async fn get_data_multi(
+        &self,
+        dataset_refs: &[odf::DatasetRef],
+        skip_if_missing_or_inaccessible: bool,
+    ) -> Result<Vec<GetDataResponse>, QueryError>;
 
     /// Lists engines known to the system and recommended for use
     async fn get_known_engines(&self) -> Result<Vec<EngineDesc>, InternalError>;

--- a/src/odf/data-utils/src/data/dataframe_ext.rs
+++ b/src/odf/data-utils/src/data/dataframe_ext.rs
@@ -255,6 +255,25 @@ impl DataFrameExt {
             Ok(Some(column.value(0)))
         }
     }
+
+    pub fn union_all(dfs: Vec<DataFrameExt>) -> Result<Option<DataFrameExt>> {
+        let mut iter = dfs.into_iter();
+        let Some(df) = iter.next() else {
+            return Ok(None);
+        };
+
+        let (state, plan) = df.into_parts();
+        let mut builder = datafusion::logical_expr::LogicalPlanBuilder::new(plan);
+
+        for df in iter {
+            let (_, plan) = df.into_parts();
+            builder = builder.union(plan)?;
+        }
+
+        let plan = builder.build()?;
+
+        Ok(Some(Self(DataFrame::new(state, plan))))
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Adds `{ molecule { activity } }` GQL endpoint similar to per project `{ molecule { project { activity } } }`.

Currently implemented as brute force `union all + order by + limit` across all announcements dataset, but allows us to add caching and other improvements under the hood in future.