### PR TITLE
Drop archetype inference from schema compatibility option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Recommendation: for ease of reading, use the following order:
 ## [Unreleased]
 ### Changed
 - Discontinued binary releases for MacOS Intel architecture (see #1323) and Windows (as we only ever supported WSL2)
+- Removed `extra.graphql.enableArchetypeInference` config option that was added for compatibility during data migrations
 
 ## [0.249.1] - 2025-09-25
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,6 +4854,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible_map"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c26f4163cf85f3d748cc5d56731a2f0840963ddd67306b808f5f23f789de3b8"
+
+[[package]]
 name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6994,6 +7000,7 @@ dependencies = [
  "dill",
  "email-utils",
  "event-sourcing",
+ "fallible_map",
  "file-utils",
  "futures",
  "http 1.3.1",

--- a/src/adapter/graphql/Cargo.toml
+++ b/src/adapter/graphql/Cargo.toml
@@ -69,6 +69,7 @@ chrono = "0.4"
 # TODO: Currently needed for type conversions but ideally should be encapsulated by kamu-core
 datafusion = { version = "50", default-features = false, features = ["serde"] }
 dill = { version = "0.14", default-features = false }
+fallible_map = { version = "0.1.1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 http = { version = "1", default-features = false }
 humansize = { version = "2", default-features = false }

--- a/src/adapter/graphql/src/config.rs
+++ b/src/adapter/graphql/src/config.rs
@@ -11,13 +11,6 @@
 
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct Config {
-    /// Enables compatibility mode where collection and versioned file
-    /// archetypes were inferred from push source read schema in addition to
-    /// using the schema attributes. This setting will be removed shortly after
-    /// migration.
-    #[serde(default)]
-    pub enable_archetype_inference: bool,
-}
+pub struct Config {}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/adapter/graphql/src/queries/datasets/dataset_request_state.rs
+++ b/src/adapter/graphql/src/queries/datasets/dataset_request_state.rs
@@ -10,6 +10,7 @@
 use std::collections::HashSet;
 use std::ops::Deref;
 
+use fallible_map::FallibleMapExt as _;
 use kamu_auth_rebac::AuthorizedAccount;
 use kamu_core::{DatasetRegistry, ResolvedDataset, auth};
 use odf::dataset::MetadataChainExt as _;
@@ -133,96 +134,36 @@ impl DatasetRequestState {
             .await
     }
 
-    #[expect(deprecated)]
     pub async fn archetype(
         &self,
         ctx: &Context<'_>,
     ) -> Result<Option<odf::schema::ext::DatasetArchetype>> {
-        let config = from_catalog_n!(ctx, crate::Config);
-
         let archetype = self
             .archetype
             .get_or_try_init::<GqlError, _, _>(async || {
-                match self.get_archetype_from_schema_attrs(ctx).await? {
-                    Some(a) => Ok(Some(a)),
-                    None if config.enable_archetype_inference => {
-                        self.infer_archetype_from_push_source_schema(ctx).await
-                    }
-                    None => Ok(None),
-                }
+                let dataset = self.resolved_dataset(ctx).await?;
+
+                let archetype = dataset
+                    .as_metadata_chain()
+                    .accept_one(odf::dataset::SearchSetDataSchemaVisitor::new())
+                    .await
+                    .int_err()?
+                    .into_event()
+                    .and_then(|e| e.schema)
+                    .try_and_then(|schema| {
+                        schema
+                            .extra
+                            .unwrap_or_default()
+                            .get::<odf::schema::ext::AttrArchetype>()
+                    })
+                    .int_err()?
+                    .map(|attr| attr.archetype);
+
+                Ok(archetype)
             })
             .await?;
 
         Ok(*archetype)
-    }
-
-    async fn get_archetype_from_schema_attrs(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Option<odf::schema::ext::DatasetArchetype>> {
-        let dataset = self.resolved_dataset(ctx).await?;
-
-        let Some(schema) = dataset
-            .as_metadata_chain()
-            .accept_one(odf::dataset::SearchSetDataSchemaVisitor::new())
-            .await
-            .int_err()?
-            .into_event()
-            .and_then(|e| e.schema)
-        else {
-            return Ok(None);
-        };
-
-        let extra = schema.extra.unwrap_or_default();
-        let attr = extra.get::<odf::schema::ext::AttrArchetype>().int_err()?;
-
-        Ok(attr.map(|attr| attr.archetype))
-    }
-
-    #[deprecated(
-        note = "This will be removed in favor of `get_archetype_from_schema_attrs` after the \
-                schema migration"
-    )]
-    async fn infer_archetype_from_push_source_schema(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Option<odf::schema::ext::DatasetArchetype>> {
-        let dataset = self.resolved_dataset(ctx).await?;
-
-        let (source, _merge) = match dataset
-            .as_metadata_chain()
-            .accept_one(kamu_core::WriterSourceEventVisitor::new(None))
-            .await
-            .int_err()?
-            .get_source_event_and_merge_strategy()
-        {
-            Ok(src) => src,
-            Err(kamu_core::ScanMetadataError::SourceNotFound(_)) => return Ok(None),
-            Err(err) => return Err(err.int_err().into()),
-        };
-
-        let Some(odf::MetadataEvent::AddPushSource(source)) = source else {
-            return Ok(None);
-        };
-
-        let Some(schema_ddl) = source.read.schema() else {
-            return Ok(None);
-        };
-
-        let push_source_columns: std::collections::BTreeSet<String> = schema_ddl
-            .iter()
-            .filter_map(|c| c.split_once(' ').map(|s| s.0.to_string()))
-            .collect();
-
-        if push_source_columns.contains(kamu_datasets::VERSION_COLUMN_NAME)
-            && push_source_columns.contains(kamu_datasets::CONTENT_HASH_COLUMN_NAME)
-        {
-            Ok(Some(odf::schema::ext::DatasetArchetype::VersionedFile))
-        } else if push_source_columns.contains("path") && push_source_columns.contains("ref") {
-            Ok(Some(odf::schema::ext::DatasetArchetype::Collection))
-        } else {
-            Ok(None)
-        }
     }
 }
 


### PR DESCRIPTION
Closes: #1371

Removes a config option that was added for the brief period of migrating collection and versioned file datasets to ODF schema.