### PR TITLE
Don't fail `kamu complete` when the output pipe is closed early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Recommendation: for ease of reading, use the following format:
 ### Fixed
 - SELinux presence detection if fixed and no longer spams warnings (#1692)
 - CLI: `kamu completions` no longer panics when the output pipe is closed early, e.g. `source <(kamu completions bash)` (#1068)
-- CLI: `kamu complete` no longer reports an internal error when the output pipe is closed early (#1068)
+- CLI: `kamu complete` no longer reports an internal error when the output pipe is closed early, and propagates other output errors instead of panicking (#1068)
 
 ## [0.266.1] - 2026-08-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Recommendation: for ease of reading, use the following format:
 ### Fixed
 - SELinux presence detection if fixed and no longer spams warnings (#1692)
 - CLI: `kamu completions` no longer panics when the output pipe is closed early, e.g. `source <(kamu completions bash)` (#1068)
+- CLI: `kamu complete` no longer reports an internal error when the output pipe is closed early (#1068)
 
 ## [0.266.1] - 2026-08-19
 ### Fixed

--- a/src/app/cli/src/commands/complete_command.rs
+++ b/src/app/cli/src/commands/complete_command.rs
@@ -190,6 +190,9 @@ impl CompleteCommand {
                             writeln!(output, "{}", pval.get_name()).int_err()?;
                         }
                     }
+                    // This path returns early, so it needs the same flush as the tail
+                    output.flush().int_err()?;
+
                     return Ok(());
                 }
             }
@@ -230,6 +233,10 @@ impl CompleteCommand {
             }
         }
 
+        // `Stdout`'s exit-time flush happens outside whichever writer we were handed,
+        // so a pipe breaking on the last buffered chunk would otherwise go unnoticed
+        output.flush().int_err()?;
+
         Ok(())
     }
 }
@@ -237,6 +244,11 @@ impl CompleteCommand {
 #[async_trait::async_trait(?Send)]
 impl Command for CompleteCommand {
     async fn run(&self) -> Result<(), CLIError> {
-        self.complete(&mut std::io::stdout()).await
+        // The completion script calls this on every Tab press and reads it through a
+        // command substitution, so the consumer can go away mid-write. Rust ignores
+        // SIGPIPE, so the write fails with `BrokenPipe` instead, which surfaced here
+        // as an "Internal error - report this problem" - `pipecheck` lets the signal
+        // terminate us instead, as it already does for `kamu completions` (#1068)
+        self.complete(&mut pipecheck::wrap(std::io::stdout())).await
     }
 }

--- a/src/app/cli/src/commands/complete_command.rs
+++ b/src/app/cli/src/commands/complete_command.rs
@@ -40,45 +40,57 @@ pub struct CompleteCommand {
 // TODO: This is an extremely hacky way to implement the completion
 // but we have to do this until clap supports custom completer functions
 impl CompleteCommand {
-    fn complete_timestamp(&self, output: &mut impl Write) {
+    fn complete_timestamp(&self, output: &mut impl Write) -> Result<(), CLIError> {
         writeln!(
             output,
             "{}",
             Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
         )
-        .unwrap();
+        .int_err()?;
+
+        Ok(())
     }
 
-    fn complete_env_var(&self, output: &mut impl Write, prefix: &str) {
+    fn complete_env_var(&self, output: &mut impl Write, prefix: &str) -> Result<(), CLIError> {
         for (k, _) in std::env::vars() {
             if k.starts_with(prefix) {
-                writeln!(output, "{k}").unwrap();
+                writeln!(output, "{k}").int_err()?;
             }
         }
+
+        Ok(())
     }
 
-    async fn complete_dataset(&self, output: &mut impl Write, prefix: &str) {
+    async fn complete_dataset(
+        &self,
+        output: &mut impl Write,
+        prefix: &str,
+    ) -> Result<(), CLIError> {
         if let Some(registry) = self.dataset_registry.as_ref() {
             let mut datasets = registry.all_dataset_handles();
             while let Some(dataset_handle) = datasets.try_next().await.unwrap() {
                 if dataset_handle.alias.dataset_name.starts_with(prefix) {
-                    writeln!(output, "{}", dataset_handle.alias).unwrap();
+                    writeln!(output, "{}", dataset_handle.alias).int_err()?;
                 }
             }
         }
+
+        Ok(())
     }
 
-    fn complete_repository(&self, output: &mut impl Write, prefix: &str) {
+    fn complete_repository(&self, output: &mut impl Write, prefix: &str) -> Result<(), CLIError> {
         if let Some(reg) = self.remote_repo_reg.as_ref() {
             for repo_id in reg.get_all_repositories() {
                 if repo_id.starts_with(prefix) {
-                    writeln!(output, "{repo_id}").unwrap();
+                    writeln!(output, "{repo_id}").int_err()?;
                 }
             }
         }
+
+        Ok(())
     }
 
-    async fn complete_alias(&self, output: &mut impl Write, prefix: &str) {
+    async fn complete_alias(&self, output: &mut impl Write, prefix: &str) -> Result<(), CLIError> {
         if let Some(registry) = self.dataset_registry.as_ref()
             && let Some(reg) = self.remote_alias_reg.as_ref()
         {
@@ -87,25 +99,29 @@ impl CompleteCommand {
                 let aliases = reg.get_remote_aliases(&hdl).await.unwrap();
                 for alias in aliases.get_by_kind(RemoteAliasKind::Pull) {
                     if alias.to_string().starts_with(prefix) {
-                        writeln!(output, "{alias}").unwrap();
+                        writeln!(output, "{alias}").int_err()?;
                     }
                 }
                 for alias in aliases.get_by_kind(RemoteAliasKind::Push) {
                     if alias.to_string().starts_with(prefix) {
-                        writeln!(output, "{alias}").unwrap();
+                        writeln!(output, "{alias}").int_err()?;
                     }
                 }
             }
         }
+
+        Ok(())
     }
 
-    fn complete_config_key(&self, output: &mut impl Write, prefix: &str) {
+    fn complete_config_key(&self, output: &mut impl Write, prefix: &str) -> Result<(), CLIError> {
         for path in self.config_service.complete_path(prefix) {
-            writeln!(output, "{path}").unwrap();
+            writeln!(output, "{path}").int_err()?;
         }
+
+        Ok(())
     }
 
-    fn complete_path(&self, output: &mut impl Write, prefix: &str) {
+    fn complete_path(&self, output: &mut impl Write, prefix: &str) -> Result<(), CLIError> {
         let path = path::Path::new(prefix);
         let mut matched_dirs = 0;
         let mut last_matched_dir: path::PathBuf = path::PathBuf::new();
@@ -117,16 +133,16 @@ impl CompleteCommand {
             for entry in glob::glob(&glb).unwrap() {
                 let p = entry.unwrap();
                 if p.is_dir() {
-                    writeln!(output, "{}{}", p.display(), std::path::MAIN_SEPARATOR).unwrap();
+                    writeln!(output, "{}{}", p.display(), std::path::MAIN_SEPARATOR).int_err()?;
                     matched_dirs += 1;
                     last_matched_dir = p;
                 } else {
-                    writeln!(output, "{}", p.display()).unwrap();
+                    writeln!(output, "{}", p.display()).int_err()?;
                 }
             }
         } else if path.is_dir() {
             for entry in fs::read_dir(path).unwrap() {
-                writeln!(output, "{}", entry.unwrap().path().display()).unwrap();
+                writeln!(output, "{}", entry.unwrap().path().display()).int_err()?;
             }
         }
 
@@ -140,8 +156,10 @@ impl CompleteCommand {
                 last_matched_dir.display(),
                 std::path::MAIN_SEPARATOR
             )
-            .unwrap();
+            .int_err()?;
         }
+
+        Ok(())
     }
 
     pub async fn complete(&self, output: &mut impl Write) -> Result<(), CLIError> {
@@ -177,10 +195,10 @@ impl CompleteCommand {
                     if let Some(val_names) = opt.get_value_names() {
                         for name in val_names {
                             match name.as_str() {
-                                "REPO" => self.complete_repository(output, to_complete),
-                                "TIME" => self.complete_timestamp(output),
-                                "VAR" => self.complete_env_var(output, to_complete),
-                                "FILE" => self.complete_path(output, to_complete),
+                                "REPO" => self.complete_repository(output, to_complete)?,
+                                "TIME" => self.complete_timestamp(output)?,
+                                "VAR" => self.complete_env_var(output, to_complete)?,
+                                "FILE" => self.complete_path(output, to_complete)?,
                                 _ => (),
                             }
                         }
@@ -208,11 +226,11 @@ impl CompleteCommand {
         // Complete positionals
         for pos in last_cmd.get_positionals() {
             match pos.get_id().as_str() {
-                "alias" => self.complete_alias(output, to_complete).await,
-                "cfgkey" => self.complete_config_key(output, to_complete),
-                "dataset" => self.complete_dataset(output, to_complete).await,
-                "file" | "manifest" => self.complete_path(output, to_complete),
-                "repository" => self.complete_repository(output, to_complete),
+                "alias" => self.complete_alias(output, to_complete).await?,
+                "cfgkey" => self.complete_config_key(output, to_complete)?,
+                "dataset" => self.complete_dataset(output, to_complete).await?,
+                "file" | "manifest" => self.complete_path(output, to_complete)?,
+                "repository" => self.complete_repository(output, to_complete)?,
                 _ => (),
             }
         }

--- a/src/app/cli/tests/tests/mod.rs
+++ b/src/app/cli/tests/tests/mod.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 mod test_access_token_registry_svc;
+mod test_complete_command;
 mod test_completions_command;
 mod test_config;
 mod test_di_graph;

--- a/src/app/cli/tests/tests/test_complete_command.rs
+++ b/src/app/cli/tests/tests/test_complete_command.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::assert_matches;
+use std::io::{ErrorKind, Write};
 use std::sync::Arc;
 
 use dill::TypedBuilder;
@@ -15,6 +17,18 @@ use kamu_cli::config::ConfigService;
 use kamu_cli::{CLIError, WorkspaceLayout};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct FailingWriter(ErrorKind);
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+        Err(self.0.into())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Err(self.0.into())
+    }
+}
 
 fn complete_command(input: &str, current: usize) -> Arc<CompleteCommand> {
     let catalog = dill::Catalog::builder()
@@ -37,6 +51,23 @@ async fn test_completes_config_keys() {
         .unwrap();
 
     assert_eq!(String::from_utf8(output).unwrap(), "engine.runtime\n");
+}
+
+#[test_log::test(tokio::test)]
+async fn test_write_errors_are_propagated() {
+    // The completion helpers used to `unwrap()` their writes, turning any output
+    // error into a panic. Config keys are the cheapest helper to reach that does
+    // not need a dataset registry
+    let err = complete_command("kamu config set engine.runt", 3)
+        .complete(&mut FailingWriter(ErrorKind::PermissionDenied))
+        .await
+        .unwrap_err();
+
+    // `.int_err()` is what the pre-existing writes in `complete()` already use, so
+    // a write error surfaces as a critical failure rather than a panic
+    let debug = format!("{err:?}");
+    assert!(debug.contains("PermissionDenied"), "{debug}");
+    assert_matches!(err, CLIError::CriticalFailure { .. });
 }
 
 // A broken pipe takes the whole process down, so unlike the cases above it can

--- a/src/app/cli/tests/tests/test_complete_command.rs
+++ b/src/app/cli/tests/tests/test_complete_command.rs
@@ -1,0 +1,89 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use dill::TypedBuilder;
+use kamu_cli::commands::*;
+use kamu_cli::config::ConfigService;
+use kamu_cli::{CLIError, WorkspaceLayout};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn complete_command(input: &str, current: usize) -> Arc<CompleteCommand> {
+    let catalog = dill::Catalog::builder()
+        .add_value(ConfigService::new(&WorkspaceLayout::new(".")))
+        .build();
+
+    CompleteCommand::builder(input.to_owned(), current)
+        .get(&catalog)
+        .unwrap()
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_completes_config_keys() {
+    let mut output = Vec::new();
+    complete_command("kamu config set engine.runt", 3)
+        .complete(&mut output)
+        .await
+        .unwrap();
+
+    assert_eq!(String::from_utf8(output).unwrap(), "engine.runtime\n");
+}
+
+// A broken pipe takes the whole process down, so unlike the cases above it can
+// only be observed from the outside
+#[cfg(unix)]
+#[test_log::test]
+fn test_broken_pipe_terminates_by_sigpipe() {
+    use std::os::unix::process::ExitStatusExt as _;
+
+    // Run outside any `.kamu` that happens to sit above the checkout
+    let workdir = tempfile::tempdir().unwrap();
+
+    // One case per completion path: a subcommand, a positional handled by a helper,
+    // and an option value, which returns early and so flushes on its own line
+    for (input, current) in [
+        ("kamu l", 1),
+        ("kamu config set engine.runt", 3),
+        ("kamu --", 1),
+    ] {
+        let (reader, writer) = std::io::pipe().unwrap();
+
+        // Closing the read end before spawning makes the very first write fail, so the
+        // test does not depend on the child being scheduled before or after this point
+        drop(reader);
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_kamu-cli"))
+            .args(["complete", input, &current.to_string()])
+            .current_dir(workdir.path())
+            .stdout(writer)
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap()
+            .wait_with_output()
+            .unwrap();
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("panicked") && !stderr.contains("Internal error"),
+            "{input:?}: {stderr}"
+        );
+        assert_eq!(
+            output.status.signal(),
+            Some(libc::SIGPIPE),
+            "{input:?}: {:?}, stderr: {stderr}",
+            output.status
+        );
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Follow-up to #1689, as requested there. Same treatment for `kamu complete`.

Related: #1068

`complete` is the command the bash script shipped in `completions` invokes on every Tab press:

```
_COMP_OUTPUTSTR="$( kamu complete -- "${COMP_WORDS[*]}" ${COMP_CWORD} )"
```

Against a closed pipe on `master` it does not panic like `completions` did - it does something arguably worse, and asks the user to file a bug for an ordinary Unix condition:

```
Error:
  0: Internal error
  1: Broken pipe (os error 32)
Help us by reporting this problem at https://github.com/kamu-data/kamu-cli/issues
```

### The fix

`run()` wraps `std::io::stdout()` in `pipecheck::wrap()`, exactly as `completions_command.rs` now does. No dependency change: #1689 already added `pipecheck` to this crate.

`complete()` flushes explicitly before returning, for the reason given in #1689 - `Stdout` is line buffered and its exit-time flush happens outside the wrapper. It has two return points, so there are two flushes.

### The `unwrap()` conversion, which is the part worth arguing about

The completion helpers wrote through `writeln!(...).unwrap()` in 11 places, while `complete()` itself already used `writeln!(...).int_err()?` in three. Two error policies for the same operation in one file, which is also why the observed failure differed depending on which completion path ran - a panic from the helpers, an "Internal error" from `complete()`.

`pipecheck` alone fixes `BrokenPipe` on both, since the process dies inside the write. It leaves every *other* write error still panicking in the helpers. So this PR also converts those 11 sites to `.int_err()?`, making the file's policy uniform and matching what `complete()` already did.

That is more than "the same as #1689", so: **happy to drop it if you would rather this PR were just the `pipecheck` line.** It is a separate commit for exactly that reason. The conversion is mechanical, changes no output, and is covered by a test that panics without it.

Deliberately left alone: the non-write `unwrap()`s in the same helpers (`datasets.try_next()`, `glob::glob()`, `fs::read_dir()`, `entry`). Those are about missing data rather than output, and converting them is a wider behavioural change than this PR should carry.

### Verification

Local, macOS:

- All three completion shapes - subcommand, positional-via-helper, and option value, which returns early - now terminate by `SIGPIPE` with empty stderr. On `master` all three give the "Internal error / report this problem" text above.
- Output is byte-identical to `master` across five completion paths: subcommand, config key, option list, top-level command list, and path completion.
- Both new failure tests were confirmed red by reverting the source: without the conversion `test_write_errors_are_propagated` panics at the raw `unwrap()` (`complete_command.rs:104`), and without `pipecheck` the pipe test fails on "Internal error". `test_completes_config_keys` passes either way, which is the point - it pins the output the refactor must not change.
- 36 tests pass in the package, `cargo fmt --check` and `make clippy` clean.

## Checklist before requesting a review

- [x] Unit and integration tests added
- [x] Compatibility:
  - [x] Network APIs: ✅
  - [x] Workspace layout and metadata: ✅
  - [x] Configuration: ✅
  - [x] Container images: ✅
- [x] Observability:
  - [x] Tracing / metrics: ✅ (n/a - local, non-server command)
  - [x] Alerts: ✅ (n/a)
- [x] Documentation:
  - [x] [Changelog](./CHANGELOG.md): ✅
  - [x] [Public documentation](https://github.com/kamu-data/kamu-docs/): ✅ (n/a - no user-facing behaviour change beyond not failing)
- [x] Downstream effects:
  - [x] [kamu-node](https://github.com/kamu-data/kamu-node): ✅
  - [x] [kamu-web-ui](https://github.com/kamu-data/kamu-web-ui): ✅

---

Used AI assistance on this; I reviewed and tested the change myself.
