### PR TITLE
GQL collection::entries support maxDepth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
+## Unreleased
+### Added
+- GQL `Collection::entries` now support `maxDepth` for navigating entries as directory hierarchy
+
 ## [0.262.0] - 2026-04-22
 ### Changed
 - Updated default RisingWave engine image that fixes Parquet compatibility bug

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -731,7 +731,16 @@ type CollectionProjection {
 	Returns the state of entries as they existed at a specified point in
 	time
 	"""
-	entries(pathPrefix: CollectionPath, maxDepth: Int, page: Int, perPage: Int): CollectionEntryConnection!
+	entries(
+		"""
+		Return only entries whose path starts with this prefix
+		"""
+		pathPrefix: CollectionPath,
+		"""
+		Return only a single entry after reaching a certain path depth. For example given enties `/a, /b, /dir/c, /dir/d` at depth 1 it will return `/a, /b`, /dir/b` - the first two as actual entries at depth 1, and the last one as an indicator that there is one or more entries under `/dir`. Using the combination of `pathPrefix` and `maxDepth` you can walk entries as a directory hierarchy.
+		"""
+		maxDepth: Int,		page: Int,		perPage: Int
+	): CollectionEntryConnection!
 	"""
 	Find entries that link to specified DIDs
 	"""

--- a/src/adapter/graphql/src/queries/datasets/adapters/collection.rs
+++ b/src/adapter/graphql/src/queries/datasets/adapters/collection.rs
@@ -124,7 +124,16 @@ impl CollectionProjection<'_> {
     pub async fn entries(
         &self,
         ctx: &Context<'_>,
+        #[graphql(desc = "Return only entries whose path starts with this prefix")]
         path_prefix: Option<CollectionPath<'static>>,
+        #[graphql(
+            desc = "Return only a single entry after reaching a certain path depth. For example \
+                    given enties `/a, /b, /dir/c, /dir/d` at depth 1 it will return `/a, /b`, \
+                    /dir/b` - the first two as actual entries at depth 1, and the last one as an \
+                    indicator that there is one or more entries under `/dir`. Using the \
+                    combination of `pathPrefix` and `maxDepth` you can walk entries as a \
+                    directory hierarchy."
+        )]
         max_depth: Option<usize>,
         page: Option<usize>,
         per_page: Option<usize>,

