### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux / amd64
+          - name: Linux / x86_64
             runs-on: ubuntu-latest
             cargo-flags: --profile ci --features ingest-ftp,web-ui
             nextest-flags: --cargo-profile ci --features ingest-ftp,web-ui
@@ -109,8 +109,8 @@ jobs:
             maximize-space: true
           # TODO: M1 cannot run docker due to lack of nested virtualization
           # See: https://github.com/marketplace/actions/setup-docker-on-macos#arm64-processors-m1-m2-m3-series-used-on-macos-14-images-are-unsupported
-          - name: MacOS / arm64
-            runs-on: macos-15
+          - name: MacOS / aarch64
+            runs-on: macos-26
             cargo-flags: --profile ci
             nextest-flags: --cargo-profile ci
             nextest-exclusions-main-set-tests: -E '!(test(::containerized::) | test(::database::) | test(::elasticsearch::) | test(::examples::))'
@@ -121,21 +121,22 @@ jobs:
             database: false
             elasticsearch: false
             maximize-space: false
+          # TODO: Restore Windows support later avoiding its slowness from blocking the main CI flow
           # TODO: DataFusion tests are temporarily disabled
           # See: https://github.com/kamu-data/kamu-cli/issues/226
-          - name: Windows / amd64
-            runs-on: windows-latest
-            cargo-flags: --profile ci
-            nextest-flags: --cargo-profile ci
-            # platform(target) is a workaround for Windows only issue in cargo-nextest upon proc macro crates
-            nextest-exclusions-main-set-tests: -E 'platform(target) & !(test(::containerized::) | test(::datafusion::) | test(::database::) | test(::elasticsearch::) | test(::examples::))'
-            nextest-exclusions-database-set-part: '& !(test(::datafusion::))'
-            nextest-exclusions-elasticsearch-set-part: '& !(test(::datafusion::))'
-            container-runtime: ''
-            ipfs: false
-            database: false
-            elasticsearch: false
-            maximize-space: false
+          # - name: Windows / x86_64
+          #   runs-on: windows-latest
+          #   cargo-flags: --profile ci
+          #   nextest-flags: --cargo-profile ci
+          #   # platform(target) is a workaround for Windows only issue in cargo-nextest upon proc macro crates
+          #   nextest-exclusions-main-set-tests: -E 'platform(target) & !(test(::containerized::) | test(::datafusion::) | test(::database::) | test(::elasticsearch::) | test(::examples::))'
+          #   nextest-exclusions-database-set-part: '& !(test(::datafusion::))'
+          #   nextest-exclusions-elasticsearch-set-part: '& !(test(::datafusion::))'
+          #   container-runtime: ''
+          #   ipfs: false
+          #   database: false
+          #   elasticsearch: false
+          #   maximize-space: false
     name: Test / ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
     services:
@@ -179,12 +180,20 @@ jobs:
       - name: Maximize build space
         if: matrix.maximize-space
         run: |
+          df -h
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h
 
       - uses: actions/checkout@v5
+
+      - name: Install mold linker
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y mold
+          echo 'RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold' >> $GITHUB_ENV
 
       - uses: actions-rs/toolchain@v1
 
@@ -212,6 +221,14 @@ jobs:
           KAMU_WEB_UI_DIR: '../../../.github'
         run: |
           cargo test ${{ matrix.cargo-flags }} --no-run
+
+      - name: Assert mold linker was used
+        if: runner.os == 'Linux'
+        run: |
+          binary=$(find target/ci/deps -maxdepth 1 -type f -executable | head -1)
+          echo "Checking: $binary"
+          readelf -p .comment "$binary"
+          readelf -p .comment "$binary" | grep mold
 
       - name: Pull test images
         if: matrix.container-runtime != ''
@@ -270,7 +287,17 @@ jobs:
           DATABASE_URL: mariadb://root:root@127.0.0.1:3306/kamu-test
         run: cargo nextest run ${{ matrix.nextest-flags }} -E 'test(::mysql::) ${{ matrix.nextest-exclusions-database-set-part }}'
 
-      # Not running on windows due to line ending differences
+      # Note: Not running on windows due to line ending differences
       - name: Check generated files
         if: "!contains(matrix.runs-on, 'windows')"
         run: git diff && git diff-index --quiet HEAD
+
+      - name: Report disk space
+        if: always()
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            wmic logicaldisk get size,freespace,caption
+          else
+            df -h
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,32 +26,32 @@ jobs:
           # Keep in sync with artifact upload matrix below
           #
           # TODO: Add minimal targets that are stripped and do not embed WebUI
-          - name: Linux / amd64 / glibc
+          - name: Linux / x86_64 / glibc
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: true
             features: ingest-ftp,web-ui
-          - name: Linux / amd64 / musl
+          - name: Linux / x86_64 / musl
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
             features: ingest-ftp,web-ui
-          - name: Linux / arm64 / glibc
+          - name: Linux / aarch64 / glibc
             runs-on: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
             features: ingest-ftp,web-ui
-          - name: Linux / arm64 / musl
+          - name: Linux / aarch64 / musl
             runs-on: ubuntu-latest
             target: aarch64-unknown-linux-musl
             use-cross: true
             features: ingest-ftp,web-ui
-          - name: MacOS / arm64
+          - name: MacOS / aarch64
             runs-on: macos-14
             target: aarch64-apple-darwin
             use-cross: false
             features: ingest-ftp,web-ui
-          # - name: Windows / amd64
+          # - name: Windows / x86_64
           #   runs-on: windows-latest
           #   target: x86_64-pc-windows-msvc
           #   use-cross: false


### PR DESCRIPTION
## Description

- Disabling Windows in `build` CI as it currently takes 2x longer than Linux build and we don't even ship it
- Using faster `mold` linker in `build` CI
- Using latest `macos-26` runner in `build`
- Renamed matrix steps for better consistency