### PR TITLE
Release (patch): 0.263.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ on:
 env:
   PACKAGE_NAME: kamu-cli
   BINARY_NAME: kamu
-  KAMU_WEB_UI_VERSION: "0.66.0"
+  KAMU_WEB_UI_VERSION: "0.67.0"
 jobs:
   build:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Recommendation: for ease of reading, use the following format:
 ### Fixed
 -->
 
+## [0.263.1] - 2026-05-20
+### Fixed
+- Elasticsearch: added ID escaping for API requests
+
 ## [0.263.0] - 2026-05-16
 ### Added
 - **Breaking:** The `read.schema` field now expects an ODF schema, replacing DDL schema with our unified format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "async-utils"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "common-macros"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3100,7 +3100,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "container-runtime"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-utils"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "database-common"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "email-utils"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "schemars 1.2.1",
  "serde",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.263.0"
+version = "0.263.1"
 
 [[package]]
 name = "env_filter"
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -5014,7 +5014,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "file-utils"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "fs_extra",
  "serde",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "format-utils"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "pretty_assertions",
 ]
@@ -5427,7 +5427,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graphql-http"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-graphql",
  "axum",
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "axum",
  "http 1.4.0",
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "init-on-startup"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "bon",
@@ -6391,7 +6391,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -6829,7 +6829,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "alloy",
  "alloy-provider",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "base32",
@@ -6952,7 +6952,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6974,7 +6974,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7022,7 +7022,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "argon2",
  "chrono",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "bon",
@@ -7088,7 +7088,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7147,7 +7147,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-web3"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -7210,7 +7210,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flow-dataset"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flow-webhook"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7280,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -7360,7 +7360,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -7435,7 +7435,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "dill",
@@ -7452,7 +7452,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -7497,7 +7497,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-task-dataset"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "common-macros",
@@ -7516,7 +7516,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-task-webhook"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7536,7 +7536,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -7553,7 +7553,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -7567,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7583,7 +7583,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "dill",
  "kamu-auth-rebac",
@@ -7592,7 +7592,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7618,7 +7618,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7635,7 +7635,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7651,7 +7651,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7666,7 +7666,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7684,7 +7684,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "chrono",
  "dill",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-services"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7709,7 +7709,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7727,7 +7727,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -7909,7 +7909,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -7917,7 +7917,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-example-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -7926,7 +7926,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "database-common",
  "indoc 2.0.7",
@@ -7939,7 +7939,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "database-common",
  "indoc 2.0.7",
@@ -7952,7 +7952,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-graphql",
  "base64",
@@ -7986,7 +7986,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "indoc 2.0.7",
  "kamu-cli-e2e-common",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -8018,7 +8018,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8053,7 +8053,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -8076,7 +8076,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-udf"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "datafusion",
  "indoc 2.0.7",
@@ -8089,7 +8089,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8126,7 +8126,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "cheap-clone",
@@ -8148,7 +8148,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8172,7 +8172,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -8191,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "arrow",
  "async-stream",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8282,7 +8282,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -8311,7 +8311,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8337,7 +8337,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "chrono",
  "csv",
@@ -8387,7 +8387,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8430,7 +8430,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8457,7 +8457,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8490,7 +8490,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8529,7 +8529,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "chrono",
  "dill",
@@ -8542,7 +8542,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8564,7 +8564,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "chrono",
  "clap",
@@ -8582,7 +8582,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-cache-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "cheap-clone",
@@ -8617,7 +8617,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-cache-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8636,7 +8636,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-cache-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "chrono",
  "dill",
@@ -8646,7 +8646,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-cache-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8665,7 +8665,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-elasticsearch"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "canonical_json",
@@ -8700,7 +8700,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-elasticsearch-macros"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8709,7 +8709,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-openai"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -8723,7 +8723,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-services"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8750,7 +8750,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -8772,7 +8772,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "database-common",
@@ -8789,7 +8789,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8809,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "chrono",
  "database-common",
@@ -8822,7 +8822,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -8855,7 +8855,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8876,7 +8876,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8902,7 +8902,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8922,7 +8922,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-postgres"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8946,7 +8946,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-repo-tests"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "chrono",
  "database-common",
