### PR TITLE
Improve nullability handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Recommendation: for ease of reading, use the following order:
 -->
 
 ## [Unreleased]
+### Changed
+- Improved handling of nullable / optional data types:
+  - Ingest merge strategies now preserve the optionality of columns
+  - Data writer will attempt to coerce column optionality, returning errors if input data contains nulls in a required field
 ### Fixed
 - Login method returns invalid credential error when login is invalid account name
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9806,6 +9806,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha3",
+ "test-group",
  "test-log",
  "thiserror 2.0.17",
  "tokio",

--- a/src/adapter/graphql/src/queries/datasets/adapters/collection.rs
+++ b/src/adapter/graphql/src/queries/datasets/adapters/collection.rs
@@ -35,7 +35,7 @@ impl Collection<'_> {
             odf::utils::schema::parse::parse_ddl_to_odf_schema(&extra_columns_ddl.join(", "))?;
 
         let schema = odf::schema::DataSchema::builder()
-            .with_changelog_system_fields(odf::metadata::DatasetVocabulary::default())
+            .with_changelog_system_fields(odf::metadata::DatasetVocabulary::default(), None)
             .extend([
                 odf::schema::DataField::string("path").description(
                     "HTTP-like path to a collection entry. Paths start with `/` and can be \

--- a/src/adapter/graphql/src/queries/datasets/adapters/versioned_file.rs
+++ b/src/adapter/graphql/src/queries/datasets/adapters/versioned_file.rs
@@ -39,7 +39,7 @@ impl<'a> VersionedFile<'a> {
             odf::utils::schema::parse::parse_ddl_to_odf_schema(&extra_columns_ddl.join(", "))?;
 
         let schema = odf::schema::DataSchema::builder()
-            .with_changelog_system_fields(odf::metadata::DatasetVocabulary::default())
+            .with_changelog_system_fields(odf::metadata::DatasetVocabulary::default(), None)
             .extend([
                 odf::schema::DataField::i32("version").description(
                     "Sequential identifier assigned to each entry as new versions are uploaded",

--- a/src/adapter/http/tests/tests/test_data_ingest.rs
+++ b/src/adapter/http/tests/tests/test_data_ingest.rs
@@ -72,7 +72,7 @@ async fn test_data_push_ingest_handler() {
                       REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                      OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                      REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL BYTE_ARRAY city (STRING);
                       OPTIONAL INT64 population;
                     }
@@ -185,7 +185,7 @@ async fn test_data_push_ingest_handler() {
                       REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                      OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                      REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL BYTE_ARRAY city (STRING);
                       OPTIONAL INT64 population;
                     }
@@ -246,7 +246,7 @@ async fn test_data_push_ingest_handler() {
                       REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                      OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                      REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL BYTE_ARRAY city (STRING);
                       OPTIONAL INT64 population;
                     }
@@ -334,7 +334,7 @@ async fn test_data_push_ingest_upload_token_no_initial_source() {
                       REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                      OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                      REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL BYTE_ARRAY city (STRING);
                       OPTIONAL INT64 population;
                     }
@@ -425,7 +425,7 @@ async fn test_data_push_ingest_upload_token_with_initial_source() {
                       REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                      OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                      REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL BYTE_ARRAY city (STRING);
                       OPTIONAL INT64 population;
                     }
@@ -508,7 +508,7 @@ async fn test_data_push_ingest_upload_content_type_not_specified() {
                       REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                      OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                      REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                       OPTIONAL BYTE_ARRAY city (STRING);
                       OPTIONAL INT64 population;
                     }

--- a/src/adapter/http/tests/tests/test_data_query.rs
+++ b/src/adapter/http/tests/tests/test_data_query.rs
@@ -284,7 +284,7 @@ async fn test_data_tail_handler() {
                         "dict_is_ordered": false,
                         "metadata": {},
                         "name": "event_time",
-                        "nullable": true,
+                        "nullable": false,
                     }, {
                         "data_type": "Utf8",
                         "dict_id": 0,
@@ -500,14 +500,14 @@ async fn test_data_query_handler_success() {
                 },
                 "subQueries": [],
                 "commitment": {
-                    "inputHash": "f1620f230a79ac4e50c086d7f02ea670763bb91abbfa3902e386689d8be98c3ebee6e",
+                    "inputHash": "f16209d5150a1d78f6977af88388c87056fc16ed829fd9463f17ef840c1ebd77d70b0",
                     "outputHash": "f16208d66e08ce876ba35ce00ea56f02faf83dbc086f877c443e3d493427ccad133f1",
                     "subQueriesHash": "f1620ca4510738395af1429224dd785675309c344b2b549632e20275c69b15ed1d210",
                 },
                 "proof": {
                     "type": "Ed25519Signature2020",
                     "verificationMethod": "did:key:z6Mko2nqhQ9wYSTS5Giab2j1aHzGnxHimqwmFeEVY8aNsVnN",
-                    "proofValue": "ujLRAWAtSUyBN1xOoqyn3plkoy0CSQd_lZMJ76jH-hp8g8gyUrzzMY8qYxArjAyyml1RN5axC5-VJEh29kCuIDw",
+                    "proofValue": "u0R35mPWQwc8lCEIsQIZZRNV5-_bcCWj43fnILcSaQeyJnhctHrDV2o_pOU7esOuojHCbDE-vW95pWyvo1FSEBA",
                 }
             }),
             response
@@ -658,14 +658,14 @@ async fn test_data_verify_handler() {
                 },
                 "subQueries": [],
                 "commitment": {
-                    "inputHash": "f1620a83cfca0b19a81550b1a60607be4d870b47b6aafb59757e16eb810d838d4dd65",
+                    "inputHash": "f162081b18ed61623301237cae3a33d4a3347d876f20358770a28db4c5724b3614b9d",
                     "outputHash": "f1620ff7f5beaf16900218a3ac4aae82cdccf764816986c7c739c716cf7dc03112a2c",
                     "subQueriesHash": "f1620ca4510738395af1429224dd785675309c344b2b549632e20275c69b15ed1d210",
                 },
                 "proof": {
                     "type": "Ed25519Signature2020",
                     "verificationMethod": "did:key:z6Mko2nqhQ9wYSTS5Giab2j1aHzGnxHimqwmFeEVY8aNsVnN",
-                    "proofValue": "uFNfLp8HHhiS6dV1RCrFytGlZsRTN6kklfNZ6v3t3-cLoDiPpOcWr8ryRbWsicLNG6lQQQlLUBomExVaiMNT8DQ",
+                    "proofValue": "uFYYvS_C8ls6UkfP3O1ZXlbzBMzNFhnub6ojqiyPcR8Wl0GTKJ9CW82w2XXxgmVUCdXE-MOhuyNclYvoOx9vzBQ",
                 }
             }),
             response
@@ -1664,12 +1664,9 @@ async fn test_metadata_handler_schema_formats() {
                             {
                                 "name": "event_time",
                                 "type": {
-                                    "kind": "Option",
-                                    "inner": {
-                                        "kind": "Timestamp",
-                                        "unit": "Millisecond",
-                                        "timezone": "UTC",
-                                    },
+                                    "kind": "Timestamp",
+                                    "unit": "Millisecond",
+                                    "timezone": "UTC",
                                 },
                             },
                             {
@@ -1717,11 +1714,9 @@ async fn test_metadata_handler_schema_formats() {
                 timezone: UTC
             - name: event_time
               type:
-                kind: Option
-                inner:
-                  kind: Timestamp
-                  unit: Millisecond
-                  timezone: UTC
+                kind: Timestamp
+                unit: Millisecond
+                timezone: UTC
             - name: city
               type:
                 kind: String
@@ -1797,7 +1792,7 @@ async fn test_metadata_handler_schema_formats() {
                                 "dict_is_ordered": false,
                                 "metadata": {},
                                 "name": "event_time",
-                                "nullable": true
+                                "nullable": false
                             },
                             {
                                 "data_type": "Utf8",
@@ -1860,7 +1855,7 @@ async fn test_metadata_handler_schema_formats() {
                             {
                                 "logicalType": "TIMESTAMP(MILLIS,true)",
                                 "name": "event_time",
-                                "repetition": "OPTIONAL",
+                                "repetition": "REQUIRED",
                                 "type": "INT64"
                             },
                             {
@@ -1896,7 +1891,7 @@ async fn test_metadata_handler_schema_formats() {
             json!({
                 "output": {
                     "schemaFormat": "Parquet",
-                    "schema": "message arrow_schema {\n  REQUIRED INT64 offset;\n  REQUIRED INT32 op;\n  REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));\n  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));\n  REQUIRED BYTE_ARRAY city (STRING);\n  REQUIRED INT64 population (INTEGER(64,false));\n}\n",
+                    "schema": "message arrow_schema {\n  REQUIRED INT64 offset;\n  REQUIRED INT32 op;\n  REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));\n  REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));\n  REQUIRED BYTE_ARRAY city (STRING);\n  REQUIRED INT64 population (INTEGER(64,false));\n}\n",
                 }
             }),
             res.json::<serde_json::Value>().await.unwrap()

--- a/src/adapter/odata/tests/tests/test_handlers.rs
+++ b/src/adapter/odata/tests/tests/test_handlers.rs
@@ -134,7 +134,7 @@ async fn test_metadata_handler() {
                 <Property Name="offset" Type="Edm.Int64" Nullable="false"/>
                 <Property Name="op" Type="Edm.Int32" Nullable="false"/>
                 <Property Name="system_time" Type="Edm.DateTimeOffset" Nullable="false"/>
-                <Property Name="date" Type="Edm.DateTimeOffset" Nullable="true"/>
+                <Property Name="date" Type="Edm.DateTimeOffset" Nullable="false"/>
                 <Property Name="city" Type="Edm.String" Nullable="true"/>
                 <Property Name="population" Type="Edm.Int64" Nullable="true"/>
                 </EntityType>

--- a/src/adapter/task-dataset/src/runners/update_dataset_task_runner.rs
+++ b/src/adapter/task-dataset/src/runners/update_dataset_task_runner.rs
@@ -151,6 +151,7 @@ impl UpdateDatasetTaskRunner {
                 | PollingIngestError::IncompatibleSchema(_)
                 | PollingIngestError::InvalidParameterFormat(_)
                 | PollingIngestError::MergeError(_)
+                | PollingIngestError::ExecutionError(_)
                 | PollingIngestError::TemplateError(_) => {
                     Ok(TaskOutcome::Failed(TaskError::empty_unrecoverable()))
                 }

--- a/src/domain/core/src/services/ingest/polling_ingest_service.rs
+++ b/src/domain/core/src/services/ingest/polling_ingest_service.rs
@@ -306,6 +306,13 @@ pub enum PollingIngestError {
     ),
 
     #[error(transparent)]
+    ExecutionError(
+        #[from]
+        #[backtrace]
+        ExecutionError,
+    ),
+
+    #[error(transparent)]
     DataValidation(
         #[from]
         #[backtrace]

--- a/src/domain/core/src/services/ingest/push_ingest_executor.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_executor.rs
@@ -128,6 +128,13 @@ pub enum PushIngestError {
     ),
 
     #[error(transparent)]
+    ExecutionError(
+        #[from]
+        #[backtrace]
+        ingest::ExecutionError,
+    ),
+
+    #[error(transparent)]
     DataValidation(
         #[from]
         #[backtrace]

--- a/src/e2e/app/cli/repo-tests/src/commands/test_ingest_command.rs
+++ b/src/e2e/app/cli/repo-tests/src/commands/test_ingest_command.rs
@@ -83,7 +83,7 @@ pub async fn test_push_ingest_from_file_ledger(kamu: KamuCliPuppet) {
               REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-              OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+              REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
               OPTIONAL BYTE_ARRAY city (STRING);
               OPTIONAL INT64 population;
             }
@@ -170,7 +170,7 @@ pub async fn test_push_ingest_from_file_snapshot_with_event_time(kamu: KamuCliPu
               REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-              OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+              REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
               OPTIONAL BYTE_ARRAY city (STRING);
               OPTIONAL INT64 population;
             }

--- a/src/e2e/app/cli/repo-tests/src/commands/test_inspect_command.rs
+++ b/src/e2e/app/cli/repo-tests/src/commands/test_inspect_command.rs
@@ -181,7 +181,7 @@ pub async fn test_inspect_schema(kamu: KamuCliPuppet) {
               REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-              OPTIONAL INT64 match_time (TIMESTAMP(MILLIS,true));
+              REQUIRED INT64 match_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 match_id;
               OPTIONAL BYTE_ARRAY player_id (STRING);
               OPTIONAL INT64 score;

--- a/src/e2e/app/cli/repo-tests/src/commands/test_log_command.rs
+++ b/src/e2e/app/cli/repo-tests/src/commands/test_log_command.rs
@@ -127,7 +127,7 @@ pub async fn test_log_command(kamu: KamuCliPuppet) {
                         DataField::i64("offset"),
                         DataField::i32("op"),
                         DataField::timestamp_millis_utc("system_time"),
-                        DataField::timestamp_millis_utc("match_time").optional(),
+                        DataField::timestamp_millis_utc("match_time"),
                         DataField::i64("match_id").optional(),
                         DataField::string("player_id").optional(),
                         DataField::i64("score").optional(),
@@ -154,7 +154,7 @@ pub async fn test_log_command(kamu: KamuCliPuppet) {
                 odf::metadata::OffsetInterval { start: 0, end: 1 },
                 actual_new_data.offset_interval
             );
-            pretty_assertions::assert_eq!(2302, actual_new_data.size);
+            pretty_assertions::assert_eq!(2286, actual_new_data.size);
 
             pretty_assertions::assert_eq!(None, actual_add_data.new_checkpoint);
             pretty_assertions::assert_eq!(
@@ -179,7 +179,7 @@ pub async fn test_log_command(kamu: KamuCliPuppet) {
                 odf::metadata::OffsetInterval { start: 2, end: 3 },
                 actual_new_data.offset_interval
             );
-            pretty_assertions::assert_eq!(2315, actual_new_data.size);
+            pretty_assertions::assert_eq!(2299, actual_new_data.size);
 
             pretty_assertions::assert_eq!(None, actual_add_data.new_checkpoint);
             pretty_assertions::assert_eq!(

--- a/src/e2e/app/cli/repo-tests/src/commands/test_pull_command.rs
+++ b/src/e2e/app/cli/repo-tests/src/commands/test_pull_command.rs
@@ -213,7 +213,7 @@ async fn test_pull_reset_derivative(kamu: KamuCliPuppet) {
           OPTIONAL INT64 offset;
           REQUIRED INT32 op;
           REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-          OPTIONAL INT64 match_time (TIMESTAMP(MILLIS,true));
+          REQUIRED INT64 match_time (TIMESTAMP(MILLIS,true));
           OPTIONAL INT64 place (INTEGER(64,false));
           OPTIONAL INT64 match_id;
           OPTIONAL BYTE_ARRAY player_id (STRING);

--- a/src/e2e/app/cli/repo-tests/src/commands/test_search_command.rs
+++ b/src/e2e/app/cli/repo-tests/src/commands/test_search_command.rs
@@ -164,7 +164,7 @@ async fn test_search_multi_user(
             ┌──────────────────────────────────┬──────┬─────────────┬────────┬─────────┬──────────┐
             │              Alias               │ Kind │ Description │ Blocks │ Records │   Size   │
             ├──────────────────────────────────┼──────┼─────────────┼────────┼─────────┼──────────┤
-            │ kamu-node/e2e-user/player-scores │ Root │ -           │      5 │       2 │ 2.25 KiB │
+            │ kamu-node/e2e-user/player-scores │ Root │ -           │      5 │       2 │ 2.23 KiB │
             └──────────────────────────────────┴──────┴─────────────┴────────┴─────────┴──────────┘
             "#
         )),
@@ -193,7 +193,7 @@ async fn test_search_multi_user(
             │                 Alias                 │    Kind    │ Description │ Blocks │ Records │   Size   │
             ├───────────────────────────────────────┼────────────┼─────────────┼────────┼─────────┼──────────┤
             │ kamu-node/e2e-user/player-leaderboard │ Derivative │ -           │      3 │       - │        - │
-            │ kamu-node/e2e-user/player-scores      │    Root    │ -           │      5 │       2 │ 2.25 KiB │
+            │ kamu-node/e2e-user/player-scores      │    Root    │ -           │      5 │       2 │ 2.23 KiB │
             └───────────────────────────────────────┴────────────┴─────────────┴────────┴─────────┴──────────┘
             "#
         )),
@@ -233,7 +233,7 @@ async fn test_search_multi_user(
             │                 Alias                 │    Kind    │ Description │ Blocks │ Records │   Size   │
             ├───────────────────────────────────────┼────────────┼─────────────┼────────┼─────────┼──────────┤
             │ kamu-node/e2e-user/player-leaderboard │ Derivative │ -           │      3 │       - │        - │
-            │ kamu-node/e2e-user/player-scores      │    Root    │ -           │      5 │       2 │ 2.25 KiB │
+            │ kamu-node/e2e-user/player-scores      │    Root    │ -           │      5 │       2 │ 2.23 KiB │
             │ kamu-node/kamu/player-scores          │    Root    │ -           │      3 │       - │        - │
             └───────────────────────────────────────┴────────────┴─────────────┴────────┴─────────┴──────────┘
             "#

--- a/src/e2e/app/cli/repo-tests/src/test_smart_transfer_protocol.rs
+++ b/src/e2e/app/cli/repo-tests/src/test_smart_transfer_protocol.rs
@@ -951,7 +951,7 @@ async fn test_smart_push_all_smart_pull_all(
               REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-              OPTIONAL INT64 match_time (TIMESTAMP(MILLIS,true));
+              REQUIRED INT64 match_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 match_id;
               OPTIONAL BYTE_ARRAY player_id (STRING);
               OPTIONAL INT64 score;
@@ -974,7 +974,7 @@ async fn test_smart_push_all_smart_pull_all(
               OPTIONAL INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-              OPTIONAL INT64 match_time (TIMESTAMP(MILLIS,true));
+              REQUIRED INT64 match_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 place (INTEGER(64,false));
               OPTIONAL INT64 match_id;
               OPTIONAL BYTE_ARRAY player_id (STRING);
@@ -1249,7 +1249,7 @@ async fn test_smart_push_recursive_smart_pull_recursive(
               REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-              OPTIONAL INT64 match_time (TIMESTAMP(MILLIS,true));
+              REQUIRED INT64 match_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 match_id;
               OPTIONAL BYTE_ARRAY player_id (STRING);
               OPTIONAL INT64 score;
@@ -1272,7 +1272,7 @@ async fn test_smart_push_recursive_smart_pull_recursive(
               OPTIONAL INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-              OPTIONAL INT64 match_time (TIMESTAMP(MILLIS,true));
+              REQUIRED INT64 match_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 place (INTEGER(64,false));
               OPTIONAL INT64 match_id;
               OPTIONAL BYTE_ARRAY player_id (STRING);
@@ -1529,7 +1529,7 @@ async fn test_simple_push_to_s3_smart_pull(
               REQUIRED INT64 offset;
               REQUIRED INT32 op;
               REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-              OPTIONAL INT64 match_time (TIMESTAMP(MILLIS,true));
+              REQUIRED INT64 match_time (TIMESTAMP(MILLIS,true));
               OPTIONAL INT64 match_id;
               OPTIONAL BYTE_ARRAY player_id (STRING);
               OPTIONAL INT64 score;

--- a/src/infra/core/src/services/ingest/polling_ingest_service_impl.rs
+++ b/src/infra/core/src/services/ingest/polling_ingest_service_impl.rs
@@ -274,6 +274,7 @@ impl PollingIngestServiceImpl {
             Err(StageDataError::BadInputSchema(e)) => Err(e.into()),
             Err(StageDataError::IncompatibleSchema(e)) => Err(e.into()),
             Err(StageDataError::MergeError(e)) => Err(e.into()),
+            Err(StageDataError::ExecutionError(e)) => Err(e.into()),
             Err(StageDataError::DataValidation(e)) => Err(e.into()),
             Err(StageDataError::EmptyCommit(_)) => Ok(PollingIngestResponse {
                 result: PollingIngestResult::UpToDate {

--- a/src/infra/core/src/services/ingest/push_ingest_executor_impl.rs
+++ b/src/infra/core/src/services/ingest/push_ingest_executor_impl.rs
@@ -158,6 +158,7 @@ impl PushIngestExecutorImpl {
             Err(StageDataError::BadInputSchema(e)) => Err(e.into()),
             Err(StageDataError::IncompatibleSchema(e)) => Err(e.into()),
             Err(StageDataError::MergeError(e)) => Err(e.into()),
+            Err(StageDataError::ExecutionError(e)) => Err(e.into()),
             Err(StageDataError::DataValidation(e)) => Err(e.into()),
             Err(StageDataError::EmptyCommit(_)) => Ok(PushIngestResult::UpToDate),
             Err(StageDataError::Internal(e)) => Err(e.into()),

--- a/src/infra/core/src/services/transform/transform_executor_impl.rs
+++ b/src/infra/core/src/services/transform/transform_executor_impl.rs
@@ -111,10 +111,10 @@ impl TransformExecutorImpl {
             tracing::warn!("Engine did not produce a schema. In future this will become an error.");
         }
 
-        if let Some(prev_schema) = request.schema {
+        if let Some(orig_schema) = request.schema {
             // Validate schema
             if let Some(new_schema) = response.output_schema {
-                DataWriterDataFusion::validate_output_schema_equivalence(&prev_schema, &new_schema)
+                DataWriterDataFusion::validate_schema_compatible(&orig_schema, &new_schema)
                     .int_err()?;
             }
         } else {

--- a/src/infra/core/tests/tests/engine/test_engine_transform.rs
+++ b/src/infra/core/tests/tests/engine/test_engine_transform.rs
@@ -897,7 +897,7 @@ async fn test_transform_empty_inputs() {
             odf::schema::DataField::i64("offset").optional(),
             odf::schema::DataField::i32("op"),
             odf::schema::DataField::timestamp_millis_utc("system_time"),
-            odf::schema::DataField::timestamp_millis_utc("event_time").optional(),
+            odf::schema::DataField::timestamp_millis_utc("event_time"),
             odf::schema::DataField::string("city").optional(),
             odf::schema::DataField::string("country"),
             odf::schema::DataField::i32("population").optional(),
@@ -941,7 +941,7 @@ async fn test_transform_empty_inputs() {
                   OPTIONAL INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   REQUIRED BYTE_ARRAY country (STRING);
                   OPTIONAL INT32 population;

--- a/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_polling_ingest.rs
@@ -127,7 +127,7 @@ async fn test_ingest_polling_snapshot() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -305,7 +305,7 @@ async fn test_ingest_polling_ledger() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 date (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -589,7 +589,7 @@ async fn test_ingest_polling_event_time_as_date() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT32 date (DATE);
+                  REQUIRED INT32 date (DATE);
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -840,7 +840,7 @@ async fn test_ingest_polling_bad_column_names_rename() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -936,7 +936,7 @@ async fn test_ingest_polling_schema_case_sensitivity() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 date (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY UPPER (STRING);
                   OPTIONAL INT64 lower;
                 }
@@ -1114,7 +1114,7 @@ async fn test_ingest_polling_preprocess_with_spark() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -1207,7 +1207,7 @@ async fn test_ingest_polling_preprocess_with_flink() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 event_time (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 event_time (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }

--- a/src/infra/core/tests/tests/test_compaction_services_impl.rs
+++ b/src/infra/core/tests/tests/test_compaction_services_impl.rs
@@ -125,7 +125,7 @@ async fn test_dataset_compact() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 date (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -381,7 +381,7 @@ async fn test_dataset_compaction_watermark_only_blocks() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 date (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -544,7 +544,7 @@ async fn test_dataset_compaction_limits() {
                       REQUIRED INT64 offset;
                       REQUIRED INT32 op;
                       REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                      OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+                      REQUIRED INT64 date (TIMESTAMP(MILLIS,true));
                       OPTIONAL BYTE_ARRAY city (STRING);
                       OPTIONAL INT64 population;
                     }
@@ -698,7 +698,7 @@ async fn test_dataset_compaction_keep_all_non_data_blocks() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 date (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -808,7 +808,7 @@ async fn test_large_dataset_compact() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 date (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }
@@ -858,7 +858,7 @@ async fn test_large_dataset_compact() {
                   REQUIRED INT64 offset;
                   REQUIRED INT32 op;
                   REQUIRED INT64 system_time (TIMESTAMP(MILLIS,true));
-                  OPTIONAL INT64 date (TIMESTAMP(MILLIS,true));
+                  REQUIRED INT64 date (TIMESTAMP(MILLIS,true));
                   OPTIONAL BYTE_ARRAY city (STRING);
                   OPTIONAL INT64 population;
                 }

--- a/src/infra/ingest-datafusion/src/merge_strategies/snapshot.rs
+++ b/src/infra/ingest-datafusion/src/merge_strategies/snapshot.rs
@@ -223,6 +223,19 @@ impl MergeStrategySnapshot {
         old: DataFrameExt,
         new: DataFrameExt,
     ) -> Result<DataFrameExt, DataFusionErrorWrapped> {
+        // NOTE: We use `old` schema as presumably it will be read according to
+        // canonical schema of the whole dataset and will represent the expected
+        // nullability, while `new` schema may be inferred and needs only to be
+        // coercible into `old`.
+        let non_null_columns: std::collections::HashSet<String> = old
+            .schema()
+            .fields()
+            .iter()
+            .filter(|f| !f.is_nullable())
+            .filter(|f| *f.name() != self.vocab.event_time_column)
+            .map(|f| f.name().clone())
+            .collect();
+
         // TODO: Schema evolution
         let a_old = TableReference::bare("old");
         let a_new = TableReference::bare("new");
@@ -301,7 +314,12 @@ impl MergeStrategySnapshot {
 
         // Note: Final sorting will be done by the caller using `sort_order()`
         // expression.
-        Ok(DataFrame::new(session_state, plan).into())
+        let df: DataFrameExt = DataFrame::new(session_state, plan).into();
+
+        // Perform nullability correction, as all columns become nullable after join
+        let df = df.assert_collumns_not_null(|f| non_null_columns.contains(f.name()))?;
+
+        Ok(df)
     }
 }
 

--- a/src/infra/ingest-datafusion/tests/mod.rs
+++ b/src/infra/ingest-datafusion/tests/mod.rs
@@ -10,4 +10,3 @@
 #![feature(assert_matches)]
 
 mod tests;
-pub mod utils;

--- a/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_append.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_append.rs
@@ -15,8 +15,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use kamu_ingest_datafusion::*;
 use odf::utils::data::DataFrameExt;
-
-use crate::utils::*;
+use odf::utils::testing;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -129,7 +128,7 @@ where
     // Sort events according to the strategy
     let actual = actual.sort(strat.sort_order()).unwrap();
 
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_changelog_stream.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_changelog_stream.rs
@@ -15,8 +15,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use kamu_ingest_datafusion::*;
 use odf::utils::data::dataframe_ext::DataFrameExt;
-
-use crate::utils::*;
+use odf::utils::testing;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -146,7 +145,7 @@ where
     // Sort events according to the strategy
     let actual = actual.sort(strat.sort_order()).unwrap();
 
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_ledger.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_ledger.rs
@@ -16,8 +16,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use kamu_ingest_datafusion::*;
 use odf::utils::data::DataFrameExt;
-
-use crate::utils::*;
+use odf::utils::testing;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -140,7 +139,7 @@ where
     // Sort events according to the strategy
     let actual = actual.sort(strat.sort_order()).unwrap();
 
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -250,7 +249,7 @@ async fn test_ledger_merge_respects_pk() {
     .merge(Some(prev), new)
     .unwrap();
     let expected = make_output_empty(&ctx);
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 
     let prev = make_input(&ctx, [(2020, "vancouver", 1), (2020, "seattle", 2)]);
     let new = make_input(&ctx, [(2020, "seattle", 3)]);
@@ -263,7 +262,7 @@ async fn test_ledger_merge_respects_pk() {
     .merge(Some(prev), new)
     .unwrap();
     let expected = make_output_empty(&ctx);
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 
     let prev = make_input(&ctx, [(2020, "vancouver", 1), (2020, "seattle", 2)]);
     let new = make_input(&ctx, [(2020, "seattle", 3)]);
@@ -280,7 +279,7 @@ async fn test_ledger_merge_respects_pk() {
     .merge(Some(prev), new)
     .unwrap();
     let expected = make_output(&ctx, [(Op::Append, 2020, "seattle", 3)]);
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 
     let prev = make_input(&ctx, [(2020, "vancouver", 1), (2020, "seattle", 2)]);
     let new = make_input(&ctx, [(2021, "seattle", 3)]);
@@ -293,7 +292,7 @@ async fn test_ledger_merge_respects_pk() {
     .merge(Some(prev), new)
     .unwrap();
     let expected = make_output(&ctx, [(Op::Append, 2021, "seattle", 3)]);
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_snapshot.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_snapshot.rs
@@ -17,8 +17,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use kamu_ingest_datafusion::*;
 use odf::utils::data::DataFrameExt;
-
-use crate::utils::*;
+use odf::utils::testing;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -177,7 +176,8 @@ where
         .unwrap()
         .without_columns(&["offset"])
         .unwrap();
-    assert_dfs_equivalent(expected, actual, true, true, true).await;
+
+    testing::assert_dfs_equivalent(expected, actual, true, false, true).await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -303,7 +303,7 @@ where
     // Sort events according to the strategy
     let actual = actual.sort(strat.sort_order()).unwrap();
 
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -449,5 +449,5 @@ async fn test_snapshot_merge_input_carries_event_time() {
     // Sort events according to the strategy
     let actual = actual.sort(strat.sort_order()).unwrap();
 
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 }

--- a/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_upsert_stream.rs
+++ b/src/infra/ingest-datafusion/tests/tests/test_merge_strategy_upsert_stream.rs
@@ -15,8 +15,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::prelude::*;
 use kamu_ingest_datafusion::*;
 use odf::utils::data::DataFrameExt;
-
-use crate::utils::*;
+use odf::utils::testing;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -31,7 +30,8 @@ where
 {
     let schema = Arc::new(Schema::new(vec![
         Field::new("op", DataType::Int32, false),
-        Field::new("year", DataType::Int32, false),
+        // Nullable because event time column has special semantics in merge strategies
+        Field::new("year", DataType::Int32, true),
         Field::new("city", DataType::Utf8, false),
         Field::new("population", DataType::Int64, false),
     ]));
@@ -75,7 +75,7 @@ where
         // TODO: Replace with UInt8 after Spark is updated
         // See: https://github.com/kamu-data/kamu-cli/issues/445
         Field::new("op", DataType::Int32, false),
-        Field::new("year", DataType::Int32, false),
+        Field::new("year", DataType::Int32, true),
         Field::new("city", DataType::Utf8, false),
         Field::new("population", DataType::Int64, false),
     ]));
@@ -146,7 +146,7 @@ where
     // Sort events according to the strategy
     let actual = actual.sort(strat.sort_order()).unwrap();
 
-    assert_dfs_equivalent(expected, actual, false, true, true).await;
+    testing::assert_dfs_equivalent(expected, actual, false, false, true).await;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/odf/data-utils/Cargo.toml
+++ b/src/odf/data-utils/Cargo.toml
@@ -57,5 +57,6 @@ pretty_assertions = { optional = true, version = "1" }
 [dev-dependencies]
 indoc = "2"
 pretty_assertions = { version = "1" }
+test-group = { version = "1" }
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { version = "1", default-features = false, features = ["rt", "macros"] }

--- a/src/odf/data-utils/src/data/dataframe_ext.rs
+++ b/src/odf/data-utils/src/data/dataframe_ext.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 
 use arrow::array::{Array, ArrowPrimitiveType, AsArray, RecordBatch};
+use arrow_schema::Field;
 use datafusion::catalog::TableProvider;
 use datafusion::common::DFSchema;
 use datafusion::config::{CsvOptions, JsonOptions, TableParquetOptions};
@@ -178,6 +179,28 @@ impl DataFrameExt {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 impl DataFrameExt {
+    /// Arrow and Datafusion have poor nullability control as nullability is
+    /// part of the schema and not of the data type. This function adds a
+    /// runtime operator to ensure that specified column does not contain nulls
+    /// and casts the result into a non-nullable field.
+    pub fn assert_collumns_not_null(self, selector: impl Fn(&Field) -> bool) -> Result<Self> {
+        let mut select = Vec::new();
+        for i in 0..self.schema().fields().len() {
+            let (relation, field) = self.schema().qualified_field(i);
+            let col = Expr::Column(Column::from((relation, field)));
+
+            let expr = if !selector(field) {
+                col
+            } else {
+                col.cast_nullability(false).alias(field.name())
+            };
+
+            select.push(expr);
+        }
+        self.select(select)
+    }
+
+    /// Brings specified columns to the beginning of the dataframe's field order
     pub fn columns_to_front(self, front_cols: &[&str]) -> Result<Self> {
         let mut columns: Vec<_> = front_cols.iter().map(|s| col(*s)).collect();
 
@@ -262,6 +285,22 @@ impl DataFrameExt {
 impl std::fmt::Debug for DataFrameExt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub trait ExprExt {
+    fn cast_nullability(self, nullable: bool) -> Expr;
+}
+
+impl ExprExt for Expr {
+    fn cast_nullability(self, nullable: bool) -> Expr {
+        if nullable {
+            return self;
+        }
+
+        crate::data::udf::assert_not_null().call(vec![self])
     }
 }
 

--- a/src/odf/data-utils/src/data/mod.rs
+++ b/src/odf/data-utils/src/data/mod.rs
@@ -12,5 +12,6 @@ pub mod dataframe_ext;
 pub mod format;
 pub mod hash;
 pub mod local_url;
+pub mod udf;
 
-pub use dataframe_ext::DataFrameExt;
+pub use dataframe_ext::{DataFrameExt, ExprExt};

--- a/src/odf/data-utils/src/data/udf.rs
+++ b/src/odf/data-utils/src/data/udf.rs
@@ -1,0 +1,92 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
+use datafusion::logical_expr::*;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+static ASSERT_NOT_NULL: std::sync::LazyLock<Arc<ScalarUDF>> =
+    std::sync::LazyLock::new(|| Arc::new(AssertNotNull::new().into()));
+
+pub fn assert_not_null() -> Arc<ScalarUDF> {
+    Arc::clone(&*ASSERT_NOT_NULL)
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct AssertNotNull {
+    signature: Signature,
+}
+
+impl AssertNotNull {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::variadic_any(Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for AssertNotNull {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "assert_not_null"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _args: &[DataType]) -> datafusion::error::Result<DataType> {
+        unreachable!("return_field_from_args should be called instead")
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> datafusion::error::Result<FieldRef> {
+        if args.arg_fields.len() != 1 {
+            return datafusion::common::plan_err!("assert_not_null accepts 1 argument");
+        }
+
+        let f = &args.arg_fields[0];
+
+        if !f.is_nullable() {
+            Ok(Arc::clone(f))
+        } else {
+            Ok(Arc::new(Field::new(
+                self.name(),
+                f.data_type().clone(),
+                false,
+            )))
+        }
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion::error::Result<ColumnarValue> {
+        let ColumnarValue::Array(arr) = &args.args[0] else {
+            return datafusion::common::exec_err!("assert_not_null expects a column argument");
+        };
+
+        if arr.null_count() != 0 {
+            return datafusion::common::exec_err!(
+                "Column {} contains {} null values while none were expected",
+                args.arg_fields[0].name(),
+                arr.null_count()
+            );
+        }
+
+        Ok(ColumnarValue::Array(arr.clone()))
+    }
+}

--- a/src/odf/data-utils/src/testing/mod.rs
+++ b/src/odf/data-utils/src/testing/mod.rs
@@ -7,11 +7,140 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use arrow::datatypes::Schema;
-use datafusion::common::DFSchema;
+use std::sync::Arc;
+
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::datatypes::{Field, Schema};
+use datafusion::common::{Column, DFSchema};
+use datafusion::prelude::col;
+use datafusion::sql::TableReference;
 use pretty_assertions::assert_eq;
 
 use crate::data::DataFrameExt;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub async fn assert_dfs_equal(lhs: DataFrameExt, rhs: DataFrameExt) {
+    pretty_assertions::assert_eq!(lhs.schema(), rhs.schema());
+
+    let lhs_batches = lhs.collect().await.unwrap();
+    let rhs_batches = rhs.collect().await.unwrap();
+
+    let lhs_count: usize = lhs_batches.iter().map(RecordBatch::num_rows).sum();
+    let rhs_count: usize = rhs_batches.iter().map(RecordBatch::num_rows).sum();
+
+    // This is a workaround for the situation where collect returns an empty vec vs.
+    // a vec containing an empty batch
+    if lhs_count == 0 && rhs_count == 0 {
+        return;
+    }
+
+    let lhs_str = datafusion::arrow::util::pretty::pretty_format_batches(&lhs_batches)
+        .unwrap()
+        .to_string();
+
+    let rhs_str = datafusion::arrow::util::pretty::pretty_format_batches(&rhs_batches)
+        .unwrap()
+        .to_string();
+
+    pretty_assertions::assert_eq!(lhs_str, rhs_str);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Checks for equivalence ignoring the order of rows and nullability of columns
+pub async fn assert_dfs_equivalent(
+    lhs: DataFrameExt,
+    rhs: DataFrameExt,
+    ignore_order: bool,
+    ignore_nullability: bool,
+    ignore_qualifiers: bool,
+) {
+    let (lhs, rhs) = if !ignore_order {
+        (lhs, rhs)
+    } else {
+        let lhs_cols = lhs
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| col(Column::from_name(f.name())).sort(false, true))
+            .collect();
+
+        let rhs_cols = rhs
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| col(Column::from_name(f.name())).sort(false, true))
+            .collect();
+
+        (lhs.sort(lhs_cols).unwrap(), rhs.sort(rhs_cols).unwrap())
+    };
+
+    let map_field =
+        |(q, f): (Option<&TableReference>, &Arc<Field>)| -> (Option<TableReference>, Arc<Field>) {
+            let q = q.cloned();
+            let f = f.clone();
+            let (q, f) = if !ignore_qualifiers {
+                (q, f)
+            } else {
+                (None, f)
+            };
+            let f = if !ignore_nullability {
+                f
+            } else {
+                Arc::new(f.as_ref().clone().with_nullable(true))
+            };
+            (q, f)
+        };
+
+    let lhs_schema_stripped = datafusion::common::DFSchema::new_with_metadata(
+        qualified_fields(lhs.schema()).map(map_field).collect(),
+        Default::default(),
+    )
+    .unwrap();
+
+    let rhs_schema_stripped = datafusion::common::DFSchema::new_with_metadata(
+        qualified_fields(rhs.schema()).map(map_field).collect(),
+        Default::default(),
+    )
+    .unwrap();
+
+    pretty_assertions::assert_eq!(lhs_schema_stripped, rhs_schema_stripped);
+
+    let lhs_batches = lhs.collect().await.unwrap();
+    let rhs_batches = rhs.collect().await.unwrap();
+
+    let lhs_count: usize = lhs_batches.iter().map(RecordBatch::num_rows).sum();
+    let rhs_count: usize = rhs_batches.iter().map(RecordBatch::num_rows).sum();
+
+    // This is a workaround for the situation where collect returns an empty vec vs.
+    // a vec containing an empty batch
+    if lhs_count == 0 && rhs_count == 0 {
+        return;
+    }
+
+    let lhs_str = datafusion::arrow::util::pretty::pretty_format_batches(&lhs_batches)
+        .unwrap()
+        .to_string();
+
+    let rhs_str = datafusion::arrow::util::pretty::pretty_format_batches(&rhs_batches)
+        .unwrap()
+        .to_string();
+
+    pretty_assertions::assert_eq!(lhs_str, rhs_str);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn qualified_fields(
+    schema: &DFSchema,
+) -> impl Iterator<Item = (Option<&TableReference>, &Arc<Field>)> {
+    schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, f)| (schema.qualified_field(i).0, f))
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/odf/data-utils/tests/tests/mod.rs
+++ b/src/odf/data-utils/tests/tests/mod.rs
@@ -7,4 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod test_assert_not_null;
+mod test_cmp;
 mod test_schema;

--- a/src/odf/data-utils/tests/tests/test_assert_not_null.rs
+++ b/src/odf/data-utils/tests/tests/test_assert_not_null.rs
@@ -1,0 +1,135 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::assert_matches::assert_matches;
+use std::sync::Arc;
+
+use datafusion::arrow::array::Int32Array;
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use opendatafabric_data_utils::data::DataFrameExt;
+use opendatafabric_data_utils::testing::assert_dfs_equivalent;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_assert_not_null_not_nullable() {
+    let ctx = SessionContext::new();
+
+    let input: DataFrameExt = ctx
+        .read_batch(
+            RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "value",
+                    DataType::Int32,
+                    false,
+                )])),
+                vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .into();
+
+    let actual = input.assert_collumns_not_null(|_| true).unwrap();
+
+    let expected = ctx
+        .read_batch(
+            RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "value",
+                    DataType::Int32,
+                    false,
+                )])),
+                vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_dfs_equivalent(expected.into(), actual, false, false, true).await;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_assert_not_null_nullable_valid() {
+    let ctx = SessionContext::new();
+
+    let input: DataFrameExt = ctx
+        .read_batch(
+            RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "value",
+                    DataType::Int32,
+                    true,
+                )])),
+                vec![Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)]))],
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .into();
+
+    let actual = input.assert_collumns_not_null(|_| true).unwrap();
+
+    let expected = ctx
+        .read_batch(
+            RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "value",
+                    DataType::Int32,
+                    false,
+                )])),
+                vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_dfs_equivalent(expected.into(), actual, false, false, true).await;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_group::group(engine, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_assert_not_null_nullable_invalid() {
+    let ctx = SessionContext::new();
+
+    let input: DataFrameExt = ctx
+        .read_batch(
+            RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    "value",
+                    DataType::Int32,
+                    true,
+                )])),
+                vec![Arc::new(Int32Array::from(vec![Some(1), None, None]))],
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .into();
+
+    let actual = input.assert_collumns_not_null(|_| true).unwrap();
+
+    let res = actual.collect().await;
+
+    assert_matches!(
+        res,
+        Err(::datafusion::error::DataFusionError::Execution(s))
+        if s == "Column value contains 2 null values while none were expected"
+    );
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/odf/data-utils/tests/tests/test_cmp.rs
+++ b/src/odf/data-utils/tests/tests/test_cmp.rs
@@ -6,140 +6,14 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
-
 use std::sync::Arc;
 
 use datafusion::arrow::array;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::DFSchema;
 use datafusion::prelude::*;
-use datafusion::sql::TableReference;
-use odf::utils::data::DataFrameExt;
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-pub async fn assert_dfs_equal(lhs: DataFrameExt, rhs: DataFrameExt) {
-    pretty_assertions::assert_eq!(lhs.schema(), rhs.schema());
-
-    let lhs_batches = lhs.collect().await.unwrap();
-    let rhs_batches = rhs.collect().await.unwrap();
-
-    let lhs_count: usize = lhs_batches.iter().map(RecordBatch::num_rows).sum();
-    let rhs_count: usize = rhs_batches.iter().map(RecordBatch::num_rows).sum();
-
-    // This is a workaround for the situation where collect returns an empty vec vs.
-    // a vec containing an empty batch
-    if lhs_count == 0 && rhs_count == 0 {
-        return;
-    }
-
-    let lhs_str = datafusion::arrow::util::pretty::pretty_format_batches(&lhs_batches)
-        .unwrap()
-        .to_string();
-
-    let rhs_str = datafusion::arrow::util::pretty::pretty_format_batches(&rhs_batches)
-        .unwrap()
-        .to_string();
-
-    pretty_assertions::assert_eq!(lhs_str, rhs_str);
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Checks for equivalence ignoring the order of rows and nullability of columns
-pub async fn assert_dfs_equivalent(
-    lhs: DataFrameExt,
-    rhs: DataFrameExt,
-    ignore_order: bool,
-    ignore_nullability: bool,
-    ignore_qualifiers: bool,
-) {
-    let (lhs, rhs) = if !ignore_order {
-        (lhs, rhs)
-    } else {
-        let lhs_cols = lhs
-            .schema()
-            .fields()
-            .iter()
-            .map(|f| col(Column::from_name(f.name())).sort(false, true))
-            .collect();
-
-        let rhs_cols = rhs
-            .schema()
-            .fields()
-            .iter()
-            .map(|f| col(Column::from_name(f.name())).sort(false, true))
-            .collect();
-
-        (lhs.sort(lhs_cols).unwrap(), rhs.sort(rhs_cols).unwrap())
-    };
-
-    let map_field =
-        |(q, f): (Option<&TableReference>, &Arc<Field>)| -> (Option<TableReference>, Arc<Field>) {
-            let q = q.cloned();
-            let f = f.clone();
-            let (q, f) = if !ignore_qualifiers {
-                (q, f)
-            } else {
-                (None, f)
-            };
-            let f = if !ignore_nullability {
-                f
-            } else {
-                Arc::new(f.as_ref().clone().with_nullable(true))
-            };
-            (q, f)
-        };
-
-    let lhs_schema_stripped = datafusion::common::DFSchema::new_with_metadata(
-        qualified_fields(lhs.schema()).map(map_field).collect(),
-        Default::default(),
-    )
-    .unwrap();
-
-    let rhs_schema_stripped = datafusion::common::DFSchema::new_with_metadata(
-        qualified_fields(rhs.schema()).map(map_field).collect(),
-        Default::default(),
-    )
-    .unwrap();
-
-    pretty_assertions::assert_eq!(lhs_schema_stripped, rhs_schema_stripped);
-
-    let lhs_batches = lhs.collect().await.unwrap();
-    let rhs_batches = rhs.collect().await.unwrap();
-
-    let lhs_count: usize = lhs_batches.iter().map(RecordBatch::num_rows).sum();
-    let rhs_count: usize = rhs_batches.iter().map(RecordBatch::num_rows).sum();
-
-    // This is a workaround for the situation where collect returns an empty vec vs.
-    // a vec containing an empty batch
-    if lhs_count == 0 && rhs_count == 0 {
-        return;
-    }
-
-    let lhs_str = datafusion::arrow::util::pretty::pretty_format_batches(&lhs_batches)
-        .unwrap()
-        .to_string();
-
-    let rhs_str = datafusion::arrow::util::pretty::pretty_format_batches(&rhs_batches)
-        .unwrap()
-        .to_string();
-
-    pretty_assertions::assert_eq!(lhs_str, rhs_str);
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-fn qualified_fields(
-    schema: &DFSchema,
-) -> impl Iterator<Item = (Option<&TableReference>, &Arc<Field>)> {
-    schema
-        .fields()
-        .iter()
-        .enumerate()
-        .map(|(i, f)| (schema.qualified_field(i).0, f))
-}
+use opendatafabric_data_utils::data::DataFrameExt;
+use opendatafabric_data_utils::testing::{assert_dfs_equal, assert_dfs_equivalent};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/odf/metadata/src/schema/schema_impl.rs
+++ b/src/odf/metadata/src/schema/schema_impl.rs
@@ -39,6 +39,10 @@ impl DataSchema {
             extra: extra.map_empty(),
         }
     }
+
+    pub fn field_by_name(&self, name: &str) -> Option<&DataField> {
+        self.fields.iter().find(|f| f.name == name)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -56,14 +60,21 @@ impl DataSchemaBuilder {
         Self::default()
     }
 
-    pub fn with_changelog_system_fields(mut self, vocab: DatasetVocabulary) -> Self {
+    pub fn with_changelog_system_fields(
+        mut self,
+        vocab: DatasetVocabulary,
+        custom_event_time_type: Option<DataType>,
+    ) -> Self {
         assert_eq!(self.fields.len(), 0);
 
         self.fields.extend([
             DataField::i64(vocab.offset_column),
             DataField::i32(vocab.operation_type_column),
             DataField::timestamp_millis_utc(vocab.system_time_column),
-            DataField::timestamp_millis_utc(vocab.event_time_column),
+            DataField::new(
+                vocab.event_time_column,
+                custom_event_time_type.unwrap_or(DataType::timestamp_millis_utc()),
+            ),
         ]);
 
         self
@@ -114,6 +125,10 @@ impl DataField {
             r#type: data_type,
             extra: None,
         }
+    }
+
+    pub fn is_optional(&self) -> bool {
+        matches!(&self.r#type, DataType::Option(_))
     }
 }
 


### PR DESCRIPTION
## Description

I've been sitting on some schema handling changes for a while. Want to get them in in preparation to work we will be doing to allow adding more columns to existing datasets

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)