### PR TITLE
Link datafusion as dynamic library

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,27 +30,27 @@ jobs:
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: true
-            features: ingest-ftp,web-ui
+            features: ingest-evm,ingest-ftp,ingest-mqtt,query-extensions-json,web-ui
           - name: Linux / x86_64 / musl
             runs-on: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
-            features: ingest-ftp,web-ui
+            features: ingest-evm,ingest-ftp,ingest-mqtt,query-extensions-json,web-ui
           - name: Linux / aarch64 / glibc
             runs-on: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
-            features: ingest-ftp,web-ui
+            features: ingest-evm,ingest-ftp,ingest-mqtt,query-extensions-json,web-ui
           - name: Linux / aarch64 / musl
             runs-on: ubuntu-latest
             target: aarch64-unknown-linux-musl
             use-cross: true
-            features: ingest-ftp,web-ui
+            features: ingest-evm,ingest-ftp,ingest-mqtt,query-extensions-json,web-ui
           - name: MacOS / aarch64
             runs-on: macos-14
             target: aarch64-apple-darwin
             use-cross: false
-            features: ingest-ftp,web-ui
+            features: ingest-evm,ingest-ftp,ingest-mqtt,query-extensions-json,web-ui
           # - name: Windows / x86_64
           #   runs-on: windows-latest
           #   target: x86_64-pc-windows-msvc
@@ -89,11 +89,17 @@ jobs:
 
       - name: Build
         shell: bash
+        # --no-default-features drops kamu-cli's `dynamic-datafusion` default so
+        # the released binary statically links datafusion (no libdatafusion_dylib.so
+        # runtime dependency). The features listed here re-include the other
+        # defaults (ingest-evm, ingest-mqtt, query-extensions-json) plus the
+        # release-only ones (ingest-ftp, web-ui).
         run: |
           ${{ env.CARGO }} build \
             -p kamu-cli \
             --release \
             --target=${{ matrix.target }} \
+            --no-default-features \
             --features=${{ matrix.features }}
 
       - name: Rename binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,8 +3707,97 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
