### PR TITLE
Improve AddPushSource and schema migrations

### DIFF
--- a/src/infra/ingest-datafusion/src/writer.rs
+++ b/src/infra/ingest-datafusion/src/writer.rs
@@ -1019,6 +1019,7 @@ impl DataWriter for DataWriterDataFusion {
             )?;
 
             // Coerce schema if needed
+            // TODO: Combine coercion and `validate_schema_compatible` into one operation
             let df = self.coerce_schema(df, dataset_schema_arrow.as_ref())?;
 
             // Validate schema matches the declared one

--- a/src/odf/dataset/src/services/metadata_chain_visitor.rs
+++ b/src/odf/dataset/src/services/metadata_chain_visitor.rs
@@ -240,6 +240,13 @@ where
             None => unreachable!(),
         }
     }
+
+    fn finish(&self) -> Result<(), Self::Error> {
+        match self {
+            Some(inner) => inner.finish(),
+            None => Ok(()),
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/odf/metadata/Cargo.toml
+++ b/src/odf/metadata/Cargo.toml
@@ -92,4 +92,4 @@ utoipa = { optional = true, version = "5", default-features = false }
 [dev-dependencies]
 indoc = "2"
 pretty_assertions = { version = "1" }
-rand = { version = "0.9", default-features = false }
+rand = { version = "0.9" }


### PR DESCRIPTION
## Description

- Support overriding push source by committing two `AddPushSource` events for the same source name in a row
  - Improved chain validators
  - De-duplicating sources in `currentPushSources` GQL API
- Improved schema nullability coercion and compatibility checks for `List` type