### PR TITLE
Partial revert "Hotfix: Molecule APIv2: announcements creation"

### DIFF
--- a/resources/molecule/molecule-announcements.yaml
+++ b/resources/molecule/molecule-announcements.yaml
@@ -62,7 +62,7 @@ content:
       kind: NdJson
       schema:
       - op INT NOT NULL
-      - event_time TIMESTAMP NOT NULL
+      - event_time TIMESTAMP
       - ipnft_uid STRING NOT NULL
       - announcement_id STRING NOT NULL
       - headline STRING NOT NULL

--- a/resources/molecule/molecule-data-room-activity.yaml
+++ b/resources/molecule/molecule-data-room-activity.yaml
@@ -75,7 +75,7 @@ content:
     read:
       kind: NdJson
       schema:
-      - event_time TIMESTAMP NOT NULL
+      - event_time TIMESTAMP
       - activity_type STRING NOT NULL
       - ipnft_uid STRING NOT NULL
       - path STRING NOT NULL

--- a/src/adapter/graphql/src/mutations/molecule_mut/v2/molecule_announcements_dataset_mut_v2.rs
+++ b/src/adapter/graphql/src/mutations/molecule_mut/v2/molecule_announcements_dataset_mut_v2.rs
@@ -76,7 +76,7 @@ impl MoleculeAnnouncementsDatasetMutV2 {
             .execute(
                 &molecule_subject,
                 &self.project.entity,
-                event_time,
+                Some(event_time),
                 announcement_record,
             )
             .await

--- a/src/adapter/graphql/src/mutations/molecule_mut/v2/molecule_data_room_mut_v2.rs
+++ b/src/adapter/graphql/src/mutations/molecule_mut/v2/molecule_data_room_mut_v2.rs
@@ -187,7 +187,11 @@ impl MoleculeDataRoomMutV2 {
             };
 
             append_global_data_room_activity_uc
-                .execute(&molecule_subject, event_time, data_room_activity_record)
+                .execute(
+                    &molecule_subject,
+                    Some(event_time),
+                    data_room_activity_record,
+                )
                 .await
                 .map_err(|e| -> GqlError {
                     use MoleculeAppendDataRoomActivityError as E;
@@ -311,7 +315,11 @@ impl MoleculeDataRoomMutV2 {
             };
 
             append_global_data_room_activity_uc
-                .execute(&molecule_subject, event_time, data_room_activity_record)
+                .execute(
+                    &molecule_subject,
+                    Some(event_time),
+                    data_room_activity_record,
+                )
                 .await
                 .map_err(|e| -> GqlError {
                     use MoleculeAppendDataRoomActivityError as E;
@@ -409,7 +417,11 @@ impl MoleculeDataRoomMutV2 {
 
         // TODO: asynchronous write of activity log
         append_global_data_room_activity_uc
-            .execute(&molecule_subject, event_time, data_room_activity_record)
+            .execute(
+                &molecule_subject,
+                Some(event_time),
+                data_room_activity_record,
+            )
             .await
             .map_err(|e| -> GqlError {
                 use MoleculeAppendDataRoomActivityError as E;
@@ -855,7 +867,11 @@ impl MoleculeDataRoomMutV2 {
             };
 
             append_global_data_room_activity_uc
-                .execute(&molecule_subject, event_time, data_room_activity_record)
+                .execute(
+                    &molecule_subject,
+                    Some(event_time),
+                    data_room_activity_record,
+                )
                 .await
                 .map_err(|e| -> GqlError {
                     use MoleculeAppendDataRoomActivityError as E;

--- a/src/odf/metadata/src/serde/serdes.rs
+++ b/src/odf/metadata/src/serde/serdes.rs
@@ -271,8 +271,6 @@ where
 pub struct DatasetDefaultVocabularyChangelogInsertionRecord<T> {
     pub op: OperationType,
 
-    pub event_time: Option<DateTime<Utc>>,
-
     #[serde(flatten)]
     pub payload: T,
 }

--- a/src/sku/molecule/domain/src/entities/molecule_announcement.rs
+++ b/src/sku/molecule/domain/src/entities/molecule_announcement.rs
@@ -127,7 +127,6 @@ impl MoleculeGlobalAnnouncementChangelogInsertionRecordExt
     fn into_announcement_record(self) -> MoleculeAnnouncementChangelogInsertionRecord {
         MoleculeAnnouncementChangelogInsertionRecord {
             op: self.op,
-            event_time: self.event_time,
             payload: self.payload.announcement,
         }
     }

--- a/src/sku/molecule/domain/src/snapshots/molecule_dataset_snapshots.rs
+++ b/src/sku/molecule/domain/src/snapshots/molecule_dataset_snapshots.rs
@@ -320,7 +320,7 @@ impl MoleculeDatasetSnapshots {
                         schema: Some(
                             [
                                 "op INT NOT NULL",
-                                "event_time TIMESTAMP NOT NULL",
+                                "event_time TIMESTAMP",
                                 "ipnft_uid STRING NOT NULL",
                                 "announcement_id STRING NOT NULL",
                                 "headline STRING NOT NULL",
@@ -422,7 +422,7 @@ impl MoleculeDatasetSnapshots {
                     read: odf::metadata::ReadStepNdJson {
                         schema: Some(
                             [
-                                "event_time TIMESTAMP NOT NULL",
+                                "event_time TIMESTAMP",
                                 "activity_type STRING NOT NULL",
                                 "ipnft_uid STRING NOT NULL",
                                 "path STRING NOT NULL",

--- a/src/sku/molecule/domain/src/use_cases/activities/molecule_append_global_data_room_activity_use_case.rs
+++ b/src/sku/molecule/domain/src/use_cases/activities/molecule_append_global_data_room_activity_use_case.rs
@@ -19,7 +19,7 @@ pub trait MoleculeAppendGlobalDataRoomActivityUseCase: Send + Sync {
     async fn execute(
         &self,
         molecule_subject: &kamu_accounts::LoggedAccount,
-        source_event_time: DateTime<Utc>,
+        source_event_time: Option<DateTime<Utc>>,
         activity_record: MoleculeDataRoomActivityPayloadRecord,
     ) -> Result<(), MoleculeAppendDataRoomActivityError>;
 }

--- a/src/sku/molecule/domain/src/use_cases/announcements/molecule_create_announcement_use_case.rs
+++ b/src/sku/molecule/domain/src/use_cases/announcements/molecule_create_announcement_use_case.rs
@@ -20,7 +20,7 @@ pub trait MoleculeCreateAnnouncementUseCase: Send + Sync {
         &self,
         molecule_subject: &kamu_accounts::LoggedAccount,
         molecule_project: &MoleculeProject,
-        source_event_time: DateTime<Utc>,
+        source_event_time: Option<DateTime<Utc>>,
         announcement_record: MoleculeAnnouncementPayloadRecord,
     ) -> Result<MoleculeCreateAnnouncementResult, MoleculeCreateAnnouncementError>;
 }

--- a/src/sku/molecule/services/src/use_cases/activities/molecule_append_data_room_activity_use_case_impl.rs
+++ b/src/sku/molecule/services/src/use_cases/activities/molecule_append_data_room_activity_use_case_impl.rs
@@ -41,7 +41,7 @@ impl MoleculeAppendGlobalDataRoomActivityUseCase
     async fn execute(
         &self,
         molecule_subject: &kamu_accounts::LoggedAccount,
-        source_event_time: DateTime<Utc>,
+        source_event_time: Option<DateTime<Utc>>,
         activity_record: MoleculeDataRoomActivityPayloadRecord,
     ) -> Result<(), MoleculeAppendDataRoomActivityError> {
         // Gain write access to global activities dataset
@@ -54,12 +54,11 @@ impl MoleculeAppendGlobalDataRoomActivityUseCase
         // Append new activity record
         let new_changelog_record = MoleculeDataRoomActivityChangelogInsertionRecord {
             op: odf::metadata::OperationType::Append,
-            event_time: Some(source_event_time),
             payload: activity_record,
         };
 
         let push_res = global_data_room_activities_writer
-            .push_ndjson_data(new_changelog_record.to_bytes(), Some(source_event_time))
+            .push_ndjson_data(new_changelog_record.to_bytes(), source_event_time)
             .await
             .int_err()?;
 

--- a/src/sku/molecule/services/src/use_cases/announcements/molecule_create_announcement_use_case_impl.rs
+++ b/src/sku/molecule/services/src/use_cases/announcements/molecule_create_announcement_use_case_impl.rs
@@ -82,7 +82,7 @@ impl MoleculeCreateAnnouncementUseCase for MoleculeCreateAnnouncementUseCaseImpl
         &self,
         molecule_subject: &kamu_accounts::LoggedAccount,
         molecule_project: &MoleculeProject,
-        source_event_time: DateTime<Utc>,
+        source_event_time: Option<DateTime<Utc>>,
         announcement: MoleculeAnnouncementPayloadRecord,
     ) -> Result<MoleculeCreateAnnouncementResult, MoleculeCreateAnnouncementError> {
         let new_announcement_id = announcement.announcement_id;
@@ -95,7 +95,6 @@ impl MoleculeCreateAnnouncementUseCase for MoleculeCreateAnnouncementUseCaseImpl
 
         let global_announcement_record = MoleculeGlobalAnnouncementChangelogInsertionRecord {
             op: odf::metadata::OperationType::Append,
-            event_time: Some(source_event_time),
             payload: MoleculeGlobalAnnouncementPayloadRecord {
                 ipnft_uid: molecule_project.ipnft_uid.clone(),
                 announcement,
@@ -109,10 +108,7 @@ impl MoleculeCreateAnnouncementUseCase for MoleculeCreateAnnouncementUseCaseImpl
             .map_err(MoleculeDatasetErrorExt::adapt::<MoleculeCreateAnnouncementError>)?;
 
         let push_res = global_announcements_writer
-            .push_ndjson_data(
-                global_announcement_record.to_bytes(),
-                Some(source_event_time),
-            )
+            .push_ndjson_data(global_announcement_record.to_bytes(), source_event_time)
             .await?;
 
         assert!(matches!(push_res, PushIngestResult::Updated { .. }));
@@ -128,10 +124,7 @@ impl MoleculeCreateAnnouncementUseCase for MoleculeCreateAnnouncementUseCaseImpl
             .map_err(MoleculeDatasetErrorExt::adapt::<MoleculeCreateAnnouncementError>)?;
 
         let push_res = project_announcements_writer
-            .push_ndjson_data(
-                project_announcement_record.to_bytes(),
-                Some(source_event_time),
-            )
+            .push_ndjson_data(project_announcement_record.to_bytes(), source_event_time)
             .await?;
 
         match push_res {

--- a/src/sku/molecule/services/src/use_cases/projects/molecule_create_project_use_case_impl.rs
+++ b/src/sku/molecule/services/src/use_cases/projects/molecule_create_project_use_case_impl.rs
@@ -201,7 +201,6 @@ impl MoleculeCreateProjectUseCase for MoleculeCreateProjectUseCaseImpl {
 
         let new_changelog_record = MoleculeProjectChangelogInsertionRecord {
             op: odf::metadata::OperationType::Append,
-            event_time: source_event_time,
             payload: project_payload,
         };
 

--- a/src/sku/molecule/services/src/use_cases/projects/molecule_disable_project_use_case_impl.rs
+++ b/src/sku/molecule/services/src/use_cases/projects/molecule_disable_project_use_case_impl.rs
@@ -73,7 +73,6 @@ impl MoleculeDisableProjectUseCase for MoleculeDisableProjectUseCaseImpl {
         // Add retraction record to disable the project
         let new_changelog_record = MoleculeProjectChangelogInsertionRecord {
             op: odf::metadata::OperationType::Retract,
-            event_time: source_event_time,
             payload: last_changelog_entry.payload,
         };
 

--- a/src/sku/molecule/services/src/use_cases/projects/molecule_enable_project_use_case_impl.rs
+++ b/src/sku/molecule/services/src/use_cases/projects/molecule_enable_project_use_case_impl.rs
@@ -106,7 +106,6 @@ impl MoleculeEnableProjectUseCase for MoleculeEnableProjectUseCaseImpl {
         // Add Append record to re-enable the project
         let new_changelog_record = MoleculeProjectChangelogInsertionRecord {
             op: odf::metadata::OperationType::Append,
-            event_time: source_event_time,
             payload: last_changelog_entry.payload,
         };
 


### PR DESCRIPTION
### Context

- This PR almost completely revert https://github.com/kamu-data/kamu-cli/pull/1519
- Changes that have not been reverted:
```rust
# molecule-data-room-activity.yaml
      - content_type STRING # <-- 
      - content_length BIGINT UNSIGNED NOT NULL
      - content_hash STRING NOT NULL # <--

# molecule_dataset_snapshots.rs
                                "content_type STRING", # <--
                                "content_length BIGINT UNSIGNED NOT NULL",
                                "content_hash STRING NOT NULL", # <--
```