--- a/src/adapter/graphql/tests/tests/test_gql_dataset_adapter_collection.rs
+++ b/src/adapter/graphql/tests/tests/test_gql_dataset_adapter_collection.rs
@@ -449,7 +449,7 @@ async fn test_collection_path_prefix_and_max_depth() {
                 {
                     "add": {
                         "entry": {
-                            "path": "/a",
+                            "path": "/0a",
                             "ref": linked,
                         }
                     }
@@ -457,7 +457,7 @@ async fn test_collection_path_prefix_and_max_depth() {
                 {
                     "add": {
                         "entry": {
-                            "path": "/1/b",
+                            "path": "/0b/1a",
                             "ref": linked,
                         }
                     }
@@ -465,78 +465,156 @@ async fn test_collection_path_prefix_and_max_depth() {
                 {
                     "add": {
                         "entry": {
-                            "path": "/1/2/c",
+                            "path": "/0b/1b/2a",
                             "ref": linked,
                         }
                     }
-                }
+                },
+                {
+                    "add": {
+                        "entry": {
+                            "path": "/0b/1b/2b",
+                            "ref": linked,
+                        }
+                    }
+                },
+                {
+                    "add": {
+                        "entry": {
+                            "path": "/0b/1c/2a",
+                            "ref": linked,
+                        }
+                    }
+                },
+                {
+                    "add": {
+                        "entry": {
+                            "path": "/0b/1c/2b",
+                            "ref": linked,
+                        }
+                    }
+                },
             ]),
         )
         .await;
 
+    let as_entries = |paths: &[&str]| -> serde_json::Value {
+        let entries = paths.iter().map(|p| {
+            json!({
+                "path": p,
+                "ref": linked,
+                "extraData": {},
+            })
+        });
+
+        serde_json::Value::Array(entries.collect())
+    };
+
+    // List all
     assert_eq!(
         harness.list_entries(&did).await,
-        json!([
-            {
-                "path": "/1/2/c",
-                "ref": linked,
-                "extraData": {},
-            },
-            {
-                "path": "/1/b",
-                "ref": linked,
-                "extraData": {},
-            },
-            {
-                "path": "/a",
-                "ref": linked,
-                "extraData": {},
-            },
+        as_entries(&[
+            "/0a",
+            "/0b/1a",
+            "/0b/1b/2a",
+            "/0b/1b/2b",
+            "/0b/1c/2a",
+            "/0b/1c/2b",
         ])
     );
 
-    // With prefix
+    // Path prefix
     assert_eq!(
-        harness.list_entries_ext(&did, Some("/1/"), None).await,
-        json!([
-            {
-                "path": "/1/2/c",
-                "ref": linked,
-                "extraData": {},
-            },
-            {
-                "path": "/1/b",
-                "ref": linked,
-                "extraData": {},
-            },
-        ])
+        harness.list_entries_ext(&did, Some("/0b/"), None).await,
+        as_entries(&["/0b/1a", "/0b/1b/2a", "/0b/1b/2b", "/0b/1c/2a", "/0b/1c/2b"])
     );
 
     assert_eq!(
-        harness.list_entries_ext(&did, Some("/1/2/"), None).await,
-        json!([
-            {
-                "path": "/1/2/c",
-                "ref": linked,
-                "extraData": {},
-            },
-        ])
+        harness.list_entries_ext(&did, Some("/0b/1b/"), None).await,
+        as_entries(&["/0b/1b/2a", "/0b/1b/2b"])
     );
 
     assert_eq!(
-        harness.list_entries_ext(&did, Some("/1/2/c"), None).await,
-        json!([
-            {
-                "path": "/1/2/c",
-                "ref": linked,
-                "extraData": {},
-            },
-        ])
+        harness.list_entries_ext(&did, Some("/0a"), None).await,
+        as_entries(&["/0a"])
     );
 
     assert_eq!(
-        harness.list_entries_ext(&did, Some("/1/2/3/"), None).await,
+        harness
+            .list_entries_ext(&did, Some("/0b/1b/2a"), None)
+            .await,
+        as_entries(&["/0b/1b/2a"])
+    );
+
+    assert_eq!(
+        harness
+            .list_entries_ext(&did, Some("/0b/1b/2a/"), None)
+            .await,
         json!([])
+    );
+
+    // Max depth limit
+    assert_eq!(
+        harness.list_entries_ext(&did, None, Some(0)).await,
+        as_entries(&[
+            "/0a",
+            // "/0b/1a",
+            // "/0b/1b/2a",
+            // "/0b/1b/2b",
+            // "/0b/1c/2a",
+            // "/0b/1c/2b",
+        ])
+    );
+
+    assert_eq!(
+        harness.list_entries_ext(&did, None, Some(1)).await,
+        as_entries(&[
+            "/0a",
+            "/0b/1a",
+            // "/0b/1b/2a",
+            // "/0b/1b/2b",
+            // "/0b/1c/2a",
+            // "/0b/1c/2b",
+        ])
+    );
+
+    assert_eq!(
+        harness.list_entries_ext(&did, None, Some(2)).await,
+        as_entries(&[
+            "/0a",
+            "/0b/1a",
+            "/0b/1b/2a",
+            // "/0b/1b/2b",
+            "/0b/1c/2a",
+            // "/0b/1c/2b",
+        ])
+    );
+
+    // Max depth AND prefix
+    assert_eq!(
+        harness.list_entries_ext(&did, Some("/0b/"), Some(2)).await,
+        as_entries(&[
+            // "/0a",
+            "/0b/1a",
+            "/0b/1b/2a",
+            // "/0b/1b/2b",
+            "/0b/1c/2a",
+            // "/0b/1c/2b",
+        ])
+    );
+
+    assert_eq!(
+        harness
+            .list_entries_ext(&did, Some("/0b/1b/"), Some(3))
+            .await,
+        as_entries(&[
+            // "/0a",
+            // "/0b/1a",
+            "/0b/1b/2a",
+            "/0b/1b/2b",
+            // "/0b/1c/2a",
+            // "/0b/1c/2b",
+        ])
     );
 }
 

--- a/src/domain/datasets/services/src/use_cases/collections/view_collection_entries_use_case_impl.rs
+++ b/src/domain/datasets/services/src/use_cases/collections/view_collection_entries_use_case_impl.rs
@@ -82,19 +82,14 @@ impl ViewCollectionEntriesUseCase for ViewCollectionEntriesUseCaseImpl {
             df
         };
 
-        let df = match path_prefix {
-            None => df,
-            Some(path_prefix) => df
-                .filter(
-                    datafusion::functions::string::starts_with()
-                        .call(vec![col("path"), lit(path_prefix.as_str())]),
-                )
-                .int_err()?,
-        };
-
-        let df = match max_depth {
-            None => df,
-            Some(_) => unimplemented!(),
+        let df = if let Some(path_prefix) = path_prefix {
+            df.filter(
+                datafusion::functions::string::starts_with()
+                    .call(vec![col("path"), lit(path_prefix.as_str())]),
+            )
+            .int_err()?
+        } else {
+            df
         };
 
         // Project changelog into a state
@@ -104,6 +99,43 @@ impl ViewCollectionEntriesUseCase for ViewCollectionEntriesUseCaseImpl {
             &odf::metadata::DatasetVocabulary::default(),
         )
         .int_err()?;
+
+        // Filter by max depth
+        // TODO: PERF: This implementation is quite inefficient.
+        let df = if let Some(max_depth) = max_depth {
+            let sort_expr = col("path").sort(true, false);
+
+            let aggr_exprs = df
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| {
+                    datafusion::functions_aggregate::expr_fn::first_value(
+                        col(f.name()),
+                        vec![sort_expr.clone()],
+                    )
+                    .alias(f.name())
+                })
+                .collect();
+
+            let df = df
+                .with_column(
+                    "__path_trimmed",
+                    datafusion::functions::unicode::substr_index().call(vec![
+                        col("path"),
+                        lit("/"),
+                        lit(i64::try_from(max_depth + 1).unwrap()),
+                    ]),
+                )
+                .int_err()?;
+
+            df.aggregate(vec![col("__path_trimmed")], aggr_exprs)
+                .int_err()?
+                .without_columns(&["__path_trimmed"])
+                .int_err()?
+        } else {
+            df
+        };
 
         let total_count = df.clone().count().await.int_err()?;
         let df = df.sort(vec![col("path").sort(true, false)]).int_err()?;

--- a/src/odf/data-utils/src/data/dataframe_ext.rs
+++ b/src/odf/data-utils/src/data/dataframe_ext.rs
@@ -41,6 +41,14 @@ impl From<DataFrame> for DataFrameExt {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 impl DataFrameExt {
+    pub fn aggregate(
+        self,
+        group_expr: Vec<Expr>,
+        aggr_expr: Vec<Expr>,
+    ) -> Result<Self, DataFusionError> {
+        self.0.aggregate(group_expr, aggr_expr).map(Self)
+    }
+
     #[tracing::instrument(level = "info", name = "DataFrame::cache", skip_all)]
     pub async fn cache(self) -> Result<Self, DataFusionError> {
         self.0.cache().await.map(Self)


### PR DESCRIPTION
Implements `maxDepth` support.

I faced a hard choice here on how to represent presence of "directories" after reaching the depth limit.

Options were:
- Make `entries()` return an enum `CollectionEntry` and `CollectionPrefix` - this seems like a nice choice but would break the existing API
- Return entry with a path but `ref == null` - `CollectionEntry` objects that have `ref` field as required so this would also be a (somewhat) breaking change and will force everyone to check for `null` everywhere, even if they don't use `maxDepth`
- After reaching max depth return only the first entry - this is what I went with. See tests for clarity. 