### PR TITLE
Enable unstable feature-unification feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,11 @@
 #   warning: the following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.4
 [future-incompat-report]
 frequency = "never"
+
+[unstable]
+feature-unification = true
+
+[resolver]
+# Reduces recompilation due to feature permutations
+# See: https://www.reddit.com/r/rust/comments/1qzvkwf/workspace_feature_permutations_hell/
+feature-unification = "workspace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ members = [
     "src/e2e/app/cli/mysql",
     "src/e2e/app/cli/sqlite",
 ]
-resolver = "2"
+resolver = "3"
 
 
 [workspace.dependencies]

--- a/src/odf/metadata/Cargo.toml
+++ b/src/odf/metadata/Cargo.toml
@@ -62,7 +62,10 @@ base64 = { version = "0.22", default-features = false, features = ["std"] }
 flatbuffers = "25"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
-serde_with = { version = "3", default-features = false }
+serde_with = { version = "3", default-features = false, features = [
+    "std",
+    "macros",
+] }
 serde_yaml = { package = "serde_yaml_ng", version = "0.10", default-features = false }
 
 # gRPC


### PR DESCRIPTION
This should significantly reduce recompilation when running tests for individual crates in the workspace (`cargo test -p blah`) and reduce growth of target dir.

See:
* https://www.reddit.com/r/rust/comments/1qzvkwf/workspace_feature_permutations_hell/
* https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#feature-unification
* https://github.com/rust-lang/rfcs/blob/master/text/3692-feature-unification.md