### PR TITLE
kamu-adapter-flow-task: remove outdated dep from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,6 @@ kamu-adapter-flow-dataset = { version = "0.263.1", path = "src/adapter/flow-data
 kamu-adapter-flow-webhook = { version = "0.263.1", path = "src/adapter/flow-webhook", default-features = false }
 kamu-adapter-task-dataset = { version = "0.263.1", path = "src/adapter/task-dataset", default-features = false }
 kamu-adapter-task-webhook = { version = "0.263.1", path = "src/adapter/task-webhook", default-features = false }
-kamu-adapter-flow-task = { version = "0.242.1", path = "src/adapter/flow-task", default-features = false }
 kamu-adapter-graphql = { version = "0.263.1", path = "src/adapter/graphql", default-features = false }
 kamu-adapter-http = { version = "0.263.1", path = "src/adapter/http", default-features = false }
 kamu-adapter-odata = { version = "0.263.1", path = "src/adapter/odata", default-features = false }


### PR DESCRIPTION
Remove a reference to a dependency that no longer exists