### PR TITLE
Release (minor) 0.266.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ on:
 env:
   PACKAGE_NAME: kamu-cli
   BINARY_NAME: kamu
-  KAMU_WEB_UI_VERSION: "0.68.0"
+  KAMU_WEB_UI_VERSION: "0.69.0"
 jobs:
   build:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Recommendation: for ease of reading, use the following format:
 ### Fixed
 -->
 
-# [Unreleased]
+## [0.266.0] - 2026-08-13
 ### Added:
 - `MySqlDatasetEntryRepository` has been implemented:
   - To fix a previously masked error w/ dataset searching in E2E tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "async-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "common-macros"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -3246,7 +3246,7 @@ checksum = "136d3e02915a2cea4d74caa8681e2d44b1c3254bdbf17d11d41d587ff858832c"
 
 [[package]]
 name = "container-runtime"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-eip712-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "alloy-core",
  "alloy-signer",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "database-common"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "email-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "schemars 1.2.2",
  "serde",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.265.0"
+version = "0.266.0"
 
 [[package]]
 name = "env_filter"
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -5237,7 +5237,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "file-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "fs_extra",
  "serde",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "format-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "pretty_assertions",
 ]
@@ -5661,7 +5661,7 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "graphql-http"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-graphql",
  "axum",
@@ -6164,7 +6164,7 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "axum",
  "http 1.5.0",
@@ -6594,7 +6594,7 @@ dependencies = [
 
 [[package]]
 name = "init-on-startup"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "bon",
@@ -6636,7 +6636,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "thiserror 2.0.20",
 ]
@@ -7136,7 +7136,7 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "alloy",
  "alloy-provider",
@@ -7222,7 +7222,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -7262,7 +7262,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-mysql"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7308,7 +7308,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7334,7 +7334,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "argon2",
  "chrono",
@@ -7355,7 +7355,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "bon",
@@ -7403,7 +7403,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7429,7 +7429,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7463,7 +7463,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-web3"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7492,7 +7492,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -7525,7 +7525,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flow-dataset"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7555,7 +7555,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flow-webhook"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7589,7 +7589,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -7668,7 +7668,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -7744,7 +7744,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -7761,7 +7761,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -7806,7 +7806,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-task-dataset"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "common-macros",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-task-webhook"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -7841,7 +7841,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "indoc 2.0.7",
@@ -7861,7 +7861,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -7875,7 +7875,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7891,7 +7891,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "dill",
  "kamu-auth-rebac",
@@ -7900,7 +7900,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7925,7 +7925,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -7942,7 +7942,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7958,7 +7958,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7973,7 +7973,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "chrono",
  "dill",
@@ -8001,7 +8001,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8016,7 +8016,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-web3-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8034,7 +8034,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -8187,7 +8187,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -8217,7 +8217,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -8225,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-example-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -8234,7 +8234,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-mysql"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "database-common",
  "indoc 2.0.7",
@@ -8247,7 +8247,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "database-common",
  "indoc 2.0.7",
@@ -8260,7 +8260,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-graphql",
  "chrono",
@@ -8289,7 +8289,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "indoc 2.0.7",
  "kamu-cli-e2e-common",
@@ -8301,7 +8301,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -8321,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -8353,7 +8353,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-cli"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -8376,7 +8376,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datafusion-udf"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "datafusion",
  "indoc 2.0.7",
@@ -8389,7 +8389,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8426,7 +8426,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "cheap-clone",
@@ -8448,7 +8448,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-mysql"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8494,7 +8494,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -8513,7 +8513,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "arrow",
  "async-stream",
@@ -8579,7 +8579,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8604,7 +8604,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -8633,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8659,7 +8659,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8686,7 +8686,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "chrono",
  "csv",
@@ -8709,7 +8709,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8779,7 +8779,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8812,7 +8812,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "database-common-macros",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8851,7 +8851,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "chrono",
  "dill",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "chrono",
  "clap",
@@ -8904,7 +8904,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8921,7 +8921,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-cache-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "cheap-clone",
@@ -8938,7 +8938,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-cache-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8957,7 +8957,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-cache-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "chrono",
  "dill",
@@ -8967,7 +8967,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-cache-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8986,7 +8986,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-elasticsearch"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "canonical_json",
@@ -9021,7 +9021,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-elasticsearch-macros"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9030,7 +9030,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-openai"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -9044,7 +9044,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9066,7 +9066,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-signing"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "bon",
@@ -9083,7 +9083,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-signing-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "bon",
@@ -9111,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9133,7 +9133,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "database-common",
@@ -9150,7 +9150,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9170,7 +9170,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -9183,7 +9183,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -9216,7 +9216,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9263,7 +9263,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-postgres"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9307,7 +9307,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-repo-tests"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "chrono",
  "database-common",
@@ -9324,7 +9324,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-services"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -9362,7 +9362,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-webhooks-sqlite"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9886,7 +9886,7 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10059,7 +10059,7 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "base64",
  "bs58 0.5.1",
@@ -10477,7 +10477,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -10565,7 +10565,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -10580,7 +10580,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-data-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -10608,7 +10608,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10633,7 +10633,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset-impl"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "arrow",
  "async-stream",
@@ -10675,7 +10675,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-metadata"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "arrow",
  "base64",
@@ -10712,7 +10712,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10734,7 +10734,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-http"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10757,7 +10757,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-inmem"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10773,7 +10773,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-lfs"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -10792,7 +10792,7 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-s3"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -12087,7 +12087,7 @@ dependencies = [
 
 [[package]]
 name = "random-strings"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "rand 0.9.5",
 ]
@@ -12831,7 +12831,7 @@ checksum = "700de91d5fd6091442d00fdd9ee790af6d4f0f480562b0f5a1e8f59e90aafe73"
 
 [[package]]
 name = "s3-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -13207,7 +13207,7 @@ dependencies = [
 
 [[package]]
 name = "server-console"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-graphql",
  "axum",