@@ -8963,7 +8963,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-services"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -9001,7 +9001,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-sqlite"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9698,7 +9698,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "base64",
  "bs58 0.5.1",
@@ -10094,7 +10094,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -10181,7 +10181,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -10196,7 +10196,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-data-utils"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -10224,7 +10224,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10249,7 +10249,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset-impl"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "arrow",
  "async-stream",
@@ -10291,7 +10291,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-metadata"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "arrow",
  "base64",
@@ -10326,7 +10326,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10348,7 +10348,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-http"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10371,7 +10371,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-inmem"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10387,7 +10387,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-lfs"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10406,7 +10406,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-s3"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -11652,7 +11652,7 @@ dependencies = [
 
 [[package]]
 name = "random-strings"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "rand 0.9.4",
 ]
@@ -12393,7 +12393,7 @@ checksum = "700de91d5fd6091442d00fdd9ee790af6d4f0f480562b0f5a1e8f59e90aafe73"
 
 [[package]]
 name = "s3-utils"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -12747,7 +12747,7 @@ dependencies = [
 
 [[package]]
 name = "server-console"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-graphql",
  "axum",
@@ -13782,7 +13782,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "axum",
  "container-runtime",
@@ -13916,7 +13916,7 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -14342,7 +14342,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.263.0"
+version = "0.263.1"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,149 +139,149 @@ resolver = "3"
 
 [workspace.dependencies]
 # Apps
-kamu-cli = { version = "0.263.0", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.263.1", path = "src/app/cli", default-features = false }
 
 # Utils
-async-utils = { version = "0.263.0", path = "src/utils/async-utils", default-features = false }
-common-macros = { version = "0.263.0", path = "src/utils/common-macros", default-features = false }
-container-runtime = { version = "0.263.0", path = "src/utils/container-runtime", default-features = false }
-crypto-utils = { version = "0.263.0", path = "src/utils/crypto-utils", default-features = false }
-database-common = { version = "0.263.0", path = "src/utils/database-common", default-features = false }
-database-common-macros = { version = "0.263.0", path = "src/utils/database-common-macros", default-features = false }
-email-utils = { version = "0.263.0", path = "src/utils/email-utils", default-features = false }
-enum-variants = { version = "0.263.0", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.263.0", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.263.0", path = "src/utils/event-sourcing-macros", default-features = false }
-file-utils = { version = "0.263.0", path = "src/utils/file-utils", default-features = false }
-format-utils = { version = "0.263.0", path = "src/utils/format-utils", default-features = false }
-graphql-http = { version = "0.263.0", path = "src/utils/graphql-http", default-features = false }
-http-common = { version = "0.263.0", path = "src/utils/http-common", default-features = false }
-init-on-startup = { version = "0.263.0", path = "src/utils/init-on-startup", default-features = false }
-internal-error = { version = "0.263.0", path = "src/utils/internal-error", default-features = false }
-kamu-cli-puppet = { version = "0.263.0", path = "src/utils/kamu-cli-puppet", default-features = false }
-kamu-datafusion-cli = { version = "0.263.0", path = "src/utils/datafusion-cli", default-features = false }
-messaging-outbox = { version = "0.263.0", path = "src/utils/messaging-outbox", default-features = false }
-multiformats = { version = "0.263.0", path = "src/utils/multiformats", default-features = false }
-observability = { version = "0.263.0", path = "src/utils/observability", default-features = false }
-random-strings = { version = "0.263.0", path = "src/utils/random-strings", default-features = false }
-s3-utils = { version = "0.263.0", path = "src/utils/s3-utils", default-features = false }
-server-console = { version = "0.263.0", path = "src/utils/server-console", default-features = false }
-test-utils = { version = "0.263.0", path = "src/utils/test-utils", default-features = false }
-time-source = { version = "0.263.0", path = "src/utils/time-source", default-features = false }
-tracing-perfetto = { version = "0.263.0", path = "src/utils/tracing-perfetto", default-features = false }
+async-utils = { version = "0.263.1", path = "src/utils/async-utils", default-features = false }
+common-macros = { version = "0.263.1", path = "src/utils/common-macros", default-features = false }
+container-runtime = { version = "0.263.1", path = "src/utils/container-runtime", default-features = false }
+crypto-utils = { version = "0.263.1", path = "src/utils/crypto-utils", default-features = false }
+database-common = { version = "0.263.1", path = "src/utils/database-common", default-features = false }
+database-common-macros = { version = "0.263.1", path = "src/utils/database-common-macros", default-features = false }
+email-utils = { version = "0.263.1", path = "src/utils/email-utils", default-features = false }
+enum-variants = { version = "0.263.1", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.263.1", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.263.1", path = "src/utils/event-sourcing-macros", default-features = false }
+file-utils = { version = "0.263.1", path = "src/utils/file-utils", default-features = false }
+format-utils = { version = "0.263.1", path = "src/utils/format-utils", default-features = false }
+graphql-http = { version = "0.263.1", path = "src/utils/graphql-http", default-features = false }
+http-common = { version = "0.263.1", path = "src/utils/http-common", default-features = false }
+init-on-startup = { version = "0.263.1", path = "src/utils/init-on-startup", default-features = false }
+internal-error = { version = "0.263.1", path = "src/utils/internal-error", default-features = false }
+kamu-cli-puppet = { version = "0.263.1", path = "src/utils/kamu-cli-puppet", default-features = false }
+kamu-datafusion-cli = { version = "0.263.1", path = "src/utils/datafusion-cli", default-features = false }
+messaging-outbox = { version = "0.263.1", path = "src/utils/messaging-outbox", default-features = false }
+multiformats = { version = "0.263.1", path = "src/utils/multiformats", default-features = false }
+observability = { version = "0.263.1", path = "src/utils/observability", default-features = false }
+random-strings = { version = "0.263.1", path = "src/utils/random-strings", default-features = false }
+s3-utils = { version = "0.263.1", path = "src/utils/s3-utils", default-features = false }
+server-console = { version = "0.263.1", path = "src/utils/server-console", default-features = false }
+test-utils = { version = "0.263.1", path = "src/utils/test-utils", default-features = false }
+time-source = { version = "0.263.1", path = "src/utils/time-source", default-features = false }
+tracing-perfetto = { version = "0.263.1", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-kamu-accounts = { version = "0.263.0", path = "src/domain/accounts/domain", default-features = false }
-kamu-auth-rebac = { version = "0.263.0", path = "src/domain/auth-rebac/domain", default-features = false }
-kamu-auth-web3 = { version = "0.263.0", path = "src/domain/auth-web3/domain", default-features = false }
-kamu-core = { version = "0.263.0", path = "src/domain/core", default-features = false }
-kamu-datasets = { version = "0.263.0", path = "src/domain/datasets/domain", default-features = false }
-kamu-flow-system = { version = "0.263.0", path = "src/domain/flow-system/domain", default-features = false }
-kamu-search = { version = "0.263.0", path = "src/domain/search/domain", default-features = false }
-kamu-task-system = { version = "0.263.0", path = "src/domain/task-system/domain", default-features = false }
-kamu-webhooks = { version = "0.263.0", path = "src/domain/webhooks/domain", default-features = false }
+kamu-accounts = { version = "0.263.1", path = "src/domain/accounts/domain", default-features = false }
+kamu-auth-rebac = { version = "0.263.1", path = "src/domain/auth-rebac/domain", default-features = false }
+kamu-auth-web3 = { version = "0.263.1", path = "src/domain/auth-web3/domain", default-features = false }
+kamu-core = { version = "0.263.1", path = "src/domain/core", default-features = false }
+kamu-datasets = { version = "0.263.1", path = "src/domain/datasets/domain", default-features = false }
+kamu-flow-system = { version = "0.263.1", path = "src/domain/flow-system/domain", default-features = false }
+kamu-search = { version = "0.263.1", path = "src/domain/search/domain", default-features = false }
+kamu-task-system = { version = "0.263.1", path = "src/domain/task-system/domain", default-features = false }
+kamu-webhooks = { version = "0.263.1", path = "src/domain/webhooks/domain", default-features = false }
 
 ## Open Data Fabric
-odf = { version = "0.263.0", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
-odf-metadata = { version = "0.263.0", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
-odf-dataset = { version = "0.263.0", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
-odf-data-utils = { version = "0.263.0", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
-odf-dataset-impl = { version = "0.263.0", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
-odf-storage = { version = "0.263.0", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
-odf-storage-http = { version = "0.263.0", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
-odf-storage-inmem = { version = "0.263.0", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
-odf-storage-lfs = { version = "0.263.0", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
-odf-storage-s3 = { version = "0.263.0", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
+odf = { version = "0.263.1", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
+odf-metadata = { version = "0.263.1", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
+odf-dataset = { version = "0.263.1", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
+odf-data-utils = { version = "0.263.1", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
+odf-dataset-impl = { version = "0.263.1", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
+odf-storage = { version = "0.263.1", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
+odf-storage-http = { version = "0.263.1", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
+odf-storage-inmem = { version = "0.263.1", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
+odf-storage-lfs = { version = "0.263.1", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
+odf-storage-s3 = { version = "0.263.1", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.263.0", path = "src/domain/accounts/services", default-features = false }
-kamu-auth-rebac-services = { version = "0.263.0", path = "src/domain/auth-rebac/services", default-features = false }
-kamu-auth-web3-services = { version = "0.263.0", path = "src/domain/auth-web3/services", default-features = false }
-kamu-datasets-services = { version = "0.263.0", path = "src/domain/datasets/services", default-features = false, features = [
+kamu-accounts-services = { version = "0.263.1", path = "src/domain/accounts/services", default-features = false }
+kamu-auth-rebac-services = { version = "0.263.1", path = "src/domain/auth-rebac/services", default-features = false }
+kamu-auth-web3-services = { version = "0.263.1", path = "src/domain/auth-web3/services", default-features = false }
+kamu-datasets-services = { version = "0.263.1", path = "src/domain/datasets/services", default-features = false, features = [
     "lfs",
     "s3",
 ] }
-kamu-flow-system-services = { version = "0.263.0", path = "src/domain/flow-system/services", default-features = false }
-kamu-search-services = { version = "0.263.0", path = "src/domain/search/services", default-features = false }
-kamu-task-system-services = { version = "0.263.0", path = "src/domain/task-system/services", default-features = false }
-kamu-webhooks-services = { version = "0.263.0", path = "src/domain/webhooks/services", default-features = false }
+kamu-flow-system-services = { version = "0.263.1", path = "src/domain/flow-system/services", default-features = false }
+kamu-search-services = { version = "0.263.1", path = "src/domain/search/services", default-features = false }
+kamu-task-system-services = { version = "0.263.1", path = "src/domain/task-system/services", default-features = false }
+kamu-webhooks-services = { version = "0.263.1", path = "src/domain/webhooks/services", default-features = false }
 
 # Infra
-kamu = { version = "0.263.0", path = "src/infra/core", default-features = false }
-kamu-datafusion-udf = { version = "0.263.0", path = "src/infra/datafusion-udf", default-features = false }
-kamu-ingest-datafusion = { version = "0.263.0", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.263.1", path = "src/infra/core", default-features = false }
+kamu-datafusion-udf = { version = "0.263.1", path = "src/infra/datafusion-udf", default-features = false }
+kamu-ingest-datafusion = { version = "0.263.1", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.263.0", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.263.0", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.263.0", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.263.0", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.263.1", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.263.1", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.263.1", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.263.1", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.263.0", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.263.0", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.263.0", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.263.0", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.263.0", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.263.1", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.263.1", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.263.1", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.263.1", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.263.1", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Datasets
-kamu-datasets-inmem = { version = "0.263.0", path = "src/infra/datasets/inmem", default-features = false }
-kamu-datasets-postgres = { version = "0.263.0", path = "src/infra/datasets/postgres", default-features = false }
-kamu-datasets-sqlite = { version = "0.263.0", path = "src/infra/datasets/sqlite", default-features = false }
-kamu-datasets-repo-tests = { version = "0.263.0", path = "src/infra/datasets/repo-tests", default-features = false }
+kamu-datasets-inmem = { version = "0.263.1", path = "src/infra/datasets/inmem", default-features = false }
+kamu-datasets-postgres = { version = "0.263.1", path = "src/infra/datasets/postgres", default-features = false }
+kamu-datasets-sqlite = { version = "0.263.1", path = "src/infra/datasets/sqlite", default-features = false }
+kamu-datasets-repo-tests = { version = "0.263.1", path = "src/infra/datasets/repo-tests", default-features = false }
 ## Search
-kamu-search-openai = { version = "0.263.0", path = "src/infra/search/openai", default-features = false }
-kamu-search-elasticsearch = { version = "0.263.0", path = "src/infra/search/elasticsearch", default-features = false }
-kamu-search-elasticsearch-macros = { version = "0.263.0", path = "src/infra/search/elasticsearch-macros", default-features = false }
-kamu-search-cache-inmem = { version = "0.263.0", path = "src/infra/search/cache-inmem", default-features = false }
-kamu-search-cache-postgres = { version = "0.263.0", path = "src/infra/search/cache-postgres", default-features = false }
-kamu-search-cache-sqlite = { version = "0.263.0", path = "src/infra/search/cache-sqlite", default-features = false }
-kamu-search-cache-repo-tests = { version = "0.263.0", path = "src/infra/search/cache-repo-tests", default-features = false }
+kamu-search-openai = { version = "0.263.1", path = "src/infra/search/openai", default-features = false }
+kamu-search-elasticsearch = { version = "0.263.1", path = "src/infra/search/elasticsearch", default-features = false }
+kamu-search-elasticsearch-macros = { version = "0.263.1", path = "src/infra/search/elasticsearch-macros", default-features = false }
+kamu-search-cache-inmem = { version = "0.263.1", path = "src/infra/search/cache-inmem", default-features = false }
+kamu-search-cache-postgres = { version = "0.263.1", path = "src/infra/search/cache-postgres", default-features = false }
+kamu-search-cache-sqlite = { version = "0.263.1", path = "src/infra/search/cache-sqlite", default-features = false }
+kamu-search-cache-repo-tests = { version = "0.263.1", path = "src/infra/search/cache-repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.263.0", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.263.0", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.263.0", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.263.0", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.263.1", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.263.1", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.263.1", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.263.1", path = "src/infra/task-system/repo-tests", default-features = false }
 ## ReBAC
-kamu-auth-rebac-inmem = { version = "0.263.0", path = "src/infra/auth-rebac/inmem", default-features = false }
-kamu-auth-rebac-repo-tests = { version = "0.263.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
-kamu-auth-rebac-postgres = { version = "0.263.0", path = "src/infra/auth-rebac/postgres", default-features = false }
-kamu-auth-rebac-sqlite = { version = "0.263.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
+kamu-auth-rebac-inmem = { version = "0.263.1", path = "src/infra/auth-rebac/inmem", default-features = false }
+kamu-auth-rebac-repo-tests = { version = "0.263.1", path = "src/infra/auth-rebac/repo-tests", default-features = false }
+kamu-auth-rebac-postgres = { version = "0.263.1", path = "src/infra/auth-rebac/postgres", default-features = false }
+kamu-auth-rebac-sqlite = { version = "0.263.1", path = "src/infra/auth-rebac/sqlite", default-features = false }
 ## Outbox
-kamu-messaging-outbox-inmem = { version = "0.263.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
-kamu-messaging-outbox-postgres = { version = "0.263.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
-kamu-messaging-outbox-sqlite = { version = "0.263.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
-kamu-messaging-outbox-repo-tests = { version = "0.263.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
+kamu-messaging-outbox-inmem = { version = "0.263.1", path = "src/infra/messaging-outbox/inmem", default-features = false }
+kamu-messaging-outbox-postgres = { version = "0.263.1", path = "src/infra/messaging-outbox/postgres", default-features = false }
+kamu-messaging-outbox-sqlite = { version = "0.263.1", path = "src/infra/messaging-outbox/sqlite", default-features = false }
+kamu-messaging-outbox-repo-tests = { version = "0.263.1", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
 ## Webhooks
-kamu-webhooks-inmem = { version = "0.263.0", path = "src/infra/webhooks/inmem", default-features = false }
-kamu-webhooks-postgres = { version = "0.263.0", path = "src/infra/webhooks/postgres", default-features = false }
-kamu-webhooks-sqlite = { version = "0.263.0", path = "src/infra/webhooks/sqlite", default-features = false }
-kamu-webhooks-repo-tests = { version = "0.263.0", path = "src/infra/webhooks/repo-tests", default-features = false }
+kamu-webhooks-inmem = { version = "0.263.1", path = "src/infra/webhooks/inmem", default-features = false }
+kamu-webhooks-postgres = { version = "0.263.1", path = "src/infra/webhooks/postgres", default-features = false }
+kamu-webhooks-sqlite = { version = "0.263.1", path = "src/infra/webhooks/sqlite", default-features = false }
+kamu-webhooks-repo-tests = { version = "0.263.1", path = "src/infra/webhooks/repo-tests", default-features = false }
 ## Web3
-kamu-auth-web3-inmem = { version = "0.263.0", path = "src/infra/auth-web3/inmem", default-features = false }
-kamu-auth-web3-postgres = { version = "0.263.0", path = "src/infra/auth-web3/postgres", default-features = false }
-kamu-auth-web3-repo-tests = { version = "0.263.0", path = "src/infra/auth-web3/repo-tests", default-features = false }
-kamu-auth-web3-sqlite = { version = "0.263.0", path = "src/infra/auth-web3/sqlite", default-features = false }
+kamu-auth-web3-inmem = { version = "0.263.1", path = "src/infra/auth-web3/inmem", default-features = false }
+kamu-auth-web3-postgres = { version = "0.263.1", path = "src/infra/auth-web3/postgres", default-features = false }
+kamu-auth-web3-repo-tests = { version = "0.263.1", path = "src/infra/auth-web3/repo-tests", default-features = false }
+kamu-auth-web3-sqlite = { version = "0.263.1", path = "src/infra/auth-web3/sqlite", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso-rebac = { version = "0.263.0", path = "src/adapter/auth-oso-rebac", default-features = false }
-kamu-adapter-auth-web3 = { version = "0.263.0", path = "src/adapter/auth-web3", default-features = false }
-kamu-adapter-flight-sql = { version = "0.263.0", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-flow-dataset = { version = "0.263.0", path = "src/adapter/flow-dataset", default-features = false }
-kamu-adapter-flow-webhook = { version = "0.263.0", path = "src/adapter/flow-webhook", default-features = false }
-kamu-adapter-task-dataset = { version = "0.263.0", path = "src/adapter/task-dataset", default-features = false }
-kamu-adapter-task-webhook = { version = "0.263.0", path = "src/adapter/task-webhook", default-features = false }
+kamu-adapter-auth-oso-rebac = { version = "0.263.1", path = "src/adapter/auth-oso-rebac", default-features = false }
+kamu-adapter-auth-web3 = { version = "0.263.1", path = "src/adapter/auth-web3", default-features = false }
+kamu-adapter-flight-sql = { version = "0.263.1", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-flow-dataset = { version = "0.263.1", path = "src/adapter/flow-dataset", default-features = false }
+kamu-adapter-flow-webhook = { version = "0.263.1", path = "src/adapter/flow-webhook", default-features = false }
+kamu-adapter-task-dataset = { version = "0.263.1", path = "src/adapter/task-dataset", default-features = false }
+kamu-adapter-task-webhook = { version = "0.263.1", path = "src/adapter/task-webhook", default-features = false }
 kamu-adapter-flow-task = { version = "0.242.1", path = "src/adapter/flow-task", default-features = false }
-kamu-adapter-graphql = { version = "0.263.0", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.263.0", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.263.0", path = "src/adapter/odata", default-features = false }
-kamu-adapter-oauth = { version = "0.263.0", path = "src/adapter/oauth", default-features = false }
+kamu-adapter-graphql = { version = "0.263.1", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.263.1", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.263.1", path = "src/adapter/odata", default-features = false }
+kamu-adapter-oauth = { version = "0.263.1", path = "src/adapter/oauth", default-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.263.0", path = "src/e2e/app/cli/common", default-features = false }
-kamu-cli-e2e-common-macros = { version = "0.263.0", path = "src/e2e/app/cli/common-macros", default-features = false }
-kamu-cli-e2e-example-tests = { version = "0.263.0", path = "src/e2e/app/cli/example-tests", default-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.263.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
+kamu-cli-e2e-common = { version = "0.263.1", path = "src/e2e/app/cli/common", default-features = false }
+kamu-cli-e2e-common-macros = { version = "0.263.1", path = "src/e2e/app/cli/common-macros", default-features = false }
+kamu-cli-e2e-example-tests = { version = "0.263.1", path = "src/e2e/app/cli/example-tests", default-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.263.1", path = "src/e2e/app/cli/repo-tests", default-features = false }
 
 [workspace.package]
-version = "0.263.0"
+version = "0.263.1"
 edition = "2024"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.263.0
+Licensed Work:             Kamu CLI Version 0.263.1
                            The Licensed Work is © 2025 Kamu Data, Inc.
 
 Additional Use Grant:      You may not use the Licensed Work for a Data Service,

--- a/resources/config-reference.md
+++ b/resources/config-reference.md
@@ -185,7 +185,7 @@
   &quot;http&quot;: {
     &quot;connectTimeout&quot;: &quot;30s&quot;,
     &quot;maxRedirects&quot;: 10,
-    &quot;userAgent&quot;: &quot;kamu-cli&#x2F;0.263.0&quot;
+    &quot;userAgent&quot;: &quot;kamu-cli&#x2F;0.263.1&quot;
   },
   &quot;mqtt&quot;: {
     &quot;brokerIdleTimeout&quot;: &quot;1s&quot;
@@ -1279,7 +1279,7 @@ the resources (for authenticated clients)
 <tr>
 <td><code>userAgent</code></td>
 <td><code>string</code></td>
-<td><code class="language-json">&quot;kamu-cli&#x2F;0.263.0&quot;</code></td>
+<td><code class="language-json">&quot;kamu-cli&#x2F;0.263.1&quot;</code></td>
 <td>Value to use for User-Agent header</td>
 </tr>
 </tbody>
@@ -1739,7 +1739,7 @@ Base type: `string`
 <td><pre><code class="language-json">{
   &quot;connectTimeout&quot;: &quot;30s&quot;,
   &quot;maxRedirects&quot;: 10,
-  &quot;userAgent&quot;: &quot;kamu-cli&#x2F;0.263.0&quot;
+  &quot;userAgent&quot;: &quot;kamu-cli&#x2F;0.263.1&quot;
 }</code></pre></td>
 <td>HTTP-specific configuration</td>
 </tr>

--- a/resources/config-schema.json
+++ b/resources/config-schema.json
@@ -845,7 +845,7 @@
           "type": "integer"
         },
         "userAgent": {
-          "default": "kamu-cli/0.263.0",
+          "default": "kamu-cli/0.263.1",
           "description": "Value to use for User-Agent header",
           "type": "string"
         }
@@ -1195,7 +1195,7 @@
           "default": {
             "connectTimeout": "30s",
             "maxRedirects": 10,
-            "userAgent": "kamu-cli/0.263.0"
+            "userAgent": "kamu-cli/0.263.1"
           },
           "description": "HTTP-specific configuration"
         },
@@ -1447,7 +1447,7 @@
         "http": {
           "connectTimeout": "30s",
           "maxRedirects": 10,
-          "userAgent": "kamu-cli/0.263.0"
+          "userAgent": "kamu-cli/0.263.1"
         },
         "mqtt": {
           "brokerIdleTimeout": "1s"

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -973,7 +973,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.263.0"
+    "version": "0.263.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -973,7 +973,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.263.0"
+    "version": "0.263.1"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## [0.263.1] - 2026-05-20
### Fixed
- Elasticsearch: added ID escaping for API requests