### PR TITLE
Add webhook secret event payload migration

### DIFF
--- a/migrations/postgres/20251018155748_modify_webhook_create_event_secret.sql
+++ b/migrations/postgres/20251018155748_modify_webhook_create_event_secret.sql
@@ -1,0 +1,23 @@
+/* ------------------------------ */
+
+UPDATE webhook_subscription_events
+SET event_payload = jsonb_set(
+    event_payload,
+    '{Created,secret}',
+    jsonb_build_object(
+        'value',
+        (
+            SELECT jsonb_agg(get_byte(decoded, gs))
+            FROM (
+                SELECT
+                    decode(event_payload->'Created'->>'secret', 'hex') AS decoded
+            ) AS d,
+            generate_series(0, length(d.decoded) - 1) AS gs
+        ),
+        'nonce', 'null'::jsonb
+    )
+)
+WHERE event_type = 'WebhookSubscriptionEventCreated'
+  AND jsonb_typeof(event_payload->'Created'->'secret') = 'string';
+
+/* ------------------------------ */


### PR DESCRIPTION
Follow-up PR for https://github.com/kamu-data/kamu-cli/pull/1416
 Added a migration for event payloads to support the new structure of secrets