+dependencies = [
+ "datafusion-core",
+ "datafusion-dylib",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "53.1.0"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "53.1.0"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "53.1.0"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow",
+ "arrow-ipc",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "hex",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "object_store",
+ "parquet",
+ "paste",
+ "recursive",
+ "sqlparser",
+ "tokio",
+ "web-time",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "53.1.0"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-core"
+version = "53.1.0"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3761,95 +3850,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-catalog"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
-dependencies = [
- "arrow",
- "async-trait",
- "dashmap",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
- "datafusion-session",
- "futures",
- "itertools 0.14.0",
- "log",
- "object_store",
- "parking_lot",
- "tokio",
-]
-
-[[package]]
-name = "datafusion-catalog-listing"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
-dependencies = [
- "arrow",
- "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "futures",
- "itertools 0.14.0",
- "log",
- "object_store",
-]
-
-[[package]]
-name = "datafusion-common"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
-dependencies = [
- "ahash 0.8.12",
- "arrow",
- "arrow-ipc",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "hex",
- "indexmap 2.14.0",
- "itertools 0.14.0",
- "libc",
- "log",
- "object_store",
- "parquet",
- "paste",
- "recursive",
- "sqlparser",
- "tokio",
- "web-time",
-]
-
-[[package]]
-name = "datafusion-common-runtime"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
-dependencies = [
- "futures",
- "log",
- "tokio",
-]
-
-[[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3883,8 +3886,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3907,8 +3909,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3930,8 +3931,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3954,8 +3954,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3984,8 +3983,15 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
+
+[[package]]
+name = "datafusion-dylib"
+version = "53.1.0"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
+dependencies = [
+ "datafusion-core",
+]
 
 [[package]]
 name = "datafusion-ethers"
@@ -4011,8 +4017,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -4035,8 +4040,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4058,8 +4062,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4071,8 +4074,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -4103,8 +4105,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4125,8 +4126,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4150,8 +4150,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4175,8 +4174,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4191,8 +4189,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4209,8 +4206,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4219,8 +4215,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4251,8 +4246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "chrono",
@@ -4271,8 +4265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4295,8 +4288,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4310,8 +4302,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4327,8 +4318,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4346,8 +4336,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4378,8 +4367,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4395,8 +4383,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4409,8 +4396,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+source = "git+https://github.com/kamu-data/datafusion?branch=53.1.0-dylib#c24043091af63a1e1e974256d41350916c390180"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -8131,20 +8117,17 @@ dependencies = [
 name = "kamu-datafusion-cli"
 version = "0.264.0"
 dependencies = [
- "arrow",
  "async-trait",
  "aws-config",
  "aws-credential-types",
  "chrono",
  "clap",
  "datafusion",
- "datafusion-common",
  "dirs",
  "futures",
  "log",
  "object_store",
  "parking_lot",
- "parquet",
  "rustyline",
  "tokio",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,13 +384,38 @@ debug = "line-tables-only"
 # Use this section to test or apply emergency overrides to dependencies
 # See: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 [patch.crates-io]
-# datafusion = { git = 'https://github.com/apache/datafusion.git', branch = 'main' }
-# datafusion-common = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
-# datafusion-execution = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
-# datafusion-expr = { git = 'https://github.com/apache/datafusion.git', tag = '42.0.0-rc1' }
-# datafusion-odata = { git = 'https://github.com/kamu-data/datafusion-odata.git', branch = '42.0.0-axum-0.6' }
-# datafusion-ethers = { git = "https://github.com/kamu-data/datafusion-ethers.git", tag = "42.0.0" }
-# object_store = { git = 'https://github.com/s373r/arrow-rs', branch = 'add-debug-logs', package = "object_store" }
 assert_cmd = { git = 'https://github.com/kamu-data/assert_cmd', branch = "deactivate-output-truncation" }
+# Use fork that lets us link datafusion as a dynamic library
+datafusion = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-catalog = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-catalog-listing = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-common = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-common-runtime = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-datasource = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-datasource-arrow = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-datasource-csv = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-datasource-json = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-datasource-parquet = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-doc = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-execution = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-expr = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-expr-common = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-functions = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-functions-aggregate = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-functions-aggregate-common = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-functions-nested = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-functions-table = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-functions-window = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-functions-window-common = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-macros = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-optimizer = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-physical-expr = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-physical-expr-adapter = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-physical-expr-common = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-physical-optimizer = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-physical-plan = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-pruning = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-session = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
+datafusion-sql = { git = "https://github.com/kamu-data/datafusion", branch = "53.1.0-dylib" }
 # dill = { path = "../dill-rs/dill" }
 # setty = { path = "../setty/setty" }

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -29,8 +29,15 @@ doctest = false
 
 
 [features]
-default = ["ingest-evm", "ingest-mqtt", "query-extensions-json"]
+default = [
+    "datafusion-dynamic",
+    "ingest-evm",
+    "ingest-mqtt",
+    "query-extensions-json",
+]
 
+# Links datafusion as a shared library to cut incremental link times during dev.
+datafusion-dynamic = ["datafusion/dynamic"]
 ingest-evm = ["kamu/ingest-evm"]
 ingest-ftp = ["kamu/ingest-ftp"]
 ingest-mqtt = ["kamu/ingest-mqtt", "dep:rumqttc"]

--- a/src/utils/datafusion-cli/Cargo.toml
+++ b/src/utils/datafusion-cli/Cargo.toml
@@ -38,7 +38,6 @@ uninlined_format_args = "allow"
 
 
 [dependencies]
-arrow = { version = "58", default-features = false }
 async-trait = "0.1"
 aws-config = "1"
 aws-credential-types = "1"
@@ -56,13 +55,11 @@ datafusion = { version = "53", features = [
     "unicode_expressions",
     "compression",
 ] }
-datafusion-common = { version = "53", default-features = false }
 dirs = "6"
 futures = "0.3"
 log = "0.4"
 object_store = { version = "0.13", features = ["aws", "gcp", "http"] }
 parking_lot = { version = "0.12" }
-parquet = { version = "58", default-features = false }
 rustyline = "18"
 tokio = { version = "1", features = [
     "macros",

--- a/src/utils/datafusion-cli/src/functions.rs
+++ b/src/utils/datafusion-cli/src/functions.rs
@@ -22,7 +22,8 @@ use std::fs::File;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use arrow::array::{
+use async_trait::async_trait;
+use datafusion::arrow::array::{
     DurationMillisecondArray,
     GenericListArray,
     Int64Array,
@@ -31,26 +32,25 @@ use arrow::array::{
     TimestampMillisecondArray,
     UInt64Array,
 };
-use arrow::buffer::{Buffer, OffsetBuffer, ScalarBuffer};
-use arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef, TimeUnit};
-use arrow::record_batch::RecordBatch;
-use arrow::util::pretty::pretty_format_batches;
-use async_trait::async_trait;
+use datafusion::arrow::buffer::{Buffer, OffsetBuffer, ScalarBuffer};
+use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef, TimeUnit};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::catalog::{Session, TableFunctionImpl};
+use datafusion::common::instant::Instant;
 use datafusion::common::{Column, plan_err};
 use datafusion::datasource::TableProvider;
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::error::Result;
 use datafusion::execution::cache::cache_manager::CacheManager;
 use datafusion::logical_expr::Expr;
+use datafusion::parquet::basic::ConvertedType;
+use datafusion::parquet::data_type::{ByteArray, FixedLenByteArray};
+use datafusion::parquet::file::reader::FileReader;
+use datafusion::parquet::file::serialized_reader::SerializedFileReader;
+use datafusion::parquet::file::statistics::Statistics;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::scalar::ScalarValue;
-use datafusion_common::instant::Instant;
-use parquet::basic::ConvertedType;
-use parquet::data_type::{ByteArray, FixedLenByteArray};
-use parquet::file::reader::FileReader;
-use parquet::file::serialized_reader::SerializedFileReader;
-use parquet::file::statistics::Statistics;
 
 #[derive(Debug)]
 pub enum Function {

--- a/src/utils/datafusion-cli/src/helper.rs
+++ b/src/utils/datafusion-cli/src/helper.rs
@@ -22,9 +22,9 @@
 use std::borrow::Cow;
 use std::cell::Cell;
 
+use datafusion::config::Dialect;
 use datafusion::sql::parser::{DFParser, Statement};
 use datafusion::sql::sqlparser::dialect::dialect_from_str;
-use datafusion_common::config::Dialect;
 use rustyline::completion::{Completer, FilenameCompleter, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::highlight::{CmdKind, Highlighter};

--- a/src/utils/datafusion-cli/src/highlighter.rs
+++ b/src/utils/datafusion-cli/src/highlighter.rs
@@ -20,10 +20,10 @@
 use std::borrow::Cow::{self, Borrowed};
 use std::fmt::Display;
 
+use datafusion::config;
 use datafusion::sql::sqlparser::dialect::{Dialect, GenericDialect, dialect_from_str};
 use datafusion::sql::sqlparser::keywords::Keyword;
 use datafusion::sql::sqlparser::tokenizer::{Token, Tokenizer};
-use datafusion_common::config;
 use rustyline::highlight::{CmdKind, Highlighter};
 
 /// The syntax highlighter.

--- a/src/utils/datafusion-cli/src/object_storage/instrumented.rs
+++ b/src/utils/datafusion-cli/src/object_storage/instrumented.rs
@@ -22,10 +22,10 @@ use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::time::Duration;
 use std::{cmp, fmt};
 
-use arrow::array::{ArrayRef, RecordBatch, StringArray};
-use arrow::util::pretty::pretty_format_batches;
 use async_trait::async_trait;
 use chrono::Utc;
+use datafusion::arrow::array::{ArrayRef, RecordBatch, StringArray};
+use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::common::HashMap;
 use datafusion::common::instant::Instant;
 use datafusion::error::DataFusionError;

--- a/src/utils/datafusion-cli/src/print_format.rs
+++ b/src/utils/datafusion-cli/src/print_format.rs
@@ -19,11 +19,11 @@
 
 use std::str::FromStr;
 
-use arrow::csv::writer::WriterBuilder;
-use arrow::datatypes::SchemaRef;
-use arrow::json::{ArrayWriter, LineDelimitedWriter};
-use arrow::record_batch::RecordBatch;
-use arrow::util::pretty::pretty_format_batches_with_options;
+use datafusion::arrow::csv::writer::WriterBuilder;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::json::{ArrayWriter, LineDelimitedWriter};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::pretty::pretty_format_batches_with_options;
 use datafusion::config::FormatOptions;
 use datafusion::error::Result;
 
@@ -112,7 +112,7 @@ fn format_batches_with_maxrows<W: std::io::Write>(
     maxrows: MaxRows,
     format_options: &FormatOptions,
 ) -> Result<()> {
-    let options: arrow::util::display::FormatOptions = format_options.try_into()?;
+    let options: datafusion::arrow::util::display::FormatOptions = format_options.try_into()?;
 
     match maxrows {
         MaxRows::Limited(maxrows) => {
@@ -199,7 +199,7 @@ impl PrintFormat {
         match self {
             // Print column headers for Table format
             Self::Table if !schema.fields().is_empty() => {
-                let format_options: arrow::util::display::FormatOptions =
+                let format_options: datafusion::arrow::util::display::FormatOptions =
                     format_options.try_into()?;
 
                 let empty_batch = RecordBatch::new_empty(schema);

--- a/src/utils/datafusion-cli/src/print_options.rs
+++ b/src/utils/datafusion-cli/src/print_options.rs
@@ -21,8 +21,8 @@ use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use arrow::datatypes::SchemaRef;
-use arrow::record_batch::RecordBatch;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::DataFusionError;
 use datafusion::common::instant::Instant;
 use datafusion::config::FormatOptions;


### PR DESCRIPTION
Related to: https://github.com/apache/datafusion/issues/6470

## Description
- Created a [tiny fork](https://github.com/apache/datafusion/compare/53.1.0...kamu-data:datafusion:53.1.0-dylib?expand=1) of `datafusion` that uses a technique from `bevy` engine to add dynamic linking option as a crate feature
- The `datafusion-dynamic` is a default feature in `kamu-cli` and through workspace feature unification it enables dynamic linking in all tests
- Release build disables default features to link statically as before
- `dev` build size impact:
  - reduces from 37 to 25 GiB without debug symbols
  - reduces from 112 GiB to 56 GiB with full debug symbols

## How it works
In the fork:
- `datafusion` becomes a facade library that links:
  - `datafusion-core` - the main guts
  - (optionally via feature) `datafusion-dylib`
- `datafusion-dylib` is a dynamic crate that also links the entire `datafusion-core`
- When the feature is enabled and `datafusion-dylib` is linked - the linker sees two sets of same symbols (one from a static and one from dynamic lib) and it automatically prefers the dynamic lib

## Downsides
- Fork maintenance - should be simple, the worst part is needing to propagate all features from the facade into guts crate
- Cargo patching - currently needs to list ALL datafusion libraries

Ideally we would some day upstream this into `datafusion` and the hacky stuff will go away.