@@ -14294,7 +14294,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "axum",
  "container-runtime",
@@ -14427,7 +14427,7 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -14854,7 +14854,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto"
-version = "0.265.0"
+version = "0.266.0"
 dependencies = [
  "conv",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36ddb69f5e41407e7a93aead3480f7c8ff076e73d01a951ae8f7ea4542c1ca0"
+checksum = "e5fdcfed8f106be3df944054aaa42bc13ae103a3ac8a9f4b08d4f053e3a743f8"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -196,7 +196,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -276,14 +276,14 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+checksum = "e64579d931b3f8eacc7c9ab0b220e87e9c4816e5c724ede1947b55c2f8e92ae5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -301,7 +301,7 @@ dependencies = [
  "alloy-rlp",
  "borsh",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -315,7 +315,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -379,7 +379,7 @@ dependencies = [
  "http 1.5.0",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -406,7 +406,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -486,7 +486,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -591,7 +591,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -724,7 +724,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower",
  "tracing",
@@ -779,7 +779,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -1522,7 +1522,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "static_assertions_next",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -1557,7 +1557,7 @@ dependencies = [
  "quote",
  "strum 0.27.2",
  "syn 2.0.119",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1623,7 +1623,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -2083,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -2146,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -2212,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -2500,6 +2500,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -2686,9 +2692,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -2820,7 +2826,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2844,7 +2850,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2855,9 +2861,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3254,7 +3260,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -3474,7 +3480,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -3561,7 +3567,7 @@ dependencies = [
  "argon2",
  "internal-error",
  "password-hash",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3804,7 +3810,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -4116,7 +4122,7 @@ dependencies = [
  "datafusion",
  "futures",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -4353,7 +4359,7 @@ dependencies = [
  "quick-xml 0.40.1",
  "regex",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -4550,6 +4556,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4699,7 +4736,7 @@ dependencies = [
  "dill-impl",
  "indoc 2.0.7",
  "multimap",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4761,7 +4798,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -4937,7 +4974,7 @@ version = "0.265.0"
 dependencies = [
  "schemars 1.2.2",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "validator",
 ]
 
@@ -5101,7 +5138,7 @@ dependencies = [
  "futures",
  "internal-error",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5128,10 +5165,11 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.12"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+checksum = "c08309dbcc659c5549a24ddb9b27027640641b282ef5768267c7e675558986a3"
 dependencies = [
+ "autocfg",
  "indenter",
  "once_cell",
 ]
@@ -5270,7 +5308,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "rustc_version 0.4.1",
 ]
 
@@ -5374,9 +5412,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -5389,9 +5427,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5399,15 +5437,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -5427,9 +5465,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -5443,26 +5481,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -5472,9 +5510,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -5537,7 +5575,7 @@ dependencies = [
  "rstar 0.8.4",
  "rstar 0.9.3",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5550,7 +5588,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
 ]
 
@@ -5741,9 +5779,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.4.1"
+version = "6.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43ccdfe15a81ab0a8af639e90254227c9a46afd9c5f5b6ec7efaa345c4b0f00"
+checksum = "75c54236f9045c8004a77942bebc52145b4844639db934a5c70fe08617fbe61a"
 dependencies = [
  "derive_builder",
  "log",
@@ -5752,7 +5790,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5974,7 +6012,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -5995,7 +6033,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "url",
@@ -6022,7 +6060,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -6113,9 +6151,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6136,7 +6174,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "utoipa",
 ]
@@ -6567,7 +6605,7 @@ dependencies = [
  "petgraph 0.8.3",
  "pretty_assertions",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -6600,7 +6638,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 name = "internal-error"
 version = "0.265.0"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6708,6 +6746,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jiter"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6734,7 +6825,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -6783,9 +6874,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -7120,7 +7211,7 @@ dependencies = [
  "test-log",
  "test-utils",
  "testing_logger",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -7163,7 +7254,7 @@ dependencies = [
  "setty",
  "sqlx",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
  "uuid",
  "zeroize",
@@ -7303,7 +7394,7 @@ dependencies = [
  "setty",
  "test-group",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tracing",
@@ -7364,7 +7455,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tracing",
@@ -7392,7 +7483,7 @@ dependencies = [
  "serde_json",
  "siwe",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "time-source",
  "tokio",
@@ -7456,7 +7547,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tracing",
@@ -7567,7 +7658,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tracing",
@@ -7636,7 +7727,7 @@ dependencies = [
  "test-group",
  "test-log",
  "test-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -7665,7 +7756,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7765,7 +7856,7 @@ dependencies = [
  "serde",
  "sqlx",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7862,7 +7953,7 @@ dependencies = [
  "regex",
  "siwe",
  "sqlx",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8071,7 +8162,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -8119,7 +8210,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml_ng",
  "sqlx",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-retry",
 ]
@@ -8253,7 +8344,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -8326,7 +8417,7 @@ dependencies = [
  "setty",
  "sqlx",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "urlencoding",
@@ -8476,7 +8567,7 @@ dependencies = [
  "test-group",
  "test-log",
  "test-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -8535,7 +8626,7 @@ dependencies = [
  "serde_with",
  "sqlx",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio-stream",
  "tracing",
 ]
@@ -8712,7 +8803,7 @@ dependencies = [
  "tempfile",
  "test-group",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "walkdir",
@@ -8825,7 +8916,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8920,7 +9011,7 @@ dependencies = [
  "sha2 0.11.0",
  "test-group",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tracing",
@@ -8986,7 +9077,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "setty",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "utoipa",
 ]
 
@@ -9035,7 +9126,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio-stream",
  "uuid",
 ]
@@ -9165,7 +9256,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
  "uuid",
 ]
@@ -9186,7 +9277,7 @@ dependencies = [
  "opendatafabric",
  "test-group",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -9261,7 +9352,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tracing",
@@ -9517,18 +9608,18 @@ dependencies = [
 
 [[package]]
 name = "liblzma"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aec2360b3933207e27908049d8e4df4e476b58180afb1e56b2a4fb72efe4ba"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
 dependencies = [
  "liblzma-sys",
 ]
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a046c7f353ba30f810545151e04f63545833803f5b86ee3ddf1517247fe560a5"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
 dependencies = [
  "cc",
  "libc",
@@ -9547,10 +9638,10 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.1",
+ "redox_syscall 0.9.2",
 ]
 
 [[package]]
@@ -9817,7 +9908,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tracing",
@@ -9872,7 +9963,7 @@ dependencies = [
  "parking_lot",
  "regex",
  "textwrap",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9915,9 +10006,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -9982,7 +10073,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unsigned-varint 0.8.0",
  "utoipa",
 ]
@@ -10032,7 +10123,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -10156,9 +10247,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -10175,9 +10266,9 @@ dependencies = [
 
 [[package]]
 name = "num-modular"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+checksum = "bd8e500409e6cd603b03e477c26a6caecdc27ac58979a53e881c75eafc079f44"
 
 [[package]]
 name = "num-order"
@@ -10303,7 +10394,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -10314,7 +10405,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -10331,7 +10422,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -10375,7 +10466,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -10400,7 +10491,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tower",
  "tower-http",
  "tracing",
@@ -10509,7 +10600,7 @@ dependencies = [
  "sha3 0.10.9",
  "test-group",
  "test-log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -10534,7 +10625,7 @@ dependencies = [
  "s3-utils",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio-stream",
  "tracing",
  "url",
@@ -10574,7 +10665,7 @@ dependencies = [
  "test-group",
  "test-log",
  "test-utils",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time-source",
  "tokio",
  "tokio-stream",
@@ -10588,7 +10679,7 @@ version = "0.265.0"
 dependencies = [
  "arrow",
  "base64",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "chrono",
  "digest 0.10.7",
@@ -10612,7 +10703,7 @@ dependencies = [
  "sqlx",
  "ssi-caips",
  "strum 0.28.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tonic",
  "tonic-prost",
  "url",
@@ -10636,7 +10727,7 @@ dependencies = [
  "pretty_assertions",
  "random-strings",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "url",
 ]
@@ -10770,7 +10861,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -10785,7 +10876,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
 ]
@@ -10821,7 +10912,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -11107,9 +11198,9 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -11117,9 +11208,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -11127,9 +11218,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -11140,9 +11231,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -11404,9 +11495,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -11655,7 +11746,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -11664,7 +11755,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -11809,7 +11900,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.43",
  "socket2 0.6.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -11831,7 +11922,7 @@ dependencies = [
  "rustls 0.23.43",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -12092,16 +12183,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -12123,7 +12214,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -12513,7 +12604,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-webpki 0.102.8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-stream",
@@ -12594,7 +12685,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -12624,7 +12715,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki 0.103.14",
  "subtle",
  "zeroize",
 ]
@@ -12683,9 +12774,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -12705,7 +12796,7 @@ version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "clipboard-win",
  "home",
@@ -12904,7 +12995,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -13060,9 +13151,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64",
  "bs58 0.5.1",
@@ -13070,6 +13161,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
  "serde_core",
@@ -13080,9 +13172,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -13138,7 +13230,7 @@ dependencies = [
  "serde_with",
  "serde_yaml_ng",
  "setty-derive",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -13534,7 +13626,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -13589,7 +13681,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -13619,7 +13711,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
  "whoami",
@@ -13633,7 +13725,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -13658,7 +13750,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
  "whoami",
@@ -13684,7 +13776,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "url",
  "uuid",
@@ -13716,7 +13808,7 @@ dependencies = [
  "ssi-crypto",
  "ssi-eip712",
  "ssi-json-ld",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -13734,7 +13826,7 @@ dependencies = [
  "async-trait",
  "pin-project",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -13795,7 +13887,7 @@ dependencies = [
  "ssi-contexts",
  "ssi-rdf",
  "static-iref",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -14081,7 +14173,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -14243,11 +14335,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -14263,9 +14355,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14616,7 +14708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -14670,7 +14762,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -14824,7 +14916,7 @@ dependencies = [
  "rustls 0.23.43",
  "rustls-pki-types",
  "sha1 0.10.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
@@ -14843,7 +14935,7 @@ dependencies = [
  "rustls 0.23.43",
  "rustls-pki-types",
  "sha1 0.10.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -15225,9 +15317,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -15238,9 +15330,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -15248,9 +15340,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -15258,9 +15350,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -15271,9 +15363,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -15307,9 +15399,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -15668,7 +15760,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,152 +143,152 @@ resolver = "3"
 
 [workspace.dependencies]
 # Apps
-kamu-cli = { version = "0.265.0", path = "src/app/cli", default-features = false }
+kamu-cli = { version = "0.266.0", path = "src/app/cli", default-features = false }
 
 # Utils
-async-utils = { version = "0.265.0", path = "src/utils/async-utils", default-features = false }
-common-macros = { version = "0.265.0", path = "src/utils/common-macros", default-features = false }
-container-runtime = { version = "0.265.0", path = "src/utils/container-runtime", default-features = false }
-crypto-eip712-utils = { version = "0.265.0", path = "src/utils/crypto-eip712-utils", default-features = false }
-crypto-utils = { version = "0.265.0", path = "src/utils/crypto-utils", default-features = false }
-database-common = { version = "0.265.0", path = "src/utils/database-common", default-features = false }
-database-common-macros = { version = "0.265.0", path = "src/utils/database-common-macros", default-features = false }
-email-utils = { version = "0.265.0", path = "src/utils/email-utils", default-features = false }
-enum-variants = { version = "0.265.0", path = "src/utils/enum-variants", default-features = false }
-event-sourcing = { version = "0.265.0", path = "src/utils/event-sourcing", default-features = false }
-event-sourcing-macros = { version = "0.265.0", path = "src/utils/event-sourcing-macros", default-features = false }
-file-utils = { version = "0.265.0", path = "src/utils/file-utils", default-features = false }
-format-utils = { version = "0.265.0", path = "src/utils/format-utils", default-features = false }
-graphql-http = { version = "0.265.0", path = "src/utils/graphql-http", default-features = false }
-http-common = { version = "0.265.0", path = "src/utils/http-common", default-features = false }
-init-on-startup = { version = "0.265.0", path = "src/utils/init-on-startup", default-features = false }
-internal-error = { version = "0.265.0", path = "src/utils/internal-error", default-features = false }
-kamu-cli-puppet = { version = "0.265.0", path = "src/utils/kamu-cli-puppet", default-features = false }
-kamu-datafusion-cli = { version = "0.265.0", path = "src/utils/datafusion-cli", default-features = false }
-messaging-outbox = { version = "0.265.0", path = "src/utils/messaging-outbox", default-features = false }
-multiformats = { version = "0.265.0", path = "src/utils/multiformats", default-features = false }
-observability = { version = "0.265.0", path = "src/utils/observability", default-features = false }
-random-strings = { version = "0.265.0", path = "src/utils/random-strings", default-features = false }
-s3-utils = { version = "0.265.0", path = "src/utils/s3-utils", default-features = false }
-server-console = { version = "0.265.0", path = "src/utils/server-console", default-features = false }
-test-utils = { version = "0.265.0", path = "src/utils/test-utils", default-features = false }
-time-source = { version = "0.265.0", path = "src/utils/time-source", default-features = false }
-tracing-perfetto = { version = "0.265.0", path = "src/utils/tracing-perfetto", default-features = false }
+async-utils = { version = "0.266.0", path = "src/utils/async-utils", default-features = false }
+common-macros = { version = "0.266.0", path = "src/utils/common-macros", default-features = false }
+container-runtime = { version = "0.266.0", path = "src/utils/container-runtime", default-features = false }
+crypto-eip712-utils = { version = "0.266.0", path = "src/utils/crypto-eip712-utils", default-features = false }
+crypto-utils = { version = "0.266.0", path = "src/utils/crypto-utils", default-features = false }
+database-common = { version = "0.266.0", path = "src/utils/database-common", default-features = false }
+database-common-macros = { version = "0.266.0", path = "src/utils/database-common-macros", default-features = false }
+email-utils = { version = "0.266.0", path = "src/utils/email-utils", default-features = false }
+enum-variants = { version = "0.266.0", path = "src/utils/enum-variants", default-features = false }
+event-sourcing = { version = "0.266.0", path = "src/utils/event-sourcing", default-features = false }
+event-sourcing-macros = { version = "0.266.0", path = "src/utils/event-sourcing-macros", default-features = false }
+file-utils = { version = "0.266.0", path = "src/utils/file-utils", default-features = false }
+format-utils = { version = "0.266.0", path = "src/utils/format-utils", default-features = false }
+graphql-http = { version = "0.266.0", path = "src/utils/graphql-http", default-features = false }
+http-common = { version = "0.266.0", path = "src/utils/http-common", default-features = false }
+init-on-startup = { version = "0.266.0", path = "src/utils/init-on-startup", default-features = false }
+internal-error = { version = "0.266.0", path = "src/utils/internal-error", default-features = false }
+kamu-cli-puppet = { version = "0.266.0", path = "src/utils/kamu-cli-puppet", default-features = false }
+kamu-datafusion-cli = { version = "0.266.0", path = "src/utils/datafusion-cli", default-features = false }
+messaging-outbox = { version = "0.266.0", path = "src/utils/messaging-outbox", default-features = false }
+multiformats = { version = "0.266.0", path = "src/utils/multiformats", default-features = false }
+observability = { version = "0.266.0", path = "src/utils/observability", default-features = false }
+random-strings = { version = "0.266.0", path = "src/utils/random-strings", default-features = false }
+s3-utils = { version = "0.266.0", path = "src/utils/s3-utils", default-features = false }
+server-console = { version = "0.266.0", path = "src/utils/server-console", default-features = false }
+test-utils = { version = "0.266.0", path = "src/utils/test-utils", default-features = false }
+time-source = { version = "0.266.0", path = "src/utils/time-source", default-features = false }
+tracing-perfetto = { version = "0.266.0", path = "src/utils/tracing-perfetto", default-features = false }
 
 # Domain
-kamu-accounts = { version = "0.265.0", path = "src/domain/accounts/domain", default-features = false }
-kamu-auth-rebac = { version = "0.265.0", path = "src/domain/auth-rebac/domain", default-features = false }
-kamu-auth-web3 = { version = "0.265.0", path = "src/domain/auth-web3/domain", default-features = false }
-kamu-signing = { version = "0.265.0", path = "src/domain/signing/domain", default-features = false }
-kamu-core = { version = "0.265.0", path = "src/domain/core", default-features = false }
-kamu-datasets = { version = "0.265.0", path = "src/domain/datasets/domain", default-features = false }
-kamu-flow-system = { version = "0.265.0", path = "src/domain/flow-system/domain", default-features = false }
-kamu-search = { version = "0.265.0", path = "src/domain/search/domain", default-features = false }
-kamu-task-system = { version = "0.265.0", path = "src/domain/task-system/domain", default-features = false }
-kamu-webhooks = { version = "0.265.0", path = "src/domain/webhooks/domain", default-features = false }
+kamu-accounts = { version = "0.266.0", path = "src/domain/accounts/domain", default-features = false }
+kamu-auth-rebac = { version = "0.266.0", path = "src/domain/auth-rebac/domain", default-features = false }
+kamu-auth-web3 = { version = "0.266.0", path = "src/domain/auth-web3/domain", default-features = false }
+kamu-signing = { version = "0.266.0", path = "src/domain/signing/domain", default-features = false }
+kamu-core = { version = "0.266.0", path = "src/domain/core", default-features = false }
+kamu-datasets = { version = "0.266.0", path = "src/domain/datasets/domain", default-features = false }
+kamu-flow-system = { version = "0.266.0", path = "src/domain/flow-system/domain", default-features = false }
+kamu-search = { version = "0.266.0", path = "src/domain/search/domain", default-features = false }
+kamu-task-system = { version = "0.266.0", path = "src/domain/task-system/domain", default-features = false }
+kamu-webhooks = { version = "0.266.0", path = "src/domain/webhooks/domain", default-features = false }
 
 ## Open Data Fabric
-odf = { version = "0.265.0", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
-odf-metadata = { version = "0.265.0", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
-odf-dataset = { version = "0.265.0", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
-odf-data-utils = { version = "0.265.0", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
-odf-dataset-impl = { version = "0.265.0", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
-odf-storage = { version = "0.265.0", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
-odf-storage-http = { version = "0.265.0", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
-odf-storage-inmem = { version = "0.265.0", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
-odf-storage-lfs = { version = "0.265.0", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
-odf-storage-s3 = { version = "0.265.0", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
+odf = { version = "0.266.0", path = "src/odf/odf", default-features = false, package = "opendatafabric" }
+odf-metadata = { version = "0.266.0", path = "src/odf/metadata", default-features = false, package = "opendatafabric-metadata" }
+odf-dataset = { version = "0.266.0", path = "src/odf/dataset", default-features = false, package = "opendatafabric-dataset" }
+odf-data-utils = { version = "0.266.0", path = "src/odf/data-utils", default-features = false, package = "opendatafabric-data-utils" }
+odf-dataset-impl = { version = "0.266.0", path = "src/odf/dataset-impl", default-features = false, package = "opendatafabric-dataset-impl" }
+odf-storage = { version = "0.266.0", path = "src/odf/storage", default-features = false, package = "opendatafabric-storage" }
+odf-storage-http = { version = "0.266.0", path = "src/odf/storage-http", default-features = false, package = "opendatafabric-storage-http" }
+odf-storage-inmem = { version = "0.266.0", path = "src/odf/storage-inmem", default-features = false, package = "opendatafabric-storage-inmem" }
+odf-storage-lfs = { version = "0.266.0", path = "src/odf/storage-lfs", default-features = false, package = "opendatafabric-storage-lfs" }
+odf-storage-s3 = { version = "0.266.0", path = "src/odf/storage-s3", default-features = false, package = "opendatafabric-storage-s3" }
 
 # Domain service layer
-kamu-accounts-services = { version = "0.265.0", path = "src/domain/accounts/services", default-features = false }
-kamu-auth-rebac-services = { version = "0.265.0", path = "src/domain/auth-rebac/services", default-features = false }
-kamu-auth-web3-services = { version = "0.265.0", path = "src/domain/auth-web3/services", default-features = false }
-kamu-signing-services = { version = "0.265.0", path = "src/domain/signing/services", default-features = false }
-kamu-datasets-services = { version = "0.265.0", path = "src/domain/datasets/services", default-features = false, features = [
+kamu-accounts-services = { version = "0.266.0", path = "src/domain/accounts/services", default-features = false }
+kamu-auth-rebac-services = { version = "0.266.0", path = "src/domain/auth-rebac/services", default-features = false }
+kamu-auth-web3-services = { version = "0.266.0", path = "src/domain/auth-web3/services", default-features = false }
+kamu-signing-services = { version = "0.266.0", path = "src/domain/signing/services", default-features = false }
+kamu-datasets-services = { version = "0.266.0", path = "src/domain/datasets/services", default-features = false, features = [
     "lfs",
     "s3",
 ] }
-kamu-flow-system-services = { version = "0.265.0", path = "src/domain/flow-system/services", default-features = false }
-kamu-search-services = { version = "0.265.0", path = "src/domain/search/services", default-features = false }
-kamu-task-system-services = { version = "0.265.0", path = "src/domain/task-system/services", default-features = false }
-kamu-webhooks-services = { version = "0.265.0", path = "src/domain/webhooks/services", default-features = false }
+kamu-flow-system-services = { version = "0.266.0", path = "src/domain/flow-system/services", default-features = false }
+kamu-search-services = { version = "0.266.0", path = "src/domain/search/services", default-features = false }
+kamu-task-system-services = { version = "0.266.0", path = "src/domain/task-system/services", default-features = false }
+kamu-webhooks-services = { version = "0.266.0", path = "src/domain/webhooks/services", default-features = false }
 
 # Infra
-kamu = { version = "0.265.0", path = "src/infra/core", default-features = false }
-kamu-datafusion-udf = { version = "0.265.0", path = "src/infra/datafusion-udf", default-features = false }
-kamu-ingest-datafusion = { version = "0.265.0", path = "src/infra/ingest-datafusion", default-features = false }
+kamu = { version = "0.266.0", path = "src/infra/core", default-features = false }
+kamu-datafusion-udf = { version = "0.266.0", path = "src/infra/datafusion-udf", default-features = false }
+kamu-ingest-datafusion = { version = "0.266.0", path = "src/infra/ingest-datafusion", default-features = false }
 ## Flow System
-kamu-flow-system-repo-tests = { version = "0.265.0", path = "src/infra/flow-system/repo-tests", default-features = false }
-kamu-flow-system-inmem = { version = "0.265.0", path = "src/infra/flow-system/inmem", default-features = false }
-kamu-flow-system-postgres = { version = "0.265.0", path = "src/infra/flow-system/postgres", default-features = false }
-kamu-flow-system-sqlite = { version = "0.265.0", path = "src/infra/flow-system/sqlite", default-features = false }
+kamu-flow-system-repo-tests = { version = "0.266.0", path = "src/infra/flow-system/repo-tests", default-features = false }
+kamu-flow-system-inmem = { version = "0.266.0", path = "src/infra/flow-system/inmem", default-features = false }
+kamu-flow-system-postgres = { version = "0.266.0", path = "src/infra/flow-system/postgres", default-features = false }
+kamu-flow-system-sqlite = { version = "0.266.0", path = "src/infra/flow-system/sqlite", default-features = false }
 ## Accounts
-kamu-accounts-inmem = { version = "0.265.0", path = "src/infra/accounts/inmem", default-features = false }
-kamu-accounts-mysql = { version = "0.265.0", path = "src/infra/accounts/mysql", default-features = false }
-kamu-accounts-postgres = { version = "0.265.0", path = "src/infra/accounts/postgres", default-features = false }
-kamu-accounts-sqlite = { version = "0.265.0", path = "src/infra/accounts/sqlite", default-features = false }
-kamu-accounts-repo-tests = { version = "0.265.0", path = "src/infra/accounts/repo-tests", default-features = false }
+kamu-accounts-inmem = { version = "0.266.0", path = "src/infra/accounts/inmem", default-features = false }
+kamu-accounts-mysql = { version = "0.266.0", path = "src/infra/accounts/mysql", default-features = false }
+kamu-accounts-postgres = { version = "0.266.0", path = "src/infra/accounts/postgres", default-features = false }
+kamu-accounts-sqlite = { version = "0.266.0", path = "src/infra/accounts/sqlite", default-features = false }
+kamu-accounts-repo-tests = { version = "0.266.0", path = "src/infra/accounts/repo-tests", default-features = false }
 ## Datasets
-kamu-datasets-inmem = { version = "0.265.0", path = "src/infra/datasets/inmem", default-features = false }
-kamu-datasets-mysql = { version = "0.265.0", path = "src/infra/datasets/mysql", default-features = false }
-kamu-datasets-postgres = { version = "0.265.0", path = "src/infra/datasets/postgres", default-features = false }
-kamu-datasets-sqlite = { version = "0.265.0", path = "src/infra/datasets/sqlite", default-features = false }
-kamu-datasets-repo-tests = { version = "0.265.0", path = "src/infra/datasets/repo-tests", default-features = false }
+kamu-datasets-inmem = { version = "0.266.0", path = "src/infra/datasets/inmem", default-features = false }
+kamu-datasets-mysql = { version = "0.266.0", path = "src/infra/datasets/mysql", default-features = false }
+kamu-datasets-postgres = { version = "0.266.0", path = "src/infra/datasets/postgres", default-features = false }
+kamu-datasets-sqlite = { version = "0.266.0", path = "src/infra/datasets/sqlite", default-features = false }
+kamu-datasets-repo-tests = { version = "0.266.0", path = "src/infra/datasets/repo-tests", default-features = false }
 ## Search
-kamu-search-openai = { version = "0.265.0", path = "src/infra/search/openai", default-features = false }
-kamu-search-elasticsearch = { version = "0.265.0", path = "src/infra/search/elasticsearch", default-features = false }
-kamu-search-elasticsearch-macros = { version = "0.265.0", path = "src/infra/search/elasticsearch-macros", default-features = false }
-kamu-search-cache-inmem = { version = "0.265.0", path = "src/infra/search/cache-inmem", default-features = false }
-kamu-search-cache-postgres = { version = "0.265.0", path = "src/infra/search/cache-postgres", default-features = false }
-kamu-search-cache-sqlite = { version = "0.265.0", path = "src/infra/search/cache-sqlite", default-features = false }
-kamu-search-cache-repo-tests = { version = "0.265.0", path = "src/infra/search/cache-repo-tests", default-features = false }
+kamu-search-openai = { version = "0.266.0", path = "src/infra/search/openai", default-features = false }
+kamu-search-elasticsearch = { version = "0.266.0", path = "src/infra/search/elasticsearch", default-features = false }
+kamu-search-elasticsearch-macros = { version = "0.266.0", path = "src/infra/search/elasticsearch-macros", default-features = false }
+kamu-search-cache-inmem = { version = "0.266.0", path = "src/infra/search/cache-inmem", default-features = false }
+kamu-search-cache-postgres = { version = "0.266.0", path = "src/infra/search/cache-postgres", default-features = false }
+kamu-search-cache-sqlite = { version = "0.266.0", path = "src/infra/search/cache-sqlite", default-features = false }
+kamu-search-cache-repo-tests = { version = "0.266.0", path = "src/infra/search/cache-repo-tests", default-features = false }
 ## Task System
-kamu-task-system-inmem = { version = "0.265.0", path = "src/infra/task-system/inmem", default-features = false }
-kamu-task-system-postgres = { version = "0.265.0", path = "src/infra/task-system/postgres", default-features = false }
-kamu-task-system-sqlite = { version = "0.265.0", path = "src/infra/task-system/sqlite", default-features = false }
-kamu-task-system-repo-tests = { version = "0.265.0", path = "src/infra/task-system/repo-tests", default-features = false }
+kamu-task-system-inmem = { version = "0.266.0", path = "src/infra/task-system/inmem", default-features = false }
+kamu-task-system-postgres = { version = "0.266.0", path = "src/infra/task-system/postgres", default-features = false }
+kamu-task-system-sqlite = { version = "0.266.0", path = "src/infra/task-system/sqlite", default-features = false }
+kamu-task-system-repo-tests = { version = "0.266.0", path = "src/infra/task-system/repo-tests", default-features = false }
 ## ReBAC
-kamu-auth-rebac-inmem = { version = "0.265.0", path = "src/infra/auth-rebac/inmem", default-features = false }
-kamu-auth-rebac-repo-tests = { version = "0.265.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
-kamu-auth-rebac-postgres = { version = "0.265.0", path = "src/infra/auth-rebac/postgres", default-features = false }
-kamu-auth-rebac-sqlite = { version = "0.265.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
+kamu-auth-rebac-inmem = { version = "0.266.0", path = "src/infra/auth-rebac/inmem", default-features = false }
+kamu-auth-rebac-repo-tests = { version = "0.266.0", path = "src/infra/auth-rebac/repo-tests", default-features = false }
+kamu-auth-rebac-postgres = { version = "0.266.0", path = "src/infra/auth-rebac/postgres", default-features = false }
+kamu-auth-rebac-sqlite = { version = "0.266.0", path = "src/infra/auth-rebac/sqlite", default-features = false }
 ## Outbox
-kamu-messaging-outbox-inmem = { version = "0.265.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
-kamu-messaging-outbox-postgres = { version = "0.265.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
-kamu-messaging-outbox-sqlite = { version = "0.265.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
-kamu-messaging-outbox-repo-tests = { version = "0.265.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
+kamu-messaging-outbox-inmem = { version = "0.266.0", path = "src/infra/messaging-outbox/inmem", default-features = false }
+kamu-messaging-outbox-postgres = { version = "0.266.0", path = "src/infra/messaging-outbox/postgres", default-features = false }
+kamu-messaging-outbox-sqlite = { version = "0.266.0", path = "src/infra/messaging-outbox/sqlite", default-features = false }
+kamu-messaging-outbox-repo-tests = { version = "0.266.0", path = "src/infra/messaging-outbox/repo-tests", default-features = false }
 ## Webhooks
-kamu-webhooks-inmem = { version = "0.265.0", path = "src/infra/webhooks/inmem", default-features = false }
-kamu-webhooks-postgres = { version = "0.265.0", path = "src/infra/webhooks/postgres", default-features = false }
-kamu-webhooks-sqlite = { version = "0.265.0", path = "src/infra/webhooks/sqlite", default-features = false }
-kamu-webhooks-repo-tests = { version = "0.265.0", path = "src/infra/webhooks/repo-tests", default-features = false }
+kamu-webhooks-inmem = { version = "0.266.0", path = "src/infra/webhooks/inmem", default-features = false }
+kamu-webhooks-postgres = { version = "0.266.0", path = "src/infra/webhooks/postgres", default-features = false }
+kamu-webhooks-sqlite = { version = "0.266.0", path = "src/infra/webhooks/sqlite", default-features = false }
+kamu-webhooks-repo-tests = { version = "0.266.0", path = "src/infra/webhooks/repo-tests", default-features = false }
 ## Web3
-kamu-auth-web3-inmem = { version = "0.265.0", path = "src/infra/auth-web3/inmem", default-features = false }
-kamu-auth-web3-postgres = { version = "0.265.0", path = "src/infra/auth-web3/postgres", default-features = false }
-kamu-auth-web3-repo-tests = { version = "0.265.0", path = "src/infra/auth-web3/repo-tests", default-features = false }
-kamu-auth-web3-sqlite = { version = "0.265.0", path = "src/infra/auth-web3/sqlite", default-features = false }
+kamu-auth-web3-inmem = { version = "0.266.0", path = "src/infra/auth-web3/inmem", default-features = false }
+kamu-auth-web3-postgres = { version = "0.266.0", path = "src/infra/auth-web3/postgres", default-features = false }
+kamu-auth-web3-repo-tests = { version = "0.266.0", path = "src/infra/auth-web3/repo-tests", default-features = false }
+kamu-auth-web3-sqlite = { version = "0.266.0", path = "src/infra/auth-web3/sqlite", default-features = false }
 
 # Adapters
-kamu-adapter-auth-oso-rebac = { version = "0.265.0", path = "src/adapter/auth-oso-rebac", default-features = false }
-kamu-adapter-auth-web3 = { version = "0.265.0", path = "src/adapter/auth-web3", default-features = false }
-kamu-adapter-flight-sql = { version = "0.265.0", path = "src/adapter/flight-sql", default-features = false }
-kamu-adapter-flow-dataset = { version = "0.265.0", path = "src/adapter/flow-dataset", default-features = false }
-kamu-adapter-flow-webhook = { version = "0.265.0", path = "src/adapter/flow-webhook", default-features = false }
-kamu-adapter-task-dataset = { version = "0.265.0", path = "src/adapter/task-dataset", default-features = false }
-kamu-adapter-task-webhook = { version = "0.265.0", path = "src/adapter/task-webhook", default-features = false }
-kamu-adapter-graphql = { version = "0.265.0", path = "src/adapter/graphql", default-features = false }
-kamu-adapter-http = { version = "0.265.0", path = "src/adapter/http", default-features = false }
-kamu-adapter-odata = { version = "0.265.0", path = "src/adapter/odata", default-features = false }
-kamu-adapter-oauth = { version = "0.265.0", path = "src/adapter/oauth", default-features = false }
+kamu-adapter-auth-oso-rebac = { version = "0.266.0", path = "src/adapter/auth-oso-rebac", default-features = false }
+kamu-adapter-auth-web3 = { version = "0.266.0", path = "src/adapter/auth-web3", default-features = false }
+kamu-adapter-flight-sql = { version = "0.266.0", path = "src/adapter/flight-sql", default-features = false }
+kamu-adapter-flow-dataset = { version = "0.266.0", path = "src/adapter/flow-dataset", default-features = false }
+kamu-adapter-flow-webhook = { version = "0.266.0", path = "src/adapter/flow-webhook", default-features = false }
+kamu-adapter-task-dataset = { version = "0.266.0", path = "src/adapter/task-dataset", default-features = false }
+kamu-adapter-task-webhook = { version = "0.266.0", path = "src/adapter/task-webhook", default-features = false }
+kamu-adapter-graphql = { version = "0.266.0", path = "src/adapter/graphql", default-features = false }
+kamu-adapter-http = { version = "0.266.0", path = "src/adapter/http", default-features = false }
+kamu-adapter-odata = { version = "0.266.0", path = "src/adapter/odata", default-features = false }
+kamu-adapter-oauth = { version = "0.266.0", path = "src/adapter/oauth", default-features = false }
 
 # E2E
-kamu-cli-e2e-common = { version = "0.265.0", path = "src/e2e/app/cli/common", default-features = false }
-kamu-cli-e2e-common-macros = { version = "0.265.0", path = "src/e2e/app/cli/common-macros", default-features = false }
-kamu-cli-e2e-example-tests = { version = "0.265.0", path = "src/e2e/app/cli/example-tests", default-features = false }
-kamu-cli-e2e-repo-tests = { version = "0.265.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
+kamu-cli-e2e-common = { version = "0.266.0", path = "src/e2e/app/cli/common", default-features = false }
+kamu-cli-e2e-common-macros = { version = "0.266.0", path = "src/e2e/app/cli/common-macros", default-features = false }
+kamu-cli-e2e-example-tests = { version = "0.266.0", path = "src/e2e/app/cli/example-tests", default-features = false }
+kamu-cli-e2e-repo-tests = { version = "0.266.0", path = "src/e2e/app/cli/repo-tests", default-features = false }
 
 [workspace.package]
-version = "0.265.0"
+version = "0.266.0"
 edition = "2024"
 homepage = "https://github.com/kamu-data/kamu-cli"
 repository = "https://github.com/kamu-data/kamu-cli"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu CLI Version 0.265.0
+Licensed Work:             Kamu CLI Version 0.266.0
                            The Licensed Work is © 2025 Kamu Data, Inc.
 
 Additional Use Grant:      You may not use the Licensed Work for a Data Service,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may not use the Licensed Work for a Data Service,
                            Further, you may not distribute the Licensed Work
                            under a different name or a brand.
 
-Change Date:               2030-07-27
+Change Date:               2030-08-13
 
 Change License:            Apache License, Version 2.0
 

--- a/resources/config-reference.md
+++ b/resources/config-reference.md
@@ -185,7 +185,7 @@
   &quot;http&quot;: {
     &quot;connectTimeout&quot;: &quot;30s&quot;,
     &quot;maxRedirects&quot;: 10,
-    &quot;userAgent&quot;: &quot;kamu-cli&#x2F;0.265.0&quot;
+    &quot;userAgent&quot;: &quot;kamu-cli&#x2F;0.266.0&quot;
   },
   &quot;mqtt&quot;: {
     &quot;brokerIdleTimeout&quot;: &quot;1s&quot;
@@ -1296,7 +1296,7 @@ the resources (for authenticated clients)
 <tr>
 <td><code>userAgent</code></td>
 <td><code>string</code></td>
-<td><code class="language-json">&quot;kamu-cli&#x2F;0.265.0&quot;</code></td>
+<td><code class="language-json">&quot;kamu-cli&#x2F;0.266.0&quot;</code></td>
 <td>Value to use for User-Agent header</td>
 </tr>
 </tbody>
@@ -1781,7 +1781,7 @@ Base type: `string`
 <td><pre><code class="language-json">{
   &quot;connectTimeout&quot;: &quot;30s&quot;,
   &quot;maxRedirects&quot;: 10,
-  &quot;userAgent&quot;: &quot;kamu-cli&#x2F;0.265.0&quot;
+  &quot;userAgent&quot;: &quot;kamu-cli&#x2F;0.266.0&quot;
 }</code></pre></td>
 <td>HTTP-specific configuration</td>
 </tr>

--- a/resources/config-schema.json
+++ b/resources/config-schema.json
@@ -860,7 +860,7 @@
           "type": "integer"
         },
         "userAgent": {
-          "default": "kamu-cli/0.265.0",
+          "default": "kamu-cli/0.266.0",
           "description": "Value to use for User-Agent header",
           "type": "string"
         }
@@ -1226,7 +1226,7 @@
           "default": {
             "connectTimeout": "30s",
             "maxRedirects": 10,
-            "userAgent": "kamu-cli/0.265.0"
+            "userAgent": "kamu-cli/0.266.0"
           },
           "description": "HTTP-specific configuration"
         },
@@ -1478,7 +1478,7 @@
         "http": {
           "connectTimeout": "30s",
           "maxRedirects": 10,
-          "userAgent": "kamu-cli/0.265.0"
+          "userAgent": "kamu-cli/0.266.0"
         },
         "mqtt": {
           "brokerIdleTimeout": "1s"

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -1104,7 +1104,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.265.0"
+    "version": "0.266.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -1104,7 +1104,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.265.0"
+    "version": "0.266.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## [0.266.0] - 2026-08-13
### Added:
- `MySqlDatasetEntryRepository` has been implemented:
  - To fix a previously masked error w/ dataset searching in E2E tests
### Changed
- Revised approaches for handling predefined accounts (mostly `PredefinedAccountsRegistrator`) (#1674):
  - Now, every predefined password account has its own unique key, even for single-tenant workspaces
  - Stricter validation of predefined accounts
- New account IDs are derived from DID secret keys, not from names (#1674):
  - `DEFAULT_ACCOUNT_ID` has been removed; now we only use `TEST_ACCOUNT_ID` for testing, 
    which does not exist in the production code paths (affects new single-tenant workspaces)
- More strict typing in some places (using `Url` and `Email` instead of `String`) (#1674)
- The uniqueness of the DID secret for accounts and datasets is guaranteed (#1674)
### Fixed
- Return JSON responses for authentication policy errors (#1675)
- Restored decimal type support in DDL schema (#1670)
- Fixed the tests failing on Fedora (MQTT, ODFEngine) (#1674):
  - MQTT: `localhost` replaced w/ direct container host
  - ODFEngine: improved handling of the initial connection: due to the nature of proxying, 
               there is a very brief initial window during which the connection may be reset