### PR TITLE
Guarantee result order in byIds() GQL endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Recommendation: for ease of reading, use the following order:
 ### Added
 - Support for re-defining the `AddPushSource`
 ### Changed
+- GQL: `byIds` and `byRefs` endpoints will return results in the same order as inputs (including duplicates) to allow `zip`'ing them on the client side
 - Schema nullability coercion now works for `List` field elements
 
 ## [0.254.1] - 2025-12-08

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -289,7 +289,10 @@ type Accounts {
 	"""
 	byId(accountId: AccountID!): Account
 	"""
-	Returns accounts by their IDs
+	Returns accounts by their IDs.
+	
+	Order of results is guaranteed to match the inputs. Duplicate inputs
+	will results in duplicate results.
 	"""
 	byIds(		accountIds: [AccountID!]!,
 		"""
@@ -322,7 +325,10 @@ type AccountsMut {
 	"""
 	byId(accountId: AccountID!): AccountMut
 	"""
-	Returns mutable accounts by their IDs
+	Returns mutable accounts by their IDs.
+	
+	Order of results is guaranteed to match the inputs. Duplicate inputs
+	will results in duplicate results.
 	"""
 	byIds(		accountIds: [AccountID!]!,
 		"""
@@ -1592,7 +1598,10 @@ type Datasets {
 	"""
 	byId(datasetId: DatasetID!): Dataset
 	"""
-	Returns multiple datasets by their IDs
+	Returns multiple datasets by their IDs.
+	
+	Order of results is guaranteed to match the inputs. Duplicate inputs
+	will results in duplicate results.
 	"""
 	byIds(		datasetIds: [DatasetID!]!,
 		"""
@@ -1605,7 +1614,8 @@ type Datasets {
 	"""
 	byRef(datasetRef: DatasetRef!): Dataset
 	"""
-	Returns multiple datasets by their IDs or aliases
+	Returns multiple datasets by their IDs or aliases. Order of results is
+	guaranteed to match the inputs.
 	"""
 	byRefs(		datasetRefs: [DatasetRef!]!,
 		"""
@@ -1633,7 +1643,10 @@ type DatasetsMut {
 	"""
 	byId(datasetId: DatasetID!): DatasetMut
 	"""
-	Returns mutable datasets by their IDs
+	Returns mutable datasets by their IDs.
+	
+	Order of results is guaranteed to match the inputs. Duplicate inputs
+	will results in duplicate results.
 	"""
 	byIds(		datasetIds: [DatasetID!]!,
 		"""


### PR DESCRIPTION
## Description

- GQL: `byIds` and `byRefs` endpoints will return results in the same order as inputs (including duplicates) to allow `zip`'ing them on the client side