### PR TITLE
fix: return JSON for authentication policy errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Recommendation: for ease of reading, use the following format:
 
 # [Unreleased]
 ### Fixed
+- Return JSON responses for authentication policy errors (#1675)
 - Restored decimal type support in DDL schema (#1670)
 
 ## [0.265.0] - 2026-07-27

--- a/src/adapter/http/src/middleware/auth_policy_layer.rs
+++ b/src/adapter/http/src/middleware/auth_policy_layer.rs
@@ -11,7 +11,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use axum::body::Body;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use graphql_parser::query::{Definition, parse_query};
 use http::{Request, StatusCode};
 use http_body_util::BodyExt;
@@ -57,10 +57,13 @@ impl<Svc> AuthPolicyMiddleware<Svc> {
 
         match current_account_subject.as_ref() {
             CurrentAccountSubject::Logged(_) => Ok(()),
-            CurrentAccountSubject::Anonymous(_) => Err(Response::builder()
-                .status(StatusCode::UNAUTHORIZED)
-                .body("Anonymous account is restricted".into())
-                .unwrap()),
+            CurrentAccountSubject::Anonymous(_) => Err((
+                StatusCode::UNAUTHORIZED,
+                axum::Json(http_common::ApiErrorResponse {
+                    message: "Anonymous account is restricted".to_string(),
+                }),
+            )
+                .into_response()),
         }
     }
 
@@ -162,5 +165,35 @@ where
 
             inner.call(request).await
         })
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_anonymous_subject_error_is_json() {
+        let mut catalog_builder = dill::CatalogBuilder::new();
+        catalog_builder.add_value(CurrentAccountSubject::anonymous(
+            kamu_accounts::AnonymousAccountReason::NoAuthenticationProvided,
+        ));
+        let catalog = catalog_builder.build();
+
+        let response = AuthPolicyMiddleware::<()>::check_http_subject(&catalog).unwrap_err();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response.headers()[http::header::CONTENT_TYPE],
+            "application/json"
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            serde_json::from_slice::<Value>(&body).unwrap(),
+            serde_json::json!({"message": "Anonymous account is restricted"})
+        );
     }
 }


### PR DESCRIPTION
## Description

Closes: #1675

I changed the authentication policy middleware to return its early `401 Unauthorized` response as JSON instead of plain text. The response now uses the same `{ "message": "..." }` shape as other HTTP API errors and includes the `application/json` content type.

I also added a focused regression test for the status, content type, and parsed response body, and documented the fix in the changelog.

## Validation

- `cargo test -p kamu-adapter-http --lib test_anonymous_subject_error_is_json -- --nocapture` (1 passed)
- `cargo clippy -p kamu-adapter-http --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/master...HEAD`

I deferred the full workspace test suite to CI because the initial local workspace compilation exceeded the available storage quota. I reran the focused test and package-level Clippy successfully with reduced debug artifacts.

## Checklist before requesting a review

- [x] Unit and integration tests added
- [x] Compatibility: the change only affects the error response representation
- [x] Observability: no new signals are required for this response-format fix
- [x] Documentation: changelog updated; no public documentation change is required
- [x] Downstream effects: none expected
