### PR TITLE
Do not panic when completions output pipe is closed early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Recommendation: for ease of reading, use the following format:
 ### Fixed
 -->
 
+## Unreleased
+### Fixed
+- CLI: `kamu completions` no longer panics when the output pipe is closed early, e.g. `source <(kamu completions bash)` (#1068)
+
 ## [0.266.1] - 2026-08-19
 ### Fixed
 - Login, OAuth: login error if system (local) username matches GitHub username (#1684)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8142,6 +8142,7 @@ dependencies = [
  "observability",
  "opendatafabric",
  "paste",
+ "pipecheck",
  "pretty_assertions",
  "prettytable-rs",
  "prometheus",
@@ -11391,6 +11392,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pipecheck"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2337597d75d3d1b25e67c7e5938c0b9cffa9626d2b1b91c940dbebd6b073ccdf"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "pkcs1"

--- a/src/app/cli/Cargo.toml
+++ b/src/app/cli/Cargo.toml
@@ -245,6 +245,7 @@ hex = { version = "0.4", default-features = false, features = [] }
 indoc = "2"
 itertools = "0.14"
 libc = "0.2" # Signal names
+pipecheck = "0.2" # Unix-style broken pipe handling for stdout
 regex = "1"
 secrecy = "0.10"
 shlex = "1" # Parsing partial input for custom completions

--- a/src/app/cli/src/commands/completions_command.rs
+++ b/src/app/cli/src/commands/completions_command.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::io::{ErrorKind, Write};
+use std::io::Write;
 
 use clap::CommandFactory as _;
 
@@ -41,27 +41,27 @@ impl CompletionsCommand {
         let mut cli = crate::cli::Cli::command();
         let bin_name = cli.get_name().to_owned();
 
-        // Note: the script is rendered into a buffer first, as
-        // `clap_complete::generate()` panics on writer errors. The fallible
-        // `Generator::try_generate()` would avoid this, but requires replicating
-        // `set_bin_name()` + `build()` by hand
-        let mut script = Vec::new();
         match self.shell {
-            clap_complete::Shell::Bash => script.extend_from_slice(BASH_COMPLETIONS.as_bytes()),
-            _ => clap_complete::generate(self.shell, &mut cli, bin_name, &mut script),
+            clap_complete::Shell::Bash => write!(output, "{BASH_COMPLETIONS}")?,
+            _ => clap_complete::generate(self.shell, &mut cli, bin_name, output),
         }
 
-        match output.write_all(&script) {
-            // Consumers may exit before reading all output, e.g. `source <(kamu completions bash)`
-            Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
-            res => Ok(res?),
-        }
+        // Every generator ends in a newline today, so `Stdout`'s line buffer is empty
+        // by now - but its exit-time flush happens outside whichever writer we were
+        // handed, so flush through that writer rather than relying on it staying so
+        output.flush()?;
+
+        Ok(())
     }
 }
 
 #[async_trait::async_trait(?Send)]
 impl Command for CompletionsCommand {
     async fn run(&self) -> Result<(), CLIError> {
-        self.write_completions(&mut std::io::stdout())
+        // `source <(kamu completions bash)`, the invocation suggested by `--help`,
+        // stops reading before the script ends. Rust ignores SIGPIPE, so the write
+        // returns `BrokenPipe`, which both `write!` and `clap_complete::generate()`
+        // turn into a panic - `pipecheck` lets the signal terminate us instead
+        self.write_completions(&mut pipecheck::wrap(std::io::stdout()))
     }
 }

--- a/src/app/cli/src/commands/completions_command.rs
+++ b/src/app/cli/src/commands/completions_command.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::io::{ErrorKind, Write};
+
 use clap::CommandFactory as _;
 
 use super::{CLIError, Command};
@@ -32,19 +34,34 @@ pub struct CompletionsCommand {
     shell: clap_complete::Shell,
 }
 
-#[async_trait::async_trait(?Send)]
-impl Command for CompletionsCommand {
-    async fn run(&self) -> Result<(), CLIError> {
+impl CompletionsCommand {
+    pub fn write_completions(&self, output: &mut impl Write) -> Result<(), CLIError> {
         // TODO: Remove once clap allows to programmatically complete values
         // See: https://github.com/clap-rs/clap/issues/568
         let mut cli = crate::cli::Cli::command();
         let bin_name = cli.get_name().to_owned();
+
+        // Note: the script is rendered into a buffer first, as
+        // `clap_complete::generate()` panics on writer errors. The fallible
+        // `Generator::try_generate()` would avoid this, but requires replicating
+        // `set_bin_name()` + `build()` by hand
+        let mut script = Vec::new();
         match self.shell {
-            clap_complete::Shell::Bash => print!("{BASH_COMPLETIONS}"),
-            _ => {
-                clap_complete::generate(self.shell, &mut cli, bin_name, &mut std::io::stdout());
-            }
+            clap_complete::Shell::Bash => script.extend_from_slice(BASH_COMPLETIONS.as_bytes()),
+            _ => clap_complete::generate(self.shell, &mut cli, bin_name, &mut script),
         }
-        Ok(())
+
+        match output.write_all(&script) {
+            // Consumers may exit before reading all output, e.g. `source <(kamu completions bash)`
+            Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
+            res => Ok(res?),
+        }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl Command for CompletionsCommand {
+    async fn run(&self) -> Result<(), CLIError> {
+        self.write_completions(&mut std::io::stdout())
     }
 }

--- a/src/app/cli/tests/tests/mod.rs
+++ b/src/app/cli/tests/tests/mod.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 mod test_access_token_registry_svc;
+mod test_completions_command;
 mod test_config;
 mod test_di_graph;
 mod test_generate_cli_markdown;

--- a/src/app/cli/tests/tests/test_completions_command.rs
+++ b/src/app/cli/tests/tests/test_completions_command.rs
@@ -1,0 +1,82 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::assert_matches;
+use std::io::{Error, ErrorKind, Write};
+use std::sync::Arc;
+
+use clap::ValueEnum as _;
+use dill::TypedBuilder;
+use kamu_cli::CLIError;
+use kamu_cli::commands::*;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct FailingWriter(ErrorKind);
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+        Err(self.0.into())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Err(self.0.into())
+    }
+}
+
+fn completions_command(shell: clap_complete::Shell) -> Arc<CompletionsCommand> {
+    CompletionsCommand::builder(shell)
+        .get(&dill::Catalog::builder().build())
+        .unwrap()
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test]
+fn test_writes_completions() {
+    for (shell, expected) in [
+        (clap_complete::Shell::Bash, "complete -F _kamu_ kamu"),
+        (clap_complete::Shell::Zsh, "#compdef kamu"),
+        (clap_complete::Shell::Fish, "complete -c kamu"),
+    ] {
+        let mut output = Vec::new();
+        completions_command(shell)
+            .write_completions(&mut output)
+            .unwrap();
+
+        let script = String::from_utf8(output).unwrap();
+        assert!(script.contains(expected), "{shell}: {script}");
+    }
+}
+
+#[test_log::test]
+fn test_broken_pipe_is_ignored() {
+    // Note: every shell other than Bash is rendered by `clap_complete::generate()`,
+    // which panics on writer errors, so this also pins the decision to render the
+    // script into a buffer first
+    for shell in clap_complete::Shell::value_variants() {
+        completions_command(*shell)
+            .write_completions(&mut FailingWriter(ErrorKind::BrokenPipe))
+            .unwrap();
+    }
+}
+
+#[test_log::test]
+fn test_other_write_errors_are_propagated() {
+    let res = completions_command(clap_complete::Shell::Bash)
+        .write_completions(&mut FailingWriter(ErrorKind::PermissionDenied));
+
+    assert_matches!(
+        res,
+        Err(CLIError::Failure { source, .. })
+            if source.downcast_ref::<Error>().map(Error::kind) == Some(ErrorKind::PermissionDenied)
+    );
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/app/cli/tests/tests/test_completions_command.rs
+++ b/src/app/cli/tests/tests/test_completions_command.rs
@@ -56,19 +56,13 @@ fn test_writes_completions() {
 }
 
 #[test_log::test]
-fn test_broken_pipe_is_ignored() {
-    // Note: every shell other than Bash is rendered by `clap_complete::generate()`,
-    // which panics on writer errors, so this also pins the decision to render the
-    // script into a buffer first
-    for shell in clap_complete::Shell::value_variants() {
-        completions_command(*shell)
-            .write_completions(&mut FailingWriter(ErrorKind::BrokenPipe))
-            .unwrap();
-    }
-}
-
-#[test_log::test]
-fn test_other_write_errors_are_propagated() {
+fn test_write_errors_are_propagated() {
+    // Note: only Bash is covered here. Every other shell is rendered by
+    // `clap_complete::generate()`, which panics rather than returning writer
+    // errors, and its fallible `try_generate()` is no escape either - `Fish`
+    // still panics internally (`clap_complete-4.6.9` `fish.rs:277`). Broken
+    // pipes are handled a level up, by the `pipecheck` writer `run()` passes in
+    // - see the test below
     let res = completions_command(clap_complete::Shell::Bash)
         .write_completions(&mut FailingWriter(ErrorKind::PermissionDenied));
 
@@ -77,6 +71,47 @@ fn test_other_write_errors_are_propagated() {
         Err(CLIError::Failure { source, .. })
             if source.downcast_ref::<Error>().map(Error::kind) == Some(ErrorKind::PermissionDenied)
     );
+}
+
+// A broken pipe takes the whole process down, so unlike the cases above it can
+// only be observed from the outside
+#[cfg(unix)]
+#[test_log::test]
+fn test_broken_pipe_terminates_by_sigpipe() {
+    use std::os::unix::process::ExitStatusExt as _;
+
+    // Run outside any `.kamu` that happens to sit above the checkout
+    let workdir = tempfile::tempdir().unwrap();
+
+    for shell in clap_complete::Shell::value_variants() {
+        let (reader, writer) = std::io::pipe().unwrap();
+
+        // Closing the read end before spawning makes the very first write fail, so the
+        // test does not depend on the child being scheduled before or after this point
+        drop(reader);
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_kamu-cli"))
+            .args(["completions", &shell.to_string()])
+            .current_dir(workdir.path())
+            .stdout(writer)
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap()
+            .wait_with_output()
+            .unwrap();
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("panicked") && !stderr.contains("has crashed"),
+            "{shell}: {stderr}"
+        );
+        assert_eq!(
+            output.status.signal(),
+            Some(libc::SIGPIPE),
+            "{shell}: {:?}, stderr: {stderr}",
+            output.status
+        );
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Closes: #1068

`kamu completions <shell>` panics with a full backtrace and the "Oh no, looks like kamu has crashed!" banner when the consumer closes the pipe early. This hits the invocation the CLI's own `--help` recommends (`src/app/cli/src/cli.rs:241`):

```
source <(kamu completions bash)
```

On `master`, `bash`, `zsh` and `fish` all exit `101`, from two different panic sites: `print!` for `bash` (`stdio.rs:1165`), and `clap_complete::generate()` for everything else (`clap_complete-4.6.9` `shell.rs:86`, `fish.rs:277`).

### The fix

Switched to [`pipecheck`](https://docs.rs/pipecheck/) as discussed. `std::io::stdout()` is wrapped in `pipecheck::wrap()` in `run()`, so a broken pipe terminates the process by SIGPIPE from inside the `write` call and `generate()` never gets the error it expects on. The buffer is gone.

For scale on the buffering objection: the `zsh` script is ~100 KB, so the first version really was materialising the whole thing.

Two smaller points:

- The `bash` branch moves from `print!` to `write!` into the same writer, so it goes through `pipecheck` too instead of panicking on its own.
- `write_completions()` flushes explicitly. `Stdout` is line buffered and its exit-time flush happens outside the wrapper, so without this a pipe breaking on the last buffered chunk would be swallowed and we would exit `0`.

The `write_completions(&mut impl Write)` seam is kept. It mirrors the sibling command in this same feature, `CompleteCommand::complete` (`src/app/cli/src/commands/complete_command.rs:147`), and keeps the per-shell content assertions as cheap in-process tests.

### On the dependency

- Its only dependency is `libc`, already a direct dependency of `kamu-cli`, so `Cargo.lock` gains exactly one entry.
- `cargo deny check` is clean: `advisories ok, bans ok, licenses ok, sources ok`.
- It is still young (0.2.0, MIT). The crate is written to be vendored if you would rather not take the dependency: `src/pipecheck.rs` is the entire implementation, self-contained and separately licensed for copy-paste. Happy to switch to an in-tree module instead, it is a small change either way.

### What this does not cover

`clap_complete::generate()` still panics on writer errors that are *not* `BrokenPipe` (`ENOSPC` when redirecting to a full disk, say) for every shell except `bash`. That is unchanged from `master` and out of scope here.

### Verification

Local, macOS, `aarch64`:

- All of `bash`, `zsh`, `fish` now terminate by `SIGPIPE` with empty stderr. Before: `101` plus the crash banner, confirmed by reverting just this file and rebuilding.
- Generated scripts byte-identical to `master` for `bash`, `zsh`, `fish`, `powershell` and `elvish`.
- `source <(kamu completions bash)` exits `0`, and `kamu completions zsh | head -1` exits `141`.
  The latter is a genuine mid-stream break rather than a first-write one, since the `zsh` script is larger than the pipe buffer.
- `cargo fmt --check`, `make clippy` and `cargo deny check` clean; the 3 new tests pass.

The regression test spawns the binary with an already-closed pipe read end, so the failing write is deterministic rather than dependent on scheduling between parent and child.

## Checklist before requesting a review

- [x] Unit and integration tests added
- [x] Compatibility:
  - [x] Network APIs: ✅
  - [x] Workspace layout and metadata: ✅
  - [x] Configuration: ✅
  - [x] Container images: ✅
- [x] Observability:
  - [x] Tracing / metrics: ✅ (n/a - removes a panic in a local, non-server command)
  - [x] Alerts: ✅ (n/a)
- [x] Documentation:
  - [x] [Changelog](./CHANGELOG.md): ✅
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅ (n/a - no user-facing behaviour change beyond not crashing)
- [x] Downstream effects:
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅

---

Used AI assistance on this; I reviewed and tested the change myself.
