### PR TITLE
Fix SELinux detection spawning a shell built-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Recommendation: for ease of reading, use the following format:
 ### Fixed
 -->
 
+## [Unreleased]
+### Fixed
+- Container runtime: SELinux presence detection no longer spawns the `command` shell built-in, which is not an
+  executable and thus always failed with `NotFound` - as a result SELinux was never detected and a
+  `Error detecting SELinux presence` warning was logged on every container start (#1692)
+
 ## [0.266.1] - 2026-08-19
 ### Fixed
 - Login, OAuth: login error if system (local) username matches GitHub username (#1684)

--- a/src/utils/container-runtime/src/runtime.rs
+++ b/src/utils/container-runtime/src/runtime.rs
@@ -557,6 +557,10 @@ fn is_selinux_present() -> bool {
     false
 }
 
+/// Mount point of the `SELinux` pseudo-filesystem (`selinuxfs`)
+#[cfg(target_os = "linux")]
+const SELINUX_FS_PATH: &str = "/sys/fs/selinux";
+
 #[cfg(target_os = "linux")]
 fn is_selinux_present() -> bool {
     use once_cell::sync::OnceCell;
@@ -564,26 +568,49 @@ fn is_selinux_present() -> bool {
     static FLAG: OnceCell<bool> = OnceCell::new();
 
     *FLAG.get_or_init(|| {
-        let output = std::process::Command::new("command")
-            .arg("-v")
-            .arg("sestatus")
-            .output();
+        let is_present = is_selinux_fs_mounted(Path::new(SELINUX_FS_PATH));
 
-        match output {
-            Ok(output) => {
-                let is_present = output.status.success();
+        tracing::debug!("SELinux present: {is_present}");
 
-                tracing::debug!("SELinux present: {is_present}");
-
-                is_present
-            }
-            Err(e) => {
-                tracing::warn!(error = ?e, "Error detecting SELinux presence");
-
-                false
-            }
-        }
+        is_present
     })
 }
 
+/// `SELinux` is enabled only when the `selinuxfs` pseudo-filesystem is mounted.
+/// The mount point directory itself exists on many distributions even when
+/// `SELinux` is disabled, so we probe for one of the attribute files that
+/// appears only once the filesystem is actually mounted.
+#[cfg(target_os = "linux")]
+fn is_selinux_fs_mounted(selinux_fs_path: &Path) -> bool {
+    selinux_fs_path.join("enforce").exists()
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selinux_not_detected_when_mount_point_is_missing() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+
+        assert!(!is_selinux_fs_mounted(&tmp_dir.path().join("selinux")));
+    }
+
+    #[test]
+    fn selinux_not_detected_when_fs_is_not_mounted() {
+        // The mount point directory exists, but `selinuxfs` is not mounted into it
+        let tmp_dir = tempfile::tempdir().unwrap();
+
+        assert!(!is_selinux_fs_mounted(tmp_dir.path()));
+    }
+
+    #[test]
+    fn selinux_detected_when_fs_is_mounted() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        std::fs::write(tmp_dir.path().join("enforce"), "0").unwrap();
+
+        assert!(is_selinux_fs_mounted(tmp_dir.path()));
+    }
+}


### PR DESCRIPTION
## Description

Closes: #1692

`is_selinux_present()` detected SELinux by running:

```rust
std::process::Command::new("command").arg("-v").arg("sestatus").output()
```

`std::process::Command` execs directly and does **not** go through a shell, but `command`
is a POSIX shell *built-in* — there is no `/usr/bin/command` or `/bin/command` binary on
mainstream distributions. The spawn therefore fails with `NotFound` (errno 2) on every
call, which has two effects:

1. The `Err` arm fires every time, logging `Error detecting SELinux presence` on every
   container start — the warning reported in the issue.
2. The `Ok` arm is unreachable, so `is_selinux_present()` has always returned `false`,
   **including on hosts that really do run SELinux**.

This replaces the subprocess with a filesystem probe: SELinux is enabled only when the
`selinuxfs` pseudo-filesystem is mounted at `/sys/fs/selinux`, so we check for one of its
attribute files (`/sys/fs/selinux/enforce`). The `warn!` is removed because the failure
class it reported can no longer occur — it is not being silenced. `debug!("SELinux
present: {is_present}")` is kept.

The probe checks `enforce` rather than the directory itself deliberately: `/sys/fs/selinux`
exists as an empty mount-point directory on many distributions even when SELinux is off
(verified — it is present and empty on a stock WSL2 Ubuntu image), so a bare-directory
probe would be a false positive. The attribute files only appear once `selinuxfs` is
actually mounted.

### Note for reviewers — this is a behaviour change on real SELinux hosts

The only consumer of the flag is the volume-mount suffix selection in
`ContainerRuntime::docker_run_cmd` (`:ro,Z` / `:Z` / `:ro` / none). Because detection has
always returned `false`, kamu has never emitted the `:z`/`:Z` relabel flags on any host.
With detection fixed, SELinux hosts will now get them. That is the intended correction —
it is why the flag exists — but it is the riskiest part of this change and I have no
SELinux host to validate it on, so it deserves a second pair of eyes.

Alternative considered and rejected: `sh -c "command -v sestatus"` (or spawning `sestatus`
directly and matching `ErrorKind::NotFound`). It works, but it keeps a subprocess on the
path and it detects *the SELinux userspace tooling being installed*, not *SELinux being
enabled* — a different question from the one the caller asks. The filesystem probe is also
unit-testable.

### Changelog

```
## [Unreleased]
### Fixed
- Container runtime: SELinux presence detection no longer spawns the `command` shell built-in, which is not an
  executable and thus always failed with `NotFound` - as a result SELinux was never detected and a
  `Error detecting SELinux presence` warning was logged on every container start (#1692)
```

## Checklist before requesting a review

- [x] Unit and integration tests added
  <!-- 3 unit tests for `is_selinux_fs_mounted` (missing mount point / directory present but
       fs not mounted / fs mounted). Integration tests were not added: the crate's existing
       integration tests need a live Docker/Podman daemon and none of them can create a
       real SELinux host. -->
- [x] Compatibility:
  - [x] Network APIs: ✅
  - [x] Workspace layout and metadata: ✅
  - [x] Configuration: ✅
  - [x] Container images: ✅
    <!-- ⚠️ One behaviour change: on hosts where SELinux really is enabled, container
         volumes now receive the `:z`/`:Z` relabel flags they were always meant to get.
         See "Note for reviewers" above. -->
- [x] Observability:
  - [x] Tracing / metrics: ✅
    <!-- The spurious `warn!` is gone; the existing `debug!("SELinux present: ...")` remains. -->
  - [x] Alerts: ✅
- [x] Documentation:
  - [x] Changelog: ✅
  - [x] Public documentation: ✅
- [x] Downstream effects:
  - [x] kamu-node: ✅
  - [x] kamu-web-ui: ✅
  - [x] release-queue: ✅
