### PR TITLE
Allow push source updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## Unreleased
+### Added
+- Support for re-defining the `AddPushSource`
+
 ## [0.254.1] - 2025-12-08
 ### Fixed
 - Fixed bug in applying projected offsets for flow states in a situation when delayed transaction

--- a/src/domain/core/src/entities/writer_metadata_state.rs
+++ b/src/domain/core/src/entities/writer_metadata_state.rs
@@ -198,6 +198,8 @@ impl From<odf::dataset::AcceptVisitorError<ScanMetadataError>> for ScanMetadataE
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// TODO: Convert into an enum to differentiate between not finding a source and
+// ambiguity between several sources.
 #[derive(Debug, thiserror::Error)]
 #[error("{message}")]
 pub struct SourceNotFoundError {
@@ -216,7 +218,7 @@ impl SourceNotFoundError {
 
 impl From<SourceNotFoundError> for PushSourceNotFoundError {
     fn from(val: SourceNotFoundError) -> Self {
-        PushSourceNotFoundError::new(val.source_name)
+        PushSourceNotFoundError::new_with_messaage(val.source_name, val.message)
     }
 }
 

--- a/src/domain/core/src/services/ingest/push_ingest_planner.rs
+++ b/src/domain/core/src/services/ingest/push_ingest_planner.rs
@@ -107,27 +107,35 @@ pub enum PushIngestPlanningError {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Error, Default)]
+#[error("{message}")]
 pub struct PushSourceNotFoundError {
     source_name: Option<String>,
+    message: String,
 }
 
 impl PushSourceNotFoundError {
     pub fn new(source_name: Option<impl Into<String>>) -> Self {
-        Self {
-            source_name: source_name.map(Into::into),
+        match source_name {
+            None => Self::new_with_messaage(
+                source_name,
+                "Dataset does not define a default push source, consider specifying the source \
+                 name",
+            ),
+            Some(source_name) => {
+                let source_name = source_name.into();
+                let message = format!("Dataset does not define a push source '{source_name}'");
+                Self::new_with_messaage(Some(source_name), message)
+            }
         }
     }
-}
 
-impl std::fmt::Display for PushSourceNotFoundError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.source_name {
-            None => write!(
-                f,
-                "Dataset does not define a default push source, consider specifying the source \
-                 name"
-            ),
-            Some(s) => write!(f, "Dataset does not define a push source '{s}'"),
+    pub fn new_with_messaage(
+        source_name: Option<impl Into<String>>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            source_name: source_name.map(Into::into),
+            message: message.into(),
         }
     }
 }

--- a/src/infra/core/tests/tests/ingest/test_push_ingest.rs
+++ b/src/infra/core/tests/tests/ingest/test_push_ingest.rs
@@ -1045,6 +1045,170 @@ async fn test_ingest_push_with_predefined_data_schema() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#[test_group::group(engine, ingest, datafusion)]
+#[test_log::test(tokio::test)]
+async fn test_ingest_push_schema_and_source_evolution() {
+    use odf::metadata::*;
+
+    let harness = IngestTestHarness::new();
+
+    let dataset_snapshot = MetadataFactory::dataset_snapshot()
+        .name("foo.bar")
+        .kind(odf::DatasetKind::Root)
+        .push_event(SetDataSchema::new(DataSchema {
+            fields: vec![
+                DataField::i64("offset"),
+                DataField::i32("op"),
+                DataField::timestamp_millis_utc("system_time"),
+                DataField::timestamp_millis_utc("event_time"),
+                DataField::string("city"),
+                DataField::i64("population"),
+            ],
+            extra: None,
+        }))
+        .push_event(
+            MetadataFactory::add_push_source()
+                .read(ReadStepNdJson {
+                    schema: Some(vec![
+                        "event_time TIMESTAMP".to_string(),
+                        "city STRING".to_string(),
+                        "population BIGINT".to_string(),
+                    ]),
+                    ..Default::default()
+                })
+                .merge(MergeStrategyLedger {
+                    primary_key: vec!["event_time".to_string(), "city".to_string()],
+                })
+                .build(),
+        )
+        .build();
+
+    let dataset_alias = dataset_snapshot.name.clone();
+    let stored = harness.create_dataset(dataset_snapshot).await;
+    let target = ResolvedDataset::from_stored(&stored, &dataset_alias);
+
+    let data_helper = harness.dataset_data_helper(&dataset_alias).await;
+
+    // 1: Initial data
+    let data = std::io::Cursor::new(indoc!(
+        r#"
+        { "event_time": "2020-01-01", "city": "A", "population": 1000 }
+        { "event_time": "2020-01-02", "city": "B", "population": 2000 }
+        { "event_time": "2020-01-03", "city": "C", "population": 3000 }
+        "#
+    ));
+
+    harness
+        .ingest_from(
+            target.clone(),
+            None,
+            DataSource::Stream(Box::new(data)),
+            PushIngestOpts::default(),
+        )
+        .await
+        .unwrap();
+
+    data_helper
+        .assert_last_data_records_eq(indoc!(
+            r#"
+            +--------+----+----------------------+----------------------+------+------------+
+            | offset | op | system_time          | event_time           | city | population |
+            +--------+----+----------------------+----------------------+------+------------+
+            | 0      | 0  | 2050-01-01T12:00:00Z | 2020-01-01T00:00:00Z | A    | 1000       |
+            | 1      | 0  | 2050-01-01T12:00:00Z | 2020-01-02T00:00:00Z | B    | 2000       |
+            | 2      | 0  | 2050-01-01T12:00:00Z | 2020-01-03T00:00:00Z | C    | 3000       |
+            +--------+----+----------------------+----------------------+------+------------+
+            "#
+        ))
+        .await;
+
+    // 2: Migrate schema by adding optional `census_url` column
+    target
+        .commit_event(
+            SetDataSchema::new(DataSchema::new(vec![
+                DataField::i64("offset"),
+                DataField::i32("op"),
+                DataField::timestamp_millis_utc("system_time"),
+                DataField::timestamp_millis_utc("event_time"),
+                DataField::string("city"),
+                DataField::i64("population"),
+                DataField::string("census_url").optional(),
+            ]))
+            .into(),
+            odf::dataset::CommitOpts {
+                system_time: Some(harness.time_source.now()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // 3: Update push source to match
+    target
+        .commit_event(
+            AddPushSource {
+                source_name: SourceState::DEFAULT_SOURCE_NAME.to_string(),
+                read: ReadStepNdJson {
+                    schema: Some(vec![
+                        "event_time TIMESTAMP".to_string(),
+                        "city STRING".to_string(),
+                        "population BIGINT".to_string(),
+                        "census_url STRING".to_string(),
+                    ]),
+                    ..Default::default()
+                }
+                .into(),
+                preprocess: None,
+                merge: MergeStrategyLedger {
+                    primary_key: vec!["event_time".to_string(), "city".to_string()],
+                }
+                .into(),
+            }
+            .into(),
+            odf::dataset::CommitOpts {
+                system_time: Some(harness.time_source.now()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // 4: Ingest new data
+    let data = std::io::Cursor::new(indoc!(
+        r#"
+        { "event_time": "2020-01-04", "city": "A", "population": 2000 }
+        { "event_time": "2020-01-05", "city": "B", "population": 3000, "census_url": null }
+        { "event_time": "2020-01-06", "city": "C", "population": 4000, "census_url": "https://c.ca/census" }
+        "#
+    ));
+
+    harness
+        .ingest_from(
+            target.clone(),
+            None,
+            DataSource::Stream(Box::new(data)),
+            PushIngestOpts::default(),
+        )
+        .await
+        .unwrap();
+
+    data_helper
+        .assert_last_data_records_eq(indoc!(
+            r#"
+            +--------+----+----------------------+----------------------+------+------------+---------------------+
+            | offset | op | system_time          | event_time           | city | population | census_url          |
+            +--------+----+----------------------+----------------------+------+------------+---------------------+
+            | 3      | 0  | 2050-01-01T12:00:00Z | 2020-01-04T00:00:00Z | A    | 2000       |                     |
+            | 4      | 0  | 2050-01-01T12:00:00Z | 2020-01-05T00:00:00Z | B    | 3000       |                     |
+            | 5      | 0  | 2050-01-01T12:00:00Z | 2020-01-06T00:00:00Z | C    | 4000       | https://c.ca/census |
+            +--------+----+----------------------+----------------------+------+------------+---------------------+
+            "#
+        ))
+        .await;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 struct IngestTestHarness {
     temp_dir: TempDir,
     dataset_registry: Arc<dyn DatasetRegistry>,


### PR DESCRIPTION
## Description

- Previously two `AddPushSource` events in the chain for the same source name would cause `SourceNotFound` error because writer was treating them as two sources that are ambiguous
- This PR allows to modify push source by committing another `AddPushSource` event for a matching name without having to do `DisablePushSource`
- I also add more tests for source and schema migrations, including in case of hard compactions

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- Replace with ❌ if the statement is false and include an explanation -->
- [x] Compatibility:
    <!-- Old clients can communicate to the new version without upgrading -->
  - [x] Network APIs: ✅
    <!-- New version will work with the old workspaces, repositories, and metadata -->
  - [x] Workspace layout and metadata: ✅
    <!-- New version can read existing user configs -->
  - [x] Configuration: ✅
    <!-- Change does not include new versions of any container images -->
  - [x] Container images: ✅
- [x] Observability:
    <!-- How will we know how the feature behaves in production, is it being used, is it working correctly? -->
  - [x] Tracing / [metrics](https://github.com/kamu-data/kamu-standards/blob/master/metrics_design.md): ✅
    <!-- How will we find out that the feature breaks -->
  - [x] Alerts: ✅
- [x] Documentation:
    <!-- Document how your changes benefit or affect the *end user* -->
  - [x] [Changelog](./CHANGELOG.md): ✅
    <!-- How will users find out about and learn how to use this feature?
         Leave checkmark if documentation is not required or generated via API schemas / CLI reference.
         Include a PR for `kamu-docs` repo or a ticket reference otherwise -->
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅
  <!-- If this change will require some updates in downstream services mark with ❌ -->
- [x] Downstream effects:
    <!-- Will the node need to be updated, e.g. with new services or DI catalog configuration? -->
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
    <!-- Will web-ui need to be updated, e.g. to new GQL / REST API schemas? -->
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅
    <!-- Non-trivial deployment instructions added to release queue -->
  - [x] [release-queue](https://github.com/orgs/kamu-data/projects/4/views/1)